### PR TITLE
Add move up/down for form blocks

### DIFF
--- a/editor/scaffolds/blocks-editor/blocks/base-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/base-block.tsx
@@ -5,6 +5,11 @@ import { useEditorState } from "@/scaffolds/editor";
 import React, { useCallback } from "react";
 import { toast } from "sonner";
 import { cn } from "@/components/lib/utils";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@radix-ui/react-icons";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export function useDeleteBlock() {
   const [state, dispatch] = useEditorState();
@@ -120,5 +125,40 @@ export function BlockAction({
     >
       {children}
     </div>
+  );
+}
+
+export function useMoveBlock() {
+  const [, dispatch] = useEditorState();
+  return useCallback(
+    (block_id: string, direction: "up" | "down") => {
+      dispatch({
+        type: direction === "up" ? "blocks/move/up" : "blocks/move/down",
+        block_id,
+      });
+    },
+    [dispatch]
+  );
+}
+
+export function MoveBlockMenuItems({ id }: { id: string }) {
+  const [state] = useEditorState();
+  const move = useMoveBlock();
+
+  const index = state.blocks.findIndex((b) => b.id === id);
+  const disabledUp = index <= 0;
+  const disabledDown = index === state.blocks.length - 1;
+
+  return (
+    <>
+      <DropdownMenuItem disabled={disabledUp} onClick={() => move(id, "up")}>
+        <ChevronUpIcon className="size-3.5" />
+        Move Up
+      </DropdownMenuItem>
+      <DropdownMenuItem disabled={disabledDown} onClick={() => move(id, "down")}>
+        <ChevronDownIcon className="size-3.5" />
+        Move Down
+      </DropdownMenuItem>
+    </>
   );
 }

