### PR TITLE
Forms - `optgrup` support

### DIFF
--- a/apps/forms/app/(api)/v1/[id]/route.ts
+++ b/apps/forms/app/(api)/v1/[id]/route.ts
@@ -159,7 +159,8 @@ export async function GET(
         *,
         fields:form_field(
           *,
-          options:form_field_option(*)
+          options:form_field_option(*),
+          optgroups:optgroup(*)
         ),
         default_page:form_document!default_form_page_id(
           *,

--- a/apps/forms/app/(workbench)/[org]/[proj]/[id]/layout.tsx
+++ b/apps/forms/app/(workbench)/[org]/[proj]/[id]/layout.tsx
@@ -116,7 +116,8 @@ export default async function Layout({
           *,
           fields:form_field(
             *,
-            options:form_field_option(*)
+            options:form_field_option(*),
+            optgroups:optgroup(*)
           ),
           store_connection:connection_commerce_store(*),
           supabase_connection:connection_supabase(*)

--- a/apps/forms/components/formfield/form-field.tsx
+++ b/apps/forms/components/formfield/form-field.tsx
@@ -1,6 +1,7 @@
 import {
   FormFieldDataSchema,
   FormInputType,
+  Optgroup,
   Option,
   PaymentFieldData,
 } from "@/types";
@@ -9,7 +10,9 @@ import { Select as HtmlSelect } from "../vanilla/select";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -50,6 +53,7 @@ import {
 import { PhoneField } from "./phone-field";
 import { RichTextEditorField } from "./richtext-field";
 import { FieldProperties } from "@/k/supported_field_types";
+import "core-js/features/map/group-by";
 
 /**
  * this disables the auto zoom in input text tag safari on iphone by setting font-size to 16px
@@ -69,6 +73,7 @@ interface IInputField {
   requiredAsterisk?: boolean;
   defaultValue?: string;
   options?: Option[];
+  optgroups?: Optgroup[];
   pattern?: string;
   step?: number;
   min?: number;
@@ -154,6 +159,7 @@ function MonoFormField({
   requiredAsterisk,
   defaultValue,
   options,
+  optgroups,
   helpText,
   readonly,
   disabled,
@@ -377,6 +383,7 @@ function MonoFormField({
             <SafeValueSelect
               {...(sharedInputProps as React.ComponentProps<"select">)}
               options={options}
+              optgroups={optgroups}
               locked={locked}
               onValueChange={onValueChange}
             />
@@ -713,12 +720,14 @@ function Root({
  */
 function SafeValueSelect({
   options: _options,
+  optgroups,
   locked,
   onValueChange: cb_onValueChange,
   ...inputProps
 }: React.ComponentProps<"select"> & {
   placeholder?: string;
   options?: Option[];
+  optgroups?: Optgroup[];
 } & {
   locked?: boolean;
 } & OnValueChange) {
@@ -733,7 +742,6 @@ function SafeValueSelect({
       value: _value as string,
       options: _options?.map((option) => ({
         ...option,
-        // map value to id if id exists
         value: option.id || option.value,
         label: option.label || option.value,
       })),
@@ -767,27 +775,37 @@ function SafeValueSelect({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        {options?.map((option) => (
-          <SelectItem
-            key={option.value}
-            value={option.value}
-            disabled={option.disabled || false}
-          >
-            {option.src ? (
-              <div className="flex items-center gap-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={option.src}
-                  alt={option.label || option.value}
-                  className="w-6 h-6 aspect-square rounded-sm mr-2"
-                />
-                {option.label || option.value}
-              </div>
-            ) : (
-              <>{option.label || option.value}</>
-            )}
-          </SelectItem>
-        ))}
+        {renderOptions({
+          options,
+          optgroups,
+          renderOption: (option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled || false}
+            >
+              {option.src ? (
+                <div className="flex items-center gap-2">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={option.src}
+                    alt={option.label || option.value}
+                    className="w-6 h-6 aspect-square rounded-sm mr-2"
+                  />
+                  {option.label || option.value}
+                </div>
+              ) : (
+                <>{option.label || option.value}</>
+              )}
+            </SelectItem>
+          ),
+          renderOptgroup: ({ label, children }) => (
+            <SelectGroup>
+              <SelectLabel>{label}</SelectLabel>
+              {children}
+            </SelectGroup>
+          ),
+        })}
       </SelectContent>
     </Select>
   );
@@ -798,17 +816,14 @@ function SafeValueSelect({
  */
 function SafeValueHtml5Select({
   options: _options,
+  optgroups,
   locked,
   onValueChange: cb_onValueChange,
   ...inputProps
 }: React.ComponentProps<"select"> & {
   placeholder?: string;
-  options?: {
-    id?: string;
-    label?: string | null;
-    value: string;
-    disabled?: boolean | null;
-  }[];
+  options?: Option[];
+  optgroups?: Optgroup[];
 } & {
   locked?: boolean;
 } & OnValueChange) {
@@ -819,17 +834,19 @@ function SafeValueHtml5Select({
     required,
   } = inputProps;
 
-  const { value, defaultValue, setValue, options } = useSafeSelectValue({
-    value: _value as string,
-    defaultValue: _defaultValue as string,
-    options: _options?.map((option) => ({
-      // map value to id if id exists
-      value: option.id || option.value,
-      label: option.label || option.value,
-      disabled: option.disabled,
-    })),
-    locked,
-  });
+  const { value, defaultValue, setValue, options } = useSafeSelectValue<Option>(
+    {
+      value: _value as string,
+      defaultValue: _defaultValue as string,
+      options: _options?.map((option) => ({
+        id: option.id,
+        value: option.id || option.value,
+        label: option.label || option.value,
+        disabled: option.disabled,
+      })),
+      locked,
+    }
+  );
 
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setValue(e.target.value);
@@ -849,16 +866,72 @@ function SafeValueHtml5Select({
           {placeholder}
         </option>
       )}
-      {options?.map((option) => (
-        <option
-          key={option.value}
-          value={option.value}
-          disabled={option.disabled || false}
-        >
-          {option.label}
-        </option>
-      ))}
+      {renderOptions({
+        options,
+        optgroups,
+        renderOption: (option) => (
+          <option
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled || false}
+          >
+            {option.label}
+          </option>
+        ),
+        renderOptgroup: ({ label, children }) => (
+          <optgroup label={label}>{children}</optgroup>
+        ),
+      })}
     </HtmlSelect>
+  );
+}
+
+function renderOptions({
+  options = [],
+  optgroups = [],
+  renderOption,
+  renderOptgroup,
+}: {
+  options?: Option[];
+  optgroups?: Optgroup[];
+  renderOption: (option: Option) => React.ReactNode;
+  renderOptgroup: ({
+    label,
+    children,
+  }: {
+    label?: string;
+    children: React.ReactNode[];
+  }) => React.ReactNode;
+}) {
+  const grouped = options.reduce(
+    (acc, option) => {
+      const key = option.optgroup_id || "ungrouped";
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(option);
+      return acc;
+    },
+    {} as Record<string, Option[]>
+  );
+
+  const renderedOptgroups = optgroups.map((optgroup) => {
+    const groupOptions = grouped[optgroup.id] || [];
+    return renderOptgroup({
+      label: optgroup.label,
+      children: groupOptions.map(renderOption),
+    });
+  });
+
+  const ungroupedOptions = grouped["ungrouped"]
+    ? grouped["ungrouped"].map(renderOption)
+    : [];
+
+  return (
+    <>
+      {renderedOptgroups}
+      {ungroupedOptions}
+    </>
   );
 }
 

--- a/apps/forms/components/formfield/form-field.tsx
+++ b/apps/forms/components/formfield/form-field.tsx
@@ -31,7 +31,7 @@ import { RadioGroup, RadioGroupItem } from "../ui/radio-group";
 import { Textarea } from "../ui/textarea";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { Card } from "../ui/card";
+import { Card, CardContent, CardHeader } from "../ui/card";
 import { Label } from "../ui/label";
 import {
   FileUploadField,
@@ -674,11 +674,32 @@ function MonoFormField({
               // TODO: need handling - this can be an array
               onValueChange={onValueChange}
             >
-              {options.map((option) => (
+              {renderOptions({
+                options,
+                optgroups,
+                renderOption: (option) => (
+                  <ToggleGroupItem key={option.id} value={option.id}>
+                    {option.label}
+                  </ToggleGroupItem>
+                ),
+                renderOptgroup: ({ id, label, children }) => (
+                  <Card key={id} className="w-full mt-4">
+                    <CardHeader>
+                      <Label>{label}</Label>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="flex items-start justify-start flex-wrap gap-1">
+                        {children}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ),
+              })}
+              {/* {options.map((option) => (
                 <ToggleGroupItem key={option.id} value={option.id}>
                   {option.label}
                 </ToggleGroupItem>
-              ))}
+              ))} */}
             </ToggleGroupRootWithValue>
           </Root>
         );
@@ -896,13 +917,19 @@ function renderOptions({
   optgroups?: Optgroup[];
   renderOption: (option: Option) => React.ReactNode;
   renderOptgroup: ({
+    id,
     label,
     children,
   }: {
+    id: string;
     label?: string;
     children: React.ReactNode[];
   }) => React.ReactNode;
 }) {
+  if (!optgroups.length) {
+    return options.map(renderOption);
+  }
+
   const grouped = options.reduce(
     (acc, option) => {
       const key = option.optgroup_id || "ungrouped";
@@ -918,6 +945,7 @@ function renderOptions({
   const renderedOptgroups = optgroups.map((optgroup) => {
     const groupOptions = grouped[optgroup.id] || [];
     return renderOptgroup({
+      id: optgroup.id,
       label: optgroup.label,
       children: groupOptions.map(renderOption),
     });
@@ -1066,7 +1094,7 @@ function ToggleGroupRootWithValue({
       variant="outline"
       {...props}
       onValueChange={onValueChange}
-      className="flex items-start justify-start flex-wrap"
+      className="flex items-start justify-start flex-wrap gap-1"
     >
       <input
         ref={ref}

--- a/apps/forms/database.types.ts
+++ b/apps/forms/database.types.ts
@@ -1240,6 +1240,7 @@ export type Database = {
           id: string
           index: number
           label: string
+          optgroup_id: string | null
           src: string | null
           value: string
         }
@@ -1251,6 +1252,7 @@ export type Database = {
           id?: string
           index?: number
           label?: string
+          optgroup_id?: string | null
           src?: string | null
           value: string
         }
@@ -1262,10 +1264,18 @@ export type Database = {
           id?: string
           index?: number
           label?: string
+          optgroup_id?: string | null
           src?: string | null
           value?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "form_field_option_optgroup_id_fkey"
+            columns: ["optgroup_id"]
+            isOneToOne: false
+            referencedRelation: "optgroup"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "grida_forms_form_field_option_form_field_id_fkey"
             columns: ["form_field_id"]
@@ -1357,6 +1367,51 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      optgroup: {
+        Row: {
+          created_at: string
+          disabled: boolean
+          form_field_id: string
+          form_id: string
+          id: string
+          index: number
+          label: string
+        }
+        Insert: {
+          created_at?: string
+          disabled?: boolean
+          form_field_id: string
+          form_id: string
+          id?: string
+          index?: number
+          label: string
+        }
+        Update: {
+          created_at?: string
+          disabled?: boolean
+          form_field_id?: string
+          form_id?: string
+          id?: string
+          index?: number
+          label?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "optgroup_form_field_id_fkey"
+            columns: ["form_field_id"]
+            isOneToOne: false
+            referencedRelation: "form_field"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "optgroup_form_id_fkey"
+            columns: ["form_id"]
+            isOneToOne: false
+            referencedRelation: "form"
             referencedColumns: ["id"]
           },
         ]
@@ -2059,6 +2114,7 @@ export type Database = {
           numeric: number | null
           richtext: Json | null
           text: string
+          text_arr: string[] | null
           timestamptz: string | null
           user_id: string | null
           varchar: string | null
@@ -2076,6 +2132,7 @@ export type Database = {
           numeric?: number | null
           richtext?: Json | null
           text: string
+          text_arr?: string[] | null
           timestamptz?: string | null
           user_id?: string | null
           varchar?: string | null
@@ -2093,6 +2150,7 @@ export type Database = {
           numeric?: number | null
           richtext?: Json | null
           text?: string
+          text_arr?: string[] | null
           timestamptz?: string | null
           user_id?: string | null
           varchar?: string | null

--- a/apps/forms/lib/forms/renderer.ts
+++ b/apps/forms/lib/forms/renderer.ts
@@ -39,6 +39,13 @@ type ClientRenderOption = {
   index?: number;
 };
 
+type ClientRenderOptgroup = {
+  id: string;
+  label?: string;
+  disabled?: boolean | null;
+  index?: number;
+};
+
 export interface ClientFieldRenderBlock<T extends FormInputType = FormInputType>
   extends BaseRenderBlock {
   type: "field";
@@ -59,6 +66,7 @@ export interface ClientFieldRenderBlock<T extends FormInputType = FormInputType>
     maxlength?: number;
     placeholder?: string;
     options?: ClientRenderOption[];
+    optgroups?: ClientRenderOptgroup[];
     autocomplete?: string;
     data?: FormFieldDataSchema | null;
     accept?: string;
@@ -416,6 +424,7 @@ export class FormRenderTree {
     const base: ClientFieldRenderBlock["field"] = {
       ...field,
       options: mkoption(field.options),
+      optgroups: field.optgroups,
       label: field.label || undefined,
       help_text: field.help_text || undefined,
       placeholder: field.placeholder || undefined,

--- a/apps/forms/scaffolds/blocks-editor/blocks/base-block.tsx
+++ b/apps/forms/scaffolds/blocks-editor/blocks/base-block.tsx
@@ -85,7 +85,7 @@ export function FlatBlockBase({
       data-focused={focused}
       className={clsx(
         "rounded-md flex flex-col gap-4 border w-full p-4 bg-background shadow-md",
-        'data-[invalid="true"]:border-destructive data-[invalid="true"]:border-2',
+        'data-[invalid="true"]:border-destructive data-[invalid="true"]:border-1 data-[invalid="true"]:border-dashed',
         'data-[focused="true"]:border-foreground data-[focused="true"]:bg-secondary'
       )}
       onPointerDown={(e) => {

--- a/apps/forms/scaffolds/blocks-editor/blocks/field-block.tsx
+++ b/apps/forms/scaffolds/blocks-editor/blocks/field-block.tsx
@@ -284,6 +284,8 @@ export function FieldBlock({
             helpText={form_field?.help_text ?? ""}
             placeholder={form_field?.placeholder ?? ""}
             options={form_field?.options}
+            optgroups={form_field?.optgroups}
+            multiple={form_field?.multiple ?? false}
             data={form_field?.data}
           />
         )}

--- a/apps/forms/scaffolds/e/form/formview.tsx
+++ b/apps/forms/scaffolds/e/form/formview.tsx
@@ -470,6 +470,7 @@ function BlockRenderer({
                   requiredAsterisk
                   helpText={field.help_text}
                   options={field.options}
+                  optgroups={field.optgroups}
                   pattern={field.pattern}
                   step={field.step}
                   min={field.min}

--- a/apps/forms/scaffolds/editor/editor.tsx
+++ b/apps/forms/scaffolds/editor/editor.tsx
@@ -64,7 +64,9 @@ function FieldEditPanelProvider({ children }: React.PropsWithChildren<{}>) {
     (init: FormFieldSave) => {
       const data: FormFieldUpsert = {
         ...init,
+        //
         options: init.options?.length ? init.options : undefined,
+        optgroups: init.optgroups?.length ? init.optgroups : undefined,
         //
         id: state.focus_field_id ?? undefined,
         form_id: state.form_id,
@@ -144,6 +146,7 @@ function FieldEditPanelProvider({ children }: React.PropsWithChildren<{}>) {
                 accept: field.accept,
                 multiple: field.multiple ?? undefined,
                 options: field.options,
+                optgroups: field.optgroups,
                 storage: field.storage,
                 reference: field.reference,
                 // TODO: add inventory support

--- a/apps/forms/scaffolds/editor/state.ts
+++ b/apps/forms/scaffolds/editor/state.ts
@@ -190,7 +190,7 @@ function formpagesinit({
 }): MenuItem[] {
   return [
     {
-      section: "Form",
+      section: "Design",
       id: "campaign",
       label: "Campaign",
       href: `/${basepath}/${document_id}/form`,
@@ -205,7 +205,7 @@ function formpagesinit({
     //   level: 1,
     // },
     {
-      section: "Form",
+      section: "Design",
       id: "form",
       label: "Form Page",
       href: `/${basepath}/${document_id}/form/edit`,
@@ -213,7 +213,7 @@ function formpagesinit({
       level: 1,
     },
     {
-      section: "Form",
+      section: "Design",
       id: "ending",
       label: "Ending Page",
       href: `/${basepath}/${document_id}/form/end`,

--- a/apps/forms/scaffolds/options/options-edit.tsx
+++ b/apps/forms/scaffolds/options/options-edit.tsx
@@ -90,8 +90,12 @@ export function initialOptionsEditState(init: {
     ...sorted_options.map((_) => ({ type: "option" as const, ..._ })),
     ...sorted_optgroups.map((_) => ({ type: "optgroup" as const, ..._ })),
   ].map((_, i) => ({ ..._, index: i }));
-  const indexed_options = allitems.filter((_) => _.type === "option");
-  const indexed_optgroups = allitems.filter((_) => _.type === "optgroup");
+  const indexed_options: Option[] = allitems.filter(
+    (_) => _.type === "option"
+  ) as Option[];
+  const indexed_optgroups: Optgroup[] = allitems.filter(
+    (_) => _.type === "optgroup"
+  ) as Optgroup[];
 
   return {
     options: indexed_options,

--- a/apps/forms/scaffolds/panels/field-edit-panel.tsx
+++ b/apps/forms/scaffolds/panels/field-edit-panel.tsx
@@ -375,13 +375,6 @@ export function FieldEditPanel({
   const save = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const indexed_options = options
-      .map((option, index) => ({
-        ...option,
-        index,
-      }))
-      .sort((a, b) => a.index - b.index);
-
     const options_inventory_upsert_diff = is_inventory_enabled
       ? Object.fromEntries(
           Object.entries(inventory ?? {}).map(([id, stock]) => [
@@ -405,7 +398,8 @@ export function FieldEditPanel({
       step,
       min,
       max,
-      options: supports_options ? indexed_options : undefined,
+      options: supports_options ? options : undefined,
+      optgroups: supports_options ? optgroups : undefined,
       autocomplete,
       data,
       accept,

--- a/apps/forms/scaffolds/panels/field-edit-panel.tsx
+++ b/apps/forms/scaffolds/panels/field-edit-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useReducer, useState } from "react";
 import {
   PanelClose,
   PanelContent,
@@ -20,7 +20,6 @@ import {
   FormInputType,
   FormFieldInit,
   PaymentFieldData,
-  Option,
   FormFieldStorageSchema,
   GridaSupabase,
   FormFieldReferenceSchema,
@@ -63,9 +62,12 @@ import {
 } from "@/k/payments_service_providers";
 import { fmt_snake_case_to_human_text } from "@/utils/fmt";
 import toast from "react-hot-toast";
-import { arrayMove } from "@dnd-kit/sortable";
 import { draftid } from "@/utils/id";
-import { OptionsEdit } from "../options/options-edit";
+import {
+  OptionsEdit,
+  initialOptionsEditState,
+  useOptionsEdit,
+} from "../options/options-edit";
 import { OptionsStockEdit } from "../options/options-sku";
 import { Switch } from "@/components/ui/switch";
 import { FormFieldUpsert } from "@/types/private/api";
@@ -261,6 +263,15 @@ export function FieldEditPanel({
   const [min, setMin] = useState<number | undefined>(init?.min);
   const [max, setMax] = useState<number | undefined>(init?.max);
 
+  // options
+  const [{ options, optgroups }, dispatchoptions] = useReducer(
+    useOptionsEdit,
+    initialOptionsEditState({
+      options: init?.options,
+      optgroups: init?.optgroups,
+    })
+  );
+
   useEffect(() => {
     setType(init?.type || "text");
     setName(init?.name || "");
@@ -273,14 +284,14 @@ export function FieldEditPanel({
     setStep(init?.step);
     setMin(init?.min);
     setMax(init?.max);
-  }, [init]);
-
-  // options
-  const [options, setOptions] = useState<Option[]>(
-    Array.from(init?.options ?? []).sort(
-      (a, b) => (a.index || 0) - (b.index || 0)
-    )
-  );
+    dispatchoptions([
+      "set",
+      {
+        options: init?.options || [],
+        optgroups: init?.optgroups || [],
+      },
+    ]);
+  }, []);
 
   const [autocomplete, setAutocomplete] = useState<FormFieldAutocompleteType[]>(
     init?.autocomplete || []
@@ -414,8 +425,14 @@ export function FieldEditPanel({
     setHelpText(schema.help_text);
     setType(schema.type);
     setRequired(schema.required);
-    setOptions(schema.options || []);
     setPattern(schema.pattern);
+    dispatchoptions([
+      "set",
+      {
+        options: schema.options || [],
+        optgroups: schema.optgroups || [],
+      },
+    ]);
   };
 
   useEffect(() => {
@@ -435,7 +452,13 @@ export function FieldEditPanel({
         setData((_data) => _data || defaults.data);
         // reset options if there were no existing options
         if (!options?.length) {
-          setOptions(defaults.options || []);
+          dispatchoptions([
+            "set",
+            {
+              options: defaults.options || [],
+              optgroups: [],
+            },
+          ]);
         }
 
         // always reset pattern
@@ -473,6 +496,7 @@ export function FieldEditPanel({
                   requiredAsterisk
                   disabled={preview_disabled}
                   options={supports_options ? options : undefined}
+                  optgroups={supports_options ? optgroups : undefined}
                   pattern={pattern}
                   step={step}
                   min={min}
@@ -570,27 +594,21 @@ export function FieldEditPanel({
               <OptionsEdit
                 disableNewOption={is_inventory_enabled}
                 options={options}
-                onAdd={() => {
-                  setOptions([...options, next_option_default(options)]);
+                optgroups={optgroups}
+                onAdd={(type) => {
+                  dispatchoptions(["add", type]);
                 }}
-                onAddMany={(values) => {
-                  const new_options = values.map((value) =>
-                    next_option_default(options, value)
-                  );
-                  setOptions([...options, ...new_options]);
+                onAddManyOptions={(values) => {
+                  dispatchoptions(["add-many-options", values]);
                 }}
-                onChange={(id, option) => {
-                  setOptions(
-                    options.map((_option: Option) =>
-                      _option.id && _option.id === id ? option : _option
-                    )
-                  );
+                onItemChange={(id, data) => {
+                  dispatchoptions(["change", { id, data }]);
                 }}
-                onRemove={(id) => {
-                  setOptions(options.filter((_) => _.id !== id));
+                onRemove={(type, id) => {
+                  dispatchoptions(["remove", { type, id }]);
                 }}
                 onSort={(from, to) => {
-                  setOptions(arrayMove(options, from, to));
+                  dispatchoptions(["sort", { from, to }]);
                 }}
               />
             </PanelPropertyFields>
@@ -1343,30 +1361,6 @@ function isHandlebarTemplate(str?: string) {
   if (!str) return false;
   const handlebarRegex = /\{\{[^{}]*\}\}/;
   return handlebarRegex.test(str);
-}
-
-function next_option_default(options: Option[], seed?: string): Option {
-  const len = options.length;
-  const val = (n: number) =>
-    seed && !options.some((_) => _.value === seed)
-      ? seed
-      : `${seed || "option_"}${n}`;
-  const label = (n: number) =>
-    seed && !options.some((_) => _.label === seed)
-      ? seed
-      : `${seed ? seed.charAt(0).toUpperCase() + seed.slice(1) : "Option"} ${n}`;
-
-  let n = len + 1;
-  while (options.some((_) => _.value === val(n))) {
-    n++;
-  }
-
-  return {
-    id: draftid(),
-    value: val(n),
-    label: label(n),
-    disabled: false,
-  };
 }
 
 function buildPreviewLabel({ name, label }: { name: string; label?: string }) {

--- a/apps/forms/types/types.ts
+++ b/apps/forms/types/types.ts
@@ -173,6 +173,7 @@ export type FormFieldInit = {
   min?: number;
   max?: number;
   options?: Option[];
+  optgroups?: Optgroup[];
   autocomplete?: FormFieldAutocompleteType[] | null;
   data?: FormFieldDataSchema | null;
   accept?: string | null;
@@ -196,6 +197,7 @@ export interface IFormField {
   min?: number | null;
   max?: number | null;
   options?: Option[];
+  optgroups?: Optgroup[];
   autocomplete?: FormFieldAutocompleteType[] | null;
   data?: FormFieldDataSchema | null;
   accept?: string | null;
@@ -251,6 +253,14 @@ export type Option = {
   label?: string;
   value: string;
   src?: string | null;
+  disabled?: boolean | null;
+  index?: number;
+  optgroup_id?: string | null;
+};
+
+export type Optgroup = {
+  id: string;
+  label?: string;
   disabled?: boolean | null;
   index?: number;
 };


### PR DESCRIPTION
We decided to add `optgroup` support, as a part of a schema, not a designer-only feature. Here's why.

1. our main philosophy over the form is 1:1 matched data and view. no transformations, no custom handling
2. while keeping 1, it often gets tidous manipulating multiple fields to result a single field output. E.g. tags with category
3. adding optgroup as a schema element does not affect any existing logics, or any layers to maintain



https://github.com/user-attachments/assets/7767f782-13cf-456e-b2b1-14f07140410f

