### PR TITLE
Canvas library shortcut label

### DIFF
--- a/editor/grida-canvas-hosted/playground/playground.tsx
+++ b/editor/grida-canvas-hosted/playground/playground.tsx
@@ -886,7 +886,7 @@ function SidebarLeft({
             <div className="flex items-center gap-2">
               <span>Open Library</span>
               <KbdGroup>
-                <Kbd>{uikbdk(M.CtrlCmd)}</Kbd>
+                <Kbd>{uikbdk(M.Shift)}</Kbd>
                 <Kbd>{uikbdk(KeyCode.KeyI)}</Kbd>
               </KbdGroup>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Correct the Library button's shortcut label from Cmd+I to Shift+I to match the actual hotkey.

---
<p><a href="https://cursor.com/agents/bc-12e35fb6-932e-4dc6-8ffa-40b4e04e8715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12e35fb6-932e-4dc6-8ffa-40b4e04e8715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the keyboard shortcut hint in the "Open Library" tooltip to correctly display Shift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->