### PR TITLE
Implement cross-window clipboard paste

### DIFF
--- a/editor/grida-canvas-react/clipboard.ts
+++ b/editor/grida-canvas-react/clipboard.ts
@@ -1,0 +1,24 @@
+export interface ClipboardPayload {
+  payload_id: string;
+  prototypes: import("@/grida-canvas").grida.program.nodes.NodePrototype[];
+  ids: string[];
+}
+
+export function encodeClipboardHtml(payload: ClipboardPayload): string {
+  const json = JSON.stringify(payload);
+  return `<span data-grida-clipboard='${json}'></span>`;
+}
+
+export function decodeClipboardHtml(html: string): ClipboardPayload | null {
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const span = doc.querySelector("[data-grida-clipboard]");
+    if (!span) return null;
+    const data = span.getAttribute("data-grida-clipboard");
+    if (!data) return null;
+    return JSON.parse(data) as ClipboardPayload;
+  } catch {
+    return null;
+  }
+}

--- a/editor/grida-canvas-react/index.ts
+++ b/editor/grida-canvas-react/index.ts
@@ -22,3 +22,4 @@ export {
   type StandaloneDocumentContentProps,
 } from "./renderer";
 export * from "./viewport";
+export { encodeClipboardHtml, decodeClipboardHtml } from "./clipboard";

--- a/editor/grida-canvas/index.ts
+++ b/editor/grida-canvas/index.ts
@@ -323,6 +323,8 @@ export namespace editor.state {
      * user clipboard - copied data
      */
     user_clipboard?: {
+      /** unique payload id for distinguishing clipboard contents */
+      payload_id: string;
       /**
        * copied node data as prototype
        */

--- a/editor/grida-canvas/reducers/document.reducer.ts
+++ b/editor/grida-canvas/reducers/document.reducer.ts
@@ -108,6 +108,7 @@ export default function documentReducer<S extends editor.state.IEditorState>(
       return produce(state, (draft) => {
         // [copy]
         draft.user_clipboard = {
+          payload_id: crypto.randomUUID(),
           ids: target_node_ids,
           prototypes: target_node_ids.map((id) =>
             grida.program.nodes.factory.createPrototypeFromSnapshot(


### PR DESCRIPTION
## Summary
- sync clipboard data to system clipboard
- parse `text/html` clipboard payload on paste events
- insert copied nodes using new IDs when pasting across windows
- centralize clipboard encode/decode logic with custom data attribute
- add unique `payload_id` to clipboard state

## Testing
- `pnpm turbo test`
