### PR TITLE
[Grida Canvas] Fix Clipboard IO

### DIFF
--- a/editor/app/(dev)/canvas/tools/io-svg/page.tsx
+++ b/editor/app/(dev)/canvas/tools/io-svg/page.tsx
@@ -93,13 +93,12 @@ export default function IOSVGPage() {
               )
             );
 
-          instance.dispatch({
-            type: "__internal/reset",
-            state: editor.state.init({
+          instance.reset(
+            editor.state.init({
               editable: true,
               document: doc,
-            }),
-          });
+            })
+          );
         }
         setResult(result);
         //

--- a/editor/components/formfield/grida-canvas/index.tsx
+++ b/editor/components/formfield/grida-canvas/index.tsx
@@ -70,14 +70,13 @@ export function GridaCanvasFormField() {
   useEffect(() => {
     fetch("/examples/canvas/sketch-teimplate-01.grida").then((res) => {
       res.json().then((file) => {
-        instance.dispatch({
-          type: "__internal/reset",
-          key: "template",
-          state: editor.state.init({
+        instance.reset(
+          editor.state.init({
             editable: true,
             document: file.document,
           }),
-        });
+          "template"
+        );
       });
     });
   }, []);

--- a/editor/grida-canvas-react/provider.tsx
+++ b/editor/grida-canvas-react/provider.tsx
@@ -1090,10 +1090,15 @@ export function useDataTransferEventTarget() {
     ) => {
       const node = await instance.createNodeFromSvg(svg);
 
-      const center_dx = typeof node.$.width === "number" ? node.$.width / 2 : 0;
+      const center_dx =
+        typeof node.$.width === "number" && node.$.width > 0
+          ? node.$.width / 2
+          : 0;
 
       const center_dy =
-        typeof node.$.height === "number" ? node.$.height / 2 : 0;
+        typeof node.$.height === "number" && node.$.height > 0
+          ? node.$.height / 2
+          : 0;
 
       const [x, y] = canvasXY(
         cmath.vector2.sub(

--- a/editor/grida-canvas-react/provider.tsx
+++ b/editor/grida-canvas-react/provider.tsx
@@ -1320,7 +1320,7 @@ export function useClipboardSync() {
         navigator.clipboard.write([clipboardItem]);
       }
     } catch (e) {
-      //
+      reportError(e);
     }
   }, [user_clipboard]);
   //

--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -479,7 +479,6 @@ export class Editor
     image: grida.program.document.ImageRef
   ): NodeProxy<grida.program.nodes.ImageNode> {
     const id = this.__createNodeId();
-    console.log("id", id);
     this.dispatch({
       type: "insert",
       id: id,

--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -109,10 +109,15 @@ export class Editor
     return this.debug;
   }
 
-  public reset(state: editor.state.IEditorState, force: boolean = false) {
+  public reset(
+    state: editor.state.IEditorState,
+    key: string | undefined = undefined,
+    force: boolean = false
+  ) {
     this.dispatch(
       {
         type: "__internal/reset",
+        key,
         state,
       },
       force

--- a/editor/grida-canvas/index.ts
+++ b/editor/grida-canvas/index.ts
@@ -2086,7 +2086,6 @@ export namespace editor.api {
     duplicate(target: "selection" | NodeID): void;
 
     setClipboardColor(color: cg.RGBA8888): void;
-    deleteNode(target: "selection" | NodeID): void;
 
     //
     selectVertex(node_id: NodeID, vertex: number): void;
@@ -2098,7 +2097,20 @@ export namespace editor.api {
     getNodeById(node_id: NodeID): NodeProxy<grida.program.nodes.Node>;
     getNodeDepth(node_id: NodeID): number;
     getNodeAbsoluteRotation(node_id: NodeID): number;
+
+    //
     insertNode(prototype: grida.program.nodes.NodePrototype): NodeID;
+    deleteNode(target: "selection" | NodeID): void;
+    //
+
+    createNodeFromSvg(
+      svg: string
+    ): Promise<NodeProxy<grida.program.nodes.ContainerNode>>;
+    createImageNode(
+      image: grida.program.document.ImageRef
+    ): NodeProxy<grida.program.nodes.ImageNode>;
+    createTextNode(text: string): NodeProxy<grida.program.nodes.TextNode>;
+    createRectangleNode(): NodeProxy<grida.program.nodes.RectangleNode>;
 
     //
     nudgeResize(

--- a/editor/grida-canvas/index.ts
+++ b/editor/grida-canvas/index.ts
@@ -629,6 +629,7 @@ export namespace editor.state {
   }): editor.state.IEditorState {
     const doc: grida.program.document.Document = {
       bitmaps: {},
+      images: {},
       properties: {},
       ...init.document,
       scenes: Object.entries(init.document.scenes ?? {}).reduce(
@@ -2054,6 +2055,14 @@ export namespace editor.api {
       scene_id: string,
       backgroundColor: grida.program.document.ISceneBackground["backgroundColor"]
     ): void;
+
+    //
+    /**
+     * creates an image (data) from the given src, registers it to the document
+     * @param src
+     */
+    createImage(src: string): Promise<grida.program.document.ImageRef>;
+
     //
     setTool(tool: editor.state.ToolMode): void;
     tryExitContentEditMode(): void;

--- a/editor/grida-canvas/plugins/recorder.ts
+++ b/editor/grida-canvas/plugins/recorder.ts
@@ -92,7 +92,7 @@ export class EditorRecorder {
 
     this.status = "playing";
     this.editor.locked = true;
-    this.editor.reset(this.initial, true);
+    this.editor.reset(this.initial, undefined, true);
 
     for (let i = 0; i < this.buffer.length; i++) {
       const current = this.buffer[i];

--- a/editor/grida-canvas/reducers/document.reducer.ts
+++ b/editor/grida-canvas/reducers/document.reducer.ts
@@ -189,10 +189,11 @@ export default function documentReducer<S extends editor.state.IEditorState>(
     case "insert": {
       let sub: grida.program.document.IPackedSceneDocument;
       if ("prototype" in action) {
+        const { id, prototype } = action;
         sub =
           grida.program.nodes.factory.create_packed_scene_document_from_prototype(
-            action.prototype,
-            nid
+            prototype,
+            (_, depth) => (depth === 0 ? (id ?? nid()) : nid())
           );
       } else if ("document" in action) {
         sub = action.document;

--- a/editor/grida-canvas/reducers/node.reducer.ts
+++ b/editor/grida-canvas/reducers/node.reducer.ts
@@ -52,6 +52,31 @@ const safe_properties: Partial<
       draft.name = value;
     },
   }),
+  position: defineNodeProperty<"position">({
+    apply: (draft, value, prev) => {
+      draft.position = value;
+    },
+  }),
+  left: defineNodeProperty<"left">({
+    apply: (draft, value, prev) => {
+      draft.left = value;
+    },
+  }),
+  top: defineNodeProperty<"top">({
+    apply: (draft, value, prev) => {
+      draft.top = value;
+    },
+  }),
+  right: defineNodeProperty<"right">({
+    apply: (draft, value, prev) => {
+      draft.right = value;
+    },
+  }),
+  bottom: defineNodeProperty<"bottom">({
+    apply: (draft, value, prev) => {
+      draft.bottom = value;
+    },
+  }),
   width: defineNodeProperty<"width">({
     apply: (draft, value, prev) => {
       if (typeof value === "number") {

--- a/editor/scaffolds/playground-canvas/playground.tsx
+++ b/editor/scaffolds/playground-canvas/playground.tsx
@@ -118,7 +118,6 @@ import {
   PreviewProvider,
 } from "@/grida-canvas-react-starter-kit/starterkit-preview";
 import { sitemap } from "@/www/data/sitemap";
-import iosvg from "@grida/io-svg";
 import iofigma from "@grida/io-figma";
 import { editor } from "@/grida-canvas";
 import { useEditor } from "@/grida-canvas-react";
@@ -742,19 +741,9 @@ function LibraryContent() {
     }).then((res) => {
       // svg content
       res.text().then((svg) => {
-        const optimized = iosvg.v0.optimize(svg).data;
-        iosvg.v0
-          .convert(optimized, {
-            name: name.split(".svg")[0],
-            currentColor: { r: 0, g: 0, b: 0, a: 1 },
-          })
-          .then((result) => {
-            if (result) {
-              editor.insertNode(result);
-            } else {
-              throw new Error("Failed to convert SVG");
-            }
-          });
+        editor.createNodeFromSvg(svg).then((node) => {
+          node.$.name = name.split(".svg")[0];
+        });
       });
     });
 

--- a/editor/scaffolds/playground-canvas/playground.tsx
+++ b/editor/scaffolds/playground-canvas/playground.tsx
@@ -213,14 +213,13 @@ export default function CanvasPlayground({
     if (!src) return;
     fetch(src).then((res) => {
       res.json().then((file) => {
-        instance.dispatch({
-          type: "__internal/reset",
-          key: src,
-          state: editor.state.init({
+        instance.reset(
+          editor.state.init({
             editable: true,
             document: file.document,
           }),
-        });
+          src
+        );
       });
     });
   }, [src]);
@@ -250,7 +249,8 @@ export default function CanvasPlayground({
                 editor.state.init({
                   editable: true,
                   document: file.document,
-                })
+                }),
+                Date.now() + ""
               );
             }}
           />

--- a/editor/scaffolds/sidecontrol/controls/positioning.tsx
+++ b/editor/scaffolds/sidecontrol/controls/positioning.tsx
@@ -34,10 +34,10 @@ export function PositioningModeControl({
 
 export function PositioningConstraintsControl({
   value,
-  onValueChange,
+  onValueCommit,
 }: {
   value: grida.program.nodes.i.IPositioning;
-  onValueChange?: (value: grida.program.nodes.i.IPositioning) => void;
+  onValueCommit?: (value: grida.program.nodes.i.IPositioning) => void;
 }) {
   return (
     <div className="w-full">
@@ -48,7 +48,7 @@ export function PositioningConstraintsControl({
           type="number"
           value={value.top ?? ""}
           onValueCommit={(v) => {
-            onValueChange?.({
+            onValueCommit?.({
               ...value,
               top: v,
             });
@@ -63,7 +63,7 @@ export function PositioningConstraintsControl({
           type="number"
           value={value.left ?? ""}
           onValueCommit={(v) => {
-            onValueChange?.({
+            onValueCommit?.({
               ...value,
               left: v,
             });
@@ -78,7 +78,7 @@ export function PositioningConstraintsControl({
             bottom: value.bottom !== undefined,
           }}
           onConstraintChange={(side, checked) => {
-            onValueChange?.({
+            onValueCommit?.({
               ...value,
               [side]: checked ? 0 : undefined,
             });
@@ -90,7 +90,7 @@ export function PositioningConstraintsControl({
           type="number"
           value={value.right ?? ""}
           onValueCommit={(v) => {
-            onValueChange?.({
+            onValueCommit?.({
               ...value,
               right: v,
             });
@@ -105,7 +105,7 @@ export function PositioningConstraintsControl({
           type="number"
           value={value.bottom ?? ""}
           onValueCommit={(v) => {
-            onValueChange?.({
+            onValueCommit?.({
               ...value,
               bottom: v,
             });

--- a/editor/scaffolds/sidecontrol/sidecontrol-node-selection.tsx
+++ b/editor/scaffolds/sidecontrol/sidecontrol-node-selection.tsx
@@ -1231,14 +1231,13 @@ function SectionPosition({ node_id }: { node_id: string }) {
               right,
               bottom,
             }}
-            onValueChange={actions.positioning}
+            onValueCommit={actions.positioning}
           />
         </PropertyLine>
         <PropertyLine>
           <PropertyLineLabel>Mode</PropertyLineLabel>
           <PositioningModeControl
             value={position}
-            //
             onValueChange={actions.positioningMode}
           />
         </PropertyLine>

--- a/editor/services/new/index.ts
+++ b/editor/services/new/index.ts
@@ -256,6 +256,7 @@ export class CanvasDocumentSetupAssistantService extends DocumentSetupAssistantS
             }),
           },
           bitmaps: {},
+          images: {},
           properties: {},
         } satisfies CanvasDocumentSnapshotSchema as {},
       })

--- a/packages/grida-canvas-io-figma/lib.ts
+++ b/packages/grida-canvas-io-figma/lib.ts
@@ -234,6 +234,7 @@ export namespace iofigma {
           },
           // TODO:
           bitmaps: {},
+          images: {},
           properties: {},
         };
       }

--- a/packages/grida-canvas-io/index.ts
+++ b/packages/grida-canvas-io/index.ts
@@ -219,6 +219,8 @@ export namespace io {
               return reject(new Error("Unknown HTML payload"));
             }
           });
+        } else {
+          return resolve(null);
         }
       });
     }

--- a/packages/grida-canvas-io/index.ts
+++ b/packages/grida-canvas-io/index.ts
@@ -183,7 +183,12 @@ export namespace io {
      *   }
      * }
      */
-    export function decode(item: DataTransferItem): Promise<DecodedItem> {
+    export function decode(
+      item: DataTransferItem,
+      config: {
+        noEmptyText: boolean;
+      } = { noEmptyText: true }
+    ): Promise<DecodedItem | null> {
       return new Promise((resolve, reject) => {
         if (item.kind === "file") {
           const file = item.getAsFile();
@@ -200,6 +205,9 @@ export namespace io {
           }
         } else if (item.kind === "string" && item.type === "text/plain") {
           item.getAsString((data) => {
+            if (config.noEmptyText && data.trim().length === 0) {
+              return resolve(null);
+            }
             return resolve({ type: "text", text: data });
           });
         } else if (item.kind === "string" && item.type === "text/html") {

--- a/packages/grida-canvas-io/index.ts
+++ b/packages/grida-canvas-io/index.ts
@@ -227,6 +227,7 @@ export namespace io {
           nodes: json.document.nodes,
           scenes: json.document.scenes,
           bitmaps: bitmaps,
+          images: json.document.images ?? {},
           properties: json.document.properties ?? {},
         },
       } satisfies JSONDocumentFileModel;

--- a/packages/grida-canvas-io/index.ts
+++ b/packages/grida-canvas-io/index.ts
@@ -15,6 +15,51 @@ export namespace io {
       ids: string[];
     }
 
+    export function encode(
+      payload: ClipboardPayload
+    ): Record<string, string | Blob> | null {
+      const result: Record<string, string | Blob> = {};
+
+      if (payload.prototypes.length === 0) {
+        return null;
+      }
+
+      // text/html (grida)
+      const __main_html = encodeClipboardHtml(payload);
+      const utf8Html = new TextEncoder().encode(__main_html);
+      result["text/html"] = new Blob([utf8Html], {
+        type: "text/html;charset=utf-8",
+      });
+
+      // text/plain (universal)
+      const __text_plain = encodeClipboardText(payload);
+      if (__text_plain) {
+        const utf8 = new TextEncoder().encode(__text_plain);
+        result["text/plain"] = new Blob([utf8], {
+          type: "text/plain;charset=utf-8",
+        });
+      }
+
+      return result;
+    }
+
+    export function encodeClipboardText(
+      payload: ClipboardPayload
+    ): string | null {
+      let __text_plain = "";
+      for (const p of payload.prototypes) {
+        if (p.type === "text") {
+          __text_plain += p.text + "\n";
+        }
+      }
+
+      if (__text_plain.trim().length > 0) {
+        return __text_plain;
+      }
+
+      return null;
+    }
+
     export function encodeClipboardHtml(payload: ClipboardPayload): string {
       const json = JSON.stringify(payload);
       const utf8Bytes = new TextEncoder().encode(json);
@@ -70,6 +115,104 @@ export namespace io {
       } catch {
         return null;
       }
+    }
+
+    export function filetype(
+      file: File
+    ): [true, ValidFileType] | [false, string] {
+      const type = file.type || file.name.split(".").pop() || file.name;
+      if (type === "image/svg+xml") {
+        return [true, "image/svg+xml" as const];
+      } else if (type === "image/png") {
+        return [true, "image/png" as const];
+      } else if (type === "image/jpeg") {
+        return [true, "image/jpeg" as const];
+      } else if (type === "image/gif") {
+        return [true, "image/gif" as const];
+      } else {
+        return [false, type];
+      }
+    }
+
+    export type ValidFileType =
+      | "image/svg+xml"
+      | "image/png"
+      | "image/jpeg"
+      | "image/gif";
+
+    export type DecodedItem =
+      | {
+          type: "image/svg+xml" | "image/png" | "image/jpeg" | "image/gif";
+          file: File;
+        }
+      | { type: "text"; text: string }
+      | { type: "clipboard"; clipboard: ClipboardPayload };
+
+    /**
+     * Decodes a DataTransferItem from the clipboard into a structured payload.
+     *
+     * This function supports three types of clipboard data:
+     * - File: Returns a payload with type 'file' and the File object.
+     * - Plain Text: Returns a payload with type 'text' and the text string.
+     * - Grida Clipboard HTML: Returns a payload with type 'clipboard' and the decoded ClipboardPayload object.
+     *
+     * The function automatically detects the kind and type of the DataTransferItem and resolves the appropriate payload.
+     *
+     * @param item The DataTransferItem from the clipboard event to decode.
+     * @returns A Promise that resolves to one of the following payloads:
+     *   - `{ type: "file", file: File }` if the item is a file
+     *   - `{ type: "text", text: string }` if the item is plain text
+     *   - `{ type: "clipboard", clipboard: ClipboardPayload }` if the item is Grida clipboard HTML
+     *
+     * @throws If the item cannot be decoded or is of an unknown/unsupported type.
+     *
+     * @example
+     * // Usage inside a paste event handler:
+     * for (const item of event.clipboardData.items) {
+     *   const payload = await io.clipboard.decode(item);
+     *   switch (payload.type) {
+     *     case 'file':
+     *       // handle file
+     *       break;
+     *     case 'text':
+     *       // handle text
+     *       break;
+     *     case 'clipboard':
+     *       // handle Grida clipboard payload
+     *       break;
+     *   }
+     * }
+     */
+    export function decode(item: DataTransferItem): Promise<DecodedItem> {
+      return new Promise((resolve, reject) => {
+        if (item.kind === "file") {
+          const file = item.getAsFile();
+          if (file) {
+            const [valid, type] = filetype(file);
+
+            if (valid) {
+              return resolve({ type: type, file });
+            } else {
+              return reject(new Error(`Unsupported file type: ${type}`));
+            }
+          } else {
+            return reject(new Error("File is not a valid file"));
+          }
+        } else if (item.kind === "string" && item.type === "text/plain") {
+          item.getAsString((data) => {
+            return resolve({ type: "text", text: data });
+          });
+        } else if (item.kind === "string" && item.type === "text/html") {
+          item.getAsString((html) => {
+            const data = io.clipboard.decodeClipboardHtml(html);
+            if (data) {
+              return resolve({ type: "clipboard", clipboard: data });
+            } else {
+              return reject(new Error("Unknown HTML payload"));
+            }
+          });
+        }
+      });
     }
   }
 

--- a/packages/grida-canvas-schema/grida.ts
+++ b/packages/grida-canvas-schema/grida.ts
@@ -278,7 +278,27 @@ export namespace grida.program.document {
   }
 
   /**
-   * contains all images (data) under this defined document in k:v pair
+   * reference to an registered image
+   */
+  export type ImageRef = {
+    type: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
+    url: string;
+    width: number;
+    height: number;
+    bytes: number;
+  };
+
+  /**
+   * contains all images (ref) under this defined document in k:v pair
+   *
+   * @see {@link IDocumentDefinition}
+   */
+  export interface IImagesRepository {
+    images: Record<string, ImageRef>;
+  }
+
+  /**
+   * contains all bitmaps (data) under this defined document in k:v pair
    *
    * @see {@link IDocumentDefinition}
    */
@@ -402,7 +422,8 @@ export namespace grida.program.document {
    * ```
    */
   export interface IDocumentDefinition
-    extends IBitmapsRepository,
+    extends IImagesRepository,
+      IBitmapsRepository,
       document.INodesRepository,
       IDocumentProperties {
     // scene: Scene;
@@ -1932,6 +1953,7 @@ export namespace grida.program.nodes {
     ): document.IPackedSceneDocument {
       const document: document.IPackedSceneDocument = {
         bitmaps: {},
+        images: {},
         nodes: {},
         scene: {
           type: "scene",


### PR DESCRIPTION
- [x] fix multiple / duplicate payload being pasted
- [x] copying text node from grida will also encode text/plain payloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for inserting and managing images within the editor, including new methods to create image, text, rectangle, and SVG nodes.
  - Enhanced clipboard functionality to support structured payloads and multiple image file types, improving copy-paste and drag-and-drop experiences.

- **Improvements**
  - Simplified and improved editor state reset logic with direct reset method calls.
  - Enhanced positioning controls and extended node property updates.
  - Improved error handling and user feedback for unsupported file types during clipboard and file operations.

- **Bug Fixes**
  - Ensured new documents and imported files include an initialized images repository for better compatibility.

- **Documentation**
  - Updated type definitions and interfaces to reflect new image management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->