### PR TITLE
Fix wasm canvas random rendering issue

### DIFF
--- a/crates/grida-canvas/src/runtime/scene.rs
+++ b/crates/grida-canvas/src/runtime/scene.rs
@@ -286,15 +286,17 @@ impl Renderer {
         // let deps_camera_changed = self.camera.changed();
         // TODO: check for dependencies
 
+        // Always compute the latest frame plan so that a subsequent flush uses up-to-date state,
+        // even if a previous frame is already pending.
+        let rect = Some(self.camera.rect());
+        self.plan = Some(self.frame(
+            rect.unwrap_or(rect::Rectangle::empty()),
+            self.camera.get_zoom(),
+            stable,
+        ));
+
+        // Only request a redraw if there isn't already one pending.
         if !self.fc.has_pending() {
-            let rect = Some(self.camera.rect());
-
-            self.plan = Some(self.frame(
-                rect.unwrap_or(rect::Rectangle::empty()),
-                self.camera.get_zoom(),
-                stable,
-            ));
-
             self.fc.queue();
             self.request_redraw();
         }

--- a/editor/grida-canvas-react-renderer-canvas-wasm/index.tsx
+++ b/editor/grida-canvas-react-renderer-canvas-wasm/index.tsx
@@ -31,19 +31,21 @@ function CanvasContent({
   className?: string;
 }) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
-  const rendererRef = useGrida2D(canvasRef);
+  const { surface, ready } = useGrida2D(canvasRef);
 
+  // onMount once surface is ready
   useLayoutEffect(() => {
-    if (rendererRef.current) {
-      onMount?.(rendererRef.current);
+    if (ready && surface) {
+      onMount?.(surface);
     }
-  }, [rendererRef.current, onMount]);
+  }, [ready, surface, onMount]);
 
+  // debug toggle
   useLayoutEffect(() => {
-    if (rendererRef.current) {
-      rendererRef.current.setDebug(debug ?? false);
+    if (ready && surface) {
+      surface.setDebug(debug ?? false);
     }
-  }, [rendererRef.current, debug]);
+  }, [ready, surface, debug]);
 
   const syncTransform = (
     surface: Grida2D,
@@ -68,37 +70,41 @@ function CanvasContent({
     surface.redraw();
   };
 
+  // sync transform when ready or dependencies change
   useLayoutEffect(() => {
-    if (rendererRef.current) {
-      syncTransform(rendererRef.current, transform, width, height);
+    if (ready && surface) {
+      syncTransform(surface, transform, width, height);
     }
-  }, [transform, width, height]);
+  }, [ready, surface, transform, width, height]);
 
+  // resize when ready or size/dpr change
   useLayoutEffect(() => {
-    if (rendererRef.current) {
-      rendererRef.current.resize(width * dpr, height * dpr);
-      syncTransform(rendererRef.current, transform, width, height);
+    if (ready && surface) {
+      surface.resize(width * dpr, height * dpr);
+      syncTransform(surface, transform, width, height);
     }
-  }, [width, height, dpr]);
+  }, [ready, surface, width, height, dpr]);
 
+  // load data once ready or when data changes
   useLayoutEffect(() => {
-    if (rendererRef.current && data) {
-      rendererRef.current.loadScene(
+    if (ready && surface && data) {
+      surface.loadScene(
         JSON.stringify({
           version: "0.0.1-beta.1+20250728",
           document: data,
         })
       );
-      rendererRef.current.redraw();
+      surface.redraw();
     }
-  }, [data]);
+  }, [ready, surface, data]);
 
+  // highlight strokes update
   useLayoutEffect(() => {
-    if (rendererRef.current) {
-      rendererRef.current.highlightStrokes(highlightStrokes);
-      rendererRef.current.redraw();
+    if (ready && surface) {
+      surface.highlightStrokes(highlightStrokes);
+      surface.redraw();
     }
-  }, [highlightStrokes]);
+  }, [ready, surface, highlightStrokes]);
 
   return (
     <canvas

--- a/editor/grida-canvas-react-renderer-canvas-wasm/use-grida2d.ts
+++ b/editor/grida-canvas-react-renderer-canvas-wasm/use-grida2d.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import init, { Grida2D } from "@grida/canvas-wasm";
 import locateFile from "./locate-file";
 
@@ -7,6 +7,7 @@ export function useGrida2D(
 ) {
   const rendererRef = useRef<Grida2D | null>(null);
   const isInitializedRef = useRef(false);
+  const [ready, setReady] = useState(false);
 
   useLayoutEffect(() => {
     if (canvasRef.current && !isInitializedRef.current) {
@@ -22,10 +23,11 @@ export function useGrida2D(
         // grida.setVerbose(true);
 
         rendererRef.current = grida;
+        setReady(true);
         console.log("grida wasm initialized");
       });
     }
   }, [canvasRef]);
 
-  return rendererRef;
+  return { surface: rendererRef.current, ready } as const;
 }


### PR DESCRIPTION
Resolves intermittent blank WASM canvas rendering and a deterministic 'pan then insert' rendering failure.

The issue stemmed from two root causes: a React race condition where effects dependent on the WASM surface were not reliably re-triggered upon its readiness, and a WASM renderer deadlock where a frame plan was not rebuilt when a redraw was already pending, leading to a 'pending but no plan' state.

---
<a href="https://cursor.com/background-agent?bcId=bc-86b8ed74-deb4-415b-bf99-e62baf0a4dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86b8ed74-deb4-415b-bf99-e62baf0a4dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

