### PR TITLE
fix: avoid mac traffic light overlap in console sidebar

### DIFF
--- a/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/layout.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(campaign)/campaigns/[campaign]/layout.tsx
@@ -28,6 +28,7 @@ import {
 import { AboutGridaWestCard } from "./about-west-card";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
+import { DarwinSidebarHeaderDragArea } from "@/host/desktop";
 type Params = { org: string; proj: string; campaign: string };
 
 export const metadata: Metadata = {
@@ -62,7 +63,8 @@ export default async function CampaignLayout({
         <div className="flex flex-1 h-full overflow-hidden">
           <div className="h-full flex flex-1 w-full">
             <Sidebar>
-              <SidebarHeader>
+              <DarwinSidebarHeaderDragArea />
+              <SidebarHeader className="desktop-drag-area">
                 <SidebarMenu>
                   <Link href={`/${org}/${proj}/campaigns`}>
                     <SidebarMenuItem>

--- a/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
+++ b/editor/app/(workbench)/[org]/[proj]/(console)/(resources)/layout.tsx
@@ -13,6 +13,7 @@ import {
 import { ArrowLeftIcon, OpenInNewWindowIcon } from "@radix-ui/react-icons";
 import { ResourceTypeIcon } from "@/components/resource-type-icon";
 import { previewlink } from "@/lib/internal/url";
+import { DarwinSidebarHeaderDragArea } from "@/host/desktop";
 import Link from "next/link";
 
 type Params = { org: string; proj: string };
@@ -31,7 +32,8 @@ export default async function Layout({
       <div className="flex flex-1 overflow-y-auto">
         <div className="h-full flex flex-1 w-full">
           <Sidebar>
-            <SidebarHeader>
+            <DarwinSidebarHeaderDragArea />
+            <SidebarHeader className="desktop-drag-area">
               <SidebarMenu>
                 <Link href={`/${org}/${proj}`}>
                   <SidebarMenuItem>


### PR DESCRIPTION
## Summary
- add DarwinSidebarHeaderDragArea to project console sidebars to account for macOS traffic lights

## Testing
- `npx turbo test --filter=./editor/...`

------
https://chatgpt.com/codex/tasks/task_e_68b009cde70c832abf2bb5180073b82c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a draggable header area in the sidebar for the desktop app on macOS, making it easier to move the window in Campaign and Resources views.

- Style
  - Applied desktop-specific styling to the sidebar header while keeping existing content and layout unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->