### PR TITLE
Grida canvas- add bool ops shortcut

### DIFF
--- a/editor/grida-canvas-hosted/playground/uxhost-actions.ts
+++ b/editor/grida-canvas-hosted/playground/uxhost-actions.ts
@@ -486,6 +486,31 @@ export const actions = {
     ],
   },
 
+  ["workbench.surface.object.boolean-union"]: {
+    name: "boolean union",
+    description: "Combine selection using union operation",
+    command: "editor.surface.action.booleanUnion",
+    keybindings: kb(KeyCode.KeyU, M.Alt | M.Shift),
+  },
+  ["workbench.surface.object.boolean-subtract"]: {
+    name: "boolean subtract",
+    description: "Subtract selection using difference operation",
+    command: "editor.surface.action.booleanSubtract",
+    keybindings: kb(KeyCode.KeyS, M.Alt | M.Shift),
+  },
+  ["workbench.surface.object.boolean-intersect"]: {
+    name: "boolean intersect",
+    description: "Intersect selection using intersection operation",
+    command: "editor.surface.action.booleanIntersect",
+    keybindings: kb(KeyCode.KeyI, M.Alt | M.Shift),
+  },
+  ["workbench.surface.object.boolean-exclude"]: {
+    name: "boolean exclude",
+    description: "Exclude selection using xor operation",
+    command: "editor.surface.action.booleanExclude",
+    keybindings: kb(KeyCode.KeyE, M.Alt | M.Shift),
+  },
+
   // TODO:
   ["workbench.surface.object.outline-stroke"]: {
     name: "outline stroke",

--- a/editor/grida-canvas-hosted/playground/uxhost-menu.md
+++ b/editor/grida-canvas-hosted/playground/uxhost-menu.md
@@ -96,10 +96,10 @@
 | `Object > Rotate 90° right`                                   | Rotate 90° right               | Rotates selection 90 degrees clockwise          | —        | ❌    |
 | `Object > Flatten`                                            | Flatten                        | Converts selection to vector paths              | ⌘E       | ✅    |
 | `Object > Outline stroke`                                     | Outline stroke                 | Converts stroke to filled shape                 | ⌥⌘O      | ❌    |
-| `Object > Boolean groups > Union`                             | Union                          | Combines shapes using union operation           | —        | ✅    |
-| `Object > Boolean groups > Subtract`                          | Subtract                       | Subtracts shapes using subtract operation       | —        | ✅    |
-| `Object > Boolean groups > Intersect`                         | Intersect                      | Creates intersection of shapes                  | —        | ✅    |
-| `Object > Boolean groups > Exclude`                           | Exclude                        | Creates exclusion of shapes                     | —        | ✅    |
+| `Object > Boolean groups > Union`                             | Union                          | Combines shapes using union operation           | ⌥⇧U      | ✅    |
+| `Object > Boolean groups > Subtract`                          | Subtract                       | Subtracts shapes using subtract operation       | ⌥⇧S      | ✅    |
+| `Object > Boolean groups > Intersect`                         | Intersect                      | Creates intersection of shapes                  | ⌥⇧I      | ✅    |
+| `Object > Boolean groups > Exclude`                           | Exclude                        | Creates exclusion of shapes                     | ⌥⇧E      | ✅    |
 | `Object > Rasterize selection`                                | Rasterize selection            | Converts selection to raster image              | —        | ❌    |
 | `Object > Show/Hide selection`                                | Show/Hide selection            | Toggles visibility of selection                 | ⇧⌘H      | ✅    |
 | `Object > Lock/Unlock selection`                              | Lock/Unlock selection          | Toggles lock state of selection                 | ⇧⌘L      | ✅    |

--- a/editor/grida-canvas-hosted/playground/uxhost-menu.tsx
+++ b/editor/grida-canvas-hosted/playground/uxhost-menu.tsx
@@ -1361,6 +1361,9 @@ function ObjectMenuContent() {
               className="text-xs"
             >
               Union
+              <DropdownMenuShortcut>
+                {keyboardShortcutText("workbench.surface.object.boolean-union")}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => instance.commands.subtract(selection)}
@@ -1368,6 +1371,9 @@ function ObjectMenuContent() {
               className="text-xs"
             >
               Subtract
+              <DropdownMenuShortcut>
+                {keyboardShortcutText("workbench.surface.object.boolean-subtract")}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => instance.commands.intersect(selection)}
@@ -1375,6 +1381,9 @@ function ObjectMenuContent() {
               className="text-xs"
             >
               Intersect
+              <DropdownMenuShortcut>
+                {keyboardShortcutText("workbench.surface.object.boolean-intersect")}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => instance.commands.exclude(selection)}
@@ -1382,6 +1391,9 @@ function ObjectMenuContent() {
               className="text-xs"
             >
               Exclude
+              <DropdownMenuShortcut>
+                {keyboardShortcutText("workbench.surface.object.boolean-exclude")}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>

--- a/editor/grida-canvas-react/viewport/hotkeys.tsx
+++ b/editor/grida-canvas-react/viewport/hotkeys.tsx
@@ -523,6 +523,83 @@ export function useEditorHotKeys() {
     }
   );
 
+  // Boolean operations
+  useHotkeys(
+    "alt+shift+u",
+    () => {
+      if (editor.backend !== "canvas") return;
+      if (selection.length < 2) return;
+      try {
+        editor.commands.op(selection, "union");
+      } catch (e) {
+        console.error(e);
+        toast.error("Boolean union failed");
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    }
+  );
+
+  useHotkeys(
+    "alt+shift+s",
+    () => {
+      if (editor.backend !== "canvas") return;
+      if (selection.length < 2) return;
+      try {
+        editor.commands.op(selection, "difference");
+      } catch (e) {
+        console.error(e);
+        toast.error("Boolean subtract failed");
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    }
+  );
+
+  useHotkeys(
+    "alt+shift+i",
+    () => {
+      if (editor.backend !== "canvas") return;
+      if (selection.length < 2) return;
+      try {
+        editor.commands.op(selection, "intersection");
+      } catch (e) {
+        console.error(e);
+        toast.error("Boolean intersect failed");
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    }
+  );
+
+  useHotkeys(
+    "alt+shift+e",
+    () => {
+      if (editor.backend !== "canvas") return;
+      if (selection.length < 2) return;
+      try {
+        editor.commands.op(selection, "xor");
+      } catch (e) {
+        console.error(e);
+        toast.error("Boolean exclude failed");
+      }
+    },
+    {
+      preventDefault: true,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    }
+  );
+
   useHotkeys("shift+h", () => {
     // TODO:
     toast.error("[flip horizontal] is not implemented yet");

--- a/editor/scaffolds/sidecontrol/controls/ext-ops.tsx
+++ b/editor/scaffolds/sidecontrol/controls/ext-ops.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import cg from "@grida/cg";
@@ -14,6 +15,7 @@ import {
   SquaresIntersectIcon,
   SquaresUniteIcon,
 } from "lucide-react";
+import { keyboardShortcutText } from "@/grida-canvas-hosted/playground/uxhost-shortcut-renderer";
 
 export function OpsControl({
   disabled,
@@ -55,6 +57,9 @@ export function OpsControl({
           >
             <SquaresUniteIcon className="size-4" />
             Union
+            <DropdownMenuShortcut>
+              {keyboardShortcutText("workbench.surface.object.boolean-union")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-xs"
@@ -63,6 +68,9 @@ export function OpsControl({
           >
             <SquaresSubtractIcon className="size-4" />
             Subtract
+            <DropdownMenuShortcut>
+              {keyboardShortcutText("workbench.surface.object.boolean-subtract")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-xs"
@@ -71,6 +79,9 @@ export function OpsControl({
           >
             <SquaresIntersectIcon className="size-4" />
             Intersect
+            <DropdownMenuShortcut>
+              {keyboardShortcutText("workbench.surface.object.boolean-intersect")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-xs"
@@ -79,6 +90,9 @@ export function OpsControl({
           >
             <SquaresExcludeIcon className="size-4" />
             Exclude
+            <DropdownMenuShortcut>
+              {keyboardShortcutText("workbench.surface.object.boolean-exclude")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four boolean operations for shape manipulation: Union, Subtract, Intersect, and Exclude
  * Keyboard shortcuts now available for each operation (Alt+Shift+U, Alt+Shift+S, Alt+Shift+I, Alt+Shift+E)
  * Shortcuts are displayed in the Object menu for quick reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->