### PR TITLE
Pasted text properties

### DIFF
--- a/editor/grida-canvas/editor.ts
+++ b/editor/grida-canvas/editor.ts
@@ -762,7 +762,8 @@ class EditorDocumentStore
     text = ""
   ): NodeProxy<grida.program.nodes.TextSpanNode> {
     const id = this.idgen.next();
-    // Use explicit scene-level target for programmatic text node creation
+    // Use explicit scene-level target for programmatic text node creation.
+    // Include key text properties so pasted/external text respects the contract.
     this.insert(
       {
         id: id,
@@ -772,6 +773,12 @@ class EditorDocumentStore
           text: text,
           layout_target_width: "auto",
           layout_target_height: "auto",
+          layout_positioning: "absolute",
+          layout_inset_left: 0,
+          layout_inset_top: 0,
+          ...editor.config.fonts.DEFAULT_TEXT_STYLE_INTER,
+          text_align: "left",
+          text_align_vertical: "top",
           fill: {
             type: "solid",
             color: kolor.colorformats.RGBA32F.BLACK,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update `createTextNode` to include default text properties for pasted text.

This ensures that externally pasted text respects the `TextSpanNode` contract by filling in missing key properties like font size, alignment, and positioning, preventing malformed text nodes.

---
<p><a href="https://cursor.com/agents/bc-9f6eb902-51a5-4873-8250-16e3c3933992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f6eb902-51a5-4873-8250-16e3c3933992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Text nodes now initialize with complete default styling, positioning, and alignment properties, ensuring consistent behavior when created in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->