### PR TITLE
[chore] internal tenant routing

### DIFF
--- a/editor/app/(api)/private/~/[org]/[proj]/preview/[...path_tokens]/route.ts
+++ b/editor/app/(api)/private/~/[org]/[proj]/preview/[...path_tokens]/route.ts
@@ -1,6 +1,6 @@
 import { createClient, createWWWClient } from "@/lib/supabase/server";
-import { notFound } from "next/navigation";
 import { NextResponse, type NextRequest } from "next/server";
+import { notFound } from "next/navigation";
 
 const IS_HOSTED = process.env.VERCEL === "1";
 
@@ -58,15 +58,11 @@ export async function GET(
 
   const request_path = path_tokens.join("/");
 
-  if (IS_HOSTED) {
-    return NextResponse.redirect(
-      `https://${www.name}.grida.site/${request_path}`,
-      { status: 302 }
-    );
-  } else {
-    return NextResponse.redirect(
-      `http://${www.name}.localhost:3000/${request_path}`,
-      { status: 302 }
-    );
-  }
+  const url = new URL(
+    request_path,
+    IS_HOSTED
+      ? `https://${www.name}.grida.site/`
+      : `http://${www.name}.localhost:3000/`
+  );
+  return NextResponse.redirect(url, { status: 302 });
 }

--- a/editor/app/(api)/private/~/[org]/[proj]/preview/documents/[docid]/default/[...path_tokens]/route.ts
+++ b/editor/app/(api)/private/~/[org]/[proj]/preview/documents/[docid]/default/[...path_tokens]/route.ts
@@ -1,0 +1,86 @@
+import { createClient, createWWWClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import { NextResponse, type NextRequest } from "next/server";
+
+const IS_HOSTED = process.env.VERCEL === "1";
+
+type Params = {
+  /**
+   * organization.id or organization.name
+   */
+  org: string;
+
+  /**
+   * project.id or project.name
+   */
+  proj: string;
+
+  /**
+   * document.id
+   */
+  docid: string;
+
+  /**
+   * tenant site path
+   */
+  path_tokens: string[];
+};
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const { org, proj, docid, path_tokens } = await params;
+
+  const client = await createClient();
+  const wwwClient = await createWWWClient();
+
+  const { data: project, error: project_err } = await client
+    .rpc(
+      "find_project",
+      {
+        p_org_ref: org,
+        p_proj_ref: proj,
+      },
+      { get: true }
+    )
+    .single();
+
+  if (project_err) {
+    console.error("project not found", project_err, "with", {
+      project_id: proj,
+      organization_id: org,
+    });
+    return notFound();
+  }
+
+  const { data: www, error: www_err } = await wwwClient
+    .from("www")
+    .select("id, name")
+    .eq("project_id", project.id)
+    .single();
+  if (www_err) return notFound();
+
+  const { data: routing, error: routing_err } = await wwwClient
+    .from("public_route")
+    .select()
+    .eq("www_id", www.id)
+    .eq("document_id", docid)
+    .single();
+
+  if (routing_err) return notFound();
+
+  const request_path = path_tokens.join("/");
+
+  if (IS_HOSTED) {
+    return NextResponse.redirect(
+      `https://${www.name}.grida.site/${routing.route_path}/${request_path}`,
+      { status: 302 }
+    );
+  } else {
+    return NextResponse.redirect(
+      `http://${www.name}.localhost:3000/${routing.route_path}/${request_path}`,
+      { status: 302 }
+    );
+  }
+}

--- a/editor/app/(api)/private/~/[org]/[proj]/preview/documents/[docid]/default/[...path_tokens]/route.ts
+++ b/editor/app/(api)/private/~/[org]/[proj]/preview/documents/[docid]/default/[...path_tokens]/route.ts
@@ -1,6 +1,6 @@
 import { createClient, createWWWClient } from "@/lib/supabase/server";
-import { notFound } from "next/navigation";
 import { NextResponse, type NextRequest } from "next/server";
+import { notFound } from "next/navigation";
 
 const IS_HOSTED = process.env.VERCEL === "1";
 
