### PR TITLE
fix(io-figma): skip unsupported figjam/deck nodes instead of throwing

### DIFF
--- a/packages/grida-canvas-io-figma/lib.ts
+++ b/packages/grida-canvas-io-figma/lib.ts
@@ -3281,7 +3281,8 @@ export namespace iofigma {
           case "TABLE_CELL":
           case "WASHI_TAPE":
           case "WIDGET":
-            throw new Error(`Unknown node type: ${node.type}`);
+            // TODO: unsupported figjam/deck node types — skip instead of throwing
+            return undefined;
         }
       }
     }


### PR DESCRIPTION
## Summary
- `SHAPE_WITH_TEXT` (and other figjam node types) appearing in `.deck` files caused the Figma → Grida conversion to throw `Unknown node type: SHAPE_WITH_TEXT`.
- Return `undefined` for these cases so the existing caller filter skips them gracefully. Marked with a `TODO` for future support.

## Test plan
- [ ] `pnpm turbo typecheck --filter='./packages/grida-canvas-io-figma'`
- [ ] `pnpm turbo test --filter='./packages/grida-canvas-io-figma'`
- [ ] Import a `.deck` file containing a `SHAPE_WITH_TEXT` node and confirm it no longer throws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Figma/FigJam import and export operations. Unsupported elements are now gracefully skipped instead of halting the entire process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->