### PR TITLE
fix(docs): correct i18n content-docs output path

### DIFF
--- a/apps/docs/scripts/docs-site-gen/copy-translations.js
+++ b/apps/docs/scripts/docs-site-gen/copy-translations.js
@@ -5,7 +5,7 @@ const fse = require("fs-extra");
 const path = require("path");
 
 const docs_site_root = path.join(__dirname, "../../");
-const docs_site_docs_root = path.join(__dirname, "../../../docs");
+const docs_site_docs_root = path.join(__dirname, "../../docs");
 
 /**
  * Loop through the docs directory.

--- a/docs/platform/translations/fr/index.md
+++ b/docs/platform/translations/fr/index.md
@@ -1,4 +1,5 @@
 ---
+id: intro
 title: Plateforme Grida
 description: Documentation de plateforme pour les clients Grida, les tags et les fonctionnalités produit associées.
 keywords:

--- a/docs/platform/translations/ja/index.md
+++ b/docs/platform/translations/ja/index.md
@@ -1,4 +1,5 @@
 ---
+id: intro
 title: Grida Platform
 description: Grida の顧客、タグ、および関連プロダクト機能に関するプラットフォーム文書です。
 keywords:

--- a/docs/platform/translations/ko/index.md
+++ b/docs/platform/translations/ko/index.md
@@ -1,4 +1,5 @@
 ---
+id: intro
 title: Grida 플랫폼
 description: Grida의 고객, 태그, 관련 제품 기능에 대한 플랫폼 문서입니다.
 keywords:


### PR DESCRIPTION
## Summary

- Translated docs pages (ko/ja/fr) were silently falling back to English — only the navbar/footer/code strings changed per locale.
- Root cause: `docs_site_docs_root` in `apps/docs/scripts/docs-site-gen/copy-translations.js` resolved to `apps/docs/` (one `..` too many) instead of `apps/docs/docs/` (where `copy-docs.js` writes the content).
- Because of this, `path.relative(docs_site_docs_root, …)` retained an erroneous leading `docs/` segment, so translated markdown was written to `i18n/<locale>/docusaurus-plugin-content-docs/current/docs/...` — a path Docusaurus never reads.
- Fix: one-character path correction (`"../../../docs"` → `"../../docs"`).

Verified via a dry-run script that replayed the exact logic: before the fix, every `ko` target landed at `current/docs/<path>`; after, targets land at `current/<path>` as Docusaurus expects.

The generated path is gitignored (`/i18n/*/docusaurus-plugin-content-docs` in `apps/docs/.gitignore`) and there's no test asserting the output layout, which is why this regressed silently until localized content was actually added.

## Test plan

- [ ] `pnpm --filter docs content:setup` runs cleanly
- [ ] `apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/platform/customers/index.md` exists after setup (not under `.../current/docs/...`)
- [ ] `pnpm --filter docs build` succeeds
- [ ] Visit `/docs/ko/platform/customers` on a preview — page body renders in Korean, not English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the directory path used by the documentation build that locates translation files.

* **Documentation**
  * Added explicit page identifiers to translated docs in French, Japanese, and Korean to ensure consistent page metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->