### PR TITLE
docs: fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 <br/>
 
-- [x] Connecy your Supabase Project (Table, Views, Storage, Auth)
+- [x] Connect your Supabase Project (Table, Views, Storage, Auth)
 - [x] Readonly Views
 - [x] Storage Connected Rich Text Editor
 - [x] CMS Ready
@@ -73,7 +73,7 @@
 - [x] Simulator
 - [x] Headless Usage - API-only usage
 - [x] 12 Supported Languages
-- [ ] Client SDK - BYO (Bring your own) Compoennt
+- [ ] Client SDK - BYO (Bring your own) Component
 - [ ] Localization
 - [ ] Custom Auth Gate
 - [ ] Accept Payments


### PR DESCRIPTION
## Summary
- fix typos in README

## Testing
- `grep -n "Connect your Supabase" -n README.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed two typographical errors in the README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->