### PR TITLE
Handle multiple font weights/styles per family

### DIFF
--- a/crates/grida-canvas/examples/figma.rs
+++ b/crates/grida-canvas/examples/figma.rs
@@ -197,7 +197,11 @@ async fn main() {
                     font_file.family, font_file.postscript_name
                 );
                 font_loader
-                    .load_font(&font_file.family, &font_file.url)
+                    .load_font_with_alias(
+                        &font_file.postscript_name,
+                        &font_file.family,
+                        &font_file.url,
+                    )
                     .await;
                 println!(
                     "✅ Font loaded: {} ({})",

--- a/crates/grida-canvas/examples/webfonts.rs
+++ b/crates/grida-canvas/examples/webfonts.rs
@@ -188,7 +188,11 @@ async fn main() {
                         font_file.family, font_file.postscript_name
                     );
                     font_loader
-                        .load_font(&font_file.family, &font_file.url)
+                        .load_font_with_alias(
+                            &font_file.postscript_name,
+                            &font_file.family,
+                            &font_file.url,
+                        )
                         .await;
                     println!(
                         "✅ Font loaded: {} ({})",

--- a/crates/grida-canvas/src/runtime/scene.rs
+++ b/crates/grida-canvas/src/runtime/scene.rs
@@ -106,10 +106,16 @@ impl Renderer {
         self.backend = Some(backend);
     }
 
+    pub fn add_font_with_alias(&mut self, alias: &str, family: &str, bytes: &[u8]) {
+        self.font_repository.borrow_mut().insert_with_alias(
+            alias.to_string(),
+            family.to_string(),
+            bytes.to_vec(),
+        );
+    }
+
     pub fn add_font(&mut self, family: &str, bytes: &[u8]) {
-        self.font_repository
-            .borrow_mut()
-            .insert(family.to_string(), bytes.to_vec());
+        self.add_font_with_alias(family, family, bytes);
     }
 
     /// Create an image from raw encoded bytes.

--- a/crates/grida-canvas/src/window/mod.rs
+++ b/crates/grida-canvas/src/window/mod.rs
@@ -341,10 +341,12 @@ impl App {
         let mut updated = false;
         let mut font_count = 0;
         while let Ok(msg) = self.font_rx.try_recv() {
-            // Use postscript name as alias if available, otherwise fallback to family
-            let alias = &msg.family;
-            self.renderer.add_font(alias, &msg.data);
-            println!("📝 Registered font with renderer: '{}'", alias);
+            self.renderer
+                .add_font_with_alias(&msg.alias, &msg.family, &msg.data);
+            println!(
+                "📝 Registered font with renderer: '{}' (family '{}')",
+                msg.alias, msg.family
+            );
             font_count += 1;
             updated = true;
         }
@@ -369,8 +371,18 @@ impl App {
         if total_fonts > 0 {
             println!("\n📋 Registered fonts:");
             println!("-------------------");
-            for (i, (family_name, font_data)) in font_repo.iter().enumerate() {
-                println!("  {}. {} ({} bytes)", i + 1, family_name, font_data.len());
+            for (i, (alias, font_data)) in font_repo.iter().enumerate() {
+                let family = font_repo
+                    .family_of(alias)
+                    .cloned()
+                    .unwrap_or_else(|| alias.to_string());
+                println!(
+                    "  {}. {} -> '{}' ({} bytes)",
+                    i + 1,
+                    alias,
+                    family,
+                    font_data.len()
+                );
             }
         }
         println!("✅ Font repository information printed");


### PR DESCRIPTION
## Summary
- preserve multiple font files using aliases
- expose font alias API in FontLoader and Renderer
- display alias and family in font repository info
- load figma and webfonts examples using aliases
- cover alias support with a new test

## Testing
- `cargo fmt --all`
- `cargo test -p cg`
- `cargo build -p cg`

------
https://chatgpt.com/codex/tasks/task_e_6853bdfed6c0832a8a1b3eda0d45b69a