@@ -72,15 +72,11 @@ export async function GET(
 
   const request_path = path_tokens.join("/");
 
-  if (IS_HOSTED) {
-    return NextResponse.redirect(
-      `https://${www.name}.grida.site/${routing.route_path}/${request_path}`,
-      { status: 302 }
-    );
-  } else {
-    return NextResponse.redirect(
-      `http://${www.name}.localhost:3000/${routing.route_path}/${request_path}`,
-      { status: 302 }
-    );
-  }
+  const url = new URL(
+    `${routing.route_path}/${request_path}`,
+    IS_HOSTED
+      ? `https://${www.name}.grida.site/`
+      : `http://${www.name}.localhost:3000/`
+  );
+  return NextResponse.redirect(url, { status: 302 });
 }

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/invitations-table.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/invitations-table.tsx
@@ -54,8 +54,8 @@ function ActionsCell({
         <DropdownMenuItem
           onClick={() => {
             const link = documentpreviewlink({
-              orgid: project.organization_id,
-              projid: project.id,
+              org: project.organization_id,
+              proj: project.id,
               docid: campaign.id,
               path: `/t/${invitation.code}`,
             });

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/quests-table.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/quests-table.tsx
@@ -264,8 +264,8 @@ export function QuestsTable() {
                         <DropdownMenuItem
                           onClick={() => {
                             const link = documentpreviewlink({
-                              orgid: project.organization_id,
-                              projid: project.id,
+                              org: project.organization_id,
+                              proj: project.id,
                               docid: campaign.id,
                               path: `/t/${quest.code}`,
                             });

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/referrers-table.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/_components/referrers-table.tsx
@@ -50,8 +50,8 @@ function ActionsCell({ row }: CellContext<ReferrerWithCustomer, unknown>) {
         <DropdownMenuItem
           onClick={() => {
             const link = documentpreviewlink({
-              orgid: project.organization_id,
-              projid: project.id,
+              org: project.organization_id,
+              proj: project.id,
               docid: id,
               path: `/t/${referrer.code}`,
             });

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/page.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/design/page.tsx
@@ -100,8 +100,8 @@ function TemplateEditor({
 
   const previewbaseurl = documentpreviewlink({
     docid: campaign.id,
-    orgid: project.organization_id,
-    projid: project.id,
+    org: project.organization_id,
+    proj: project.id,
   });
 
   const props = usePropsEditor<TemplateData.West_Referrral__Duo_001>({

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
@@ -10,10 +10,10 @@ import {
   SidebarProvider,
   SidebarGroupLabel,
 } from "@/components/ui/sidebar";
-import { ArrowLeftIcon } from "@radix-ui/react-icons";
+import { ArrowLeftIcon, OpenInNewWindowIcon } from "@radix-ui/react-icons";
 import { ResourceTypeIcon } from "@/components/resource-type-icon";
-import Link from "next/link";
 import { previewlink } from "@/lib/internal/url";
+import Link from "next/link";
 
 type Params = { org: string; proj: string };
 
@@ -125,13 +125,13 @@ export default async function Layout({
                     </Link>
                   </SidebarMenu>
                   <SidebarMenu>
-                    <Link href={previewlink({ org, proj, path: "/p/login" })}>
+                    <Link
+                      href={previewlink({ org, proj, path: "/p/login" })}
+                      target="_blank"
+                    >
                       <SidebarMenuItem>
                         <SidebarMenuButton size="sm">
-                          <ResourceTypeIcon
-                            type="customer-portal"
-                            className="size-4"
-                          />
+                          <OpenInNewWindowIcon className="size-4" />
                           Customer Portal
                         </SidebarMenuButton>
                       </SidebarMenuItem>

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
@@ -13,6 +13,7 @@ import {
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import { ResourceTypeIcon } from "@/components/resource-type-icon";
 import Link from "next/link";
+import { previewlink } from "@/lib/internal/url";
 
 type Params = { org: string; proj: string };
 
@@ -119,6 +120,19 @@ export default async function Layout({
                         <SidebarMenuButton size="sm">
                           <ResourceTypeIcon type="connect" className="size-4" />
                           Connections
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    </Link>
+                  </SidebarMenu>
+                  <SidebarMenu>
+                    <Link href={previewlink({ org, proj, path: "/p/login" })}>
+                      <SidebarMenuItem>
+                        <SidebarMenuButton size="sm">
+                          <ResourceTypeIcon
+                            type="customer-portal"
+                            className="size-4"
+                          />
+                          Customer Portal
                         </SidebarMenuButton>
                       </SidebarMenuItem>
                     </Link>

--- a/editor/components/resource-type-icon.tsx
+++ b/editor/components/resource-type-icon.tsx
@@ -27,6 +27,7 @@ import {
   PlugIcon,
   TagIcon,
   LockKeyholeIcon,
+  BookUserIcon,
 } from "lucide-react";
 import { SupabaseLogo } from "./logos";
 
@@ -56,6 +57,7 @@ export type ResourceTypeIconName =
   | "connect"
   | "campaign"
   | "customer"
+  | "customer-portal"
   | "user"
   | "i18n"
   | "supabase"
@@ -134,6 +136,8 @@ export function ResourceTypeIcon({
     case "user":
     case "customer":
       return <AvatarIcon {...props} />;
+    case "customer-portal":
+      return <BookUserIcon {...props} />;
     case "i18n":
       return <LanguagesIcon {...props} />;
     case "view-gallery":

--- a/editor/database-generated.types.ts
+++ b/editor/database-generated.types.ts
@@ -4199,6 +4199,16 @@ export type Database = {
           enabled: boolean
         }[]
       }
+      find_project: {
+        Args: { p_org_ref: string; p_proj_ref: string }
+        Returns: {
+          created_at: string
+          id: number
+          name: string
+          organization_id: number
+          ref_id: string | null
+        }[]
+      }
       flatten_jsonb_object_values: {
         Args: { obj: Json }
         Returns: string

--- a/editor/lib/internal/url.ts
+++ b/editor/lib/internal/url.ts
@@ -1,20 +1,57 @@
+type Params = {
+  /**
+   * organization.id or organization.name
+   */
+  org: string | number;
+
+  /**
+   * project.id or project.name
+   */
+  proj: string | number;
+
+  /**
+   * tenant site path
+   */
+  path?: string[] | string;
+};
+
+/**
+ * Convert path tokens to a relative path
+ *
+ * @example
+ * ```ts
+ * relpath(["a", "b", "c"]) // "a/b/c"
+ * relpath("a/b/c") // "a/b/c"
+ * relpath(["/a", "b", "c"]) // "a/b/c"
+ * relpath("/a/b/c") // "a/b/c"
+ * ```
+ */
+function relpath(path_tokens: string | string[] = "") {
+  let path = "";
+  if (Array.isArray(path_tokens)) {
+    path = path_tokens.join("/");
+  } else {
+    path = typeof path_tokens === "string" ? path_tokens : "";
+  }
+  if (path.startsWith("/")) {
+    path = path.substring(1);
+  }
+  return path;
+}
+
+export function previewlink({ org, proj, path }: Params) {
+  const baseurl = `/private/~/${org}/${proj}/preview`;
+  return `${baseurl}/${relpath(path)}`;
+}
+
 export function documentpreviewlink({
-  orgid,
-  projid,
+  org,
+  proj,
   docid,
   path,
-}: {
-  orgid: number;
-  projid: number;
+}: Params & {
   docid: string;
-  path?: string;
 }) {
-  const baseurl = `/private/~/${orgid}/${projid}/preview/documents/${docid}/default`;
-  if (path) {
-    if (path.startsWith("/")) {
-      path = path.substring(1);
-    }
-    return `${baseurl}/${path}`;
-  }
-  return baseurl;
+  const baseurl = `/private/~/${org}/${proj}/preview/documents/${docid}/default`;
+  return `${baseurl}/${relpath(path)}`;
 }

--- a/supabase/migrations/20250420143431_find_project.sql
+++ b/supabase/migrations/20250420143431_find_project.sql
@@ -1,0 +1,17 @@
+---------------------------------------------------------------------
+-- [RPC] find project --
+---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.find_project(
+  p_org_ref text,
+  p_proj_ref text
+)
+RETURNS SETOF public.project AS $$
+BEGIN
+  RETURN QUERY
+  SELECT p.*
+  FROM public.project p
+  JOIN public.organization o ON o.id = p.organization_id
+  WHERE (o.id::text = p_org_ref OR o.name = p_org_ref)
+  AND (p.id::text = p_proj_ref OR p.name = p_proj_ref);
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/supabase/schemas/project.sql
+++ b/supabase/schemas/project.sql
@@ -1,5 +1,3 @@
-
----------------------------------------------------------------------
 -- [Project] --
 ---------------------------------------------------------------------
 create table public.project (
@@ -126,3 +124,23 @@ BEGIN
       updated_at = now();
 END;
 $$ LANGUAGE plpgsql VOLATILE;
+
+
+
+---------------------------------------------------------------------
+-- [RPC] find project --
+---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.find_project(
+  p_org_ref text,
+  p_proj_ref text
+)
+RETURNS SETOF public.project AS $$
+BEGIN
+  RETURN QUERY
+  SELECT p.*
+  FROM public.project p
+  JOIN public.organization o ON o.id = p.organization_id
+  WHERE (o.id::text = p_org_ref OR o.name = p_org_ref)
+  AND (p.id::text = p_proj_ref OR p.name = p_proj_ref);
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
this pr introduces find_project rpc, for locating project either by id (org.id + proj.id) or name (org.name + proj.name)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Customer Portal" sidebar menu item, providing quick access to the customer portal page.
  - Added new API endpoints to support tenant site and document previews based on organization and project references.

- **Improvements**
  - Enhanced link generation for document previews, standardizing parameter names for consistency across the app.
  - Updated resource icons to include a new "customer-portal" type for improved visual identification.

- **Bug Fixes**
  - Fixed inconsistencies in preview link construction by unifying parameter handling.

- **Database**
  - Added a new database function to efficiently retrieve projects by organization and project references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->