### PR TITLE
Forms - X-Supabase Storage support for `richtext` types

### DIFF
--- a/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upload/signed-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upload/signed-url/route.ts
@@ -17,33 +17,34 @@ type Context = {
   };
 };
 
+// Note: this is currentlu not used.
+// upsert: false
 export async function POST(req: NextRequest, context: Context) {
   const { form_id, field_id } = context.params;
 
-  throw new Error("Not implemented");
+  const path = queryorbody("path", {
+    searchParams: req.nextUrl.searchParams,
+    body: await req.json(),
+  });
 
-  // const path = queryorbody("path", {
-  //   searchParams: req.nextUrl.searchParams,
-  //   body: await req.json(),
-  // });
+  assert(path);
 
-  // assert(path);
+  const { data, error } = await sign({
+    form_id,
+    field_id,
+    path,
+    options: {
+      upsert: false,
+    },
+  });
 
-  // const { data, error } = await sign({
-  //   form_id,
-  //   field_id,
-  //   path,
-  //   options: {
-  //     upsert: false,
-  //   },
-  // });
-
-  // return NextResponse.json(<FormsApiResponse<SignedUploadUrlData>>{
-  //   data: data,
-  //   error: error,
-  // });
+  return NextResponse.json(<FormsApiResponse<SignedUploadUrlData>>{
+    data: data,
+    error: error,
+  });
 }
 
