### PR TITLE
Refactor API hooks to use dynamic base URL for hosted environments

### DIFF
--- a/editor/app/(api)/(public)/v1/submit/[id]/hooks.ts
+++ b/editor/app/(api)/(public)/v1/submit/[id]/hooks.ts
@@ -4,7 +4,10 @@ import { Env } from "@/env";
 import { resend } from "@/clients/resend";
 import EmailTemplate from "@/theme/templates-email/formcomplete/default";
 
-const GRIDA_S2S_PRIVATE_API_KEY = process.env.GRIDA_S2S_PRIVATE_API_KEY;
+// In hosted env, avoid calling the deployment domain (`*.vercel.app`) since it
+// can be protected upstream (401) even when our app routes would allow it.
+const HOOK_BASE_URL = Env.server.IS_HOSTED ? Env.web.HOST : Env.server.HOST;
+const GRIDA_S2S_PRIVATE_API_KEY = process.env.GRIDA_S2S_PRIVATE_API_KEY ?? null;
 
 const bird = new Bird(
   process.env.BIRD_WORKSPACE_ID as string,
@@ -24,7 +27,7 @@ export namespace OnSubmit {
     response_id: string;
     session_id: string;
   }) {
-    return fetch(`${Env.server.HOST}/v1/submit/${form_id}/hooks/clearsession`, {
+    return fetch(`${HOOK_BASE_URL}/v1/submit/${form_id}/hooks/clearsession`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -43,7 +46,7 @@ export namespace OnSubmit {
     form_id: string;
     response_id: string;
   }) {
-    return fetch(`${Env.server.HOST}/v1/submit/${form_id}/hooks/postindexing`, {
+    return fetch(`${HOOK_BASE_URL}/v1/submit/${form_id}/hooks/postindexing`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -62,7 +65,7 @@ export namespace OnSubmit {
     response_id: string;
   }) {
     return fetch(
-      `${Env.server.HOST}/v1/submit/${form_id}/hooks/notification-respondent-email`,
+      `${HOOK_BASE_URL}/v1/submit/${form_id}/hooks/notification-respondent-email`,
       {
         headers: {
           "Content-Type": "application/json",

--- a/editor/app/(api)/(public)/v1/submit/[id]/hooks/notification-respondent-email/route.ts
+++ b/editor/app/(api)/(public)/v1/submit/[id]/hooks/notification-respondent-email/route.ts
@@ -14,7 +14,7 @@ type Params = { id: string };
  * This route uses `service_role` and can send emails, so it must not be
  * callable by arbitrary third-parties.
  */
-const GRIDA_S2S_PRIVATE_API_KEY = process.env.GRIDA_S2S_PRIVATE_API_KEY;
+const GRIDA_S2S_PRIVATE_API_KEY = process.env.GRIDA_S2S_PRIVATE_API_KEY ?? null;
 
 export async function POST(
   req: NextRequest,
@@ -22,8 +22,7 @@ export async function POST(
     params: Promise<Params>;
   }
 ) {
-  const provided =
-    req.headers.get("x-grida-s2s-key") ?? req.headers.get("x-hook-secret");
+  const provided = req.headers.get("x-grida-s2s-key");
   if (!GRIDA_S2S_PRIVATE_API_KEY) {
     console.error(
       "notification-respondent-email/err/misconfigured: GRIDA_S2S_PRIVATE_API_KEY missing"


### PR DESCRIPTION
Update the API hooks in the submission process to utilize a dynamic base URL that adapts based on the hosting environment. This change prevents potential 401 errors when accessing protected domains and ensures the GRIDA S2S private API key is safely handled. Additionally, clean up the handling of the API key in the notification email route for improved security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling for API configuration to ensure consistent default values.

* **Chores**
  * Simplified API header validation logic for better maintainability.
  * Updated API endpoint configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->