### PR TITLE
feat(www): add Grida Fonts to resources

### DIFF
--- a/editor/www/data/sitemap.ts
+++ b/editor/www/data/sitemap.ts
@@ -41,6 +41,7 @@ export namespace sitemap {
     studio: "https://grida.studio",
     corssh: "https://cors.sh",
     blog: "/blog",
+    fonts: "https://fonts.grida.co",
     changelog: "https://x.com/univ___erse",
   };
 
@@ -100,6 +101,11 @@ export namespace sitemap {
       title: "Library",
       href: links.library,
       description: "Free hand picked design resources",
+    } satisfies Item,
+    fonts: {
+      title: "Fonts",
+      href: links.fonts,
+      description: "Open Fonts API",
     } satisfies Item,
     tools: {
       title: "Tools",

--- a/editor/www/footer.tsx
+++ b/editor/www/footer.tsx
@@ -86,6 +86,12 @@ export default function Footer() {
                   Tools
                 </Link>
                 <Link
+                  href={sitemap.links.fonts}
+                  className="text-xs md:text-sm text-muted-foreground"
+                >
+                  Grida Fonts
+                </Link>
+                <Link
                   href={sitemap.links.ai_models}
                   className="text-xs md:text-sm text-muted-foreground"
                 >


### PR DESCRIPTION
## Summary
- add fonts link to sitemap with description "Open Fonts API"
- link Grida Fonts in footer resources
- avoid listing Fonts in header navigation

## Testing
- `pnpm test --filter=./editor/www`


------
https://chatgpt.com/codex/tasks/task_e_68b018f8ce40832a8656fdf2a458f702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated “Fonts” destination across the site.
  - New “Fonts” link in global navigation provides direct access to the Open Fonts API (fonts.grida.co).
  - Added “Grida Fonts” item in the footer’s Resources section for quicker discovery and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->