+// upsert: true
 export async function PUT(req: NextRequest, context: Context) {
   const { form_id, field_id } = context.params;
 

--- a/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upload/signed-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upload/signed-url/route.ts
@@ -20,26 +20,28 @@ type Context = {
 export async function POST(req: NextRequest, context: Context) {
   const { form_id, field_id } = context.params;
 
-  const path = queryorbody("path", {
-    searchParams: req.nextUrl.searchParams,
-    body: await req.json(),
-  });
+  throw new Error("Not implemented");
 
-  assert(path);
+  // const path = queryorbody("path", {
+  //   searchParams: req.nextUrl.searchParams,
+  //   body: await req.json(),
+  // });
 
-  const { data, error } = await sign({
-    form_id,
-    field_id,
-    path,
-    options: {
-      upsert: false,
-    },
-  });
+  // assert(path);
 
-  return NextResponse.json(<FormsApiResponse<SignedUploadUrlData>>{
-    data: data,
-    error: error,
-  });
+  // const { data, error } = await sign({
+  //   form_id,
+  //   field_id,
+  //   path,
+  //   options: {
+  //     upsert: false,
+  //   },
+  // });
+
+  // return NextResponse.json(<FormsApiResponse<SignedUploadUrlData>>{
+  //   data: data,
+  //   error: error,
+  // });
 }
 
 export async function PUT(req: NextRequest, context: Context) {

--- a/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upsert/signed-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upsert/signed-url/route.ts
@@ -9,6 +9,7 @@ import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { NextRequest, NextResponse } from "next/server";
 import assert from "assert";
+import { queryorbody } from "@/utils/qs";
 
 type Context = {
   params: {
@@ -16,33 +17,6 @@ type Context = {
     field_id: string;
   };
 };
-
-// Note: this is currentlu not used.
-// upsert: false
-export async function POST(req: NextRequest, context: Context) {
-  const { form_id, field_id } = context.params;
-
-  const path = queryorbody("path", {
-    searchParams: req.nextUrl.searchParams,
-    body: await req.json(),
-  });
-
-  assert(path);
-
-  const { data, error } = await sign({
-    form_id,
-    field_id,
-    path,
-    options: {
-      upsert: false,
-    },
-  });
-
-  return NextResponse.json(<FormsApiResponse<SignedUploadUrlData>>{
-    data: data,
-    error: error,
-  });
-}
 
 // upsert: true
 export async function PUT(req: NextRequest, context: Context) {
@@ -68,16 +42,6 @@ export async function PUT(req: NextRequest, context: Context) {
     data: data,
     error: error,
   });
-}
-
-function queryorbody(
-  key: string,
-  b: {
-    searchParams: URLSearchParams;
-    body: any;
-  }
-) {
-  return b.searchParams.get(key) || b.body?.[key];
 }
 
 async function sign({

--- a/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upsert/signed-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/fields/[field_id]/file/upsert/signed-url/route.ts
@@ -50,6 +50,7 @@ export async function PUT(req: NextRequest, context: Context) {
   if (!field) return notFound();
 
   const fs = new FieldStorageService(
+    field.id,
     field.storage as FormFieldStorageSchema,
     form.supabase_connection
   );

--- a/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
@@ -63,7 +63,7 @@ async function handler(
     form.supabase_connection
   );
 
-  const res = fs.createSignedUploadUrlFromFile(row_id, file, options);
+  const res = await fs.createSignedUploadUrlFromFile(row_id, file, options);
 
   return NextResponse.json(res);
 }

--- a/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
@@ -5,6 +5,7 @@ import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { FieldStorageService } from "@/services/form/storage";
 import type { FormFieldStorageSchema } from "@/types";
+import assert from "assert";
 
 type Context = {
   params: {
@@ -50,13 +51,17 @@ async function handler(
       `
     )
     .eq("id", form_id)
+    .filter("fields.id", "eq", field_id)
     .single();
 
   if (formerr) console.error(formerr);
   if (!form) return notFound();
 
-  const field = form.fields.find((f) => f.id === field_id);
-  if (!field) return notFound();
+  const { fields } = form;
+
+  assert(fields.length === 1);
+  const field = fields[0];
+  assert(field);
 
   const fs = new FieldStorageService(
     field.storage as FormFieldStorageSchema,

--- a/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
@@ -64,6 +64,7 @@ async function handler(
   assert(field);
 
   const fs = new FieldStorageService(
+    field.id,
     field.storage as FormFieldStorageSchema,
     form.supabase_connection
   );

--- a/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
@@ -63,12 +63,7 @@ async function handler(
     form.supabase_connection
   );
 
-  const res = fs.createSignedUploadUrlFromFile(
-    file,
-    // TODO: provide context
-    {},
-    options
-  );
+  const res = fs.createSignedUploadUrlFromFile(row_id, file, options);
 
   return NextResponse.json(res);
 }

--- a/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
+++ b/apps/forms/app/(api)/private/editor/[form_id]/rows/[row_id]/fields/[field_id]/files/signed-upload-url/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CreateSignedUploadUrlRequest } from "@/types/private/api";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import { FieldStorageService } from "@/services/form/storage";
+import type { FormFieldStorageSchema } from "@/types";
+
+type Context = {
+  params: {
+    form_id: string;
+    row_id: string;
+    field_id: string;
+  };
+};
+
+export function POST(req: NextRequest, context: Context) {
+  return handler(req, context, {
+    upsert: false,
+  });
+}
+
+export function PUT(req: NextRequest, context: Context) {
+  return handler(req, context, {
+    upsert: true,
+  });
+}
+
+async function handler(
+  req: NextRequest,
+  context: Context,
+  options?: { upsert: boolean }
+) {
+  const body = (await req.json()) as CreateSignedUploadUrlRequest;
+
+  const { file } = body;
+
+  const { form_id, row_id, field_id } = context.params;
+
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient(cookieStore);
+
+  const { data: form, error: formerr } = await supabase
+    .from("form")
+    .select(
+      `
+        *,
+        fields:form_field( id, storage ),
+        supabase_connection:connection_supabase(*)
+      `
+    )
+    .eq("id", form_id)
+    .single();
+
+  if (formerr) console.error(formerr);
+  if (!form) return notFound();
+
+  const field = form.fields.find((f) => f.id === field_id);
+  if (!field) return notFound();
+
+  const fs = new FieldStorageService(
+    field.storage as FormFieldStorageSchema,
+    form.supabase_connection
+  );
+
+  const res = fs.createSignedUploadUrlFromFile(
+    file,
+    // TODO: provide context
+    {},
+    options
+  );
+
+  return NextResponse.json(res);
+}

--- a/apps/forms/app/(api)/submit/[id]/route.ts
+++ b/apps/forms/app/(api)/submit/[id]/route.ts
@@ -589,7 +589,7 @@ async function submit({
   > = {};
 
   // @ts-ignore // TODO: provide all context - currently this is only used for x-supabase storage
-  const pathrendercontext: TemplateVariables.ConnectedDatasourcePostgresTransactionCompleteContext =
+  const pathrendercontext: TemplateVariables.FormConnectedDatasourcePostgresTransactionCompleteContext =
     {
       TABLE: { pks: X_SUPABASE_MAIN_TABLE_PKS },
       NEW: RECORD!,
@@ -1015,7 +1015,7 @@ class ResponseFieldFilesProcessor {
     readonly connections: {
       supabase: ConnectionSupabaseJoint | null;
     },
-    readonly context: TemplateVariables.ConnectedDatasourcePostgresTransactionCompleteContext
+    readonly context: TemplateVariables.FormConnectedDatasourcePostgresTransactionCompleteContext
   ) {}
 
   // this can be reused since we only support one connection per form.

--- a/apps/forms/app/(api)/v1/session/[session]/field/[field]/file/preview/public-url/route.ts
+++ b/apps/forms/app/(api)/v1/session/[session]/field/[field]/file/preview/public-url/route.ts
@@ -1,6 +1,6 @@
 import { client } from "@/lib/supabase/server";
 import { SessionStorageServices } from "@/services/form/storage";
-import { FormsApiResponse, SessionPublicUrlData } from "@/types/private/api";
+import { FormsApiResponse, StoragePublicUrlData } from "@/types/private/api";
 import assert from "assert";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -46,7 +46,7 @@ export async function GET(
     file: { path: path },
   });
 
-  return NextResponse.json(<FormsApiResponse<SessionPublicUrlData>>{
+  return NextResponse.json(<FormsApiResponse<StoragePublicUrlData>>{
     data: publicurldata,
     error: null,
   });

--- a/apps/forms/components/formfield/file-upload-field/uploader.ts
+++ b/apps/forms/components/formfield/file-upload-field/uploader.ts
@@ -12,7 +12,7 @@ import type {
 import type {
   CreateSessionSignedUploadUrlRequest,
   FormsApiResponse,
-  SessionPublicUrlData,
+  StoragePublicUrlData,
   SessionSignedUploadUrlData,
 } from "@/types/private/api";
 import { SupabaseStorageExtensions } from "@/lib/supabase/storage-ext";
@@ -135,7 +135,7 @@ function makeRequestUrlResolver({
       },
     });
 
-    const data = (await res.json()) as FormsApiResponse<SessionPublicUrlData>;
+    const data = (await res.json()) as FormsApiResponse<StoragePublicUrlData>;
     return data.data;
   };
 }

--- a/apps/forms/components/panels/side-panel.tsx
+++ b/apps/forms/components/panels/side-panel.tsx
@@ -95,7 +95,7 @@ export function PanelPropertyField({
                 <HoverCardTrigger type="button">
                   <QuestionMarkCircledIcon className="inline ms-2 align-middle opacity-50" />
                 </HoverCardTrigger>
-                <HoverCardContent>
+                <HoverCardContent className="max-w-md w-full">
                   <article className="prose prose-sm dark:prose-invert text-muted-foreground">
                     {help}
                   </article>

--- a/apps/forms/lib/private/index.ts
+++ b/apps/forms/lib/private/index.ts
@@ -1,7 +1,31 @@
-import type { ConnectionSupabaseJoint, GridaSupabase } from "@/types";
+import type { GridaSupabase } from "@/types";
+import {
+  CreateSignedUploadUrlRequest,
+  EditorApiResponse,
+  SignedUploadUrlData,
+} from "@/types/private/api";
 import Axios from "axios";
 
 export namespace PrivateEditorApi {
+  export namespace Files {
+    export function createSignedUploadUrl({
+      form_id,
+      field_id,
+      row_id,
+      file,
+    }: {
+      form_id: string;
+      field_id: string;
+      row_id: string;
+      file: CreateSignedUploadUrlRequest["file"];
+    }) {
+      return Axios.post<EditorApiResponse<SignedUploadUrlData>>(
+        `/private/editor/${form_id}/rows/${row_id}/fields/${field_id}/files/create-upload-url`,
+        { file }
+      );
+    }
+  }
+
   export namespace FormFieldFile {
     export function file_request_upsert_url({
       form_id,

--- a/apps/forms/lib/private/index.ts
+++ b/apps/forms/lib/private/index.ts
@@ -2,6 +2,50 @@ import type { ConnectionSupabaseJoint, GridaSupabase } from "@/types";
 import Axios from "axios";
 
 export namespace PrivateEditorApi {
+  export namespace FormFieldFile {
+    export function file_request_upsert_url({
+      form_id,
+      field_id,
+      filepath,
+    }: {
+      form_id: string;
+      field_id: string;
+      filepath: string;
+    }) {
+      return `/private/editor/${form_id}/fields/${field_id}/file/upload/signed-url?path=${filepath}`;
+    }
+
+    export function file_preview_url({
+      params,
+      options,
+    }: {
+      params: {
+        form_id: string;
+        field_id: string;
+        filepath: string;
+      };
+      options?: {
+        width?: number;
+        download?: boolean;
+      };
+    }) {
+      const { form_id, field_id, filepath } = params;
+
+      const base = `/private/editor/${form_id}/fields/${field_id}/file/preview/src?path=${filepath}`;
+
+      if (options) {
+        const { width, download } = options;
+        const params = new URLSearchParams();
+        if (width) params.set("width", width.toString());
+        if (download) params.set("download", "true");
+
+        return base + "&" + params.toString();
+      }
+
+      return base;
+    }
+  }
+
   export namespace SupabaseConnection {
     export async function createConnection(
       form_id: string,

--- a/apps/forms/lib/private/index.ts
+++ b/apps/forms/lib/private/index.ts
@@ -12,7 +12,7 @@ export namespace PrivateEditorApi {
       field_id: string;
       filepath: string;
     }) {
-      return `/private/editor/${form_id}/fields/${field_id}/file/upload/signed-url?path=${filepath}`;
+      return `/private/editor/${form_id}/fields/${field_id}/file/upsert/signed-url?path=${filepath}`;
     }
 
     export function file_preview_url({

--- a/apps/forms/lib/private/index.ts
+++ b/apps/forms/lib/private/index.ts
@@ -3,6 +3,7 @@ import {
   CreateSignedUploadUrlRequest,
   EditorApiResponse,
   SignedUploadUrlData,
+  StoragePublicUrlData,
 } from "@/types/private/api";
 import Axios from "axios";
 
@@ -27,6 +28,20 @@ export namespace PrivateEditorApi {
   }
 
   export namespace FormFieldFile {
+    export function getPublicUrl({
+      form_id,
+      field_id,
+      filepath,
+    }: {
+      form_id: string;
+      field_id: string;
+      filepath: string;
+    }) {
+      return Axios.get<EditorApiResponse<StoragePublicUrlData>>(
+        `/private/editor/${form_id}/fields/${field_id}/file/preview/public-url?path=${filepath}`
+      );
+    }
+
     export function file_request_upsert_url({
       form_id,
       field_id,

--- a/apps/forms/lib/private/index.ts
+++ b/apps/forms/lib/private/index.ts
@@ -20,7 +20,7 @@ export namespace PrivateEditorApi {
       file: CreateSignedUploadUrlRequest["file"];
     }) {
       return Axios.post<EditorApiResponse<SignedUploadUrlData>>(
-        `/private/editor/${form_id}/rows/${row_id}/fields/${field_id}/files/create-upload-url`,
+        `/private/editor/${form_id}/rows/${row_id}/fields/${field_id}/files/signed-upload-url`,
         { file }
       );
     }

--- a/apps/forms/lib/templating/index.ts
+++ b/apps/forms/lib/templating/index.ts
@@ -10,6 +10,17 @@ export namespace TemplateVariables {
     | FormConnectedDatasourcePostgresTransactionCompleteContext
     | XSupabase.PostgresQuerySelectContext;
 
+  type ContextMap = {
+    global: GlobalContext;
+    current_file: CurrentFileContext;
+    form: FormContext;
+    form_agent: FormAgentContext;
+    form_session: FormSessionContext;
+    form_response: FormResponseContext;
+    connected_datasource_postgres_transaction_complete: FormConnectedDatasourcePostgresTransactionCompleteContext;
+    "x-supabase.postgrest_query_select": XSupabase.PostgresQuerySelectContext;
+  };
+
   export interface GlobalContext {
     /**
      * getter - system generated uuidv4 - unique on each render
@@ -104,25 +115,19 @@ export namespace TemplateVariables {
         pks: string[];
       };
       RECORD: R;
-      NEW: R;
     }
   }
 
   export interface FormConnectedDatasourcePostgresTransactionCompleteContext<
     R extends Record<string, any> = Record<string, any>,
   > extends FormResponseContext,
-      XSupabase.PostgresQuerySelectContext<R> {}
+      XSupabase.PostgresQuerySelectContext<R> {
+    NEW: R;
+  }
 
   export interface ContextVariableInfo {
     type: string;
-    context:
-      | "global"
-      | "form"
-      | "form_agent"
-      | "form_session"
-      | "form_response"
-      | "connected_datasource_postgres_transaction_complete"
-      | "connected_datasource_postgres_select_record";
+    context: keyof ContextMap;
     available: "always" | "conditional";
     evaluation: "runtime" | "compiletime";
   }
@@ -185,7 +190,7 @@ export namespace TemplateVariables {
     },
     TABLE: {
       type: "object",
-      context: "connected_datasource_postgres_transaction_complete",
+      context: "x-supabase.postgrest_query_select",
       available: "always",
       evaluation: "compiletime",
     },
@@ -197,7 +202,7 @@ export namespace TemplateVariables {
     },
     RECORD: {
       type: "object",
-      context: "connected_datasource_postgres_select_record",
+      context: "x-supabase.postgrest_query_select",
       available: "always",
       evaluation: "compiletime",
     },
@@ -261,6 +266,13 @@ export namespace TemplateVariables {
         NEW: z.record(z.unknown()).describe("New record from the select query"),
       })
     );
+
+  export function createContext<K extends keyof ContextMap = keyof ContextMap>(
+    context: K,
+    data: Omit<ContextMap[K], "uuid">
+  ) {
+    return data;
+  }
 
   export namespace Validation {
     export type ContextPropertyAvailability<T> = {

--- a/apps/forms/lib/templating/index.ts
+++ b/apps/forms/lib/templating/index.ts
@@ -19,6 +19,7 @@ export namespace TemplateVariables {
     form_response: FormResponseContext;
     connected_datasource_postgres_transaction_complete: FormConnectedDatasourcePostgresTransactionCompleteContext;
     "x-supabase.postgrest_query_select": XSupabase.PostgresQuerySelectContext;
+    "x-supabase.postgrest_query_insert_select": XSupabase.PostgresQueryInsertSelectContext;
   };
 
   export interface GlobalContext {
@@ -116,12 +117,18 @@ export namespace TemplateVariables {
       };
       RECORD: R;
     }
+
+    export interface PostgresQueryInsertSelectContext<
+      R extends Record<string, any> = Record<string, any>,
+    > extends PostgresQuerySelectContext<R> {
+      NEW: R;
+    }
   }
 
   export interface FormConnectedDatasourcePostgresTransactionCompleteContext<
     R extends Record<string, any> = Record<string, any>,
   > extends FormResponseContext,
-      XSupabase.PostgresQuerySelectContext<R> {
+      XSupabase.PostgresQueryInsertSelectContext<R> {
     NEW: R;
   }
 

--- a/apps/forms/lib/templating/template.ts
+++ b/apps/forms/lib/templating/template.ts
@@ -22,9 +22,13 @@ function createGridaHandlebars(
   return GridaHandlebars;
 }
 
-export function render(source: string, context: TemplateVariables.Context) {
+export function render(
+  source: string,
+  context: TemplateVariables.Context,
+  options?: CompileOptions
+) {
   const GridaHandlebars = createGridaHandlebars();
-  return GridaHandlebars.compile(source)(context);
+  return GridaHandlebars.compile(source, options)(context);
 }
 
 // export function validate(

--- a/apps/forms/lib/templating/template.ts
+++ b/apps/forms/lib/templating/template.ts
@@ -1,13 +1,48 @@
-import Handlebars from "handlebars";
+import { create } from "handlebars";
 import { ObjectPath } from "./@types";
+import { v4 as uuid } from "uuid";
 import { z } from "zod";
 import type { TemplateVariables } from ".";
 import type { i18n } from "i18next";
 import type { Translation } from "@/i18n/resources";
 
-export function render(source: string, context: TemplateVariables.Context) {
-  return Handlebars.compile(source)(context);
+function createGridaHandlebars(
+  features: {
+    uuid?: boolean;
+  } = { uuid: true }
+) {
+  const GridaHandlebars = create();
+
+  if (features.uuid) {
+    GridaHandlebars.registerHelper("uuid", function () {
+      return uuid();
+    });
+  }
+
+  return GridaHandlebars;
 }
+
+export function render(source: string, context: TemplateVariables.Context) {
+  const GridaHandlebars = createGridaHandlebars();
+  return GridaHandlebars.compile(source)(context);
+}
+
+// export function validate(
+//   source: string,
+//   policy: "x-supabase-storage-compile-time-renderable-single-file-path-template"
+// ) {
+//   const validator = createGridaHandlebars({});
+//   switch (policy) {
+//     // the compile time renderable path shall not contain context like `uuid` or `file.*`
+//     // this path should be rendered solely based on the context without a
+//     case "x-supabase-storage-compile-time-renderable-single-file-path-template": {
+//       const context = TemplateVariables.Validation.availability(
+//         TemplateVariables.ConnectedDatasourcePostgresSelectRecordContextSchema,
+//         (p) => p.evaluation === "compiletime"
+//       );
+//     }
+//   }
+// }
 
 export function getRenderedTexts({
   shape,

--- a/apps/forms/scaffolds/blocks-editor/blocks/image-block.tsx
+++ b/apps/forms/scaffolds/blocks-editor/blocks/image-block.tsx
@@ -22,7 +22,7 @@ import {
 } from "./base-block";
 import { useEditorState } from "@/scaffolds/editor";
 import * as Tooltip from "@radix-ui/react-tooltip";
-import { MediaPicker } from "@/scaffolds/mediapicker";
+import { AdminMediaPicker } from "@/scaffolds/mediapicker";
 
 export function ImageBlock({
   id,
@@ -90,7 +90,7 @@ export function ImageBlock({
         </div>
       </BlockHeader>
       <div>
-        <MediaPicker
+        <AdminMediaPicker
           open={pickerOpen}
           onOpenChange={setPickerOpen}
           onUseImage={onChangeImage}

--- a/apps/forms/scaffolds/grid/file-cell.tsx
+++ b/apps/forms/scaffolds/grid/file-cell.tsx
@@ -80,6 +80,11 @@ export function FileEditCell({
 
   const canAddNewFile = multiple || files?.length === 0;
 
+  const uploader = async (file: File | Blob) => {
+    // TODO: commit the changes
+    return "";
+  };
+
   return (
     <Popover open modal>
       <PopoverTrigger asChild>
@@ -200,13 +205,14 @@ export function FileEditCell({
             <Tooltip>
               <TooltipTrigger className="w-full">
                 <Button
-                  // FIXME: allow upload - need service layer
-                  disabled
-                  // disabled={!canAddNewFile}
+                  disabled={!canAddNewFile}
                   variant="outline"
                   size="sm"
                   className="w-full"
-                  onClick={() => setMediaPickerOpen(true)}
+                  onClick={() => {
+                    toast.error("Not implemented yet - contact support");
+                    // setMediaPickerOpen(true)
+                  }}
                 >
                   <PlusIcon className="me-2" />
                   Add File
@@ -218,8 +224,8 @@ export function FileEditCell({
                 </TooltipContent>
               )}
             </Tooltip>
-            {/* TODO: need a custom uploader */}
             <MediaPicker
+              uploader={uploader}
               open={mediaPickerOpen}
               onOpenChange={setMediaPickerOpen}
               onUseImage={(src) => {

--- a/apps/forms/scaffolds/grid/response-grid.tsx
+++ b/apps/forms/scaffolds/grid/response-grid.tsx
@@ -722,6 +722,7 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
       case "richtext": {
         return (
           <RichTextEditCell
+            field_id={column.key}
             defaultValue={unwrapped}
             onValueCommit={(v) => {
               commit({ value: v });

--- a/apps/forms/scaffolds/grid/response-grid.tsx
+++ b/apps/forms/scaffolds/grid/response-grid.tsx
@@ -615,9 +615,13 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
         val = parseFloat(val);
         break;
       case "datetime-local": {
-        // convert local time to UTC
-        const date = new Date(val);
-        val = date.toISOString();
+        try {
+          const date = new Date(val);
+          val = date.toISOString();
+        } catch (e) {
+          // when user leaves the field empty
+          return;
+        }
       }
     }
 
@@ -625,7 +629,12 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
   };
 
   try {
-    const unwrapped = value ? unwrapFeildValue(value, type) : undefined;
+    const unwrapped = unwrapFeildValue(value, type);
+
+    if (!FieldSupports.file_alias(type) && unwrapped === undefined) {
+      console.log("unwrapped", unwrapped);
+      return <NotSupportedEditCell />;
+    }
 
     switch (type as FormInputType) {
       case "email":
@@ -675,7 +684,9 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
             ref={ref as React.RefObject<HTMLInputElement>}
             type={type}
             className="w-full px-2 appearance-none outline-none border-none"
-            defaultValue={fmtdatetimelocal(unwrapped as string)}
+            defaultValue={
+              unwrapped ? fmtdatetimelocal(unwrapped as string) : undefined
+            }
             onKeyDown={onKeydown}
             onBlur={onBlur}
           />
@@ -778,16 +789,20 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
       case "signature":
       case "payment":
       default:
-        return (
-          <div className="px-2 w-full text-muted-foreground">
-            This field can&apos;t be edited
-          </div>
-        );
+        return <NotSupportedEditCell />;
     }
   } catch (e) {
     console.error(e);
     return <JsonEditCell {...props} />;
   }
+}
+
+function NotSupportedEditCell() {
+  return (
+    <div className="px-2 w-full text-muted-foreground">
+      This field can&apos;t be edited
+    </div>
+  );
 }
 
 function Empty({ value }: { value?: null | undefined | "" }) {

--- a/apps/forms/scaffolds/grid/response-grid.tsx
+++ b/apps/forms/scaffolds/grid/response-grid.tsx
@@ -722,6 +722,7 @@ function FieldEditCell(props: RenderEditCellProps<GFResponseRow>) {
       case "richtext": {
         return (
           <RichTextEditCell
+            row_id={row.__gf_id}
             field_id={column.key}
             defaultValue={unwrapped}
             onValueCommit={(v) => {

--- a/apps/forms/scaffolds/grid/richtext-cell.tsx
+++ b/apps/forms/scaffolds/grid/richtext-cell.tsx
@@ -43,14 +43,14 @@ export function RichTextEditCell({
 }) {
   const [state] = useEditorState();
   const uploader = async (file: File) => {
-    const res = await PrivateEditorApi.Files.createSignedUploadUrl({
+    const createsignedres = await PrivateEditorApi.Files.createSignedUploadUrl({
       form_id: state.form_id,
       field_id: field_id,
       row_id: row_id,
       file: filemeta(file),
     });
 
-    const { data, error } = res.data;
+    const { data, error } = createsignedres.data;
 
     if (error || !data) {
       throw error;
@@ -66,8 +66,19 @@ export function RichTextEditCell({
       throw uploaded.error;
     }
 
-    // TODO: we need a public url.
-    return uploaded.data.path;
+    const path = uploaded.data.path;
+
+    const publicurlres = await PrivateEditorApi.FormFieldFile.getPublicUrl({
+      field_id: field_id,
+      form_id: state.form_id,
+      filepath: path,
+    });
+
+    if (publicurlres.data.error || !publicurlres.data.data) {
+      throw publicurlres.data.error;
+    }
+
+    return publicurlres.data.data.publicUrl;
   };
 
   const editor = useCreateBlockNote({

--- a/apps/forms/scaffolds/grid/richtext-cell.tsx
+++ b/apps/forms/scaffolds/grid/richtext-cell.tsx
@@ -14,8 +14,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
 import { useCreateBlockNote } from "@blocknote/react";
 import { useEditorState } from "../editor";
-import { EditorApiResponse, SignedUploadUrlData } from "@/types/private/api";
 import { SupabaseStorageExtensions } from "@/lib/supabase/storage-ext";
+import { PrivateEditorApi } from "@/lib/private";
 
 const { table: _noop1, ...remainingSpecs } = defaultBlockSpecs;
 const schema = BlockNoteSchema.create({
@@ -30,33 +30,26 @@ function safevalue(value: any) {
 }
 
 export function RichTextEditCell({
+  row_id,
   field_id,
   defaultValue,
   onValueCommit,
 }: {
+  row_id: string;
   field_id: string;
   defaultValue?: any;
   onValueCommit?: (value: any) => void;
 }) {
   const [state] = useEditorState();
   const uploader = async (file: File) => {
-    const res = await fetch(
-      // FIXME: invalid route
-      `/private/editor/${state.form_id}/fields/${field_id}/file/upload/signed-url`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          // we need a dedicated cms storage api for this, for now, we are just randomly generating a path
-          file: {
-            name: file.name,
-            size: file.size,
-          },
-        }),
-      }
-    );
+    const res = await PrivateEditorApi.Files.createSignedUploadUrl({
+      form_id: state.form_id,
+      field_id: field_id,
+      row_id: row_id,
+      file: { name: file.name, size: file.size },
+    });
 
-    const { data, error } =
-      (await res.json()) as EditorApiResponse<SignedUploadUrlData>;
+    const { data, error } = res.data;
 
     if (error || !data) {
       throw error;

--- a/apps/forms/scaffolds/grid/richtext-cell.tsx
+++ b/apps/forms/scaffolds/grid/richtext-cell.tsx
@@ -13,7 +13,9 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
 import { useCreateBlockNote } from "@blocknote/react";
-import { useEffect } from "react";
+import { useEditorState } from "../editor";
+import { EditorApiResponse, SignedUploadUrlData } from "@/types/private/api";
+import { SupabaseStorageExtensions } from "@/lib/supabase/storage-ext";
 
 const { table: _noop1, ...remainingSpecs } = defaultBlockSpecs;
 const schema = BlockNoteSchema.create({
@@ -28,15 +30,56 @@ function safevalue(value: any) {
 }
 
 export function RichTextEditCell({
+  field_id,
   defaultValue,
   onValueCommit,
 }: {
+  field_id: string;
   defaultValue?: any;
   onValueCommit?: (value: any) => void;
 }) {
+  const [state] = useEditorState();
+  const uploader = async (file: File) => {
+    const res = await fetch(
+      // FIXME: invalid route
+      `/private/editor/${state.form_id}/fields/${field_id}/file/upload/signed-url`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          // we need a dedicated cms storage api for this, for now, we are just randomly generating a path
+          file: {
+            name: file.name,
+            size: file.size,
+          },
+        }),
+      }
+    );
+
+    const { data, error } =
+      (await res.json()) as EditorApiResponse<SignedUploadUrlData>;
+
+    if (error || !data) {
+      throw error;
+    }
+
+    const uploaded =
+      await SupabaseStorageExtensions.uploadToSupabaseS3SignedUrl(
+        data.signedUrl,
+        file
+      );
+
+    if (uploaded.error || !uploaded.data) {
+      throw uploaded.error;
+    }
+
+    // TODO: we need a public url.
+    return uploaded.data.path;
+  };
+
   const editor = useCreateBlockNote({
     schema: schema,
     initialContent: safevalue(defaultValue),
+    uploadFile: uploader,
   });
 
   const onSaveClick = () => {

--- a/apps/forms/scaffolds/grid/richtext-cell.tsx
+++ b/apps/forms/scaffolds/grid/richtext-cell.tsx
@@ -16,6 +16,7 @@ import { useCreateBlockNote } from "@blocknote/react";
 import { useEditorState } from "../editor";
 import { SupabaseStorageExtensions } from "@/lib/supabase/storage-ext";
 import { PrivateEditorApi } from "@/lib/private";
+import { filemeta } from "@/utils/file";
 
 const { table: _noop1, ...remainingSpecs } = defaultBlockSpecs;
 const schema = BlockNoteSchema.create({
@@ -46,7 +47,7 @@ export function RichTextEditCell({
       form_id: state.form_id,
       field_id: field_id,
       row_id: row_id,
-      file: { name: file.name, size: file.size },
+      file: filemeta(file),
     });
 
     const { data, error } = res.data;

--- a/apps/forms/scaffolds/mediapicker/index.tsx
+++ b/apps/forms/scaffolds/mediapicker/index.tsx
@@ -10,14 +10,24 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/spinner";
 import { useUploadFile } from "../media";
 
+export function AdminMediaPicker({
+  ...props
+}: Omit<React.ComponentProps<typeof MediaPicker>, "uploader">) {
+  const uploadFile = useUploadFile();
+
+  return <MediaPicker {...props} uploader={uploadFile} />;
+}
+
 export function MediaPicker({
   open,
   onOpenChange,
   onUseImage,
+  uploader,
 }: {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   onUseImage?: (url: string) => void;
+  uploader?: (file: File | Blob) => Promise<string>;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -37,7 +47,7 @@ export function MediaPicker({
               <FromUrl />
             </TabsContent>
             <TabsContent value="upload" className="h-full">
-              <FromFilePicker onUseImage={onUseImage} />
+              <FromFilePicker uploader={uploader} onUseImage={onUseImage} />
             </TabsContent>
             <TabsContent value="search" className="h-full">
               <div>Search content</div>
@@ -79,8 +89,10 @@ function FromUrl() {
 
 function FromFilePicker({
   onUseImage,
+  uploader,
 }: {
   onUseImage?: (url: string) => void;
+  uploader?: (file: File | Blob) => Promise<string>;
 }) {
   const [uploading, setUploading] = useState(false);
   const [src, setSrc] = useState<string | null>(null);
@@ -95,8 +107,6 @@ function FromFilePicker({
   const plainfile = plainFiles[0];
   const file = filesContent[0];
 
-  const uploadFile = useUploadFile();
-
   useEffect(() => {
     if (file) {
       const blob = new Blob([file.content], { type: file.type });
@@ -107,7 +117,7 @@ function FromFilePicker({
   useEffect(() => {
     if (plainfile) {
       setUploading(true);
-      uploadFile(plainfile)
+      uploader?.(plainfile)
         .then(setSrc)
         .finally(() => setUploading(false));
     }

--- a/apps/forms/scaffolds/options/options-edit.tsx
+++ b/apps/forms/scaffolds/options/options-edit.tsx
@@ -30,7 +30,7 @@ import {
 import { fmt_snake_case_to_human_text } from "@/utils/fmt";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { Button } from "@/components/ui/button";
-import { MediaPicker } from "../mediapicker";
+import { AdminMediaPicker } from "../mediapicker";
 import type { Option } from "@/types";
 import { Input } from "@/components/ui/input";
 
@@ -251,7 +251,7 @@ function OptionEditItem({
             onChange={(e) => setLabel(e.target.value)}
           />
           <div>
-            <MediaPicker
+            <AdminMediaPicker
               open={mediaPickerOpen}
               onOpenChange={setMediaPickerOpen}
               onUseImage={(src) => {

--- a/apps/forms/scaffolds/panels/field-edit-panel.tsx
+++ b/apps/forms/scaffolds/panels/field-edit-panel.tsx
@@ -79,6 +79,7 @@ import { NameInput } from "./name-input";
 import { LockClosedIcon, ReloadIcon } from "@radix-ui/react-icons";
 import { PrivateEditorApi } from "@/lib/private";
 import { Badge } from "@/components/ui/badge";
+import { ContextVariablesTable } from "../template-editor/about-variable-table";
 
 // @ts-ignore
 const default_field_init: {
@@ -1057,6 +1058,11 @@ function SupabaseStorageSettings({
             <PanelPropertyField
               label={"Upload Path"}
               description="The file upload path. (Leave leading and trailing slashes off)"
+              help={
+                <>
+                  <ContextVariablesTable schema="x-supabase.postgrest_query_insert_select" />
+                </>
+              }
             >
               <PropertyTextInput
                 placeholder="public/{{RECORD.id}}/photos/{{file.name}}"

--- a/apps/forms/scaffolds/panels/field-edit-panel.tsx
+++ b/apps/forms/scaffolds/panels/field-edit-panel.tsx
@@ -1014,37 +1014,45 @@ function SupabaseStorageSettings({
               label={"Bucket"}
               description="The bucket name to upload the file to."
             >
-              <Select
-                required
-                value={bucket}
-                onValueChange={(value) => setBucket(value)}
-              >
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={
-                      buckets ? (
-                        <>Select Bucket</>
-                      ) : (
-                        <div className="flex gap-2">
-                          <Spinner /> Loading...
-                        </div>
-                      )
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {buckets?.map((bucket) => (
-                    <SelectItem key={bucket.id} value={bucket.id}>
-                      <span>
-                        {bucket.name}
-                        <small className="ms-2 text-muted-foreground">
-                          {bucket.public ? "public" : ""}
-                        </small>
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              {buckets ? (
+                <>
+                  <Select
+                    required
+                    value={bucket}
+                    onValueChange={(value) => setBucket(value)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select Bucket" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {buckets?.map((bucket) => (
+                        <SelectItem key={bucket.id} value={bucket.id}>
+                          <span>
+                            {bucket.name}
+                            <small className="ms-2 text-muted-foreground">
+                              {bucket.public ? "public" : ""}
+                            </small>
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </>
+              ) : (
+                <>
+                  <Select required disabled>
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={
+                          <div className="flex gap-2">
+                            <Spinner /> Loading...
+                          </div>
+                        }
+                      />
+                    </SelectTrigger>
+                  </Select>
+                </>
+              )}
             </PanelPropertyField>
             <PanelPropertyField
               label={"Upload Path"}

--- a/apps/forms/scaffolds/panels/field-edit-panel.tsx
+++ b/apps/forms/scaffolds/panels/field-edit-panel.tsx
@@ -903,7 +903,7 @@ export function FieldEditPanel({
               </PanelPropertyField>
             </PanelPropertyFields>
           </PanelPropertySection>
-          {FieldSupports.file_alias(type) && state.connections.supabase && (
+          {FieldSupports.file_upload(type) && state.connections.supabase && (
             <>
               <hr />
               <SupabaseStorageSettings
@@ -999,9 +999,14 @@ function SupabaseStorageSettings({
       <PanelPropertyFields>
         <PanelPropertyField
           label={"Enabled Storage"}
-          description="Enable Supabase Storage to store files in your Supabase project."
+          description="Enable Supabase Storage to store files in your Supabase project. (Required)"
         >
-          <Switch checked={enabled} onCheckedChange={onEnabledChange} />
+          <Switch
+            // IMPORTANT: the custom storage is required since we do not provide a alternate cdn solution. built in storage works only with a 'response' model, where we can't enforce this on x-supabase connection.
+            required
+            checked={enabled}
+            onCheckedChange={onEnabledChange}
+          />
         </PanelPropertyField>
         {enabled && (
           <>
@@ -1046,7 +1051,7 @@ function SupabaseStorageSettings({
               description="The file upload path. (Leave leading and trailing slashes off)"
             >
               <PropertyTextInput
-                placeholder="public/{{NEW.id}}/photos/{{file.name}}"
+                placeholder="public/{{RECORD.id}}/photos/{{file.name}}"
                 value={path}
                 required
                 pattern="^(?!\/).*"

--- a/apps/forms/scaffolds/template-editor/about-variable-table.tsx
+++ b/apps/forms/scaffolds/template-editor/about-variable-table.tsx
@@ -36,7 +36,7 @@ function flattenSchema(
   return result;
 }
 export function ContextVariablesTable() {
-  const about = flattenSchema(TemplateVariables.schema);
+  const about = flattenSchema(TemplateVariables.FormResonseContextSchema);
 
   return (
     <Table>

--- a/apps/forms/scaffolds/template-editor/about-variable-table.tsx
+++ b/apps/forms/scaffolds/template-editor/about-variable-table.tsx
@@ -35,8 +35,12 @@ function flattenSchema(
 
   return result;
 }
-export function ContextVariablesTable() {
-  const about = flattenSchema(TemplateVariables.FormResonseContextSchema);
+export function ContextVariablesTable({
+  schema,
+}: {
+  schema: TemplateVariables.ContextName;
+}) {
+  const about = flattenSchema(TemplateVariables.schemas[schema]);
 
   return (
     <Table>

--- a/apps/forms/scaffolds/template-editor/template-editor.tsx
+++ b/apps/forms/scaffolds/template-editor/template-editor.tsx
@@ -232,7 +232,7 @@ export function TemplateEditor({
                           <TabsTrigger value="data">Test Data</TabsTrigger>
                         </TabsList>
                         <TabsContent value="variables">
-                          <ContextVariablesTable />
+                          <ContextVariablesTable schema="form_response" />
                         </TabsContent>
                         <TabsContent value="data" className="relative">
                           <header className="absolute right-4 top-4">

--- a/apps/forms/services/form/storage.ts
+++ b/apps/forms/services/form/storage.ts
@@ -1,4 +1,5 @@
 import { GRIDA_FORMS_RESPONSE_BUCKET } from "@/k/env";
+import { UniqueFileNameGenerator } from "@/lib/forms/storage";
 import { SupabasePostgRESTOpenApi } from "@/lib/supabase-postgrest";
 import { client } from "@/lib/supabase/server";
 import { TemplateVariables } from "@/lib/templating";
@@ -21,6 +22,7 @@ import assert from "assert";
 
 export class FieldStorageService {
   constructor(
+    readonly field_id: string,
     readonly storage: FormFieldStorageSchema | null,
     readonly supabase_connection: ConnectionSupabaseJoint | null
   ) {
@@ -122,9 +124,13 @@ export class FieldStorageService {
           throw new Error("storage type not supported");
         }
       }
+    } else {
+      const basepath = `response/${row_id}/${this.field_id}/`;
+      const uniqueFileNameGenerator = new UniqueFileNameGenerator();
+      const uniqueFileName = uniqueFileNameGenerator.name(file.name);
+      const renderedpath = basepath + uniqueFileName;
+      return this.createSignedUploadUrl(renderedpath, options);
     }
-
-    throw new Error("storage type not supported");
   }
 
   async createSignedUpsertUrlFromPath(path: string) {

--- a/apps/forms/services/form/storage.ts
+++ b/apps/forms/services/form/storage.ts
@@ -99,10 +99,11 @@ export class FieldStorageService {
           assert(row, "row not found");
 
           const rowcontext = TemplateVariables.createContext(
-            "x-supabase.postgrest_query_select",
+            "x-supabase.postgrest_query_insert_select",
             {
               TABLE: { pks },
               RECORD: row,
+              NEW: row,
             }
           );
 

--- a/apps/forms/services/form/storage.ts
+++ b/apps/forms/services/form/storage.ts
@@ -264,3 +264,22 @@ export namespace SessionStorageServices {
     }
   }
 }
+
+export function parseStorageUrlOptions(searchParams: URLSearchParams) {
+  const qwidth = searchParams.get("width");
+  const width = Number(qwidth) || undefined;
+  const qdownload = searchParams.get("download");
+  const download = qdownload === "true" || qdownload === "1";
+  const format = download ? "origin" : undefined;
+  const options = {
+    download: download,
+    format: format,
+    transform: {
+      width: width,
+      height: width,
+      // resize: width ? ("contain" as const) : undefined,
+    },
+  };
+
+  return options;
+}

--- a/apps/forms/services/form/storage.ts
+++ b/apps/forms/services/form/storage.ts
@@ -1,11 +1,16 @@
 import { GRIDA_FORMS_RESPONSE_BUCKET } from "@/k/env";
+import { SupabasePostgRESTOpenApi } from "@/lib/supabase-postgrest";
 import { client } from "@/lib/supabase/server";
 import { TemplateVariables } from "@/lib/templating";
 import {
   FileStorage,
   SessionStagedFileStorage,
 } from "@/services/form/session-storage";
-import { createXSupabaseClient } from "@/services/x-supabase";
+import {
+  GridaXSupabaseService,
+  XSupabase,
+  createXSupabaseClient,
+} from "@/services/x-supabase";
 import {
   ConnectionSupabaseJoint,
   FormFieldDefinition,
@@ -22,6 +27,23 @@ export class FieldStorageService {
     //
   }
 
+  private _m_xsupabaseclient: XSupabase.Client | null = null;
+  private async getXSupabaseClient() {
+    if (this._m_xsupabaseclient) {
+      return this._m_xsupabaseclient;
+    }
+
+    assert(this.supabase_connection, "supabase_connection not found");
+    this._m_xsupabaseclient = await createXSupabaseClient(
+      this.supabase_connection.supabase_project_id,
+      {
+        service_role: true,
+      }
+    );
+
+    return this._m_xsupabaseclient;
+  }
+
   private _m_fileStorage: FileStorage | null = null;
   private async getFileStorage() {
     if (this._m_fileStorage) {
@@ -31,12 +53,7 @@ export class FieldStorageService {
     if (this.storage) {
       if (this.storage.type === "x-supabase") {
         assert(this.supabase_connection, "supabase_connection not found");
-        const client = await createXSupabaseClient(
-          this.supabase_connection.supabase_project_id,
-          {
-            service_role: true,
-          }
-        );
+        const client = await this.getXSupabaseClient();
 
         this._m_fileStorage = new FileStorage(client, this.storage.bucket);
         return this._m_fileStorage;
@@ -50,10 +67,63 @@ export class FieldStorageService {
   }
 
   async createSignedUploadUrlFromFile(
+    row_id: string,
     file: CreateSignedUploadUrlRequest["file"],
-    context: TemplateVariables.Context
+    options?: { upsert: boolean }
   ) {
-    // /
+    if (this.storage) {
+      switch (this.storage.type) {
+        case "x-supabase": {
+          const { path: pathtemplate } = this.storage;
+
+          const xclient = await this.getXSupabaseClient();
+
+          const xsupaservice = new GridaXSupabaseService();
+          const conn = await xsupaservice.getConnection(
+            this.supabase_connection!
+          );
+
+          const { sb_table_name, sb_table_schema } = conn?.main_supabase_table!;
+          const { pks } =
+            SupabasePostgRESTOpenApi.parse_supabase_postgrest_schema_definition(
+              sb_table_schema
+            );
+
+          const pk = pks[0];
+          const { data: row, error } = await xclient
+            .from(sb_table_name)
+            .select("*")
+            .eq(pk, row_id)
+            .single();
+          if (error) throw error;
+          assert(row, "row not found");
+
+          const rowcontext = TemplateVariables.createContext(
+            "x-supabase.postgrest_query_select",
+            {
+              TABLE: { pks },
+              RECORD: row,
+            }
+          );
+
+          const filecontext = TemplateVariables.createContext("current_file", {
+            file,
+          });
+
+          const renderedpath = XSupabase.Storage.renderpath(pathtemplate, {
+            ...rowcontext,
+            ...filecontext,
+          });
+
+          return this.createSignedUploadUrl(renderedpath, options);
+        }
+        default: {
+          throw new Error("storage type not supported");
+        }
+      }
+    }
+
+    throw new Error("storage type not supported");
   }
 
   async createSignedUpsertUrlFromPath(path: string) {

--- a/apps/forms/services/x-supabase/index.ts
+++ b/apps/forms/services/x-supabase/index.ts
@@ -220,10 +220,14 @@ export namespace XSupabase {
       }
     }
 
-    export function renderpath<R extends Record<string, any> = Record<string, any>>(
+    export function renderpath<
+      R extends Record<string, any> = Record<string, any>,
+    >(
       pathtemplate: string,
-      data: TemplateVariables.XSupabase.PostgresQuerySelectContext<R> &
-        TemplateVariables.CurrentFileContext
+      data:
+        | TemplateVariables.XSupabase.PostgresQueryInsertSelectContext<R>
+        | (TemplateVariables.XSupabase.PostgresQueryInsertSelectContext<R> &
+            TemplateVariables.CurrentFileContext)
     ) {
       return render(pathtemplate, data, { strict: true });
     }

--- a/apps/forms/services/x-supabase/index.ts
+++ b/apps/forms/services/x-supabase/index.ts
@@ -220,13 +220,12 @@ export namespace XSupabase {
       }
     }
 
-    export function renderpath<
-      R extends Record<string, any> = Record<string, any>,
-    >(
+    export function renderpath<R extends Record<string, any> = Record<string, any>>(
       pathtemplate: string,
-      data: TemplateVariables.XSupabase.PostgresQuerySelectContext<R>
+      data: TemplateVariables.XSupabase.PostgresQuerySelectContext<R> &
+        TemplateVariables.CurrentFileContext
     ) {
-      return render(pathtemplate, data);
+      return render(pathtemplate, data, { strict: true });
     }
   }
 }

--- a/apps/forms/services/x-supabase/index.ts
+++ b/apps/forms/services/x-supabase/index.ts
@@ -127,12 +127,21 @@ export namespace XSupabase {
         };
 
     export class ConnectedClient {
+      /**
+       * dummy table info since this does not use a table variable
+       */
+      table_dummy: TemplateVariables.XSupabase.PostgresQuerySelectContext["TABLE"] =
+        {
+          pks: [] as string[],
+        };
+
       constructor(public readonly storage: SupabaseClient["storage"]) {}
 
       async exists(storage: XSupabaseStorageSchema, row: Record<string, any>) {
         assert(storage.type === "x-supabase");
         const { bucket, path: pathtemplate } = storage;
         const renderedpath = renderpath(pathtemplate, {
+          TABLE: this.table_dummy,
           NEW: row,
           RECORD: row,
         });
@@ -151,6 +160,7 @@ export namespace XSupabase {
         assert(fieldstorage.type === "x-supabase");
         const { bucket, path: pathtemplate } = fieldstorage;
         const renderedpath = renderpath(pathtemplate, {
+          TABLE: this.table_dummy,
           NEW: row,
           RECORD: row,
         });
@@ -172,6 +182,7 @@ export namespace XSupabase {
           ([bucket, fields]: [string, XSupabaseStorageSchema[]]) => {
             const paths = fields.map((f) => {
               const renderedpath = renderpath(f.path, {
+                TABLE: this.table_dummy,
                 NEW: row,
                 RECORD: row,
               });
@@ -213,7 +224,7 @@ export namespace XSupabase {
       R extends Record<string, any> = Record<string, any>,
     >(
       pathtemplate: string,
-      data: TemplateVariables.ConnectedDatasourcePostgresSelectRecordContext<R>
+      data: TemplateVariables.XSupabase.PostgresQuerySelectContext<R>
     ) {
       return render(pathtemplate, data);
     }

--- a/apps/forms/types/private/api.ts
+++ b/apps/forms/types/private/api.ts
@@ -53,6 +53,6 @@ export interface SignedUploadUrlData {
 
 export type SessionSignedUploadUrlData = SignedUploadUrlData;
 
-export type SessionPublicUrlData = {
+export type StoragePublicUrlData = {
   publicUrl: string;
 };

--- a/apps/forms/types/private/api.ts
+++ b/apps/forms/types/private/api.ts
@@ -40,6 +40,8 @@ export interface CreateSignedUploadUrlRequest {
   file: {
     name: string;
     size: number;
+    type: string;
+    lastModified: number;
   };
 }
 export type CreateSessionSignedUploadUrlRequest = CreateSignedUploadUrlRequest;

--- a/apps/forms/types/private/api.ts
+++ b/apps/forms/types/private/api.ts
@@ -36,13 +36,13 @@ export type FormsApiResponse<T, E = any> = (
   | { data: T; error: null }
 ) & { message?: string };
 
-export interface CreateSessionSignedUploadUrlRequest {
+export interface CreateSignedUploadUrlRequest {
   file: {
     name: string;
     size: number;
   };
 }
-
+export type CreateSessionSignedUploadUrlRequest = CreateSignedUploadUrlRequest;
 export interface SignedUploadUrlData {
   signedUrl: string;
   path: string;

--- a/apps/forms/utils/file.ts
+++ b/apps/forms/utils/file.ts
@@ -1,0 +1,8 @@
+export function filemeta(file: File) {
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+    lastModified: file.lastModified,
+  };
+}

--- a/apps/forms/utils/qs.ts
+++ b/apps/forms/utils/qs.ts
@@ -12,3 +12,13 @@ export const qval = (v?: string | null) => {
 export const qboolean = (v: string | null): boolean => {
   return v === "1" || v === "true" || v === "on";
 };
+
+export function queryorbody(
+  key: string,
+  b: {
+    searchParams: URLSearchParams;
+    body: any;
+  }
+) {
+  return b.searchParams.get(key) || b.body?.[key];
+}


### PR DESCRIPTION
- [x] new context `uuid`
- [ ] ~new context `file.name`~
- [x] context table
- [x] x-supabase storage support in richtext
- [ ] storage config validation
  - [x] must be public
  - [ ] multiple not supported (for file type alias)
- [ ] upload image from editor
  - [x] richtext
  - [ ] ~file alias~
- [ ] upload image from editor - x-supabase-storage
  - [x] richtext
  - [ ] ~file alias~



https://github.com/gridaco/grida/assets/16307013/0f8fc44a-c557-4993-8bb2-659b9793ba9a


