### PR TITLE
Fix root node snapping edge case

### DIFF
--- a/editor/grida-canvas/reducers/tools/snap.ts
+++ b/editor/grida-canvas/reducers/tools/snap.ts
@@ -2,6 +2,7 @@ import grida from "@grida/schema";
 import cmath from "@grida/cmath";
 import { SnapToObjectsResult, snapToCanvasGeometry } from "@grida/cmath/_snap";
 import { editor } from "@/grida-canvas";
+import { domapi } from "../../backends/dom";
 
 const q = 1;
 
@@ -100,8 +101,12 @@ export function getSnapTargets(
   selection: string[],
   {
     document_ctx,
+    scene_id,
+    document,
   }: {
     document_ctx: grida.program.document.internal.INodesRepositoryRuntimeHierarchyContext;
+    scene_id?: string;
+    document?: grida.program.document.Document;
   }
 ): string[] {
   // set of each sibling and parent of selection
@@ -116,6 +121,26 @@ export function getSnapTargets(
         .flat()
     )
   ).filter((node_id) => !selection.includes(node_id));
+
+  if (snap_target_node_ids.length === 0) {
+    const is_root_only = selection.every(
+      (node_id) => editor.dq.getParentId(document_ctx, node_id) === null
+    );
+
+    if (is_root_only) {
+      const scene_root_count =
+        document && scene_id
+          ? document.scenes[scene_id]?.children.length ?? 0
+          : 0;
+
+      const is_single_root_selection =
+        scene_root_count === 1 && selection.length === 1;
+
+      if (!is_single_root_selection) {
+        snap_target_node_ids.push(domapi.k.EDITOR_CONTENT_ELEMENT_ID);
+      }
+    }
+  }
 
   return snap_target_node_ids;
 }


### PR DESCRIPTION
## Summary
- avoid snapping single-root documents to 0,0

## Testing
- `npx turbo test`
- `npx turbo build` *(fails to fetch fonts)*