### PR TITLE
Scene deletion headless tree

### DIFF
--- a/editor/grida-canvas-react-starter-kit/starterkit-hierarchy/tree-scene.tsx
+++ b/editor/grida-canvas-react-starter-kit/starterkit-hierarchy/tree-scene.tsx
@@ -163,7 +163,14 @@ export function ScenesList() {
     },
     dataLoader: {
       getItem(itemId) {
-        return scenesmap[itemId];
+        const item = scenesmap[itemId];
+        if (item) return item;
+        // Root or deleted scene: tree may hold stale refs until rebuildTree runs.
+        // Return a stub so syncDataLoaderFeature doesn't throw "returned undefined".
+        if (itemId === "<document>") {
+          return { id: "<document>", name: "<document>" } as grida.program.nodes.SceneNode;
+        }
+        return { id: itemId, name: "" } as grida.program.nodes.SceneNode;
       },
       getChildren: (itemId) => {
         if (itemId === "<document>") {
@@ -210,7 +217,7 @@ export function ScenesList() {
     <Tree tree={tree} indent={0}>
       {tree.getItems().map((item) => {
         const scene = item.getItemData();
-        if (!scene) return null;
+        if (!scene || !scenesmap[scene.id]) return null;
         const isRenaming = item.isRenaming();
         return (
           <SceneItemContextMenuWrapper


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevent "Headless Tree: sync dataLoader returned undefined" error when deleting a scene by making the data loader robust to stale cache.

The error occurred because React re-rendered after a scene deletion before the tree's internal cache could be rebuilt. This led the tree's `dataLoader` to attempt fetching a non-existent item, returning `undefined` and causing a crash. The fix ensures `getItem` returns a stub for missing items and that deleted items are filtered out during render, preventing the race condition.

---
<p><a href="https://cursor.com/agents/bc-7f7bc08b-2736-4c34-8e52-54d7b53172d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f7bc08b-2736-4c34-8e52-54d7b53172d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing or stale scene references in the canvas hierarchy, preventing rendering errors when data becomes unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->