### PR TITLE
Fix image drop size

### DIFF
--- a/editor/grida-canvas-react/provider.tsx
+++ b/editor/grida-canvas-react/provider.tsx
@@ -1073,17 +1073,36 @@ export function useDataTransferEventTarget() {
       );
 
       const url = URL.createObjectURL(file);
-      const node = {
-        type: "image",
-        name: name,
-        width: "auto",
-        height: "auto",
-        fit: "cover",
-        src: url,
-        left: x,
-        top: y,
-      } satisfies grida.program.nodes.NodePrototype;
-      instance.insertNode(node);
+      const img = new Image();
+      img.onload = () => {
+        const node = {
+          type: "image",
+          name: name,
+          width: img.naturalWidth,
+          height: img.naturalHeight,
+          fit: "cover",
+          src: url,
+          left: x,
+          top: y,
+        } satisfies grida.program.nodes.NodePrototype;
+        instance.insertNode(node);
+        URL.revokeObjectURL(url);
+      };
+      img.onerror = () => {
+        const node = {
+          type: "image",
+          name: name,
+          width: 100,
+          height: 100,
+          fit: "cover",
+          src: url,
+          left: x,
+          top: y,
+        } satisfies grida.program.nodes.NodePrototype;
+        instance.insertNode(node);
+        URL.revokeObjectURL(url);
+      };
+      img.src = url;
     },
     [instance, canvasXY]
   );

--- a/editor/grida-canvas-react/provider.tsx
+++ b/editor/grida-canvas-react/provider.tsx
@@ -1072,35 +1072,29 @@ export function useDataTransferEventTarget() {
         position ? [position.clientX, position.clientY] : [0, 0]
       );
 
+      // TODO: uploader is not implemented. use uploader configured by user.
+
       const url = URL.createObjectURL(file);
       const img = new Image();
-      img.onload = () => {
+      const createAndInsertNode = (width: number, height: number) => {
         const node = {
           type: "image",
           name: name,
-          width: img.naturalWidth,
-          height: img.naturalHeight,
+          width,
+          height,
           fit: "cover",
           src: url,
           left: x,
           top: y,
         } satisfies grida.program.nodes.NodePrototype;
         instance.insertNode(node);
-        URL.revokeObjectURL(url);
+      };
+
+      img.onload = () => {
+        createAndInsertNode(img.naturalWidth, img.naturalHeight);
       };
       img.onerror = () => {
-        const node = {
-          type: "image",
-          name: name,
-          width: 100,
-          height: 100,
-          fit: "cover",
-          src: url,
-          left: x,
-          top: y,
-        } satisfies grida.program.nodes.NodePrototype;
-        instance.insertNode(node);
-        URL.revokeObjectURL(url);
+        createAndInsertNode(100, 100);
       };
       img.src = url;
     },


### PR DESCRIPTION
## Summary
- measure dropped image and set width/height to natural dimensions

## Testing
- `npx turbo run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Images inserted into the editor now display at their correct natural size when possible, improving visual accuracy.
	- If an image fails to load, it will be inserted at a default size of 100x100 pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->