### PR TITLE
Fix block revert reorder

### DIFF
--- a/editor/scaffolds/editor/reducers/block.reducer.ts
+++ b/editor/scaffolds/editor/reducers/block.reducer.ts
@@ -367,7 +367,12 @@ export default function blockReducer(
             if (section) {
               // BLOCK THIS ACTION
               // revert the move
-              draft.blocks = arrayMove(draft.blocks, newIndex, oldIndex);
+              draft.blocks = arrayMove(draft.blocks, newIndex, oldIndex).map(
+                (block, index) => ({
+                  ...block,
+                  local_index: index,
+                })
+              );
               return;
             }
           }


### PR DESCRIPTION
## Summary
- ensure indices are restored when invalid block drag is reverted

## Testing
- `pnpm -F editor lint` *(fails: `Cannot read properties of undefined (reading 'allow')`)*
- `pnpm -F editor test`
