### PR TITLE
feat(cmath): add gradient transform from control points

### DIFF
--- a/packages/grida-cmath/__tests__/cmath.ui.gradient.test.ts
+++ b/packages/grida-cmath/__tests__/cmath.ui.gradient.test.ts
@@ -1,0 +1,69 @@
+import cmath from "..";
+
+describe("cmath.ui.gradient", () => {
+  it("returns identity transform for base linear gradient", () => {
+    const points = cmath.ui.gradient.baseControlPoints("linear_gradient");
+    const t = cmath.ui.gradient.transformFromControlPoints(
+      points,
+      "linear_gradient"
+    );
+    expect(t[0][0]).toBeCloseTo(1);
+    expect(t[0][1]).toBeCloseTo(0);
+    expect(t[0][2]).toBeCloseTo(0);
+    expect(t[1][0]).toBeCloseTo(0);
+    expect(t[1][1]).toBeCloseTo(1);
+    expect(t[1][2]).toBeCloseTo(0);
+  });
+
+  it("returns identity transform for base radial gradient", () => {
+    const points = cmath.ui.gradient.baseControlPoints("radial_gradient");
+    const t = cmath.ui.gradient.transformFromControlPoints(
+      points,
+      "radial_gradient"
+    );
+    expect(t[0][0]).toBeCloseTo(1);
+    expect(t[0][1]).toBeCloseTo(0);
+    expect(t[0][2]).toBeCloseTo(0);
+    expect(t[1][0]).toBeCloseTo(0);
+    expect(t[1][1]).toBeCloseTo(1);
+    expect(t[1][2]).toBeCloseTo(0);
+  });
+
+  it("translates radial gradient control points", () => {
+    const base = cmath.ui.gradient.baseControlPoints("radial_gradient");
+    const t: cmath.Vector2 = [0.2, 0.3];
+    const points = {
+      A: [base.A[0] + t[0], base.A[1] + t[1]] as cmath.Vector2,
+      B: [base.B[0] + t[0], base.B[1] + t[1]] as cmath.Vector2,
+      C: [base.C[0] + t[0], base.C[1] + t[1]] as cmath.Vector2,
+    };
+    const transform = cmath.ui.gradient.transformFromControlPoints(
+      points,
+      "radial_gradient"
+    );
+    expect(transform[0][2]).toBeCloseTo(t[0]);
+    expect(transform[1][2]).toBeCloseTo(t[1]);
+    expect(transform[0][0]).toBeCloseTo(1);
+    expect(transform[1][1]).toBeCloseTo(1);
+  });
+
+  it("computes rotation for linear gradient", () => {
+    const base = cmath.ui.gradient.baseControlPoints("linear_gradient");
+    const points = {
+      A: [0.5, 0.5] as cmath.Vector2,
+      B: [0.5, 1.5] as cmath.Vector2,
+      C: base.C,
+    };
+    const transform = cmath.ui.gradient.transformFromControlPoints(
+      points,
+      "linear_gradient"
+    );
+    expect(transform[0][0]).toBeCloseTo(0);
+    expect(transform[0][1]).toBeCloseTo(-1);
+    expect(transform[1][0]).toBeCloseTo(1);
+    expect(transform[1][1]).toBeCloseTo(0);
+    expect(transform[0][2]).toBeCloseTo(1);
+    expect(transform[1][2]).toBeCloseTo(0.5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `cmath.ui.gradient` namespace for control point transforms
- switch Figma IO gradient mapping to new cmath utility
- cover gradient transform logic with tests

## Testing
- `pnpm turbo test --filter=./packages/grida-cmath --filter=./packages/grida-canvas-io-figma`

------
https://chatgpt.com/codex/tasks/task_e_68b34704e8e0832a909692a3b728608b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced gradient control-point and transformation utilities in the math library, enabling consistent, accurate gradient handling across the app.

- Refactor
  - Replaced local gradient calculations in the Figma importer with shared math utilities. No changes to the public API.

- Tests
  - Added comprehensive tests validating base, translation, and rotation behaviors for gradient transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->