### PR TITLE
Cmd+b sidebar shortcut

### DIFF
--- a/editor/components/ui/sidebar.tsx
+++ b/editor/components/ui/sidebar.tsx
@@ -30,7 +30,7 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
-const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_KEYBOARD_SHORTCUT = "";
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";


### PR DESCRIPTION
Disable the Cmd+B keyboard shortcut for the sidebar.

This prevents conflicts with other shortcuts (e.g., toggle bold in the canvas) by setting the `SIDEBAR_KEYBOARD_SHORTCUT` constant to an empty string, which `event.key` will never match.

---
<p><a href="https://cursor.com/agents?id=bc-b9d3baec-4373-48be-a1af-bfc0e3eb12ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9d3baec-4373-48be-a1af-bfc0e3eb12ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Disabled the keyboard shortcut for toggling the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->