### PR TITLE
Implement rect tiling in math2

### DIFF
--- a/crates/grida-math2/src/lib.rs
+++ b/crates/grida-math2/src/lib.rs
@@ -53,7 +53,7 @@ pub use rect::{
     get_scale_factors, get_uniform_gap as rect_get_uniform_gap, inset as rect_inset, intersection,
     intersects, is_identical as rect_identical, is_uniform as rect_uniform, offset,
     pad as rect_pad, positive as rect_positive, quantize as rect_quantize, rotate as rect_rotate,
-    to_9points, to_9points_chunk, transform as rect_transform, union,
+    tile as rect_tile, to_9points, to_9points_chunk, transform as rect_transform, union,
 };
 pub use snap::axis::{
     AxisAlignedPoint, Movement, Snap1DResult, Snap2DAxisAlignedResult, Snap2DAxisConfig,

--- a/crates/grida-math2/src/rect.rs
+++ b/crates/grida-math2/src/rect.rs
@@ -272,6 +272,39 @@ pub fn union(rects: &[Rectangle]) -> Rectangle {
     }
 }
 
+/// Tiles the rectangle into a grid of equally sized rectangles.
+///
+/// The `size` parameter specifies the number of `(columns, rows)`.
+/// Each must evenly divide the rectangle's width and height respectively.
+///
+/// # Panics
+///
+/// Panics if the provided column or row count is zero or does not
+/// evenly divide the rectangle dimensions.
+pub fn tile(rect: Rectangle, size: (usize, usize)) -> Vec<Rectangle> {
+    let (cols, rows) = size;
+    assert!(cols > 0 && rows > 0, "size must be greater than zero");
+
+    let tile_w = rect.width / cols as f32;
+    let tile_h = rect.height / rows as f32;
+
+    assert!(tile_w.fract() == 0.0, "columns must evenly divide width");
+    assert!(tile_h.fract() == 0.0, "rows must evenly divide height");
+
+    let mut out = Vec::with_capacity(cols * rows);
+    for r in 0..rows {
+        for c in 0..cols {
+            out.push(Rectangle {
+                x: rect.x + c as f32 * tile_w,
+                y: rect.y + r as f32 * tile_h,
+                width: tile_w,
+                height: tile_h,
+            });
+        }
+    }
+    out
+}
+
 /// Boolean operations on rectangles.
 pub mod boolean {
     use super::{Rectangle, intersection};

--- a/crates/grida-math2/tests/rect.rs
+++ b/crates/grida-math2/tests/rect.rs
@@ -111,3 +111,19 @@ fn axis_projection_intersection_overlaps() {
     let inter = axis_projection_intersection(&rects, Axis::X);
     assert_eq!(inter, Some([15.0, 25.0]));
 }
+
+#[test]
+fn tile_basic() {
+    let r = rect(0.0, 0.0, 100.0, 40.0);
+    let out = math2::rect_tile(r, (2, 2));
+    assert_eq!(out.len(), 4);
+    assert_eq!(out[0], rect(0.0, 0.0, 50.0, 20.0));
+    assert_eq!(out[3], rect(50.0, 20.0, 50.0, 20.0));
+}
+
+#[test]
+#[should_panic]
+fn tile_invalid_divisor() {
+    let r = rect(0.0, 0.0, 100.0, 40.0);
+    let _ = math2::rect_tile(r, (3, 2));
+}


### PR DESCRIPTION
## Summary
- add `rect::tile` for splitting rectangles into a grid
- export `rect_tile` from crate
- test tiling, including failure case

## Testing
- `cargo test -p math2`

------
https://chatgpt.com/codex/tasks/task_e_68527f1d60a4832a913cb697d8d1b869