### PR TITLE
Upgrades to corner radius handler to appear on four sides in rectangle

### DIFF
--- a/apps/forms/grida-react-canvas/action.ts
+++ b/apps/forms/grida-react-canvas/action.ts
@@ -427,7 +427,7 @@ export type EditorSurface_StartGesture = {
   gesture:
     | Pick<GestureScale, "type" | "direction" | "selection">
     | Pick<GestureRotate, "type" | "selection">
-    | Pick<GestureCornerRadius, "type" | "node_id">
+    | Pick<GestureCornerRadius, "type" | "node_id" | "direction">
     | Pick<GestureCurve, "type" | "control" | "node_id" | "segment">
     | Pick<GestureTranslateVertex, "type" | "node_id" | "vertex">;
 };

--- a/apps/forms/grida-react-canvas/provider.tsx
+++ b/apps/forms/grida-react-canvas/provider.tsx
@@ -2363,12 +2363,13 @@ export function useEventTarget() {
 
   // #region drag resize handle
   const startCornerRadiusGesture = useCallback(
-    (selection: string) => {
+    (selection: string, direction: cmath.CardinalDirection) => {
       dispatch({
         type: "surface/gesture/start",
         gesture: {
           type: "corner-radius",
           node_id: selection,
+          direction,
         },
       });
     },

--- a/apps/forms/grida-react-canvas/reducers/event-target.reducer.ts
+++ b/apps/forms/grida-react-canvas/reducers/event-target.reducer.ts
@@ -873,27 +873,27 @@ export default function eventTargetReducer<S extends IDocumentEditorState>(
               break;
             }
             case "corner-radius": {
-              const { node_id } = draft.gesture;
+              const { node_id, direction } = draft.gesture;
               const [dx, dy] = delta;
-              const d = -Math.round(dx);
+              const d = (direction.includes("e") ? -1 : 1 ) * Math.round(dx);
               const node = document.__getNodeById(draft, node_id);
 
               if (!("cornerRadius" in node)) {
                 return;
               }
 
-              // TODO: get accurate fixed width
-              // TODO: also handle by height
               const fixed_width =
-                typeof node.width === "number" ? node.width : undefined;
-              const maxRaius = fixed_width ? fixed_width / 2 : undefined;
+                typeof node.width === "number" ? node.width : 0;
+              const fixed_height =
+                typeof node.height === "number" ? node.height : 0;
+              const maxRadius = Math.min(fixed_width, fixed_height) / 2;
 
               const nextRadius =
                 (typeof node.cornerRadius == "number" ? node.cornerRadius : 0) +
                 d;
 
               const nextRadiusClamped = Math.floor(
-                Math.min(maxRaius ?? Infinity, Math.max(0, nextRadius))
+                Math.min(maxRadius ?? Infinity, Math.max(0, nextRadius))
               );
               draft.document.nodes[node_id] = nodeReducer(node, {
                 type: "node/change/cornerRadius",

--- a/apps/forms/grida-react-canvas/reducers/surface.reducer.ts
+++ b/apps/forms/grida-react-canvas/reducers/surface.reducer.ts
@@ -131,7 +131,7 @@ export default function surfaceReducer<S extends IDocumentEditorState>(
           //
         }
         case "corner-radius": {
-          const { node_id } = gesture;
+          const { node_id, direction } = gesture;
 
           return produce(state, (draft) => {
             self_selectNode(draft, "reset", node_id);
@@ -140,6 +140,7 @@ export default function surfaceReducer<S extends IDocumentEditorState>(
               movement: cmath.vector2.zero,
               initial_bounding_rectangle: cdom.getNodeBoundingRect(node_id)!,
               node_id: node_id,
+              direction,
             };
           });
         }

--- a/apps/forms/grida-react-canvas/state.ts
+++ b/apps/forms/grida-react-canvas/state.ts
@@ -241,6 +241,7 @@ export type GestureCornerRadius = IGesture & {
   type: "corner-radius";
   node_id: string;
   initial_bounding_rectangle: cmath.Rectangle | null;
+  direction: cmath.CardinalDirection;
 };
 
 export type GestureDraw = IGesture & {

--- a/apps/forms/grida-react-canvas/viewport/surface.tsx
+++ b/apps/forms/grida-react-canvas/viewport/surface.tsx
@@ -504,7 +504,12 @@ function NodeOverlay({
           )}
           {supports.cornerRadius(node.type) &&
             !supports.children(node.type) && (
-              <NodeOverlayCornerRadiusHandle anchor="se" node_id={node_id} />
+              <>
+                <NodeOverlayCornerRadiusHandle anchor="ne" node_id={node_id} />
+                <NodeOverlayCornerRadiusHandle anchor="se" node_id={node_id} />
+                <NodeOverlayCornerRadiusHandle anchor="sw" node_id={node_id} />
+                <NodeOverlayCornerRadiusHandle anchor="nw" node_id={node_id} />
+              </>
             )}
           <LayerOverlayRotationHandle anchor="nw" node_id={node_id} />
           <LayerOverlayRotationHandle anchor="ne" node_id={node_id} />
@@ -540,7 +545,7 @@ function NodeOverlayCornerRadiusHandle({
   const bind = useSurfaceGesture({
     onDragStart: ({ event }) => {
       event.preventDefault();
-      startCornerRadiusGesture(node_id);
+      startCornerRadiusGesture(node_id, anchor);
     },
   });
 


### PR DESCRIPTION
This PR has the following changes:

1. Corner handles appear on four sides
2. Drag direction to alter corner radius is consistent across four corners, inwards drag increases the corner radius and outwards drag decreases the corner radius.
3. There is a maximum radii set to Math.min(node.height, node.width)/2, cross references the Figma and also got the hint from one of the comments

Related issue - https://github.com/gridaco/grida/issues/222

Videos recording demonstrating this fix:


https://github.com/user-attachments/assets/ab9aa457-37e2-41e1-8b44-a7120850a918


https://github.com/user-attachments/assets/3374ab8e-14b0-42fe-b68b-4330bbfaac3b

