### PR TITLE
Fix rotation handle orientation

### DIFF
--- a/editor/grida-canvas-react/viewport/surface.tsx
+++ b/editor/grida-canvas-react/viewport/surface.tsx
@@ -953,7 +953,7 @@ function LayerOverlayRotationHandle({
   const bind = useSurfaceGesture({
     onDragStart: ({ event }) => {
       event.preventDefault();
-      editor.startRotateGesture(node_id);
+      editor.startRotateGesture(node_id, anchor);
     },
   });
 

--- a/editor/grida-canvas/action.ts
+++ b/editor/grida-canvas/action.ts
@@ -534,7 +534,9 @@ export type EditorSurface_StartGesture = {
   gesture:
     | Pick<editor.gesture.GestureGuide, "type" | "axis" | "idx">
     | Pick<editor.gesture.GestureScale, "type" | "direction" | "selection">
-    | Pick<editor.gesture.GestureRotate, "type" | "selection">
+    | (Pick<editor.gesture.GestureRotate, "type" | "selection"> & {
+        anchor: cmath.CardinalDirection;
+      })
     | (Pick<editor.gesture.GestureSort, "type" | "node_id"> & {
         selection: string[];
       })

--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -1510,12 +1510,13 @@ export class Editor
   }
   // #endregion drag resize handle
 
-  startRotateGesture(selection: string) {
+  startRotateGesture(selection: string, anchor: cmath.CardinalDirection) {
     this.dispatch({
       type: "surface/gesture/start",
       gesture: {
         type: "rotate",
         selection,
+        anchor,
       },
     });
   }

--- a/editor/grida-canvas/index.ts
+++ b/editor/grida-canvas/index.ts
@@ -1980,7 +1980,7 @@ export namespace editor.api {
     startSortGesture(selection: string | string[], node_id: string): void;
     startGapGesture(selection: string | string[], axis: "x" | "y"): void;
     startCornerRadiusGesture(selection: string): void;
-    startRotateGesture(selection: string): void;
+    startRotateGesture(selection: string, anchor: cmath.CardinalDirection): void;
     startTranslateVertexGesture(node_id: string, vertex: number): void;
     startCurveGesture(
       node_id: string,

--- a/editor/grida-canvas/reducers/methods/transform.ts
+++ b/editor/grida-canvas/reducers/methods/transform.ts
@@ -584,23 +584,27 @@ function __self_update_gesture_transform_rotate(
   draft: Draft<editor.state.IEditorState>
 ) {
   assert(draft.gesture.type === "rotate", "Gesture type must be rotate");
-  const { movement, selection } = draft.gesture;
+  const { selection, offset, initial_bounding_rectangle, rotation: initial_rotation } =
+    draft.gesture;
   const { rotate_with_quantize } = draft.gesture_modifiers;
   const { rotation_quantize_step } = draft;
 
-  const _angle = cmath.principalAngle(
-    // TODO: need to store the initial angle and subtract
-    // TODO: get anchor and calculate the offset
-    // TODO: translate the movement (distance) relative to the center of the node
-    cmath.vector2.angle(cmath.vector2.zero, movement)
-  );
+  const center: cmath.Vector2 = [
+    initial_bounding_rectangle.x + initial_bounding_rectangle.width / 2,
+    initial_bounding_rectangle.y + initial_bounding_rectangle.height / 2,
+  ];
+
+  const pointer_angle = cmath.vector2.angle(center, draft.pointer.position);
+  const handle_angle = cmath.vector2.angle(cmath.vector2.zero, offset);
+
+  const delta = cmath.principalAngle(pointer_angle - handle_angle);
 
   const _user_q =
     typeof rotate_with_quantize === "number"
       ? rotate_with_quantize
       : rotation_quantize_step;
   const q = Math.max(0.01, _user_q);
-  const angle = cmath.quantize(_angle, q);
+  const angle = cmath.quantize(initial_rotation + delta, q);
 
   const node = editor.dq.__getNodeById(draft, selection);
 

--- a/editor/grida-canvas/reducers/surface.reducer.ts
+++ b/editor/grida-canvas/reducers/surface.reducer.ts
@@ -10,6 +10,26 @@ import grida from "@grida/schema";
 import { self_clearSelection, self_selectNode } from "./methods";
 import type { BitmapEditorBrush } from "@grida/bitmap";
 
+function rotation_handle_offset(
+  rect: cmath.Rectangle,
+  anchor: cmath.CardinalDirection
+): cmath.Vector2 {
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const anchor_pos: Record<cmath.CardinalDirection, cmath.Vector2> = {
+    nw: [rect.x, rect.y],
+    ne: [rect.x + rect.width, rect.y],
+    se: [rect.x + rect.width, rect.y + rect.height],
+    sw: [rect.x, rect.y + rect.height],
+    n: [rect.x + rect.width / 2, rect.y],
+    e: [rect.x + rect.width, rect.y + rect.height / 2],
+    s: [rect.x + rect.width / 2, rect.y + rect.height],
+    w: [rect.x, rect.y + rect.height / 2],
+  };
+  const pos = anchor_pos[anchor];
+  return cmath.vector2.sub(pos, [cx, cy]);
+}
+
 function createLayoutSnapshot(
   state: editor.state.IEditorState,
   group: string | null,
@@ -328,14 +348,17 @@ function __self_start_gesture(
       break;
     }
     case "rotate": {
-      const { selection } = gesture;
+      const { selection, anchor } = gesture;
 
       self_selectNode(draft, "reset", selection);
+      const rect = cdom.getNodeBoundingRect(selection)!;
+
+      const offset = rotation_handle_offset(rect, anchor);
+
       __self_start_gesture_rotate(draft, {
         selection: selection,
-        initial_bounding_rectangle: cdom.getNodeBoundingRect(selection)!,
-        // TODO: the offset of rotation handle relative to the center of the rectangle
-        offset: cmath.vector2.zero,
+        initial_bounding_rectangle: rect,
+        offset: offset,
       });
       //
       break;


### PR DESCRIPTION
## Summary
- calculate rotation around handle anchor
- pass anchor when starting rotate gesture
- compute new rotation on pointer move

## Testing
- `pnpm turbo typecheck` *(fails: Cannot find module '@grida/cmath' or its corresponding type declarations)*
- `pnpm turbo test`