### PR TITLE
feat(hud): canvas-based snap guide overlay

### DIFF
--- a/editor/grida-canvas-react/viewport/ui/snap.tsx
+++ b/editor/grida-canvas-react/viewport/ui/snap.tsx
@@ -6,13 +6,11 @@ import {
   useTransformState,
 } from "@/grida-canvas-react/provider";
 import { useCurrentEditor, useEditorState } from "@/grida-canvas-react";
-import cmath from "@grida/cmath";
-import { guide } from "@grida/cmath/_snap";
-import { Crosshair } from "./crosshair";
-import { Rule } from "./rule";
-import { Line } from "./line";
+import { useViewport } from "../context";
+import { SnapGuide as SnapGuideCanvas } from "@grida/hud/react";
+import { WorkbenchColors } from "@/grida-canvas-react/ui-config";
 
-function useSnapGuide(): guide.SnapGuide | undefined {
+export function SnapGuide() {
   const editor = useCurrentEditor();
   const surface_snapping = useEditorState(
     editor,
@@ -22,6 +20,7 @@ function useSnapGuide(): guide.SnapGuide | undefined {
   const { gesture } = useGestureState();
   const cem = useContentEditModeMinimalState();
   const tool = useToolState();
+  const viewport = useViewport();
 
   const shouldShow = useMemo(
     () =>
@@ -34,60 +33,16 @@ function useSnapGuide(): guide.SnapGuide | undefined {
     [gesture, cem?.type, tool.type]
   );
 
-  return useMemo(() => {
-    if (shouldShow && surface_snapping) {
-      const { lines, points, rules: rays } = guide.plot(surface_snapping);
-      // finally, map the vectors to the surface space
-      return {
-        lines: lines.map((l) => cmath.ui.transformLine(l, transform)),
-        points: points.map((p) => cmath.vector2.transform(p, transform)),
-        rules: rays.map((r) => {
-          const axis = r[0];
-          return [axis, cmath.delta.transform(r[1], axis, transform)];
-        }),
-      } satisfies guide.SnapGuide;
-    }
-  }, [shouldShow, transform, surface_snapping]);
-}
-
-const Z_INDEX = 999999;
-
-export function SnapGuide() {
-  const guide = useSnapGuide();
-
-  if (!guide) return <></>;
+  const snapping = shouldShow ? surface_snapping : undefined;
 
   return (
-    <div className="pointer-events-none">
-      {guide.lines.map((l, i) => (
-        <Line key={i} {...l} zIndex={Z_INDEX} />
-      ))}
-      {guide.rules.map(([axis, offset], i) => (
-        <Rule
-          key={i}
-          axis={cmath.counterAxis(axis)}
-          offset={offset}
-          width={1}
-          zIndex={Z_INDEX}
-        />
-      ))}
-      {guide.points.map((p, i) => {
-        return (
-          <div
-            key={i}
-            style={{
-              position: "absolute",
-              zIndex: Z_INDEX,
-              left: p[0],
-              top: p[1],
-              transform: "translate(-50%, -50%)",
-              willChange: "transform",
-            }}
-          >
-            <Crosshair />
-          </div>
-        );
-      })}
-    </div>
+    <SnapGuideCanvas
+      width={viewport?.clientWidth ?? 0}
+      height={viewport?.clientHeight ?? 0}
+      transform={transform}
+      snapping={snapping}
+      color={WorkbenchColors.red}
+      className="fixed inset-0"
+    />
   );
 }

--- a/editor/grida-canvas-react/viewport/ui/snap.tsx
+++ b/editor/grida-canvas-react/viewport/ui/snap.tsx
@@ -42,7 +42,7 @@ export function SnapGuide() {
       transform={transform}
       snapping={snapping}
       color={WorkbenchColors.red}
-      className="fixed inset-0"
+      className="absolute inset-0 z-[999999]"
     />
   );
 }

--- a/editor/package.json
+++ b/editor/package.json
@@ -39,6 +39,7 @@
     "@grida/color": "workspace:*",
     "@grida/fonts": "workspace:*",
     "@grida/history": "workspace:*",
+    "@grida/hud": "workspace:*",
     "@grida/io": "workspace:*",
     "@grida/io-figma": "workspace:*",
     "@grida/mixed-properties": "workspace:*",

--- a/packages/grida-canvas-hud/README.md
+++ b/packages/grida-canvas-hud/README.md
@@ -12,7 +12,7 @@ In industry terms: Blender calls this "Overlays", Unity calls it "Gizmos", game 
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────┐
 │  Viewport (event target, gestures)  │
 │  ┌───────────────────────────────┐  │
@@ -80,10 +80,10 @@ The migration is incremental — each feature can move independently. The HUD ca
 ### Imperative (core)
 
 ```ts
-import { SnapGuideCanvas } from "@grida/hud";
+import { HUDCanvas } from "@grida/hud";
 
 const canvas = document.createElement("canvas");
-const hud = new SnapGuideCanvas(canvas, { color: "#e83829" });
+const hud = new HUDCanvas(canvas, { color: "#e83829" });
 
 hud.setSize(window.innerWidth, window.innerHeight);
 hud.setTransform(viewportTransform);

--- a/packages/grida-canvas-hud/README.md
+++ b/packages/grida-canvas-hud/README.md
@@ -1,0 +1,105 @@
+# @grida/hud
+
+Canvas-based heads-up display (HUD) for the Grida editor viewport.
+
+Replaces per-frame React DOM/SVG rendering with imperative Canvas 2D draw calls. A single `<canvas>` element replaces dozens of individually positioned and reconciled DOM nodes, eliminating React reconciliation, DOM mutation, and browser layout costs from the hot path.
+
+## What is a HUD?
+
+The HUD is the non-content visual chrome drawn on top of the viewport: snap guides, rulers, selection handles, measurement lines, spacing indicators, pixel grids. Everything the operator sees that isn't part of the document itself.
+
+In industry terms: Blender calls this "Overlays", Unity calls it "Gizmos", game engines call it "HUD". We use HUD.
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│  Viewport (event target, gestures)  │
+│  ┌───────────────────────────────┐  │
+│  │  Content canvas (document)    │  │
+│  └───────────────────────────────┘  │
+│  ┌───────────────────────────────┐  │
+│  │  HUD canvas (this package)    │  │  ← pointer-events: none
+│  └───────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
+The HUD is a transparent `<canvas>` layered above the content. It receives draw commands and renders them imperatively. It does not own state or handle events.
+
+### Core / React split
+
+- **Core** (`@grida/hud`) — imperative canvas renderer classes. No React dependency. Can be used with any framework or standalone.
+- **React** (`@grida/hud/react`) — thin `useEffect`-based wrappers that bridge editor state to the core renderer.
+
+## Current features
+
+### Snap guide
+
+Renders snap alignment feedback during drag gestures:
+
+- **Lines** — axis-aligned segments connecting aligned agent/anchor points
+- **Rules** — full-viewport lines for guide snapping
+- **Crosshairs** — X markers at snap hit points
+- **Labels** — gap measurement pills on spacing snap lines
+
+## Primitives
+
+At the lowest level, the HUD draws a small set of geometric primitives. Many higher-level features decompose into the same shapes:
+
+| Primitive    | Description                              | Used by                                           |
+| ------------ | ---------------------------------------- | ------------------------------------------------- |
+| Line segment | `(x1,y1)→(x2,y2)`, optional label        | Snap lines, measurement lines, spacing indicators |
+| Rule         | Axis-aligned line spanning full viewport | Guide snapping, ruler guides                      |
+| Crosshair    | Small X marker at a point                | Snap hit points                                   |
+| Label pill   | Text with background at a point          | Gap measurements, size labels                     |
+
+Snap guides and ruler guides are the same primitive (a line) — one has a label, one does not. As more features move to the HUD, they will compose from these same primitives rather than introducing new rendering concepts.
+
+## Growth path
+
+Features currently rendered as React DOM in `surface.tsx` that can progressively move here:
+
+| Feature                        | Current                                   | Primitives needed            |
+| ------------------------------ | ----------------------------------------- | ---------------------------- |
+| **Snap guides**                | **HUD canvas**                            | Line, Rule, Crosshair, Label |
+| Measurement guides             | React SVG (`<Line>`, `<MeterLabel>`)      | Line, Label                  |
+| Ruler guides (draggable lines) | React SVG (`<Rule>`)                      | Rule                         |
+| Selection bounding box         | React div with border                     | Rect (stroke)                |
+| Resize handles                 | React div                                 | Rect (fill), Circle          |
+| Rotation handle                | React div                                 | Circle, Line                 |
+| Corner radius handles          | React SVG                                 | Arc, Circle                  |
+| Pixel grid                     | Separate `<canvas>` (`@grida/pixel-grid`) | Grid (could merge)           |
+| Marquee / lasso                | React div / SVG                           | Rect (stroke), Path          |
+| Spacing gap indicators         | React SVG                                 | Line, Label                  |
+| Node padding/gap overlays      | React div                                 | Rect (fill, translucent)     |
+
+The migration is incremental — each feature can move independently. The HUD canvas coexists with remaining DOM overlays during the transition.
+
+## Usage
+
+### Imperative (core)
+
+```ts
+import { SnapGuideCanvas } from "@grida/hud";
+
+const canvas = document.createElement("canvas");
+const hud = new SnapGuideCanvas(canvas, { color: "#e83829" });
+
+hud.setSize(window.innerWidth, window.innerHeight);
+hud.setTransform(viewportTransform);
+hud.draw(snapGuideData); // or undefined to clear
+```
+
+### React
+
+```tsx
+import { SnapGuide } from "@grida/hud/react";
+
+<SnapGuide
+  width={viewport.clientWidth}
+  height={viewport.clientHeight}
+  transform={transform}
+  snapping={surface_snapping}
+  color="#e83829"
+/>;
+```

--- a/packages/grida-canvas-hud/hud.ts
+++ b/packages/grida-canvas-hud/hud.ts
@@ -1,0 +1,267 @@
+import type cmath from "@grida/cmath";
+
+const DEFAULT_COLOR = "#f44336";
+const DEFAULT_LABEL_FG = "#ffffff";
+const DEFAULT_LINE_WIDTH = 0.5;
+const CROSSHAIR_SIZE = 4;
+const LABEL_FONT = "10px sans-serif";
+const LABEL_FONT_HEIGHT = 14;
+const LABEL_PADDING_X = 4;
+const LABEL_PADDING_Y = 2;
+const LABEL_BORDER_RADIUS = 4;
+const LABEL_OFFSET = 16;
+
+// ---------------------------------------------------------------------------
+// Draw primitives — the atoms every HUD feature composes from.
+//
+// All coordinates are in **document space** unless noted otherwise.
+// The HUD canvas applies the viewport transform so callers never convert.
+// ---------------------------------------------------------------------------
+
+/**
+ * A line segment in document space, extending `cmath.ui.Line` with
+ * an optional `dashed` style.
+ */
+export interface HUDLine extends cmath.ui.Line {
+  dashed?: boolean;
+}
+
+/**
+ * A full-viewport axis-aligned line (infinite extent) at a given offset.
+ *
+ * `axis` indicates which axis the `offset` lives on:
+ * - `"x"` → vertical line at x=offset
+ * - `"y"` → horizontal line at y=offset
+ *
+ * Offset is in document space; the renderer projects it to screen.
+ */
+export interface HUDRule {
+  axis: "x" | "y";
+  offset: number;
+}
+
+/**
+ * A complete set of draw commands for one frame.
+ *
+ * The HUD clears the canvas and draws everything in this struct each frame.
+ * Callers build a `HUDDraw` from their domain data (snap result, measurement,
+ * guide state, etc.) and hand it to `HUDCanvas.draw()`.
+ */
+export interface HUDDraw {
+  lines?: HUDLine[];
+  rules?: HUDRule[];
+  points?: cmath.Vector2[];
+}
+
+export interface HUDCanvasOptions {
+  color?: string;
+}
+
+/**
+ * Imperative Canvas 2D renderer for the HUD overlay.
+ *
+ * Owns a single `<canvas>` element and draws {@link HUDDraw} command lists
+ * each frame. All drawing is immediate-mode: the canvas is cleared and
+ * fully redrawn on every `draw()` call.
+ *
+ * The viewport transform is assumed to be axis-aligned (scale + translate only,
+ * no rotation/shear). The off-diagonal components of the transform matrix are
+ * ignored.
+ */
+export class HUDCanvas {
+  private ctx: CanvasRenderingContext2D;
+  private dpr: number;
+  private transform: cmath.Transform = [
+    [1, 0, 0],
+    [0, 1, 0],
+  ];
+  private color: string;
+  private width = 0;
+  private height = 0;
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    options?: HUDCanvasOptions
+  ) {
+    this.ctx = canvas.getContext("2d")!;
+    this.dpr = window.devicePixelRatio || 1;
+    this.color = options?.color ?? DEFAULT_COLOR;
+  }
+
+  setColor(color: string) {
+    this.color = color;
+  }
+
+  setSize(w: number, h: number) {
+    if (this.width === w && this.height === h) return;
+    this.dpr = window.devicePixelRatio || 1;
+    this.width = w;
+    this.height = h;
+    this.canvas.width = w * this.dpr;
+    this.canvas.height = h * this.dpr;
+    this.canvas.style.width = `${w}px`;
+    this.canvas.style.height = `${h}px`;
+  }
+
+  setTransform(transform: cmath.Transform) {
+    this.transform = transform;
+  }
+
+  /**
+   * Clear the canvas and draw all primitives in `commands`.
+   * Pass `undefined` to clear without drawing (e.g. when no overlay is active).
+   */
+  draw(commands: HUDDraw | undefined) {
+    const ctx = this.ctx;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    if (!commands) return;
+
+    const { lines, rules, points } = commands;
+
+    if (rules && rules.length > 0) this.drawRules(rules);
+    if (lines && lines.length > 0) this.drawLines(lines);
+    if (points && points.length > 0) this.drawPoints(points);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Coordinate helpers
+  // ---------------------------------------------------------------------------
+
+  private applyViewTransform() {
+    const [[sx, , tx], [, sy, ty]] = this.transform;
+    this.ctx.setTransform(
+      sx * this.dpr,
+      0,
+      0,
+      sy * this.dpr,
+      tx * this.dpr,
+      ty * this.dpr
+    );
+  }
+
+  private applyScreenTransform() {
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+  }
+
+  /** Project a scalar offset on `axis` to screen-space. */
+  private deltaToScreen(offset: number, axis: "x" | "y"): number {
+    const i = axis === "x" ? 0 : 1;
+    const row = this.transform[i];
+    return row[i] * offset + row[2];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Primitive renderers
+  // ---------------------------------------------------------------------------
+
+  private drawRules(rules: HUDRule[]) {
+    const ctx = this.ctx;
+    this.applyScreenTransform();
+    ctx.strokeStyle = this.color;
+    ctx.lineWidth = DEFAULT_LINE_WIDTH;
+
+    for (const { axis, offset } of rules) {
+      const screenOffset = this.deltaToScreen(offset, axis);
+      ctx.beginPath();
+      if (axis === "x") {
+        ctx.moveTo(screenOffset, 0);
+        ctx.lineTo(screenOffset, this.height);
+      } else {
+        ctx.moveTo(0, screenOffset);
+        ctx.lineTo(this.width, screenOffset);
+      }
+      ctx.stroke();
+    }
+  }
+
+  private drawLines(lines: HUDLine[]) {
+    const ctx = this.ctx;
+    const zoom = this.transform[0][0];
+    const [[sx, , tx], [, sy, ty]] = this.transform;
+
+    // -- strokes in document space --
+    this.applyViewTransform();
+    ctx.strokeStyle = this.color;
+    ctx.lineWidth = DEFAULT_LINE_WIDTH / zoom;
+
+    let dashed = false;
+    for (const line of lines) {
+      if (line.dashed && !dashed) {
+        ctx.setLineDash([4 / zoom, 3 / zoom]);
+        dashed = true;
+      } else if (!line.dashed && dashed) {
+        ctx.setLineDash([]);
+        dashed = false;
+      }
+      ctx.beginPath();
+      ctx.moveTo(line.x1, line.y1);
+      ctx.lineTo(line.x2, line.y2);
+      ctx.stroke();
+    }
+    if (dashed) ctx.setLineDash([]);
+
+    // -- labels in screen space --
+    this.applyScreenTransform();
+    ctx.font = LABEL_FONT;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    for (const line of lines) {
+      if (!line.label) continue;
+
+      const midX = (line.x1 + line.x2) / 2;
+      const midY = (line.y1 + line.y2) / 2;
+      const lx = sx * midX + tx;
+      const ly = sy * midY + ty;
+
+      // offset label perpendicular to line direction
+      const isVertical =
+        Math.abs(line.x2 - line.x1) < Math.abs(line.y2 - line.y1);
+      const labelX = isVertical ? lx + LABEL_OFFSET : lx;
+      const labelY = isVertical ? ly : ly + LABEL_OFFSET;
+
+      const metrics = ctx.measureText(line.label);
+      const tw = metrics.width + LABEL_PADDING_X * 2;
+      const th = LABEL_FONT_HEIGHT + LABEL_PADDING_Y * 2;
+
+      // background pill
+      ctx.fillStyle = this.color;
+      ctx.beginPath();
+      ctx.roundRect(
+        labelX - tw / 2,
+        labelY - th / 2,
+        tw,
+        th,
+        LABEL_BORDER_RADIUS
+      );
+      ctx.fill();
+
+      // text
+      ctx.fillStyle = DEFAULT_LABEL_FG;
+      ctx.fillText(line.label, labelX, labelY);
+    }
+  }
+
+  private drawPoints(points: cmath.Vector2[]) {
+    const ctx = this.ctx;
+    this.applyScreenTransform();
+    ctx.strokeStyle = this.color;
+    ctx.lineWidth = DEFAULT_LINE_WIDTH;
+
+    const half = CROSSHAIR_SIZE / 2;
+    const [[sx, , tx], [, sy, ty]] = this.transform;
+
+    ctx.beginPath();
+    for (const [px, py] of points) {
+      const scrX = sx * px + tx;
+      const scrY = sy * py + ty;
+      ctx.moveTo(scrX - half, scrY - half);
+      ctx.lineTo(scrX + half, scrY + half);
+      ctx.moveTo(scrX + half, scrY - half);
+      ctx.lineTo(scrX - half, scrY + half);
+    }
+    ctx.stroke();
+  }
+}

--- a/packages/grida-canvas-hud/hud.ts
+++ b/packages/grida-canvas-hud/hud.ts
@@ -88,13 +88,14 @@ export class HUDCanvas {
     this.color = options?.color ?? DEFAULT_COLOR;
   }
 
-  setColor(color: string) {
-    this.color = color;
+  setColor(color?: string) {
+    this.color = color ?? DEFAULT_COLOR;
   }
 
   setSize(w: number, h: number) {
-    if (this.width === w && this.height === h) return;
-    this.dpr = window.devicePixelRatio || 1;
+    const dpr = window.devicePixelRatio || 1;
+    if (this.width === w && this.height === h && this.dpr === dpr) return;
+    this.dpr = dpr;
     this.width = w;
     this.height = h;
     this.canvas.width = w * this.dpr;

--- a/packages/grida-canvas-hud/index.ts
+++ b/packages/grida-canvas-hud/index.ts
@@ -1,0 +1,8 @@
+export {
+  HUDCanvas,
+  type HUDCanvasOptions,
+  type HUDDraw,
+  type HUDLine,
+  type HUDRule,
+} from "./hud";
+export { snapGuideToHUDDraw } from "./snap-guide";

--- a/packages/grida-canvas-hud/package.json
+++ b/packages/grida-canvas-hud/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@grida/hud",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Canvas-based heads-up display for the Grida editor viewport",
+  "keywords": [
+    "canvas",
+    "design",
+    "editor",
+    "grida",
+    "hud",
+    "overlay",
+    "react",
+    "snap"
+  ],
+  "homepage": "https://grida.co/packages/@grida/hud",
+  "license": "MIT",
+  "author": "softmarshmallow",
+  "repository": "https://github.com/gridaco/grida",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup index.ts react.tsx --format cjs,esm --dts",
+    "dev": "tsup index.ts react.tsx --format cjs,esm --dts --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@grida/cmath": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "react": "^19.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  }
+}

--- a/packages/grida-canvas-hud/react.tsx
+++ b/packages/grida-canvas-hud/react.tsx
@@ -19,7 +19,7 @@ export const SnapGuide: React.FC<SnapGuideProps> = (props) => {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const rendererRef = React.useRef<HUDCanvas | null>(null);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!canvasRef.current) return;
     if (!rendererRef.current) {
       rendererRef.current = new HUDCanvas(canvasRef.current, {
@@ -27,16 +27,13 @@ export const SnapGuide: React.FC<SnapGuideProps> = (props) => {
       });
     }
 
-    if (props.color) rendererRef.current.setColor(props.color);
+    rendererRef.current.setColor(props.color);
     rendererRef.current.setSize(props.width, props.height);
     rendererRef.current.setTransform(props.transform);
 
     const guideData = props.snapping ? guide.plot(props.snapping) : undefined;
     const draw = snapGuideToHUDDraw(guideData);
-    const rafId = requestAnimationFrame(() => {
-      rendererRef.current?.draw(draw);
-    });
-    return () => cancelAnimationFrame(rafId);
+    rendererRef.current.draw(draw);
   }, [props.width, props.height, props.transform, props.snapping, props.color]);
 
   return (

--- a/packages/grida-canvas-hud/react.tsx
+++ b/packages/grida-canvas-hud/react.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import type cmath from "@grida/cmath";
+import { guide, type SnapResult } from "@grida/cmath/_snap";
+import { HUDCanvas } from "./hud";
+import { snapGuideToHUDDraw } from "./snap-guide";
+
+export interface SnapGuideProps {
+  width: number;
+  height: number;
+  transform: cmath.Transform;
+  snapping: SnapResult | undefined;
+  color?: string;
+  className?: string;
+}
+
+export const SnapGuide: React.FC<SnapGuideProps> = (props) => {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const rendererRef = React.useRef<HUDCanvas | null>(null);
+
+  React.useEffect(() => {
+    if (!canvasRef.current) return;
+    if (!rendererRef.current) {
+      rendererRef.current = new HUDCanvas(canvasRef.current, {
+        color: props.color,
+      });
+    }
+
+    if (props.color) rendererRef.current.setColor(props.color);
+    rendererRef.current.setSize(props.width, props.height);
+    rendererRef.current.setTransform(props.transform);
+
+    const guideData = props.snapping ? guide.plot(props.snapping) : undefined;
+    const draw = snapGuideToHUDDraw(guideData);
+    const rafId = requestAnimationFrame(() => {
+      rendererRef.current?.draw(draw);
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [props.width, props.height, props.transform, props.snapping, props.color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: props.width,
+        height: props.height,
+        pointerEvents: "none",
+      }}
+      className={props.className}
+    />
+  );
+};

--- a/packages/grida-canvas-hud/snap-guide.ts
+++ b/packages/grida-canvas-hud/snap-guide.ts
@@ -1,0 +1,22 @@
+import type { guide } from "@grida/cmath/_snap";
+import type { HUDDraw } from "./hud";
+
+/**
+ * Convert a `guide.SnapGuide` (the output of `guide.plot()`) into a
+ * generic {@link HUDDraw} command list.
+ *
+ * Lines pass through directly (HUDLine extends cmath.ui.Line).
+ * Points pass through directly (both are cmath.Vector2).
+ * Rules are destructured from tuples to objects.
+ */
+export function snapGuideToHUDDraw(
+  sg: guide.SnapGuide | undefined
+): HUDDraw | undefined {
+  if (!sg) return undefined;
+
+  return {
+    lines: sg.lines,
+    rules: sg.rules.map(([axis, offset]) => ({ axis, offset })),
+    points: sg.points,
+  };
+}

--- a/packages/grida-canvas-hud/tsconfig.json
+++ b/packages/grida-canvas-hud/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@grida/history':
         specifier: workspace:*
         version: link:../packages/grida-history
+      '@grida/hud':
+        specifier: workspace:*
+        version: link:../packages/grida-canvas-hud
       '@grida/io':
         specifier: workspace:*
         version: link:../packages/grida-canvas-io
@@ -1027,6 +1030,25 @@ importers:
 
   packages/grida-canvas-color: {}
 
+  packages/grida-canvas-hud:
+    dependencies:
+      '@grida/cmath':
+        specifier: workspace:*
+        version: link:../grida-cmath
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^24
+        version: 24.12.2
+      '@types/react':
+        specifier: 19.1.3
+        version: 19.1.3
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+
   packages/grida-canvas-io:
     dependencies:
       '@grida/cg':
@@ -1190,6 +1212,15 @@ importers:
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.7.0)
 
   packages/grida-canvas-sequence: {}
+
+  packages/grida-canvas-state-poc:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-canvas-sync:
     devDependencies:
@@ -7009,8 +7040,22 @@ packages:
     peerDependencies:
       react: 19.2.3
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.0.18':
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
@@ -7023,17 +7068,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
@@ -7690,6 +7750,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -7734,6 +7798,10 @@ packages:
 
   cheap-ruler@4.0.0:
     resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -8224,9 +8292,6 @@ packages:
   csstype@3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -8550,6 +8615,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -10406,6 +10475,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -10731,6 +10803,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -11758,6 +11833,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pbf@4.0.1:
     resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
@@ -13687,6 +13766,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strnum@2.1.1:
     resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
 
@@ -13936,8 +14018,16 @@ packages:
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
@@ -14461,6 +14551,11 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -14499,6 +14594,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.0.18:
@@ -22102,6 +22225,14 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.3
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -22110,6 +22241,15 @@ snapshots:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@24.12.2)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
@@ -22120,13 +22260,29 @@ snapshots:
       msw: 2.12.10(@types/node@24.12.2)(typescript@5.9.3)
       vite: 7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.18':
@@ -22135,7 +22291,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -22979,6 +23145,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk-template@0.4.0:
@@ -23009,6 +23183,8 @@ snapshots:
   chardet@2.1.1: {}
 
   cheap-ruler@4.0.0: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -23526,10 +23702,7 @@ snapshots:
 
   csstype@3.1.0: {}
 
-  csstype@3.1.3: {}
-
-  csstype@3.2.3:
-    optional: true
+  csstype@3.2.3: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
     dependencies:
@@ -23851,6 +24024,8 @@ snapshots:
       mimic-response: 3.1.0
 
   dedent@1.7.1: {}
+
+  deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
     dependencies:
@@ -26168,6 +26343,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -26466,6 +26643,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -27415,7 +27594,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       css-tree: 1.1.3
-      csstype: 3.1.3
+      csstype: 3.2.3
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 7.0.1
       react: 19.2.3
@@ -27948,6 +28127,8 @@ snapshots:
     optional: true
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pbf@4.0.1:
     dependencies:
@@ -30398,6 +30579,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strnum@2.1.1: {}
 
   style-to-js@1.1.21:
@@ -30678,7 +30863,11 @@ snapshots:
 
   tinyqueue@3.0.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.0.3: {}
+
+  tinyspy@4.0.4: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -31243,6 +31432,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.3
@@ -31259,6 +31469,49 @@ snapshots:
       terser: 5.39.0
       tsx: 4.21.0
       yaml: 2.7.0
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+      vite-node: 3.2.4(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.12.2
+      jsdom: 20.0.3(canvas@2.11.2(encoding@0.1.13))
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@grida/hud` package — an imperative Canvas 2D renderer that replaces React DOM/SVG snap guide overlays
- Replace 10-20 per-frame SVG elements with a single `<canvas>` and ~30 draw calls, eliminating React reconciliation, DOM mutations, and browser layout from the drag hot path
- Define generic draw primitives (`HUDLine`, `HUDRule`, `Vector2` points) that measurement guides, ruler overlays, and other surface chrome can progressively adopt

## Test plan
- [x] Open editor, create 3-4 rectangles with equal spacing
- [x] Drag one near siblings — verify red snap lines, crosshairs, and spacing gap labels appear at correct positions
- [x] Verify full-viewport guide rules appear when snapping to explicit guides
- [x] Verify all guides disappear immediately on mouse-up
- [x] Verify no visual flicker or stale guides during rapid drag
- [x] Run `pnpm turbo typecheck` and `pnpm turbo build --filter='@grida/hud'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snap guides now render via a dedicated canvas HUD overlay positioned over the viewport, improving visual consistency and sizing to the viewport.
  * Snap rendering is enabled only when visible; when disabled the HUD remains inactive.

* **Documentation**
  * Added comprehensive README documenting the HUD overlay, primitives, usage examples, and migration path for viewport overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->