### PR TITLE
`cf223` [Grida Canvas] focus motion - transform with animate

### DIFF
--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/page.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/page.tsx
@@ -66,23 +66,18 @@ function TemplateEditorRoot() {
 }
 
 type EditorTab = "referrer" | "invitation-ux-overlay" | "invitation" | "theme";
-type CanvasScene = "referrer" | "invitation";
 type CanvasComponent = "referrer" | "invitation-ux-overlay" | "invitation";
 
-function getCanvasFocus(
-  tab: EditorTab
-): { scene: CanvasScene; node: CanvasComponent } | null {
+function getCanvasFocus(tab: EditorTab): { node: CanvasComponent } | null {
   switch (tab) {
     case "referrer":
-      return { scene: "referrer", node: "referrer" };
+      return { node: "referrer" };
     case "invitation-ux-overlay":
       return {
-        scene: "invitation",
         node: "invitation-ux-overlay",
       };
     case "invitation":
       return {
-        scene: "invitation",
         node: "invitation",
       };
     default:

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/template-duo-001-viewer.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/template-duo-001-viewer.tsx
@@ -11,31 +11,21 @@ import {
   EditorSurface,
   StandaloneSceneContent,
   standaloneDocumentReducer,
+  useDocument,
 } from "@/grida-react-canvas";
 import {
   AutoInitialFitTransformer,
   StandaloneSceneBackground,
   UserCustomTemplatesProvider,
 } from "@/grida-react-canvas/renderer";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Selection,
-  Zoom,
-} from "@/scaffolds/sidecontrol/sidecontrol-node-selection";
-import { SidebarRoot } from "@/components/sidebar";
+import { Zoom } from "@/scaffolds/sidecontrol/sidecontrol-node-selection";
 import { WorkbenchUI } from "@/components/workbench";
 import { cn } from "@/utils";
-import {
-  PreviewButton,
-  PreviewProvider,
-} from "@/grida-react-canvas-starter-kit/starterkit-preview";
-import { useCampaign } from "../store";
+import { PreviewProvider } from "@/grida-react-canvas-starter-kit/starterkit-preview";
 import { Platform } from "@/lib/platform";
 import { TemplateData } from "@/theme/templates/west-referral/templates";
-import {
-  PropsEditorInstance,
-  ReadonlyPropsEditorInstance,
-} from "@/scaffolds/props-editor";
+import { ReadonlyPropsEditorInstance } from "@/scaffolds/props-editor";
+import { useTransform } from "@/grida-react-canvas/provider";
 
 const document: IDocumentEditorInit = {
   editable: true,
@@ -56,6 +46,8 @@ const document: IDocumentEditorInit = {
         properties: {},
         props: {},
         overrides: {},
+        top: -1000,
+        left: 0,
       },
       invitation: {
         id: "invitation",
@@ -92,29 +84,18 @@ const document: IDocumentEditorInit = {
         overrides: {},
       },
     },
-    entry_scene_id: "referrer",
+    entry_scene_id: "main",
     scenes: {
-      referrer: {
+      main: {
         type: "scene",
-        id: "referrer",
+        id: "main",
         name: "Referrer's Page",
-        children: ["referrer"],
+        children: ["referrer", "invitation", "invitation-ux-overlay"],
         guides: [],
         constraints: {
           children: "multiple",
         },
-        order: 1,
-      },
-      invitation: {
-        type: "scene",
-        id: "invitation",
-        name: "Invitee's Page",
-        children: ["invitation", "invitation-ux-overlay"],
-        guides: [],
-        constraints: {
-          children: "multiple",
-        },
-        order: 2,
+        order: 0,
       },
     },
   },
@@ -171,7 +152,7 @@ export function CampaignTemplateDuo001Viewer({
   locale,
   onDoubleClick,
 }: {
-  focus: { scene: string; node?: string };
+  focus: { node?: string };
   props: ReadonlyPropsEditorInstance<TemplateData.West_Referrral__Duo_001>;
   campaign: Platform.WEST.Referral.CampaignPublic;
   locale: "en" | "ko";
@@ -182,18 +163,12 @@ export function CampaignTemplateDuo001Viewer({
     initDocumentEditorState(document)
   );
 
-  useEffect(() => {
-    dispatch({ type: "load", scene: focus.scene });
-    if (focus.node) {
-      dispatch({ type: "select", selectors: [[focus.node]] });
-    }
-  }, [focus.scene, focus.node]);
-
   return (
     <CampaignViewerContextAndPropsContext.Provider
       value={{ ...props, campaign: campaign, locale }}
     >
       <StandaloneDocumentEditor editable initial={state} dispatch={dispatch}>
+        <EditorUXServer focus={focus} />
         <UserCustomTemplatesProvider
           templates={{
             "grida_west_referral.duo-000.referrer":
@@ -241,6 +216,21 @@ export function CampaignTemplateDuo001Viewer({
       </StandaloneDocumentEditor>
     </CampaignViewerContextAndPropsContext.Provider>
   );
+}
+
+// will be removed after useEditor is ready
+function EditorUXServer({ focus }: { focus: { node?: string } }) {
+  const { select } = useDocument();
+  const { fit } = useTransform();
+
+  useEffect(() => {
+    if (focus.node) {
+      select([focus.node]);
+      fit([focus.node], { margin: 64, animate: true });
+    }
+  }, [focus.node]);
+  //
+  return <></>;
 }
 
 function CustomComponent_Viewer__Referrer(componentprops: any) {

--- a/editor/grida-react-canvas/provider.tsx
+++ b/editor/grida-react-canvas/provider.tsx
@@ -2233,17 +2233,17 @@ export function useTransform() {
         selector
       );
 
-      if (ids.length === 0) {
+      const cdom = new domapi.CanvasDOM(scene.transform);
+
+      const rects = ids
+        .map((id) => cdom.getNodeBoundingRect(id))
+        .filter((r) => r) as cmath.Rectangle[];
+
+      if (rects.length === 0) {
         return;
       }
 
-      const cdom = new domapi.CanvasDOM(scene.transform);
-
-      const area = cmath.rect.union(
-        ids
-          .map((id) => cdom.getNodeBoundingRect(id))
-          .filter((r) => r) as cmath.Rectangle[]
-      );
+      const area = cmath.rect.union(rects);
 
       const _view = domapi.get_viewport_rect();
       const view = { x: 0, y: 0, width: _view.width, height: _view.height };

--- a/editor/grida-react-canvas/provider.tsx
+++ b/editor/grida-react-canvas/provider.tsx
@@ -2118,6 +2118,43 @@ export function useCurrentScene(): UseScene {
   return useScene(state.scene_id!);
 }
 
+function animateTransformTo(
+  from: cmath.Transform,
+  to: cmath.Transform,
+  update: (t: cmath.Transform) => void
+) {
+  const duration = 200; // ms
+  const start = performance.now();
+
+  function lerp(a: number, b: number, t: number) {
+    return a + (b - a) * t;
+  }
+
+  function step(now: number) {
+    const elapsed = now - start;
+    const progress = Math.min(elapsed / duration, 1);
+
+    const next: cmath.Transform = [
+      [0, 0, 0],
+      [0, 0, 0],
+    ] as cmath.Transform;
+
+    for (let i = 0; i < 2; i++) {
+      for (let j = 0; j < 3; j++) {
+        next[i][j] = lerp(from[i][j], to[i][j], progress);
+      }
+    }
+
+    update(next);
+
+    if (progress < 1) {
+      requestAnimationFrame(step);
+    }
+  }
+
+  requestAnimationFrame(step);
+}
+
 export function useTransform() {
   const [_, dispatch] = __useInternal();
   const scene = useCurrentScene();
@@ -2182,7 +2219,13 @@ export function useTransform() {
   const fit = useCallback(
     (
       selector: grida.program.document.Selector,
-      margin: number | [number, number, number, number] = 64
+      options: {
+        margin?: number | [number, number, number, number];
+        animate?: boolean;
+      } = {
+        margin: 64,
+        animate: false,
+      }
     ) => {
       const ids = document.querySelector(
         scene.document_ctx,
@@ -2205,12 +2248,25 @@ export function useTransform() {
       const _view = domapi.get_viewport_rect();
       const view = { x: 0, y: 0, width: _view.width, height: _view.height };
 
-      const transform = cmath.ext.viewport.transformToFit(view, area, margin);
+      const transform = cmath.ext.viewport.transformToFit(
+        view,
+        area,
+        options.margin
+      );
 
-      dispatch({
-        type: "transform",
-        transform: transform,
-      });
+      if (options.animate) {
+        animateTransformTo(scene.transform, transform, (t) => {
+          dispatch({
+            type: "transform",
+            transform: t,
+          });
+        });
+      } else {
+        dispatch({
+          type: "transform",
+          transform: transform,
+        });
+      }
     },
     [
       dispatch,

--- a/editor/grida-react-canvas/viewport/hotkeys.tsx
+++ b/editor/grida-react-canvas/viewport/hotkeys.tsx
@@ -851,12 +851,12 @@ export function useEditorHotKeys() {
   });
 
   useHotkeys("shift+1, shift+9", (e) => {
-    fit("*", 64);
+    fit("*", { margin: 64 });
     toast.success(`Zoom to fit`);
   });
 
   useHotkeys("shift+2", (e) => {
-    fit("selection", 64);
+    fit("selection", { margin: 64, animate: true });
     toast.success(`Zoom to selection`);
   });
 

--- a/editor/scaffolds/sidebar/sidebar-node-hierarchy-list.tsx
+++ b/editor/scaffolds/sidebar/sidebar-node-hierarchy-list.tsx
@@ -193,7 +193,7 @@ function NodeHierarchyItemContextMenuWrapper({
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() => {
-            fit([node_id]);
+            fit([node_id], { margin: 64, animate: true });
           }}
           className="text-xs"
         >


### PR DESCRIPTION
Transform (focus / fit) with `animate: true` - zero-dependency


https://github.com/user-attachments/assets/ebb1f261-f50e-4d7d-a6c0-496c18052731



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified focus handling in the campaign viewer and related components by consolidating scenes and updating focus logic to use only node references.
  - Updated zoom and fit operations to support margin and animation options for a smoother viewport experience.
- **Style**
  - Improved node positioning and viewport fitting for better visual alignment.
- **Chores**
  - Cleaned up unused imports and streamlined component structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->