### PR TITLE
fix: changed Supabase getSession API to getUser

### DIFF
--- a/apps/forms/app/(workspace)/dashboard/new/page.tsx
+++ b/apps/forms/app/(workspace)/dashboard/new/page.tsx
@@ -31,9 +31,9 @@ export default async function OnboardWithNewFormPage({
 
   const supabase = createServerComponentClient(cookieStore);
 
-  const { data } = await supabase.auth.getUser();
+  const { data: auth } = await supabase.auth.getUser();
   // if no auth, sign in, redirect back here
-  if (data.session === null || data.session.user === null) {
+  if (!auth.user) {
     const search = new URLSearchParams(searchParams).toString();
     const uri = encodeURIComponent("/dashboard/new?" + search);
     redirect("/sign-in?redirect_uri=" + uri);

--- a/apps/forms/app/(workspace)/dashboard/new/page.tsx
+++ b/apps/forms/app/(workspace)/dashboard/new/page.tsx
@@ -31,7 +31,7 @@ export default async function OnboardWithNewFormPage({
 
   const supabase = createServerComponentClient(cookieStore);
 
-  const { data } = await supabase.auth.getSession();
+  const { data } = await supabase.auth.getUser();
   // if no auth, sign in, redirect back here
   if (data.session === null || data.session.user === null) {
     const search = new URLSearchParams(searchParams).toString();

--- a/apps/forms/middleware.ts
+++ b/apps/forms/middleware.ts
@@ -51,7 +51,7 @@ export async function middleware(req: NextRequest) {
   const supabase = createMiddlewareClient({ req, res });
 
   // Refresh session if expired - required for Server Components
-  await supabase.auth.getSession();
+  await supabase.auth.getUser();
 
   return res;
 }


### PR DESCRIPTION
Changed the supabase.auth.getSession to auth.getUser as the docs recommends to use getUser since getSession can be spoofed.

More info can be found here - https://supabase.com/docs/guides/auth/server-side/nextjs