### PR TITLE
`cf192` Grida Canvas - "repeat duplicate"

### DIFF
--- a/apps/forms/grida-react-canvas/reducers/document.reducer.ts
+++ b/apps/forms/grida-react-canvas/reducers/document.reducer.ts
@@ -163,7 +163,7 @@ export default function documentReducer<S extends IDocumentEditorState>(
       return produce(state, (draft) => {
         const target_node_ids =
           target === "selection" ? state.selection : [target];
-        self_duplicateNode(draft, ...target_node_ids);
+        self_duplicateNode(draft, new Set(target_node_ids));
       });
       break;
     }

--- a/apps/forms/grida-react-canvas/reducers/methods/duplicate.ts
+++ b/apps/forms/grida-react-canvas/reducers/methods/duplicate.ts
@@ -1,24 +1,36 @@
 import type { Draft } from "immer";
-import type { IDocumentEditorState } from "../../state";
+import type { ActiveDuplication, IDocumentEditorState } from "../../state";
 import { document } from "../../document-query";
 import { self_insertSubDocument } from "./insert";
 import { self_selectNode } from "./selection";
 import assert from "assert";
 import nid from "../tools/id";
 import { grida } from "@/grida";
+import { domapi } from "@/grida-react-canvas/domapi";
+import { cmath } from "@grida/cmath";
 
 export function self_duplicateNode<S extends IDocumentEditorState>(
   draft: Draft<S>,
-  ...node_ids: string[]
+  _targets: Set<grida.program.nodes.NodeID>
 ) {
-  const new_top_ids = [];
-  for (const node_id of node_ids) {
-    if (node_id === draft.document.root_id) continue;
+  const targets = Array.from(_targets);
+  const origins: string[] = [];
+  const clones: string[] = [];
+
+  const cdom = new domapi.CanvasDOM(draft.transform);
+  const nextdelta = get_repeating_translation_delta(
+    draft.active_duplication,
+    targets,
+    cdom
+  );
+
+  for (const origin_id of targets) {
+    if (origin_id === draft.document.root_id) continue;
 
     // serialize the node
     const prototype = grida.program.nodes.factory.createPrototypeFromSnapshot(
       draft.document,
-      node_id
+      origin_id
     );
 
     // create sub document with prototype
@@ -28,15 +40,94 @@ export function self_duplicateNode<S extends IDocumentEditorState>(
         nid
       );
 
-    const parent_id = document.getParentId(draft.document_ctx, node_id);
+    const parent_id = document.getParentId(draft.document_ctx, origin_id);
     assert(parent_id, `Parent node not found`);
 
     // insert the sub document
-    self_insertSubDocument(draft, parent_id, sub);
+    const clone_id = self_insertSubDocument(draft, parent_id, sub);
 
-    new_top_ids.push(sub.root_id);
+    // apply the delta
+    if (nextdelta) {
+      const clone_node = draft.document.nodes[clone_id];
+      if ("left" in clone_node && typeof clone_node.left === "number") {
+        clone_node.left = (clone_node.left ?? 0) + nextdelta[0];
+      }
+      if ("top" in clone_node && typeof clone_node.top === "number") {
+        clone_node.top = (clone_node.top ?? 0) + nextdelta[1];
+      }
+      draft.document.nodes[clone_id] = clone_node;
+    }
+
+    origins.push(origin_id);
+    clones.push(clone_id);
   }
 
+  // set the active duplication
+  draft.active_duplication = {
+    origins: origins,
+    clones: clones,
+  };
+
   // after
-  self_selectNode(draft, "reset", ...new_top_ids);
+  self_selectNode(draft, "reset", ...clones);
 }
+
+function get_repeating_translation_delta(
+  prev: ActiveDuplication | null,
+  targets: grida.program.nodes.NodeID[],
+  cdom: domapi.CanvasDOM
+): cmath.Vector2 | null {
+  //
+  if (
+    prev &&
+    prev.origins.length > 0 &&
+    prev.clones.length > 0 &&
+    prev.origins.length === targets.length &&
+    JSON.stringify(prev.clones) === JSON.stringify(targets)
+  ) {
+    // if the duplication is repeatable => the targets are current active duplication's clones
+
+    const a = prev.origins;
+    const b = prev.clones;
+    const a_rects = a
+      .map((a) => cdom.getNodeBoundingRect(a))
+      .filter((r): r is cmath.Rectangle => r !== null);
+    const b_rects = b
+      .map((b) => cdom.getNodeBoundingRect(b))
+      .filter((r): r is cmath.Rectangle => r !== null);
+
+    const a_rect = cmath.rect.union(a_rects);
+    const b_rect = cmath.rect.union(b_rects);
+    const a_pos: cmath.Vector2 = [a_rect.x, a_rect.y];
+    const b_pos: cmath.Vector2 = [b_rect.x, b_rect.y];
+
+    // assert(
+    //   Math.abs(a_rect.width - b_rect.width) < 0.01 &&
+    //     Math.abs(a_rect.height - b_rect.height) < 0.01,
+    //   "the active duplication is invalid and modified"
+    // );
+
+    const diff = cmath.vector2.sub(b_pos, a_pos);
+
+    return diff;
+  }
+
+  return null;
+}
+
+// accumulated duplicate
+// [set]
+// - as clone / duplicate happens, we save each id of original and duplicated.
+// [reset]
+// - as history changes backward, reset. (accumulated duplicate related states are reset (set null) as history goes backward)
+// - as the focus (selection) changes, reset.
+// 1. save & get the comparison a-group and b-group
+// 2. calculate the transform diff based on group's bounding box
+// 3. apply the diff the the next, c-group
+
+/**
+ * last movement of translate (move) gesture
+ *
+ * this is saved and used when "repeat duplicate"
+ */
+// last_translate_movement?: cmath.Vector2;

--- a/apps/forms/grida-react-canvas/reducers/methods/duplicate.ts
+++ b/apps/forms/grida-react-canvas/reducers/methods/duplicate.ts
@@ -62,14 +62,14 @@ export function self_duplicateNode<S extends IDocumentEditorState>(
     clones.push(clone_id);
   }
 
-  // set the active duplication
+  // after
+  self_selectNode(draft, "reset", ...clones);
+
+  // after selection, finally set the active duplication
   draft.active_duplication = {
     origins: origins,
     clones: clones,
   };
-
-  // after
-  self_selectNode(draft, "reset", ...clones);
 }
 
 function get_repeating_translation_delta(
@@ -101,11 +101,11 @@ function get_repeating_translation_delta(
     const a_pos: cmath.Vector2 = [a_rect.x, a_rect.y];
     const b_pos: cmath.Vector2 = [b_rect.x, b_rect.y];
 
-    // assert(
-    //   Math.abs(a_rect.width - b_rect.width) < 0.01 &&
-    //     Math.abs(a_rect.height - b_rect.height) < 0.01,
-    //   "the active duplication is invalid and modified"
-    // );
+    assert(
+      Math.abs(a_rect.width - b_rect.width) < 0.01 &&
+        Math.abs(a_rect.height - b_rect.height) < 0.01,
+      "the active duplication is invalid and modified"
+    );
 
     const diff = cmath.vector2.sub(b_pos, a_pos);
 
@@ -114,20 +114,3 @@ function get_repeating_translation_delta(
 
   return null;
 }
-
-// accumulated duplicate
-// [set]
-// - as clone / duplicate happens, we save each id of original and duplicated.
-// [reset]
-// - as history changes backward, reset. (accumulated duplicate related states are reset (set null) as history goes backward)
-// - as the focus (selection) changes, reset.
-// 1. save & get the comparison a-group and b-group
-// 2. calculate the transform diff based on group's bounding box
-// 3. apply the diff the the next, c-group
-
-/**
- * last movement of translate (move) gesture
- *
- * this is saved and used when "repeat duplicate"
- */
-// last_translate_movement?: cmath.Vector2;

--- a/apps/forms/grida-react-canvas/reducers/methods/transform.ts
+++ b/apps/forms/grida-react-canvas/reducers/methods/transform.ts
@@ -144,6 +144,10 @@ function __self_update_gesture_transform_translate(
 
       // set the flag
       draft.gesture.is_currently_cloned = true;
+      draft.active_duplication = {
+        origins: initial_selection,
+        clones: initial_clone_ids,
+      };
 
       break;
     }
@@ -161,6 +165,7 @@ function __self_update_gesture_transform_translate(
       draft.selection = initial_selection;
       draft.surface_measurement_target = undefined;
       draft.surface_measurement_targeting_locked = false;
+      draft.active_duplication = null;
       break;
     }
   }

--- a/apps/forms/grida-react-canvas/state.ts
+++ b/apps/forms/grida-react-canvas/state.ts
@@ -541,6 +541,9 @@ interface IDocumentEditorEventTargetState {
  *      - as long as the history (change) is made within the clone, it kept valid.
  *    - as history changes backward, reset. (accumulated duplicate related states are reset (set null) as history goes backward)
  *    - as the focus (selection) changes, reset.
+ *
+ * **Note:** currently we simply reset whenever selection is changed.
+ * => this is enough for now, but as we support api access, we'll actually need to track the change.
  */
 export interface ActiveDuplication {
   origins: grida.program.nodes.NodeID[];


### PR DESCRIPTION

 * used for "repeated duplicate", where accumulating the delta between the original and the clone, forwarding that delta to the next clone.
 *
 * [accumulated duplicate]
 * - [set]
 *    - as clone / duplicate happens, we save each id of original and duplicated.
 * - [reset]
 *    - whenever the active clone is considered no longer valid, e.g. when origianl is deleted. (to detect this easily we use a strict diff of the selection change)
 *    - the current history change shall only contain the diff of the clone, otherwise, reset.
 *      - this includes the selection change.
 *      - as long as the history (change) is made within the clone, it kept valid.
 *    - as history changes backward, reset. (accumulated duplicate related states are reset (set null) as history goes backward)
 *    - as the focus (selection) changes, reset.
 *
 * **Note:** currently we simply reset whenever selection is changed.
 * => this is enough for now, but as we support api access, we'll actually need to track the change.

https://github.com/user-attachments/assets/a3b73992-66e5-4723-b727-a3f5f30b67bd