--- a/editor/scaffolds/blocks-editor/blocks/base-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/base-block.tsx
@@ -5,10 +5,7 @@ import { useEditorState } from "@/scaffolds/editor";
 import React, { useCallback } from "react";
 import { toast } from "sonner";
 import { cn } from "@/components/lib/utils";
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from "@radix-ui/react-icons";
+import { ArrowUpIcon, ArrowDownIcon } from "@radix-ui/react-icons";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export function useDeleteBlock() {
@@ -152,11 +149,14 @@ export function MoveBlockMenuItems({ id }: { id: string }) {
   return (
     <>
       <DropdownMenuItem disabled={disabledUp} onClick={() => move(id, "up")}>
-        <ChevronUpIcon className="size-3.5" />
+        <ArrowUpIcon className="size-3.5" />
         Move Up
       </DropdownMenuItem>
-      <DropdownMenuItem disabled={disabledDown} onClick={() => move(id, "down")}>
-        <ChevronDownIcon className="size-3.5" />
+      <DropdownMenuItem
+        disabled={disabledDown}
+        onClick={() => move(id, "down")}
+      >
+        <ArrowDownIcon className="size-3.5" />
         Move Down
       </DropdownMenuItem>
     </>

--- a/editor/scaffolds/blocks-editor/blocks/divider-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/divider-block.tsx
@@ -18,6 +18,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { Button } from "@/components/ui/button";
 
@@ -44,6 +45,7 @@ export function DividerBlock({ id }: EditorFlatFormBlock) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <MoveBlockMenuItems id={id} />
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/blocks-editor/blocks/field-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/field-block.tsx
@@ -23,6 +23,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { useEditorState, useFormFields } from "@/scaffolds/editor";
 import type { FormFieldDefinition } from "@/grida-forms-hosted/types";
@@ -330,6 +331,7 @@ export function FormFieldBlockMenuItems({
           Edit Field Definition
         </DropdownMenuItem>
       )}
+      <MoveBlockMenuItems id={block_id} />
       <DropdownMenuItem
         variant="destructive"
         onClick={() => deleteBlock(block_id)}

--- a/editor/scaffolds/blocks-editor/blocks/header-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/header-block.tsx
@@ -20,6 +20,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { Button } from "@/components/ui/button";
 import { MinimalTiptapHeadlessEditor } from "@/kits/minimal-tiptap";
@@ -74,6 +75,7 @@ export function HeaderBlock({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <MoveBlockMenuItems id={id} />
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/blocks-editor/blocks/html-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/html-block.tsx
@@ -15,6 +15,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { useEditorState } from "@/scaffolds/editor";
 import { Button } from "@/components/ui/button";
@@ -73,6 +74,7 @@ export function HtmlBlock({ id, body_html }: EditorFlatFormBlock) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <MoveBlockMenuItems id={id} />
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/blocks-editor/blocks/image-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/image-block.tsx
@@ -20,6 +20,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { useEditorState } from "@/scaffolds/editor";
 import {
@@ -84,6 +85,7 @@ export function ImageBlock({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent>
+                <MoveBlockMenuItems id={id} />
                 <DropdownMenuItem
                   variant="destructive"
                   onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/blocks-editor/blocks/pdf-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/pdf-block.tsx
@@ -19,6 +19,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { useEditorState } from "@/scaffolds/editor";
 import { PDFViewer } from "@/components/pdf-viewer";
@@ -55,6 +56,7 @@ export function PdfBlock({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <MoveBlockMenuItems id={id} />
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/blocks-editor/blocks/video-block.tsx
+++ b/editor/scaffolds/blocks-editor/blocks/video-block.tsx
@@ -21,6 +21,7 @@ import {
   FlatBlockBase,
   useBlockFocus,
   useDeleteBlock,
+  MoveBlockMenuItems,
 } from "./base-block";
 import { useEditorState } from "@/scaffolds/editor";
 import dynamic from "next/dynamic";
@@ -68,6 +69,7 @@ export function VideoBlock({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <MoveBlockMenuItems id={id} />
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => deleteBlock(id)}

--- a/editor/scaffolds/editor/action.ts
+++ b/editor/scaffolds/editor/action.ts
@@ -92,7 +92,9 @@ export type FormsBlockAction =
   | FormsBlockBlockTitleAction
   | FormsBlockBlockDescriptionAction
   | FormsBlockFocusBlockAction
-  | FormsBlockBlurBlockAction;
+  | FormsBlockBlurBlockAction
+  | FormsBlockMoveUpAction
+  | FormsBlockMoveDownAction;
 
 export type FormsBlockCreateNewPendingBlockAction =
   | {
@@ -180,6 +182,16 @@ export interface FormsBlockFocusBlockAction {
 
 export interface FormsBlockBlurBlockAction {
   type: "blocks/blur";
+}
+
+export interface FormsBlockMoveUpAction {
+  type: "blocks/move/up";
+  block_id: string;
+}
+
+export interface FormsBlockMoveDownAction {
+  type: "blocks/move/down";
+  block_id: string;
 }
 
 // #endregion block

--- a/editor/scaffolds/editor/reducer.ts
+++ b/editor/scaffolds/editor/reducer.ts
@@ -103,6 +103,8 @@ export function reducer(state: EditorState, action: EditorAction): EditorState {
     case "blocks/image/src":
     case "blocks/video/src":
     case "blocks/sort":
+    case "blocks/move/up":
+    case "blocks/move/down":
     case "blocks/focus":
     case "blocks/blur":
       return blockReducer(state, action);

--- a/editor/scaffolds/editor/reducers/block.reducer.ts
+++ b/editor/scaffolds/editor/reducers/block.reducer.ts
@@ -10,6 +10,8 @@ import type {
   FormsBlockCreateNewPendingBlockAction,
   FormsBlockDeleteBlockAction,
   FormsBlockFocusBlockAction,
+  FormsBlockMoveUpAction,
+  FormsBlockMoveDownAction,
   FormsBlockHtmlBlockBodyAction,
   FormsBlockImageBlockSrcAction,
   FormsBlockResolvePendingBlockAction,
@@ -210,6 +212,24 @@ export default function blockReducer(
         );
 
         self_sort(draft, [oldIndex, newIndex]);
+      });
+    }
+    case "blocks/move/up": {
+      const { block_id } = action as any;
+      return produce(state, (draft) => {
+        const index = draft.blocks.findIndex((b) => b.id === block_id);
+        if (index > 0) {
+          self_sort(draft, [index, index - 1]);
+        }
+      });
+    }
+    case "blocks/move/down": {
+      const { block_id } = action as any;
+      return produce(state, (draft) => {
+        const index = draft.blocks.findIndex((b) => b.id === block_id);
+        if (index !== -1 && index < draft.blocks.length - 1) {
+          self_sort(draft, [index, index + 1]);
+        }
       });
     }
     case "blocks/delete": {

--- a/editor/scaffolds/editor/reducers/block.reducer.ts
+++ b/editor/scaffolds/editor/reducers/block.reducer.ts
@@ -215,7 +215,7 @@ export default function blockReducer(
       });
     }
     case "blocks/move/up": {
-      const { block_id } = action as any;
+      const { block_id } = <FormsBlockMoveUpAction>action;
       return produce(state, (draft) => {
         const index = draft.blocks.findIndex((b) => b.id === block_id);
         if (index > 0) {
@@ -224,7 +224,7 @@ export default function blockReducer(
       });
     }
     case "blocks/move/down": {
-      const { block_id } = action as any;
+      const { block_id } = <FormsBlockMoveDownAction>action;
       return produce(state, (draft) => {
         const index = draft.blocks.findIndex((b) => b.id === block_id);
         if (index !== -1 && index < draft.blocks.length - 1) {


### PR DESCRIPTION
## Summary
- enable moving form blocks up and down
- handle move actions in editor reducer
- expose move menu items on non-section blocks

## Testing
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Move Up" and "Move Down" options to the block action menus in the editor, allowing users to reorder blocks directly from the dropdown menu. These options are disabled when a block is already at the top or bottom of the list.
- **Bug Fixes**
  - None.
- **Documentation**
  - None.
- **Refactor**
  - None.
- **Style**
  - None.
- **Tests**
  - None.
- **Chores**
  - None.
- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->