### PR TITLE
fix: ux issues with number gesture for radius/rotation and color picker

### DIFF
--- a/editor/grida-canvas-hosted/playground/toolbar.tsx
+++ b/editor/grida-canvas-hosted/playground/toolbar.tsx
@@ -368,7 +368,7 @@ function ClipboardColor() {
       >
         <ColorPicker
           color={color}
-          onColorChange={editor.surface.a11ySetClipboardColor.bind(editor)}
+          onColorChange={editor.surface.a11ySetClipboardColor.bind(editor.surface)}
           options={options}
         />
       </PopoverContent>

--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -1525,31 +1525,22 @@ class EditorDocumentStore
     const node = this.getNodeSnapshotById(
       node_id
     ) as grida.program.nodes.UnknwonNode;
-    const allCornerRadius = {
-      cornerRadius: node.cornerRadius,
-      cornerRadiusTopLeft: node.cornerRadiusTopLeft,
-      cornerRadiusTopRight: node.cornerRadiusTopRight,
-      cornerRadiusBottomRight: node.cornerRadiusBottomRight,
-      cornerRadiusBottomLeft: node.cornerRadiusBottomLeft,
+
+    const applyDelta = (
+      currentValue: number | undefined,
+      delta: number
+    ): number => {
+      const startValue = currentValue ?? 0;
+      const newValue = startValue + delta;
+      return Math.max(0, newValue);
     };
 
     const next = {
-      ...allCornerRadius,
-      cornerRadius: allCornerRadius.cornerRadius
-        ? allCornerRadius.cornerRadius + delta
-        : undefined,
-      cornerRadiusTopLeft: allCornerRadius.cornerRadiusTopLeft
-        ? allCornerRadius.cornerRadiusTopLeft + delta
-        : undefined,
-      cornerRadiusTopRight: allCornerRadius.cornerRadiusTopRight
-        ? allCornerRadius.cornerRadiusTopRight + delta
-        : undefined,
-      cornerRadiusBottomRight: allCornerRadius.cornerRadiusBottomRight
-        ? allCornerRadius.cornerRadiusBottomRight + delta
-        : undefined,
-      cornerRadiusBottomLeft: allCornerRadius.cornerRadiusBottomLeft
-        ? allCornerRadius.cornerRadiusBottomLeft + delta
-        : undefined,
+      cornerRadius: applyDelta(node.cornerRadius, delta),
+      cornerRadiusTopLeft: applyDelta(node.cornerRadiusTopLeft, delta),
+      cornerRadiusTopRight: applyDelta(node.cornerRadiusTopRight, delta),
+      cornerRadiusBottomRight: applyDelta(node.cornerRadiusBottomRight, delta),
+      cornerRadiusBottomLeft: applyDelta(node.cornerRadiusBottomLeft, delta),
     };
 
     this.dispatch({
@@ -4102,7 +4093,7 @@ export class NodeProxy<T extends grida.program.nodes.Node> {
     });
   }
 
-  public changeRotation(change: editor.api.NumberChange) {
+  public changeRotation = (change: editor.api.NumberChange) => {
     const value = resolveNumberChangeValue(
       this.doc.getNodeSnapshotById(
         this.node_id

--- a/editor/scaffolds/sidecontrol/controls/corner-radius.tsx
+++ b/editor/scaffolds/sidecontrol/controls/corner-radius.tsx
@@ -156,6 +156,7 @@ function Radius4Control({
             type="number"
             value={topLeft}
             onValueCommit={(v) => onCommit(v, 0)}
+            min={0}
           />
         </PropertyInputContainer>
         <PropertyInputContainer>
@@ -165,6 +166,7 @@ function Radius4Control({
             type="number"
             value={topRight}
             onValueCommit={(v) => onCommit(v, 1)}
+            min={0}
           />
         </PropertyInputContainer>
       </div>
@@ -176,6 +178,7 @@ function Radius4Control({
             type="number"
             value={bottomLeft}
             onValueCommit={(v) => onCommit(v, 3)}
+            min={0}
           />
         </PropertyInputContainer>
         <PropertyInputContainer>
@@ -185,6 +188,7 @@ function Radius4Control({
             type="number"
             value={bottomRight}
             onValueCommit={(v) => onCommit(v, 2)}
+            min={0}
           />
         </PropertyInputContainer>
       </div>

--- a/editor/scaffolds/sidecontrol/ui/label-with-number-gesture.tsx
+++ b/editor/scaffolds/sidecontrol/ui/label-with-number-gesture.tsx
@@ -24,6 +24,7 @@ export function PropertyLineLabelWithNumberGesture({
     sensitivity,
     onValueChange: onValueChange,
     axisForValue: "x",
+    uxPointerLock: false,
   });
 
   return (


### PR DESCRIPTION
fix some issues with radius/rotation input and color picker as the below video shows, and I changed the cursor behavior when sliding on the title. I think keeping the `cursor-ew-resize` showing is better ?  


https://github.com/user-attachments/assets/1a7f937a-c351-4cdd-ad7d-fe34cebb7871



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corner radius inputs now enforce non-negative values, preventing invalid negative entries during editing.

* **Refactor**
  * Improved internal corner radius calculation logic for better consistency.
  * Optimized gesture handling configuration in number input interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->