### PR TITLE
Fix wasm canvas random rendering issue

### DIFF
--- a/crates/grida-canvas-wasm/lib/index.ts
+++ b/crates/grida-canvas-wasm/lib/index.ts
@@ -70,6 +70,10 @@ class ApplicationFactory {
     canvas: HTMLCanvasElement,
     options: CreateWebGLCanvasSurfaceOptions = { fontFallback: true }
   ) {
+    if (canvas.width === 0 || canvas.height === 0) {
+      throw new Error("Canvas size is zero. Set width/height before creating WebGL surface.");
+    }
+
     const context = canvas.getContext("webgl2", {
       antialias: true,
       depth: true,
@@ -91,7 +95,8 @@ class ApplicationFactory {
       options.fontFallback
     );
     const _ = new Grida2D(this.module, ptr);
-    _.resize(canvas.width, canvas.height);
+    // initial size passed to _init already; avoid redundant resize here
+    // _.resize(canvas.width, canvas.height);
 
     return _;
   }

--- a/editor/grida-canvas-react-renderer-canvas-wasm/index.tsx
+++ b/editor/grida-canvas-react-renderer-canvas-wasm/index.tsx
@@ -34,23 +34,33 @@ function CanvasContent({
   const rendererRef = React.useRef<Grida2D | null>(null);
 
   useLayoutEffect(() => {
-    if (canvasRef.current && !rendererRef.current) {
-      const canvasel = canvasRef.current;
-      init({
-        locateFile: locateFile,
-      }).then((factory) => {
-        console.log("grida wasm initialized");
-        const grida = factory.createWebGLCanvasSurface(canvasel);
-        grida.runtime_renderer_set_cache_tile(false);
-        // grida.setDebug(true);
-        // grida.setVerbose(true);
+    if (!canvasRef.current || rendererRef.current) return;
+    if (width <= 0 || height <= 0) return;
 
-        rendererRef.current = grida;
+    const canvasel = canvasRef.current;
+    canvasel.width = width * dpr;
+    canvasel.height = height * dpr;
+    let cancelled = false;
 
-        onMount?.(grida);
-      });
-    }
-  }, []);
+    init({
+      locateFile: locateFile,
+    }).then((factory) => {
+      if (cancelled) return;
+      console.log("grida wasm initialized");
+      const grida = factory.createWebGLCanvasSurface(canvasel);
+      grida.runtime_renderer_set_cache_tile(false);
+      // grida.setDebug(true);
+      // grida.setVerbose(true);
+
+      rendererRef.current = grida;
+
+      onMount?.(grida);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [width, height, dpr]);
 
   useLayoutEffect(() => {
     if (rendererRef.current) {
@@ -121,6 +131,7 @@ function CanvasContent({
       style={{
         width: `${width}px`,
         height: `${height}px`,
+        display: "block",
       }}
       className={className}
     />

--- a/editor/grida-canvas-react/renderer.tsx
+++ b/editor/grida-canvas-react/renderer.tsx
@@ -76,7 +76,7 @@ export function __WIP_UNSTABLE_WasmContent({ editor }: { editor: Editor }) {
   });
 
   return (
-    <SizeProvider className="w-full h-full">
+    <SizeProvider className="w-full h-full relative flex">
       <Canvas
         width={100}
         height={100}


### PR DESCRIPTION
Defer WASM canvas initialization until the canvas has a non-zero size to fix random rendering failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-3475db9f-72ba-4218-87c9-f74d8b64e985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3475db9f-72ba-4218-87c9-f74d8b64e985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

