### PR TITLE
[Grida Canvas] A11y - Copy As PNG

### DIFF
--- a/docs/editor/features/README.md
+++ b/docs/editor/features/README.md
@@ -2,3 +2,4 @@
 - [re-ordering properties](./property-re-order.md)
 - [hide and show right inspection panel](./right-inspector-panel-show-hide.md)
 - [vector network editor](./vector-network-editor.md)
+- [copy selection as PNG](./copy-as-png.md)

--- a/docs/editor/features/copy-as-png.md
+++ b/docs/editor/features/copy-as-png.md
@@ -1,0 +1,9 @@
+# Copy as PNG
+
+Copy the current selection to the system clipboard as a PNG image.
+
+- **Keyboard**: Cmd + Shift + C
+- **Context menu**: Copy/Paste as… → Copy as PNG
+
+This feature is available only when using the canvas (WASM) backend.
+

--- a/docs/editor/shortcuts/index.md
+++ b/docs/editor/shortcuts/index.md
@@ -12,3 +12,4 @@
 | Text tool            | T         |
 | Cursor (Select) tool | V         |
 | Lasso tool           | Q         |
+| Copy as PNG          | Cmd + Shift + C |

--- a/editor/grida-canvas-react/use-context-menu-actions.ts
+++ b/editor/grida-canvas-react/use-context-menu-actions.ts
@@ -14,6 +14,7 @@ export interface ContextMenuAction {
 type ContextMenuActionType =
   | "copy"
   | "paste"
+  | "copyAsPNG"
   | "bringToFront"
   | "sendToBack"
   | "groupWithContainer"
@@ -102,6 +103,12 @@ export function useContextMenuActions(ids: string[]): ContextMenuActions {
       paste: {
         label: "Paste",
         onSelect: handlePaste,
+      },
+      copyAsPNG: {
+        label: "Copy as PNG",
+        shortcut: "⇧⌘C",
+        disabled: backend !== "canvas" || !hasSelection,
+        onSelect: () => editor.a11yCopyAsImage("png"),
       },
       bringToFront: {
         label: "Bring to front",
@@ -192,6 +199,7 @@ export function useContextMenuActions(ids: string[]): ContextMenuActions {
       hasSelection,
       canFlatten,
       targetSingleOrSelection,
+      backend,
     ]
   );
 }

--- a/editor/grida-canvas-react/viewport/hotkeys.tsx
+++ b/editor/grida-canvas-react/viewport/hotkeys.tsx
@@ -58,6 +58,11 @@ export const keybindings_sheet = [
     keys: ["meta+c"],
   },
   {
+    name: "copy as png",
+    description: "Copy selection as PNG",
+    keys: ["meta+shift+c"],
+  },
+  {
     name: "paste",
     description: "Paste from the clipboard",
     keys: ["meta+v"],
@@ -744,6 +749,24 @@ export function useEditorHotKeys() {
     enableOnContentEditable: false,
     enableOnFormTags: false,
   });
+
+  useHotkeys(
+    "meta+shift+c, ctrl+shift+c",
+    () => {
+      if (editor.backend === "canvas") {
+        const task = editor.a11yCopyAsImage("png");
+        toast.promise(task, {
+          success: "Copied as PNG",
+          error: "Failed to copy as PNG",
+        });
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnContentEditable: false,
+      enableOnFormTags: false,
+    }
+  );
 
   // paste is handled via data transfer
   // useHotkeys("paste, meta+v, ctrl+v", () => editor.a11yPaste(), {

--- a/editor/grida-canvas-react/viewport/surface-context-menu.tsx
+++ b/editor/grida-canvas-react/viewport/surface-context-menu.tsx
@@ -54,6 +54,14 @@ function ContextMenuContent() {
     <_ContextMenuContent className="w-52">
       <ActionItem action={actions.copy} />
       <ActionItem action={actions.paste} />
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="text-xs">
+          Copy/Paste as...
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          <ActionItem action={actions.copyAsPNG} />
+        </ContextMenuSubContent>
+      </ContextMenuSub>
       <ContextMenuSeparator />
       <ActionItem action={actions.bringToFront} />
       <ActionItem action={actions.sendToBack} />

--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -712,6 +712,35 @@ export class Editor
     });
   }
 
+  public async writeClipboardMedia(
+    target: "selection" | editor.NodeID,
+    format: "png"
+  ): Promise<boolean> {
+    assert(this.backend === "canvas", "Editor is not using canvas backend");
+    const ids = target === "selection" ? this.mstate.selection : [target];
+    if (ids.length === 0) return false;
+    const id = ids[0];
+    const data = await this.exportNodeAs(id, "PNG");
+    const blob = new Blob([data], { type: "image/png" });
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    return true;
+  }
+
+  public async a11yCopyAsImage(format: "png"): Promise<boolean> {
+    if (this.mstate.content_edit_mode?.type === "vector") {
+      const { selected_vertices, selected_segments, selected_tangents } =
+        this.mstate.content_edit_mode.selection;
+      const hasSelection =
+        selected_vertices.length > 0 ||
+        selected_segments.length > 0 ||
+        selected_tangents.length > 0;
+      if (!hasSelection) return false;
+    } else {
+      if (this.mstate.selection.length === 0) return false;
+    }
+    return await this.writeClipboardMedia("selection", format);
+  }
+
   public a11yCopy() {
     if (this.mstate.content_edit_mode?.type === "vector") {
       const { selected_vertices, selected_segments, selected_tangents } =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Copy selection as PNG to the system clipboard.
  - Keyboard shortcuts: Cmd+Shift+C (macOS) / Ctrl+Shift+C (Windows/Linux).
  - Context menu: Copy/Paste as… → Copy as PNG.
  - Availability: Canvas (WASM) backend only.
  - Feedback: Shows success or error notification after attempting to copy.

- Documentation
  - Added “Copy as PNG” feature documentation.
  - Linked from the Editor features list.
  - Updated Shortcuts table with the new command and shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->