### PR TITLE
Add rotation quantization step

### DIFF
--- a/editor/grida-canvas/features.md
+++ b/editor/grida-canvas/features.md
@@ -91,6 +91,7 @@ This document lists all implemented features including the ones that are not yet
 - [x] lock to dominant axis while translate (`shift`)
 - [x] preserve aspect ratio while scale (`shift`)
 - [x] quantize rotation (rotate by 15 degrees) (`shift`)
+- [x] quantize rotation by 1 degree by default
 
 **Snapping**
 

--- a/editor/grida-canvas/index.ts
+++ b/editor/grida-canvas/index.ts
@@ -55,6 +55,13 @@ export namespace editor.config {
        */
       __unstable_brush_tool: "on" | "off";
     };
+
+    /**
+     * base quantization step for rotation in degrees
+     *
+     * @default 1
+     */
+    rotation_quantize_step: number;
   }
 
   /**
@@ -87,6 +94,11 @@ export namespace editor.config {
    * snap threshold applyed when nudge (fake gesture) is applied
    */
   export const DEFAULT_SNAP_NUDGE_THRESHOLD = 0.5;
+
+  /**
+   * default quantization step for rotation gestures (in degrees)
+   */
+  export const DEFAULT_ROTATION_QUANTIZE_STEP = 1;
 
   export const DEFAULT_HIT_TESTING_CONFIG: state.HitTestingConfig = {
     target: "auto",
@@ -546,7 +558,9 @@ export namespace editor.state {
       //
       editor.state.IEditorHistoryExtensionState,
       editor.state.IDocumentState,
-      grida.program.document.IDocumentTemplatesRepository {}
+      grida.program.document.IDocumentTemplatesRepository {
+    rotation_quantize_step: number;
+  }
 
   /**
    * @deprecated
@@ -588,7 +602,9 @@ export namespace editor.state {
 
   export interface IEditorStateInit
     extends Pick<editor.config.IEditorConfig, "editable" | "debug">,
-      Partial<Pick<editor.config.IEditorConfig, "flags">>,
+      Partial<
+        Pick<editor.config.IEditorConfig, "flags" | "rotation_quantize_step">
+      >,
       grida.program.document.IDocumentTemplatesRepository {
     document: Pick<
       grida.program.document.Document,
@@ -653,6 +669,9 @@ export namespace editor.state {
       flags: {
         __unstable_brush_tool: "off",
       },
+      rotation_quantize_step:
+        init.rotation_quantize_step ??
+        editor.config.DEFAULT_ROTATION_QUANTIZE_STEP,
       ...__RESET_SCENE_STATE,
       ...init,
       document: doc,

--- a/editor/grida-canvas/reducers/methods/transform.ts
+++ b/editor/grida-canvas/reducers/methods/transform.ts
@@ -586,6 +586,7 @@ function __self_update_gesture_transform_rotate(
   assert(draft.gesture.type === "rotate", "Gesture type must be rotate");
   const { movement, selection } = draft.gesture;
   const { rotate_with_quantize } = draft.gesture_modifiers;
+  const { rotation_quantize_step } = draft;
 
   const _angle = cmath.principalAngle(
     // TODO: need to store the initial angle and subtract
@@ -595,8 +596,9 @@ function __self_update_gesture_transform_rotate(
   );
 
   const _user_q =
-    typeof rotate_with_quantize === "number" ? rotate_with_quantize : 0;
-  // quantize value - even when quantize modifier is off, we still use 0.01 as the default value
+    typeof rotate_with_quantize === "number"
+      ? rotate_with_quantize
+      : rotation_quantize_step;
   const q = Math.max(0.01, _user_q);
   const angle = cmath.quantize(_angle, q);
 


### PR DESCRIPTION
## Summary
- quantize rotation by default at one degree
- expose base rotation quantize step via editor config
- apply rotation_quantize_step in reducer
- document default rotation quantization

## Testing
- `pnpm turbo test`