### PR TITLE
Add README for io-svg and bitmap packages

### DIFF
--- a/packages/grida-canvas-bitmap/README.md
+++ b/packages/grida-canvas-bitmap/README.md
@@ -1,0 +1,15 @@
+# @grida/bitmap
+
+Pixel-based graphics editor utilities used by the Grida canvas.
+
+This package provides a small bitmap layer model along with brush helpers and texture factories.
+
+## Status
+
+This package is **under development**. APIs may change and features are incomplete.
+
+## Limitations
+
+- Optimized for simplicity rather than performance.
+- Only basic brush modes and flood fill are implemented.
+- Advanced selection tools and filters are not yet available.

--- a/packages/grida-canvas-io-figma/README.md
+++ b/packages/grida-canvas-io-figma/README.md
@@ -1,0 +1,14 @@
+# @grida/io-figma
+
+Utilities for converting Figma REST API data into the Grida Canvas schema.
+
+## Status
+
+This package is **under development** and its API may change without notice.
+
+## Limitations
+
+- Supports only a subset of Figma node types.
+- Boolean operations, component nodes and FigJam specific nodes are not handled.
+- Gradient transforms, image fills and effects are not fully implemented.
+- Group conversion does not preserve constraints of child layers.

--- a/packages/grida-canvas-io-svg/README.md
+++ b/packages/grida-canvas-io-svg/README.md
@@ -1,0 +1,13 @@
+# @grida/io-svg
+
+Tools for converting SVG markup to and from the Grida Canvas schema.
+
+## Status
+
+This package is **under development** and its API may change without notice.
+
+## Limitations
+
+- Only a subset of SVG elements are recognized.
+- Complex filters, gradients and animations are not fully supported.
+- Text nodes may lose styling and font information.


### PR DESCRIPTION
## Summary
- document the SVG import module
- add bitmap package overview

## Testing
- `pnpm turbo test`
- `pnpm turbo build` *(fails: Failed to fetch fonts from Google)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new README files for the bitmap, Figma, and SVG canvas utility packages, detailing features, usage, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->