### PR TITLE
chore: Body images full width

### DIFF
--- a/editor/theme/templates/enterprise/west-referral/invitation/page.tsx
+++ b/editor/theme/templates/enterprise/west-referral/invitation/page.tsx
@@ -349,7 +349,7 @@ export default function InvitationPageTemplate({
               {t.about_event}
             </header>
             {design.article && (
-              <article className="prose prose-sm dark:prose-invert prose-img:w-full">
+              <article className="prose prose-sm dark:prose-invert prose-img:!w-full">
                 <span
                   dangerouslySetInnerHTML={{ __html: design.article.html }}
                 />

--- a/editor/theme/templates/enterprise/west-referral/referrer/page.tsx
+++ b/editor/theme/templates/enterprise/west-referral/referrer/page.tsx
@@ -419,7 +419,7 @@ export default function ReferrerPageTemplate({
               </header>
 
               {design.article && (
-                <article className="prose prose-sm dark:prose-invert prose-img:w-full">
+                <article className="prose prose-sm dark:prose-invert prose-img:!w-full">
                   <span
                     dangerouslySetInnerHTML={{ __html: design.article.html }}
                   />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Force all images within the referral event page prose body to be full width.

The `prose-img:!w-full` Tailwind class with `!important` ensures that images embedded in the prose body of referral event pages (referrer and invitation) always render at full width, overriding any inline styles or other CSS provided by users in their HTML content. This addresses the lack of control over image width in user-generated HTML.

---
[Slack Thread](https://gridaco.slack.com/archives/D092H6CJCFL/p1772947797590659?thread_ts=1772947797.590659&cid=D092H6CJCFL)

<p><a href="https://cursor.com/agents/bc-eab03f0e-4e49-5765-8f03-b368c8a2291e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eab03f0e-4e49-5765-8f03-b368c8a2291e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced image rendering in article content on enterprise referral pages to display images at full width for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->