### PR TITLE
feat: add Rust toolchain configuration and update CI workflow

### DIFF
--- a/.github/workflows/build-canvas.yml
+++ b/.github/workflows/build-canvas.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
 
       - name: Add wasm32-unknown-emscripten target
         run: rustup target add wasm32-unknown-emscripten

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+profile = "minimal"


### PR DESCRIPTION
- Introduced a new `rust-toolchain.toml` file specifying the Rust version 1.92.0 with a minimal profile.
- Updated the GitHub Actions workflow to use the specified Rust toolchain version for builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/config-only change that pins the compiler version; main risk is unexpected build breakage if some crates rely on a different Rust version.
> 
> **Overview**
> Pins the project’s Rust toolchain to `1.92.0` by adding `rust-toolchain.toml` (minimal profile), making local and CI builds use a consistent compiler version.
> 
> Updates the `build-canvas` GitHub Actions workflow to explicitly install Rust `1.92.0` via `dtolnay/rust-toolchain`, reducing CI drift from `stable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce2b36f3b923c861515b76707b558b29344e37e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured explicit Rust toolchain version (1.92.0) for builds via GitHub Actions workflow and new toolchain configuration file with minimal profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->