### PR TITLE
fix [Grida Forms] File upload not working on iframe embeds #172

### DIFF
--- a/apps/forms/components/extension/file-upload.tsx
+++ b/apps/forms/components/extension/file-upload.tsx
@@ -219,6 +219,11 @@ export const FileUploader = forwardRef<
 
     const dropzoneState = useDropzone({
       ...opts,
+      // we need to turn this off for android webview and iframe embeds
+      // othersise, we will get
+      // Error: Cannot open the file picker because the https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API is not supported and no <input> was provided.
+      // @see https://github.com/gridaco/grida/issues/172
+      useFsAccessApi: false,
       onDrop,
       onDropRejected: () => setIsFileTooBig(true),
       onDropAccepted: () => setIsFileTooBig(false),

--- a/apps/forms/components/formfield/file-upload-field/file-upload-field.tsx
+++ b/apps/forms/components/formfield/file-upload-field/file-upload-field.tsx
@@ -72,7 +72,8 @@ export const FileUploadField = ({
       value={files}
       onValueChange={handleValueChange}
       dropzoneOptions={dropzone}
-      includeFiles={isMultipartFile}
+      // include files is required for the *required to work with dropped files. (files selected via file picker works automatically)
+      includeFiles
     >
       <FileUploaderTrigger>
         <>

--- a/apps/forms/components/formfield/file-upload-field/file-upload-field.tsx
+++ b/apps/forms/components/formfield/file-upload-field/file-upload-field.tsx
@@ -74,15 +74,23 @@ export const FileUploadField = ({
       dropzoneOptions={dropzone}
       includeFiles={isMultipartFile}
     >
-      {isMultipartFile && <FileValue name={name} required={required} />}
-      {!isMultipartFile && (
-        <UploadedFileValue
-          name={name}
-          required={required}
-          value={uploadedFilesPaths}
-        />
-      )}
       <FileUploaderTrigger>
+        <>
+          {/* @see https://github.com/gridaco/grida/issues/172 */}
+          {/* this is required to be present since we are not using fs access api. */}
+          <FileValue
+            // removing the name will prevent the field from being included in form data.
+            name={isMultipartFile ? name : undefined}
+            required={required}
+          />
+          {!isMultipartFile && (
+            <UploadedFileValue
+              name={name}
+              required={required}
+              value={uploadedFilesPaths}
+            />
+          )}
+        </>
         <Card>
           <div className="flex items-center justify-center h-40 w-full rounded-md">
             <p className="text-muted-foreground text-center">


### PR DESCRIPTION
- drops fsAceessApi usage
- uses vanilla input for file upload

Related https://github.com/react-dropzone/react-dropzone/issues/1127