### PR TITLE
docs(skills): canvas-docs-svg-kit

### DIFF
--- a/.agents/skills/canvas-docs-svg-kit/SKILL.md
+++ b/.agents/skills/canvas-docs-svg-kit/SKILL.md
@@ -171,7 +171,7 @@ The kit's primitives are stylised — close to the product but not pixel-clones.
 | Primitive                    | Source file (in `editor/`)                                                            | What to read for                                         |
 | ---------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | Selection chrome / handles   | `grida-canvas-react/viewport/surface.tsx`                                             | Handle sizes, hover states, modifier behaviour           |
-| Size meter (live readout)    | `grida-canvas-react/viewport/ui/size.tsx`                                             | Badge geometry, position relative to selection           |
+| Size meter (live readout)    | `grida-canvas-react/viewport/ui/meter.tsx`                                            | Badge geometry, position relative to selection           |
 | Distance meter (measurement) | `grida-canvas-react/viewport/ui/measurement.tsx`, `vector-measurement.tsx`            | What measurement actually shows (distance, axis-aligned) |
 | Workbench colours            | `grida-canvas-react/ui-config.ts` → `WorkbenchColors`                                 | Canonical hex values: `sky #00a6f4`, `red #f44336`, etc. |
 | Keycap                       | `components/ui/kbd.tsx`                                                               | Pill geometry, font, fg/bg tokens                        |

--- a/.agents/skills/canvas-docs-svg-kit/SKILL.md
+++ b/.agents/skills/canvas-docs-svg-kit/SKILL.md
@@ -84,8 +84,8 @@ When the kit changes, walk the grep output and update each file.
 4. **Crib structure from [`examples/`](examples/).** Two finished figures live there:
    - `text-node-auto-size-edges.svg` — two-column before/after with hot edges, ripples, cursors, size badges, and a legend card.
    - `text-node-auto-size-alignment.svg` — three-column comparison with anchor pins and ghost outlines.
-5. **Save to `docs/editor/features/img/`** (or sibling `img/` dir next to the doc). Name: `<feature>-<description>.svg`, kebab-case.
-6. **Embed via Markdown.** `![alt text](img/your-figure.svg)`. The `alt` should describe what the figure shows, not name the file.
+5. **Save to `docs/editor/resources/`.** Name: `<feature>-<description>.svg`, kebab-case.
+6. **Embed via Markdown.** `![alt text](../resources/your-figure.svg)` from a doc under `docs/editor/features/`. The `alt` should describe what the figure shows, not name the file.
 
 ## Snippet files
 

--- a/.agents/skills/canvas-docs-svg-kit/SKILL.md
+++ b/.agents/skills/canvas-docs-svg-kit/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: canvas-docs-svg-kit
+description: >
+  Author SVG figures for canvas user docs at docs/editor/. Provides reusable
+  primitives (selection chrome, size badges, anchor pins, resize cursors,
+  click ripples), color/typography tokens, a starter template, and finished
+  examples to crib from. Use when drawing diagrams that explain canvas UI
+  behaviour — gestures, alignment, before/after states — that a screenshot
+  alone can't capture. Trigger phrases: "svg diagram", "draw a figure",
+  "visual for docs", "explain this gesture visually", "before/after diagram".
+---
+
+# Canvas Docs SVG Kit
+
+A snippet library for drawing SVG figures used in canvas user docs.
+
+**Companion to:** [`canvas-user-docs`](../canvas-user-docs/SKILL.md).
+Use that skill for prose, this one for the visuals embedded inside it.
+
+## Why SVG, not a screenshot
+
+Screenshots are easy to capture but expensive over time:
+
+- **Stale by default.** UI shifts; the screenshot keeps showing the old state until someone re-captures it. There is no diff, no warning, no test that fails.
+- **Repo weight.** Every re-capture is a new binary blob in git history. WebP at 960 × 960 is ~30–80 KB each; PNG is multiples of that. Across years of captures it compounds, and old blobs never leave history.
+- **Frozen in time.** A screenshot shows one moment of one configuration. A diagram explains the rule across configurations.
+
+So: **when SVG can carry the meaning, prefer SVG.** SVGs are text — diff-able, hand-editable, version-controlled like code. Reserve screenshots for cases where the actual rendered chrome (real fonts, real pixels) is the point.
+
+## When to draw an SVG figure
+
+Reach for a custom SVG when a screenshot can't carry the story alone:
+
+- A **gesture** (the clickable target isn't visible at rest — double-click, drag, hover).
+- A **before / after** that needs the two states side-by-side.
+- A **rule** that hinges on an invisible anchor or pivot (alignment, snapping, hit-testing).
+
+If a single screenshot of the editor would communicate the whole point, use a screenshot. Don't redraw real UI in SVG when you don't have to.
+
+## Hard constraints
+
+These are baked into the kit. Don't fight them.
+
+- **Inline `<style>` only.** Never reference an external stylesheet. Docusaurus serves docs SVGs via `<img src>`, which sandboxes the SVG: external CSS, scripts, and cross-file `<use href>` are all blocked.
+- **No cross-file `<use>`.** Every reused fragment must physically live inside the SVG's own `<defs>`. Copy from `snippets/`, don't import.
+- **Self-contained = SEO-safe.** Inline-styled SVGs are indexed as images. Inline React components in MDX are not — they become HTML.
+- **Output size: 960 × 960.** The viewport for all figures, matching `docs/AGENTS.md` screenshot conventions. Use `viewBox="0 0 960 960" width="960" height="960"`.
+- **Watermark every kit-produced SVG** (see below).
+- **No emojis. No marketing voice.** Same neutral tone as the prose.
+
+## Watermark every kit-produced SVG
+
+So we can enumerate, audit, and migrate kit assets later without reading each file, **every SVG produced via this kit must carry two markers**:
+
+1. A top-level XML comment immediately before the root `<svg>` (grep-friendly):
+
+   ```xml
+   <!-- @generated-by: canvas-docs-svg-kit v1 -->
+   ```
+
+2. A `<metadata>` element as the first child of `<svg>` (SVG-spec-native, survives minification and SVGO passes that strip comments):
+
+   ```xml
+   <metadata>canvas-docs-svg-kit/v1</metadata>
+   ```
+
+Both markers are present in `snippets/template.svg`, so they propagate automatically when you copy from the template. If you start a figure from scratch, paste both before composing anything else.
+
+**Versioning.** Bump `v1 → v2` only on a breaking change to tokens or primitives (e.g. selection blue changes hex, or anchor pin geometry changes). Same-version figures are guaranteed visually consistent.
+
+**Enumerate kit assets:**
+
+```sh
+grep -rl "canvas-docs-svg-kit" docs/editor/
+```
+
+When the kit changes, walk the grep output and update each file.
+
+## Workflow
+
+1. **Start from the template.** Copy [`snippets/template.svg`](snippets/template.svg) — it has the canvas, fonts, all `<defs>`, all class tokens, and shadow filters wired up.
+2. **Browse [`snippets/primitives.svg`](snippets/primitives.svg)** for the bird's-eye catalog of every primitive. For deeper inspection of a specific family, open the focused chunk file (see _Snippet files_ below).
+3. **Compose your figure** inside the marked region of the template, using the existing classes. Don't reinvent stroke widths, colors, or fonts — that's how visuals drift.
+4. **Crib structure from [`examples/`](examples/).** Two finished figures live there:
+   - `text-node-auto-size-edges.svg` — two-column before/after with hot edges, ripples, cursors, size badges, and a legend card.
+   - `text-node-auto-size-alignment.svg` — three-column comparison with anchor pins and ghost outlines.
+5. **Save to `docs/editor/features/img/`** (or sibling `img/` dir next to the doc). Name: `<feature>-<description>.svg`, kebab-case.
+6. **Embed via Markdown.** `![alt text](img/your-figure.svg)`. The `alt` should describe what the figure shows, not name the file.
+
+## Snippet files
+
+`snippets/` is structured as **one overview catalog plus focused per-family files**:
+
+| File             | Role                                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `template.svg`   | **Starter** — copy this to begin a new figure. Has every CSS class, def, filter, and symbol pre-wired.   |
+| `primitives.svg` | **Index / overview catalog** — every primitive in one tall canvas. Skim here first.                      |
+| `cursors.svg`    | **Cursors** — pointer, move, grab, grabbing, rotate, h-resize, v-resize. With sizes and hotspot offsets. |
+| `meters.svg`     | **Meters** — `.badge` (size, blue) and `.badge-distance` (measurement, red) variants side-by-side.       |
+| `handles.svg`    | **Handles & pins** — square `.handle`, `#ft-handle` (circle), `#anchor-pin`.                             |
+| `keycap.svg`     | **Keycap** — modifier-key pill variants (single letter, glyph, multi-char, combos).                      |
+
+**When to look in which:**
+
+- Quick scan of "what exists" → `primitives.svg`.
+- Picking a specific cursor / badge variant / handle / keycap → the per-family file. They show variants, sizes, hotspots, and source references that the index can only hint at.
+
+> **Note on canvas size.** Snippet files exceed the 960 × 960 figure mandate (e.g. `cursors.svg` is 960 × 720, `primitives.svg` is 960 × 1400). That mandate applies to **doc figures** — kit reference catalogs are not embedded in docs and may be tall.
+
+## What's in the kit
+
+### Primitives (in `snippets/template.svg` defs)
+
+| Primitive                 | How to use                                                                                       | Where it shines                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| **Selection chrome**      | `<rect class="sel-outline">` + four `<rect class="handle">` corners + `class="baseline"`         | Showing a selected node                                  |
+| **Size badge**            | `<rect class="badge">` + `<text class="badge-text">` with `filter="url(#badge-shadow)"`          | Live `w × h` readout under selection                     |
+| **Anchor pin**            | `<g transform="translate(cx,cy)"><use href="#anchor-pin"/></g>` + `filter="url(#pin-shadow)"`    | A point that stays fixed across states                   |
+| **Resize cursor**         | `<use href="#cursor-h">` or `<use href="#cursor-v">`                                             | Edges/handles that respond to a drag                     |
+| **Click ripple**          | Two concentric `<circle class="ripple">` / `class="ripple-2">`                                   | Marking a tap or double-click target                     |
+| **Hot edge**              | `<line class="edge-hot">`                                                                        | The edge a gesture targets                               |
+| **Ghost outline**         | `<rect class="ghost">`                                                                           | Where the bounds used to be                              |
+| **Arrow (gray)**          | `<line class="arrow" marker-end="url(#ah)">`                                                     | Generic flow / step transitions                          |
+| **Arrow (red)**           | `<line class="arrow-red" marker-end="url(#ah-red)">`                                             | Motion or change being highlighted                       |
+| **Legend card**           | `<rect class="legend-box">` rounded panel                                                        | Symbol key at the bottom of a figure                     |
+| **Distance meter**        | `<rect class="badge-distance">` + `<text class="badge-text">` with `filter="url(#badge-shadow)"` | Measurement readout (red variant of size badge)          |
+| **Keycap**                | `<rect class="kbd-bg">` + `<text class="kbd-text">` (h≈20, rx=3, px=8)                           | Modifier-key pill (Alt, Shift, ⌘) in interaction figures |
+| **Free-transform handle** | `<g transform="translate(cx,cy)"><use href="#ft-handle"/></g>`                                   | Circular corner grip — rotate / scale gesture target     |
+| **Cursor — pointer**      | `<use href="#cursor-pointer">`                                                                   | Default arrow cursor                                     |
+| **Cursor — move**         | `<use href="#cursor-move">`                                                                      | 4-direction translate gesture                            |
+| **Cursor — grab**         | `<use href="#cursor-grab">` / `<use href="#cursor-grabbing">`                                    | Drag affordance (open/closed hand)                       |
+| **Cursor — rotate**       | `<use href="#cursor-rotate">` (wrap in `transform="rotate(θ)"` to orient)                        | Rotation drag at a corner                                |
+
+### Color tokens
+
+| Class / value | Hex       | Use                                                               |
+| ------------- | --------- | ----------------------------------------------------------------- |
+| canvas bg     | `#ECECEC` | Page background (matches editor canvas)                           |
+| selection     | `#0D99FF` | Selection outline, handles, baseline, size badge                  |
+| hot           | `#FF3B30` | Hot edges, anchor pin, motion arrows                              |
+| measurement   | `#f44336` | Distance badge — `WorkbenchColors.red`, the canonical product red |
+| text          | `#0a0a0a` | Headings, node text content                                       |
+| caption       | `#6b7280` | Subtitles, captions, legend captions                              |
+| ghost         | `#b5b5b5` | Dashed outline of original/previous bounds                        |
+| keycap bg     | `#f1f5f9` | Keycap pill background (`bg-muted` from kbd.tsx)                  |
+| keycap border | `#cbd5e1` | Keycap pill border                                                |
+| keycap text   | `#475569` | Keycap label text (`text-muted-foreground`)                       |
+| panel border  | `#e5e5e5` | Legend card border, cell borders in catalog                       |
+
+> **Slight drift, intentional.** The kit's `selection` (`#0D99FF`) is Figma blue; the product's canonical `WorkbenchColors.sky` is `#00a6f4`. Same for `hot` (`#FF3B30`) vs `WorkbenchColors.red` (`#f44336`). The new `measurement` token uses the canonical product red. A future kit pass may harmonise these — for now, the difference is visually negligible (~3% off) and keeps existing figures stable.
+
+### Typography tokens
+
+| Class          | Spec                                         | Use                           |
+| -------------- | -------------------------------------------- | ----------------------------- |
+| `.doc-heading` | 26px, 600, `-0.3px` letter-spacing           | Figure title                  |
+| `.col-title`   | 16–18px, 600                                 | Column or section heading     |
+| `.step-label`  | 11px, 500, uppercase, `0.6px` letter-spacing | Eyebrow above column titles   |
+| `.caption`     | 13–14px, `#6b7280`                           | Subtitles and captions        |
+| `.badge-text`  | 10–11px, SF Mono, 600                        | Inside size / distance badges |
+| `.kbd-text`    | 11px, 500, `0.2px` letter-spacing            | Keycap label                  |
+| `.label-mono`  | 12–14px, SF Mono                             | Inline code in labels         |
+| `.node-text`   | 22–28px, `-0.3px` letter-spacing             | Text rendered inside a node   |
+
+Font stack: `-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif` for prose; `'SF Mono', Menlo, Consolas, monospace` for code/badges.
+
+## Ground truth in the editor
+
+The kit's primitives are stylised — close to the product but not pixel-clones. When a primitive is unclear or you need to match the actual UI more carefully, go to source:
+
+| Primitive                    | Source file (in `editor/`)                                                            | What to read for                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Selection chrome / handles   | `grida-canvas-react/viewport/surface.tsx`                                             | Handle sizes, hover states, modifier behaviour           |
+| Size meter (live readout)    | `grida-canvas-react/viewport/ui/size.tsx`                                             | Badge geometry, position relative to selection           |
+| Distance meter (measurement) | `grida-canvas-react/viewport/ui/measurement.tsx`, `vector-measurement.tsx`            | What measurement actually shows (distance, axis-aligned) |
+| Workbench colours            | `grida-canvas-react/ui-config.ts` → `WorkbenchColors`                                 | Canonical hex values: `sky #00a6f4`, `red #f44336`, etc. |
+| Keycap                       | `components/ui/kbd.tsx`                                                               | Pill geometry, font, fg/bg tokens                        |
+| Image-paint editor handles   | `grida-canvas-react/viewport/ui/surface-image-editor.tsx`                             | Translate / scale / rotate handle layout, cursors        |
+| Cursor PNG asset set         | `public/assets/css-cursors-macos/*.png` (move, grab, grabbing, \*-rotate, pointer, …) | Reference look for cursors the kit doesn't ship          |
+| Custom rotate cursor SVG     | `components/cursor/cursor-data.ts` → `template_rotate_svg(angle)`                     | The kit's `#cursor-rotate` symbol is lifted from here    |
+
+Rule of thumb: if you find yourself inventing a primitive that maps to a real product UI element, check the source first — the names and tokens above are usually nearby.
+
+## Common pitfalls
+
+- **Anchor-pin offset bug.** The pin must use `<g transform="translate(cx, cy)"><use href="#anchor-pin"/></g>` — not `<use x y>` on a `<symbol>` with negative viewBox. The latter shifts the visual centre by half the use-box and breaks alignment.
+- **Crisp rendering.** Use `shape-rendering: crispEdges` and `.5` half-pixel offsets on 1px strokes (e.g. `x="0.5" y="0.5" width="279"`). Otherwise borders go fuzzy.
+- **Badge padding.** Badge width = `text_width + ~20px`. Tight badges look amateur. Recentre `<g translate>` after resizing badges.
+- **Symbol coordinates trap.** A `<symbol viewBox="-12 -12 24 24">` placed with `<use x="0" y="0" width="24" height="24">` puts the symbol's `(0,0)` at use-box centre `(12, 12)`. Prefer plain `<g id="...">` placed with `transform="translate"` for primitives that need a precise anchor point.
+- **Don't tile multiple SVGs into one.** One figure per file. Two SVGs side-by-side in the doc beats one giant 1920px figure.
+- **Render check.** Always render with `resvg` before committing (see _Verify before publishing_). Browsers are forgiving; resvg is not.
+- **XML strictness traps that resvg catches but browsers ignore.** Two real ones the kit has hit:
+  - **No `<` characters inside `<style>` content** unless the block is wrapped in `<![CDATA[ ... ]]>`. So `/* foo <kbd> bar */` inside the CSS block will fail with `expected 'kbd' tag, not 'style'`. Either CDATA-wrap the whole block, or rephrase the comment to drop the `<`.
+  - **No `--` inside `<!-- ... -->` comments** (XML spec). A "nested comment" like `<!-- inside <!-- here --> -->` parses as `comment contains '--'`. If you need to show comment syntax inside a comment, use an alternative marker (`:::`, `###`, etc.).
+
+## Verify before publishing
+
+**SVG composition is geometry — never ship without verifying it.** The kit's most common bugs (anchor pin shifted by 12px, badge text flush against pill edges, baseline missing the right edge) have all been caught only because someone looked at the rendered figure. Type-checking won't help you here.
+
+**Tier 1: render with `resvg`, then look.** (Always do this.)
+
+Editing an SVG without rendering it is editing blind. The geometry-by-arithmetic bugs in this kit (anchor pin offset, badge padding, container overflow) repeatedly slip through when you reason about coordinates without seeing the result. `resvg` is the standard SVG rasteriser used elsewhere in the project — already installed and what `cg-reftest` uses for golden comparisons. It's the right tool here too.
+
+```sh
+resvg path/to/figure.svg /tmp/check.png
+```
+
+Then open `/tmp/check.png` and inspect:
+
+1. **Containment.** Every text element sits _inside_ its container `<rect>` with visible breathing room on all four sides. Watch especially for hex/code labels at the bottom of legend or token panels — text baselines plus descenders frequently overshoot the panel by a few pixels. The container `<rect>` doesn't clip, so overflow looks like "text touches the panel edge" rather than getting cut off.
+2. **Anchor pins.** Each pin's red dot lands exactly on the intended edge or point. Off-by-12px errors come from `<symbol>`/`<use>` viewBox arithmetic.
+3. **Badge padding.** At least ~10px of background visible to the left and right of badge text glyphs.
+4. **Crisp strokes.** 1px lines should be sharp, not fuzzy. If they're soft, the shape is missing its `.5` half-pixel offset.
+5. **Balance.** Top vs bottom padding inside containers should be roughly equal. Heavily top-loaded or bottom-loaded panels read as broken.
+
+After every meaningful edit, re-run `resvg` and re-inspect. Don't skip this step on "small" tweaks — moving a `y` by a few pixels inside a container is exactly when overflow happens.
+
+**Then check the doc page** in Docusaurus dev (`pnpm --filter docs start`) and confirm the figure embeds cleanly with the `alt` text.
+
+**Tier 2: agent-assisted visual review.**
+
+For complex figures, render with `resvg` (Tier 1) and feed the resulting PNG into the [`vision`](../vision/SKILL.md) skill — that sidesteps loading the image into your own context and gets a fresh pair of eyes on it:
+
+```sh
+resvg figure.svg /tmp/figure.png
+# then ask vision:
+#   "Do all anchor pins sit exactly on the marked edges? Do badges have
+#    visible padding around the text? Any text touching container edges?"
+```
+
+Trust your own eyes over the vision model for final sign-off, but it's good at catching the things you'd otherwise have to scrutinise pixel-by-pixel.
+
+**Tier 3: programmatic (write a validator when bugs recur).**
+
+When the same kind of bug surfaces in two or three figures, build a small validator script (`scripts/svg-kit-lint.mjs`). Two complementary approaches:
+
+- **Static lint over the SVG source.** Parse each `*.svg` and assert: watermark comment + `<metadata>` element present, `viewBox="0 0 960 960"`, no external `<link>`/`<style src>`/cross-file `<use href>`, every `<use href="#anchor-pin">` wrapped in a `<g transform="translate(...)">`. Cheap, no rendering needed.
+- **Render-and-diff via `resvg`.** Rasterise each figure and either (a) byte-compare against a checked-in golden PNG, or (b) hand it to `vision` with a fixed prompt and parse pass/fail. Catches geometry bugs that the static lint can't reason about.
+
+We don't have this validator yet — add it the first time you find yourself fixing the same bug twice.
+
+**Pre-publish checklist:**
+
+- [ ] Watermark comment present (`@generated-by: canvas-docs-svg-kit v1`)
+- [ ] `<metadata>canvas-docs-svg-kit/v1</metadata>` is the first child of `<svg>`
+- [ ] Inline `<style>` only — no external stylesheet references
+- [ ] No `<use href="other.svg#…">` — all referenced ids exist in this file
+- [ ] Viewport is `960 × 960`
+- [ ] Colors and fonts come from token classes, not ad-hoc values
+- [ ] Strokes are crisp (half-pixel offsets where needed)
+- [ ] Badges have ~10px horizontal padding inside the pill
+- [ ] Anchor pins land exactly on the intended point (not shifted by viewBox)
+- [ ] Tier 1 visual review passed
+- [ ] Embedded with descriptive `alt` text, not the filename
+
+## Graduating beyond copy-paste
+
+If this skill's snippets are being copied into 5+ figures across the docs and starting to drift, that's the signal to build a small templating script (`pnpm docs:svg`) that expands placeholders like `<MeterBadge w="280" h="90"/>` into inlined SVG. Until then, copy-paste keeps things lean and predictable.

--- a/.agents/skills/canvas-docs-svg-kit/SKILL.md
+++ b/.agents/skills/canvas-docs-svg-kit/SKILL.md
@@ -95,7 +95,7 @@ When the kit changes, walk the grep output and update each file.
 | ---------------- | -------------------------------------------------------------------------------------------------------- |
 | `template.svg`   | **Starter** — copy this to begin a new figure. Has every CSS class, def, filter, and symbol pre-wired.   |
 | `primitives.svg` | **Index / overview catalog** — every primitive in one tall canvas. Skim here first.                      |
-| `cursors.svg`    | **Cursors** — pointer, move, grab, grabbing, rotate, h-resize, v-resize. With sizes and hotspot offsets. |
+| `cursors.svg`    | **Cursors** — pointer, move, grab, grabbing, rotate, h-resize, v-resize, crosshair, text. With sizes and hotspot offsets. |
 | `meters.svg`     | **Meters** — `.badge` (size, blue) and `.badge-distance` (measurement, red) variants side-by-side.       |
 | `handles.svg`    | **Handles & pins** — square `.handle`, `#ft-handle` (circle), `#anchor-pin`.                             |
 | `keycap.svg`     | **Keycap** — modifier-key pill variants (single letter, glyph, multi-char, combos).                      |

--- a/.agents/skills/canvas-docs-svg-kit/SKILL.md
+++ b/.agents/skills/canvas-docs-svg-kit/SKILL.md
@@ -91,14 +91,14 @@ When the kit changes, walk the grep output and update each file.
 
 `snippets/` is structured as **one overview catalog plus focused per-family files**:
 
-| File             | Role                                                                                                     |
-| ---------------- | -------------------------------------------------------------------------------------------------------- |
-| `template.svg`   | **Starter** — copy this to begin a new figure. Has every CSS class, def, filter, and symbol pre-wired.   |
-| `primitives.svg` | **Index / overview catalog** — every primitive in one tall canvas. Skim here first.                      |
+| File             | Role                                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `template.svg`   | **Starter** — copy this to begin a new figure. Has every CSS class, def, filter, and symbol pre-wired.                    |
+| `primitives.svg` | **Index / overview catalog** — every primitive in one tall canvas. Skim here first.                                       |
 | `cursors.svg`    | **Cursors** — pointer, move, grab, grabbing, rotate, h-resize, v-resize, crosshair, text. With sizes and hotspot offsets. |
-| `meters.svg`     | **Meters** — `.badge` (size, blue) and `.badge-distance` (measurement, red) variants side-by-side.       |
-| `handles.svg`    | **Handles & pins** — square `.handle`, `#ft-handle` (circle), `#anchor-pin`.                             |
-| `keycap.svg`     | **Keycap** — modifier-key pill variants (single letter, glyph, multi-char, combos).                      |
+| `meters.svg`     | **Meters** — `.badge` (size, blue) and `.badge-distance` (measurement, red) variants side-by-side.                        |
+| `handles.svg`    | **Handles & pins** — square `.handle`, `#ft-handle` (circle), `#anchor-pin`.                                              |
+| `keycap.svg`     | **Keycap** — modifier-key pill variants (single letter, glyph, multi-char, combos).                                       |
 
 **When to look in which:**
 

--- a/.agents/skills/canvas-docs-svg-kit/examples/text-node-auto-size-alignment.svg
+++ b/.agents/skills/canvas-docs-svg-kit/examples/text-node-auto-size-alignment.svg
@@ -1,0 +1,291 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg { fill: #ECECEC; }
+
+      .doc-heading { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub { font-size: 14px; fill: #6b7280; }
+      .col-title { font-size: 16px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption { font-size: 13px; fill: #6b7280; }
+      .label-mono { font-size: 12px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .sel-outline { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      .ghost { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+
+      .pin-line { stroke: #FF3B30; stroke-width: 1; stroke-dasharray: 3 3; opacity: 0.6; }
+
+      .badge { fill: #0D99FF; }
+      .badge-text { font-size: 10px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+
+      .node-text { font-size: 22px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      .arrow { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head { fill: #9ca3af; }
+      .arrow-red { stroke: #FF3B30; stroke-width: 1.25; fill: none; opacity: 0.85; }
+      .arrow-red-head { fill: #FF3B30; }
+
+      .legend-box { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+    </style>
+
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="ah-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-red-head"/>
+    </marker>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.22"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- Anchor pin: drawn so that (cx, cy) is the literal anchor point.
+         No <symbol> indirection — placed directly with translate(). -->
+    <g id="anchor-pin">
+      <circle cx="0" cy="0" r="9" fill="#FF3B30" opacity="0.18"/>
+      <circle cx="0" cy="0" r="5.5" fill="#FF3B30"/>
+      <circle cx="0" cy="0" r="2" fill="#ffffff"/>
+    </g>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <text x="480" y="58" class="doc-heading" text-anchor="middle">Alignment is preserved</text>
+  <text x="480" y="84" class="doc-sub" text-anchor="middle">The anchor side stays fixed. The opposite side moves in.</text>
+
+  <!-- column dividers -->
+  <line x1="320" y1="120" x2="320" y2="780" stroke="#dcdcdc" stroke-width="1"/>
+  <line x1="640" y1="120" x2="640" y2="780" stroke="#dcdcdc" stroke-width="1"/>
+
+  <!-- =============================================================
+       Geometry plan (per column, inside the group transform):
+         BEFORE box: 280 × 90  at (0, 0)..(280, 90)   ← y-center = 45
+         AFTER  box: 140 × 90, position depends on alignment
+                     LEFT   :   0..140
+                     CENTER :  70..210  (centered on x=140)
+                     RIGHT  : 140..280  (right edge stays at 280)
+       Anchor pin center (in box-local coords):
+         LEFT   : (  0, 45)
+         CENTER : (140, 45)
+         RIGHT  : (280, 45)
+       Pin is a <g> placed via translate(cx, cy), so position is exact.
+     ============================================================= -->
+
+  <!-- ============================================================ -->
+  <!-- LEFT-aligned                                                 -->
+  <!-- ============================================================ -->
+  <text x="160" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="160" y="172" class="col-title" text-anchor="middle">Left</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(20, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="14" y="56" class="node-text">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor on left edge, vertically centered -->
+    <g transform="translate(0, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="160" y1="365" x2="160" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER -->
+  <g transform="translate(20, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="0.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="14" y="56" class="node-text">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="139.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still on left edge -->
+    <g transform="translate(0, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="0" y1="-12" x2="0" y2="102" class="pin-line"/>
+
+    <!-- inward arrow on the moving (right) edge: from old right (280) toward new right (140) -->
+    <line x1="270" y1="45" x2="148" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(33, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="160" y="650" class="caption" text-anchor="middle">Left edge stays put.</text>
+  <text x="160" y="670" class="caption" text-anchor="middle">Right edge moves in.</text>
+
+  <!-- ============================================================ -->
+  <!-- CENTER-aligned                                               -->
+  <!-- ============================================================ -->
+  <text x="480" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="480" y="172" class="col-title" text-anchor="middle">Center</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(340, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="140" y="56" class="node-text" text-anchor="middle">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor at center -->
+    <g transform="translate(140, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="480" y1="365" x2="480" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: new box 70..210, centered on x=140 -->
+  <g transform="translate(340, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="70.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="140" y="56" class="node-text" text-anchor="middle">Hello world</text>
+    <line x1="70.5" y1="64.5" x2="209.5" y2="64.5" class="baseline"/>
+    <rect x="66.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="206.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="66.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="206.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still at center -->
+    <g transform="translate(140, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="140" y1="-12" x2="140" y2="102" class="pin-line"/>
+
+    <!-- both edges move inward -->
+    <line x1="10" y1="45" x2="62" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+    <line x1="270" y1="45" x2="218" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="480" y="650" class="caption" text-anchor="middle">Center stays put.</text>
+  <text x="480" y="670" class="caption" text-anchor="middle">Both edges move inward.</text>
+
+  <!-- ============================================================ -->
+  <!-- RIGHT-aligned                                                -->
+  <!-- ============================================================ -->
+  <text x="800" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="800" y="172" class="col-title" text-anchor="middle">Right</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(660, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="266" y="56" class="node-text" text-anchor="end">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor on right edge -->
+    <g transform="translate(280, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="800" y1="365" x2="800" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: new box 140..280 -->
+  <g transform="translate(660, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="140.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="266" y="56" class="node-text" text-anchor="end">Hello world</text>
+    <line x1="140.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="136.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still on right edge -->
+    <g transform="translate(280, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="280" y1="-12" x2="280" y2="102" class="pin-line"/>
+
+    <!-- inward arrow on the moving (left) edge -->
+    <line x1="10" y1="45" x2="132" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(173, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="800" y="650" class="caption" text-anchor="middle">Right edge stays put.</text>
+  <text x="800" y="670" class="caption" text-anchor="middle">Left edge moves in.</text>
+
+  <!-- ============================================================ -->
+  <!-- legend                                                       -->
+  <!-- ============================================================ -->
+  <g transform="translate(140, 800)">
+    <rect x="0" y="0" width="680" height="120" rx="10" class="legend-box"/>
+
+    <g transform="translate(54, 42)">
+      <use href="#anchor-pin"/>
+      <text x="22" y="5" class="caption">Anchor — the side that stays fixed</text>
+    </g>
+
+    <g transform="translate(40, 80)">
+      <rect x="0" y="-6" width="42" height="12" class="ghost"/>
+      <text x="54" y="3" class="caption">Original bounds before auto sizing</text>
+    </g>
+
+    <g transform="translate(390, 42)">
+      <line x1="0" y1="0" x2="32" y2="0" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+      <text x="46" y="5" class="caption">Edge that moves inward</text>
+    </g>
+
+    <g transform="translate(390, 80)">
+      <rect x="0" y="-8" width="56" height="16" rx="4" class="badge"/>
+      <text x="28" y="4" class="badge-text" text-anchor="middle">w × h</text>
+      <text x="68" y="3" class="caption">Live size readout</text>
+    </g>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/examples/text-node-auto-size-edges.svg
+++ b/.agents/skills/canvas-docs-svg-kit/examples/text-node-auto-size-edges.svg
@@ -1,0 +1,239 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg { fill: #ECECEC; }
+      .panel { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+
+      .doc-heading { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .col-title { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .caption { font-size: 14px; fill: #6b7280; }
+      .label-mono { font-size: 14px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .step-num { font-size: 11px; fill: #ffffff; font-weight: 700; font-family: 'SF Pro Text', sans-serif; }
+      .step-bg { fill: #0a0a0a; }
+      .step-label { font-size: 12px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+
+      /* selection chrome — thin, crisp */
+      .sel-outline { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      /* hot edge — animated double-click target */
+      .edge-hot { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2 { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+
+      /* size readout badge */
+      .badge { fill: #0D99FF; }
+      .badge-text { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.2px; }
+
+      /* cursor icon */
+      .cursor { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+
+      .node-text { font-size: 26px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      .arrow { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head { fill: #9ca3af; }
+
+      .legend-box { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+    </style>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- horizontal resize cursor (↔) -->
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+    <!-- vertical resize cursor (↕) -->
+    <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
+      <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Double-click an edge to reset size to auto</text>
+  <text x="480" y="86" class="caption" text-anchor="middle">The axis you click resets. The other axis stays put.</text>
+
+  <!-- ============================================================ -->
+  <!-- LEFT column: width auto                                      -->
+  <!-- ============================================================ -->
+  <g transform="translate(60, 130)">
+    <text x="200" y="20" class="step-label" text-anchor="middle">Left or right edge</text>
+    <text x="200" y="44" class="col-title" text-anchor="middle">resets <tspan class="label-mono">width</tspan> to auto</text>
+  </g>
+
+  <!-- BEFORE: oversized width text node -->
+  <g transform="translate(80, 220)">
+    <!-- selection outline (crisp at .5) -->
+    <rect x="0.5" y="0.5" width="359" height="119" class="sel-outline"/>
+    <!-- text -->
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <!-- baseline guide -->
+    <line x1="0.5" y1="84.5" x2="359.5" y2="84.5" class="baseline"/>
+    <!-- corner handles 8x8 centred on corners -->
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="356.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="116.5" width="7" height="7" class="handle"/>
+    <rect x="356.5" y="116.5" width="7" height="7" class="handle"/>
+
+    <!-- hot edges -->
+    <line x1="0.5" y1="0" x2="0.5" y2="120" class="edge-hot"/>
+    <line x1="359.5" y1="0" x2="359.5" y2="120" class="edge-hot"/>
+
+    <!-- click ripple on left edge -->
+    <circle cx="0.5" cy="60" r="10" class="ripple"/>
+    <circle cx="0.5" cy="60" r="16" class="ripple-2"/>
+    <!-- click ripple on right edge -->
+    <circle cx="359.5" cy="60" r="10" class="ripple"/>
+    <circle cx="359.5" cy="60" r="16" class="ripple-2"/>
+
+    <!-- resize cursors at hot edges -->
+    <use href="#cursor-h" x="-32" y="52" width="28" height="16" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-h" x="364" y="52" width="28" height="16" filter="url(#cursor-shadow)"/>
+
+    <!-- size badge centred under selection -->
+    <g transform="translate(136, 132)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">360 × 120</text>
+    </g>
+
+    <!-- step number -->
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">1</text>
+    </g>
+  </g>
+
+  <!-- arrow down -->
+  <line x1="260" y1="394" x2="260" y2="448" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: width hugs the text -->
+  <g transform="translate(140, 470)">
+    <rect x="0.5" y="0.5" width="159" height="119" class="sel-outline"/>
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <line x1="0.5" y1="84.5" x2="159.5" y2="84.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="156.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="116.5" width="7" height="7" class="handle"/>
+    <rect x="156.5" y="116.5" width="7" height="7" class="handle"/>
+
+    <g transform="translate(36, 132)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">auto × 120</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">2</text>
+    </g>
+  </g>
+
+  <!-- ============================================================ -->
+  <!-- RIGHT column: height auto                                    -->
+  <!-- ============================================================ -->
+  <g transform="translate(540, 130)">
+    <text x="200" y="20" class="step-label" text-anchor="middle">Top or bottom edge</text>
+    <text x="200" y="44" class="col-title" text-anchor="middle">resets <tspan class="label-mono">height</tspan> to auto</text>
+  </g>
+
+  <!-- BEFORE: oversized height text node -->
+  <g transform="translate(580, 200)">
+    <rect x="0.5" y="0.5" width="259" height="199" class="sel-outline"/>
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <line x1="0.5" y1="84.5" x2="259.5" y2="84.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="196.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="196.5" width="7" height="7" class="handle"/>
+
+    <!-- hot top & bottom edges -->
+    <line x1="0" y1="0.5" x2="260" y2="0.5" class="edge-hot"/>
+    <line x1="0" y1="199.5" x2="260" y2="199.5" class="edge-hot"/>
+
+    <!-- ripples -->
+    <circle cx="130" cy="0.5" r="10" class="ripple"/>
+    <circle cx="130" cy="0.5" r="16" class="ripple-2"/>
+    <circle cx="130" cy="199.5" r="10" class="ripple"/>
+    <circle cx="130" cy="199.5" r="16" class="ripple-2"/>
+
+    <!-- resize cursors -->
+    <use href="#cursor-v" x="122" y="-32" width="16" height="28" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-v" x="122" y="204" width="16" height="28" filter="url(#cursor-shadow)"/>
+
+    <g transform="translate(86, 212)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">260 × 200</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">1</text>
+    </g>
+  </g>
+
+  <line x1="710" y1="478" x2="710" y2="528" class="arrow" marker-end="url(#ah)"/>
+
+  <g transform="translate(580, 550)">
+    <rect x="0.5" y="0.5" width="259" height="49" class="sel-outline"/>
+    <text x="14" y="36" class="node-text">Hello world</text>
+    <line x1="0.5" y1="46.5" x2="259.5" y2="46.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="46.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="46.5" width="7" height="7" class="handle"/>
+
+    <g transform="translate(86, 62)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">260 × auto</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">2</text>
+    </g>
+  </g>
+
+  <!-- ============================================================ -->
+  <!-- legend                                                       -->
+  <!-- ============================================================ -->
+  <g transform="translate(140, 800)">
+    <rect x="0" y="0" width="680" height="120" rx="10" class="legend-box"/>
+
+    <g transform="translate(40, 40)">
+      <line x1="0" y1="6" x2="28" y2="6" class="edge-hot"/>
+      <circle cx="14" cy="6" r="6" class="ripple"/>
+      <text x="46" y="11" class="caption">Hot edge — your double-click target</text>
+    </g>
+
+    <g transform="translate(40, 78)">
+      <use href="#cursor-h" x="0" y="-2" width="22" height="14"/>
+      <text x="36" y="11" class="caption">Resize cursor appears on hover</text>
+    </g>
+
+    <g transform="translate(390, 40)">
+      <rect x="0" y="-6" width="64" height="22" rx="4" class="badge"/>
+      <text x="32" y="10" class="badge-text" text-anchor="middle">w × h</text>
+      <text x="76" y="11" class="caption">Live size readout</text>
+    </g>
+
+    <g transform="translate(390, 78)">
+      <rect x="-3.5" y="2.5" width="7" height="7" class="handle"/>
+      <text x="20" y="11" class="caption">Selection corner handle</text>
+    </g>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/cursors.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/cursors.svg
@@ -1,0 +1,163 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  cursors
+
+  Focused catalog of every cursor symbol in the kit. Each cell shows the
+  cursor at its native size (with shadow), labelled with its `<use>` id and
+  natural width × height.
+
+  All paths are also defined in template.svg.
+  Source for canonical cursor look:
+    editor/public/assets/css-cursors-macos/*.png   (macOS-style PNG set)
+    editor/components/cursor/cursor-data.ts        (rotate inline SVG)
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 720"
+     width="960"
+     height="720"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+      .doc-heading   { font-size: 24px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 13px; fill: #6b7280; }
+      .cell-bg       { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .cell-title    { font-size: 13px; fill: #0a0a0a; font-weight: 600; }
+      .cell-class    { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .cell-meta     { font-size: 10px; fill: #9ca3af; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .cursor        { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+      .cursor-hand   { fill: #ffffff; stroke: #0a0a0a; stroke-width: 1.5; stroke-linejoin: round; }
+    </style>
+
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <symbol id="cursor-pointer" viewBox="0 0 14 18" overflow="visible">
+      <path d="M 1 1 L 1 15 L 5 11.5 L 7.5 17 L 9.5 16 L 7 10.8 L 12 10.8 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-move" viewBox="0 0 24 24" overflow="visible">
+      <path d="M 12 2 L 16 6 L 14 6 L 14 10 L 18 10 L 18 8 L 22 12 L 18 16 L 18 14 L 14 14 L 14 18 L 16 18 L 12 22 L 8 18 L 10 18 L 10 14 L 6 14 L 6 16 L 2 12 L 6 8 L 6 10 L 10 10 L 10 6 L 8 6 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-grab" viewBox="0 0 16 18" overflow="visible">
+      <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M8.6 17.5Q7 17.5 6 17q-1.2-.5-2-1.5t-1.6-2.6L.6 8.2v-1q0-.4.7-.6H2q.4.3.6.7l1.6 2.9.2.2h.3V10l-1-7q-.1-.7.1-1a1 1 0 0 1 1-.5 1 1 0 0 1 1.1 1l1.1 5.2v-6q0-.6.4-1 .3-.3.9-.3a1.2 1.2 0 0 1 1.2 1.2v6l1-5.2a1 1 0 0 1 1-1h.3q.5 0 .8.5l.2 1-.9 5.3 1.2-3.5q.2-.5.5-.7a1 1 0 0 1 1.6.3q.3.3.2.9l-1.2 6.5a8 8 0 0 1-1.8 4.2q-1.4 1.5-4 1.5Z"
+            class="cursor-hand"/>
+    </symbol>
+    <symbol id="cursor-grabbing" viewBox="0 0 14 13" overflow="visible">
+      <path d="M6.71.5q.39 0 .73.2l.09.06a1 1 0 0 1 .43.83v.66q.1.05.18.03l.01-.03v-.01l.16-.54.05-.15a1 1 0 0 1 .82-.63q.59-.1 1.06.27.26.18.38.5.1.3.04.6l-.15.88-.01.1q.04.04.13.04h.05l.24-.39V2.9q.3-.4.76-.46.4-.05.74.14l.1.06q.42.32.43.83 0 .84-.13 1.63-.12.77-.35 1.74l-.05.27a8 8 0 0 1-1.05 2.67q-.7 1.11-1.89 1.67-1.18.56-2.8.56-1.85 0-3.28-.92a6 6 0 0 1-1.96-2.16l-.2-.4A8.5 8.5 0 0 1 .5 4.93c0-.51.11-1 .41-1.36a1.5 1.5 0 0 1 1.06-.58q.28-.02.5.04l.15.05.27.1.05.27.25 1.27.02.07v.01h.01l.03.01.02-.01v-.05L2.75 2.3q-.08-.3.03-.61.11-.32.37-.5.48-.36 1.07-.27.31.04.56.26.19.17.27.39l.05.14.15.53v.01l.01.02.05.01q.07 0 .14-.03v-.66a1 1 0 0 1 .42-.83q.38-.27.83-.26Z"
+            class="cursor-hand"/>
+    </symbol>
+    <symbol id="cursor-rotate" viewBox="0 0 26 24" overflow="visible">
+      <path fill="#000000" fill-rule="evenodd" clip-rule="evenodd"
+            d="M23 15.5h-6.43l2.65-2.79A7.72 7.72 0 0 0 13 9.5a7.72 7.72 0 0 0-6.22 3.21l2.65 2.79H3V8.75l1.74 1.83A10.5 10.5 0 0 1 13 6.5c3.32 0 6.3 1.59 8.26 4.08L23 8.75v6.75Z"/>
+      <path fill="none" stroke="#ffffff" stroke-width="0.75"
+            d="M23 15.88h.38V7.8l-.65.68-1.45 1.52A10.85 10.85 0 0 0 13 6.13c-3.3 0-6.25 1.5-8.28 3.88L3.27 8.5l-.64-.68v8.07h7.67l-.6-.64-2.43-2.55A7.32 7.32 0 0 1 13 9.88c2.3 0 4.36 1.08 5.73 2.8l-2.43 2.56-.6.63H23Z"/>
+    </symbol>
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
+      <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="720"/>
+
+  <text x="40" y="50" class="doc-heading">Cursors</text>
+  <text x="40" y="74" class="doc-sub">Stylised line-art cursors. For higher-fidelity reference see the macOS PNG set in editor/public/assets/css-cursors-macos/</text>
+
+  <!-- 4 columns × 2 rows = 8 cells, last cell unused -->
+  <!-- cell: 215 × 240, gap 20, starting at x=40, y=110 -->
+
+  <!-- pointer -->
+  <g transform="translate(40, 110)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">pointer</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-pointer"</text>
+    <text x="16" y="62" class="cell-meta">14 × 18 · hotspot 0,0</text>
+    <use href="#cursor-pointer" x="100" y="120" width="14" height="18" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">default arrow</text>
+  </g>
+
+  <!-- move -->
+  <g transform="translate(265, 110)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">move</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-move"</text>
+    <text x="16" y="62" class="cell-meta">24 × 24 · hotspot 12,12</text>
+    <use href="#cursor-move" x="95" y="115" width="24" height="24" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">4-direction translate</text>
+  </g>
+
+  <!-- grab -->
+  <g transform="translate(490, 110)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">grab</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-grab"</text>
+    <text x="16" y="62" class="cell-meta">16 × 18 · hotspot 8,9</text>
+    <use href="#cursor-grab" x="99" y="115" width="16" height="18" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">drag affordance (open)</text>
+  </g>
+
+  <!-- grabbing -->
+  <g transform="translate(715, 110)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">grabbing</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-grabbing"</text>
+    <text x="16" y="62" class="cell-meta">14 × 13 · hotspot 7,7</text>
+    <use href="#cursor-grabbing" x="100" y="118" width="14" height="13" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">drag in progress (closed)</text>
+  </g>
+
+  <!-- rotate -->
+  <g transform="translate(40, 370)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">rotate</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-rotate"</text>
+    <text x="16" y="62" class="cell-meta">26 × 24 · hotspot 13,12</text>
+    <use href="#cursor-rotate" x="94" y="115" width="26" height="24" filter="url(#cursor-shadow)"/>
+    <text x="107" y="200" class="cell-meta" text-anchor="middle">rotation drag</text>
+    <text x="107" y="216" class="cell-meta" text-anchor="middle">wrap in rotate(θ) to orient</text>
+  </g>
+
+  <!-- h-resize -->
+  <g transform="translate(275, 370)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">h-resize</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-h"</text>
+    <text x="16" y="62" class="cell-meta">28 × 16 · hotspot 14,8</text>
+    <use href="#cursor-h" x="93" y="119" width="28" height="16" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">edge resize, horizontal</text>
+  </g>
+
+  <!-- v-resize -->
+  <g transform="translate(490, 370)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">v-resize</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-v"</text>
+    <text x="16" y="62" class="cell-meta">16 × 28 · hotspot 8,14</text>
+    <use href="#cursor-v" x="99" y="113" width="16" height="28" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">edge resize, vertical</text>
+  </g>
+
+  <!-- empty cell as note -->
+  <g transform="translate(715, 370)">
+    <rect width="205" height="240" rx="8" fill="#fafafa" stroke="#e5e5e5" stroke-dasharray="3 3"/>
+    <text x="107" y="115" class="cell-class" text-anchor="middle">For a higher-fidelity</text>
+    <text x="107" y="135" class="cell-class" text-anchor="middle">cursor, embed the macOS</text>
+    <text x="107" y="155" class="cell-class" text-anchor="middle">PNG via base64 data URI.</text>
+    <text x="107" y="180" class="cell-meta" text-anchor="middle">editor/public/assets/</text>
+    <text x="107" y="195" class="cell-meta" text-anchor="middle">css-cursors-macos/*.png</text>
+  </g>
+
+  <!-- usage example -->
+  <text x="40" y="660" class="cell-title">Usage</text>
+  <g transform="translate(40, 675)">
+    <text x="0" y="14" class="cell-class">&lt;use href="#cursor-rotate" x="500" y="100" width="26" height="24" filter="url(#cursor-shadow)"/&gt;</text>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/cursors.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/cursors.svg
@@ -12,9 +12,9 @@
     editor/components/cursor/cursor-data.ts        (rotate inline SVG)
 -->
 <svg xmlns="http://www.w3.org/2000/svg"
-     viewBox="0 0 960 720"
+     viewBox="0 0 960 960"
      width="960"
-     height="720"
+     height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
   <metadata>canvas-docs-svg-kit/v1</metadata>
   <defs>
@@ -64,15 +64,23 @@
     <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
       <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
     </symbol>
+    <symbol id="cursor-crosshair" viewBox="0 0 20 20" overflow="visible">
+      <path d="M 9 0 H 11 V 9 H 20 V 11 H 11 V 20 H 9 V 11 H 0 V 9 H 9 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-text" viewBox="0 0 8 20" overflow="visible">
+      <path d="M 0 0 H 8 V 2 H 5 V 18 H 8 V 20 H 0 V 18 H 3 V 2 H 0 Z" class="cursor"/>
+    </symbol>
   </defs>
 
-  <rect class="canvas-bg" width="960" height="720"/>
+  <rect class="canvas-bg" width="960" height="960"/>
 
   <text x="40" y="50" class="doc-heading">Cursors</text>
   <text x="40" y="74" class="doc-sub">Stylised line-art cursors. For higher-fidelity reference see the macOS PNG set in editor/public/assets/css-cursors-macos/</text>
 
-  <!-- 4 columns × 2 rows = 8 cells, last cell unused -->
-  <!-- cell: 215 × 240, gap 20, starting at x=40, y=110 -->
+  <!-- 4 columns × 3 rows = 12 cells -->
+  <!-- cell: 205 × 240, gap 20. columns x=40, 265, 490, 715. rows y=110, 370, 630 -->
+
+  <!-- ROW 1 -->
 
   <!-- pointer -->
   <g transform="translate(40, 110)">
@@ -114,6 +122,8 @@
     <text x="107" y="210" class="cell-meta" text-anchor="middle">drag in progress (closed)</text>
   </g>
 
+  <!-- ROW 2 -->
+
   <!-- rotate -->
   <g transform="translate(40, 370)">
     <rect width="205" height="240" rx="8" class="cell-bg"/>
@@ -126,12 +136,12 @@
   </g>
 
   <!-- h-resize -->
-  <g transform="translate(275, 370)">
+  <g transform="translate(265, 370)">
     <rect width="205" height="240" rx="8" class="cell-bg"/>
     <text x="16" y="28" class="cell-title">h-resize</text>
     <text x="16" y="46" class="cell-class">use href="#cursor-h"</text>
     <text x="16" y="62" class="cell-meta">28 × 16 · hotspot 14,8</text>
-    <use href="#cursor-h" x="93" y="119" width="28" height="16" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-h" x="88" y="119" width="28" height="16" filter="url(#cursor-shadow)"/>
     <text x="107" y="210" class="cell-meta" text-anchor="middle">edge resize, horizontal</text>
   </g>
 
@@ -141,23 +151,42 @@
     <text x="16" y="28" class="cell-title">v-resize</text>
     <text x="16" y="46" class="cell-class">use href="#cursor-v"</text>
     <text x="16" y="62" class="cell-meta">16 × 28 · hotspot 8,14</text>
-    <use href="#cursor-v" x="99" y="113" width="16" height="28" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-v" x="94" y="113" width="16" height="28" filter="url(#cursor-shadow)"/>
     <text x="107" y="210" class="cell-meta" text-anchor="middle">edge resize, vertical</text>
   </g>
 
-  <!-- empty cell as note -->
+  <!-- crosshair -->
   <g transform="translate(715, 370)">
-    <rect width="205" height="240" rx="8" fill="#fafafa" stroke="#e5e5e5" stroke-dasharray="3 3"/>
-    <text x="107" y="115" class="cell-class" text-anchor="middle">For a higher-fidelity</text>
-    <text x="107" y="135" class="cell-class" text-anchor="middle">cursor, embed the macOS</text>
-    <text x="107" y="155" class="cell-class" text-anchor="middle">PNG via base64 data URI.</text>
-    <text x="107" y="180" class="cell-meta" text-anchor="middle">editor/public/assets/</text>
-    <text x="107" y="195" class="cell-meta" text-anchor="middle">css-cursors-macos/*.png</text>
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">crosshair</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-crosshair"</text>
+    <text x="16" y="62" class="cell-meta">20 × 20 · hotspot 10,10</text>
+    <use href="#cursor-crosshair" x="92" y="117" width="20" height="20" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">point pick · vector draw</text>
+  </g>
+
+  <!-- ROW 3 -->
+
+  <!-- text -->
+  <g transform="translate(40, 630)">
+    <rect width="205" height="240" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">text</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-text"</text>
+    <text x="16" y="62" class="cell-meta">8 × 20 · hotspot 4,10</text>
+    <use href="#cursor-text" x="100" y="117" width="8" height="20" filter="url(#cursor-shadow)"/>
+    <text x="107" y="210" class="cell-meta" text-anchor="middle">I-beam · text insertion</text>
+  </g>
+
+  <!-- note -->
+  <g transform="translate(265, 630)">
+    <rect width="655" height="240" rx="8" fill="#fafafa" stroke="#e5e5e5" stroke-dasharray="3 3"/>
+    <text x="327" y="110" class="cell-class" text-anchor="middle">For a higher-fidelity cursor, embed the macOS PNG via base64 data URI.</text>
+    <text x="327" y="140" class="cell-meta" text-anchor="middle">editor/public/assets/css-cursors-macos/*.png</text>
   </g>
 
   <!-- usage example -->
-  <text x="40" y="660" class="cell-title">Usage</text>
-  <g transform="translate(40, 675)">
-    <text x="0" y="14" class="cell-class">&lt;use href="#cursor-rotate" x="500" y="100" width="26" height="24" filter="url(#cursor-shadow)"/&gt;</text>
+  <text x="40" y="910" class="cell-title">Usage</text>
+  <g transform="translate(40, 925)">
+    <text x="0" y="14" class="cell-class">&lt;use href="#cursor-crosshair" x="100" y="100" width="20" height="20" filter="url(#cursor-shadow)"/&gt;</text>
   </g>
 </svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/handles.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/handles.svg
@@ -1,0 +1,105 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  handles
+
+  The kit's three "point" primitives:
+    .handle             → square corner handle (selection chrome)
+    #ft-handle          → circle handle (free-transform grip)
+    #anchor-pin         → red dot with halo (anchor point — fixed point in space)
+
+  Each is positioned via translate(cx, cy) so the centre lands exactly on
+  (cx, cy) — important for visual accuracy in alignment figures.
+
+  Source for the canonical look:
+    editor/grida-canvas-react/viewport/surface.tsx               (square handle)
+    editor/grida-canvas-react/viewport/ui/surface-image-editor.tsx  (circle / free-transform)
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 480"
+     width="960"
+     height="480"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+      .doc-heading   { font-size: 24px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 13px; fill: #6b7280; }
+      .cell-bg       { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .cell-title    { font-size: 13px; fill: #0a0a0a; font-weight: 600; }
+      .cell-class    { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .cell-meta     { font-size: 10px; fill: #9ca3af; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle        { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle-circle { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.5; }
+    </style>
+
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <g id="anchor-pin">
+      <circle cx="0" cy="0" r="9" fill="#FF3B30" opacity="0.18"/>
+      <circle cx="0" cy="0" r="5.5" fill="#FF3B30"/>
+      <circle cx="0" cy="0" r="2" fill="#ffffff"/>
+    </g>
+    <g id="ft-handle">
+      <circle cx="0" cy="0" r="7" class="handle-circle"/>
+    </g>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="480"/>
+
+  <text x="40" y="50" class="doc-heading">Handles &amp; pins</text>
+  <text x="40" y="74" class="doc-sub">Three "point" primitives. Each positioned via translate(cx, cy) — the centre lands exactly on the target point.</text>
+
+  <!-- Square handle -->
+  <g transform="translate(40, 110)">
+    <rect width="293" height="320" rx="8" class="cell-bg"/>
+    <text x="20" y="30" class="cell-title">Square handle</text>
+    <text x="20" y="50" class="cell-class">.handle · 7×7 corner</text>
+
+    <!-- show against a selection outline so role is clear -->
+    <rect x="86.5" y="120.5" width="120" height="80" class="sel-outline"/>
+    <rect x="83" y="117"  width="7" height="7" class="handle"/>
+    <rect x="203" y="117" width="7" height="7" class="handle"/>
+    <rect x="83" y="197"  width="7" height="7" class="handle"/>
+    <rect x="203" y="197" width="7" height="7" class="handle"/>
+
+    <text x="146" y="270" class="cell-meta" text-anchor="middle">selection corner — resize gesture</text>
+  </g>
+
+  <!-- Free-transform handle (circle variant) -->
+  <g transform="translate(353, 110)">
+    <rect width="293" height="320" rx="8" class="cell-bg"/>
+    <text x="20" y="30" class="cell-title">Free-transform handle</text>
+    <text x="20" y="50" class="cell-class">#ft-handle · .handle-circle</text>
+
+    <rect x="86.5" y="120.5" width="120" height="80" class="sel-outline" opacity="0.5"/>
+    <g transform="translate(86, 120)"><use href="#ft-handle"/></g>
+    <g transform="translate(206, 120)"><use href="#ft-handle"/></g>
+    <g transform="translate(86, 200)"><use href="#ft-handle"/></g>
+    <g transform="translate(206, 200)"><use href="#ft-handle"/></g>
+
+    <text x="146" y="270" class="cell-meta" text-anchor="middle">corner grip — rotate / scale gesture</text>
+  </g>
+
+  <!-- Anchor pin -->
+  <g transform="translate(666, 110)">
+    <rect width="254" height="320" rx="8" class="cell-bg"/>
+    <text x="20" y="30" class="cell-title">Anchor pin</text>
+    <text x="20" y="50" class="cell-class">#anchor-pin · #pin-shadow</text>
+
+    <line x1="40" y1="160" x2="214" y2="160" stroke="#b5b5b5" stroke-width="1" stroke-dasharray="3 3"/>
+    <g transform="translate(127, 160)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <text x="127" y="240" class="cell-meta" text-anchor="middle">a fixed point in space</text>
+    <text x="127" y="256" class="cell-meta" text-anchor="middle">(centre is exactly on cx, cy)</text>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/keycap.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/keycap.svg
@@ -1,0 +1,107 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  keycap
+
+  Modifier-key pill (kbd-style). Use in interaction figures to show which
+  key the user holds during a gesture (Alt-hover, Shift-resize, etc.).
+
+  Source for the canonical look:
+    editor/components/ui/kbd.tsx
+      bg-muted, text-muted-foreground, h-5, min-w-5, px-1, rounded-sm, text-xs
+
+  Sizing recipe (matches kbd.tsx):
+    height = 20            (h-5 ≈ 20px)
+    rx     = 3             (rounded-sm)
+    width  = max(20, glyphs * 8 + 16)
+                           (px-1 each side ≈ 8px padding total, plus glyph room)
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 360"
+     width="960"
+     height="360"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg   { fill: #ECECEC; }
+      .doc-heading { font-size: 24px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub     { font-size: 13px; fill: #6b7280; }
+      .cell-bg     { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .cell-title  { font-size: 13px; fill: #0a0a0a; font-weight: 600; }
+      .cell-class  { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .cell-meta   { font-size: 10px; fill: #9ca3af; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .kbd-bg      { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
+      .kbd-text    { font-size: 11px; fill: #475569; font-weight: 500; letter-spacing: 0.2px; }
+    </style>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="360"/>
+
+  <text x="40" y="50" class="doc-heading">Keycap</text>
+  <text x="40" y="74" class="doc-sub">Modifier-key pill. Width varies with content; height fixed at 20.</text>
+
+  <g transform="translate(40, 110)">
+    <rect width="880" height="220" rx="8" class="cell-bg"/>
+
+    <text x="20" y="32" class="cell-title">Variants</text>
+    <text x="20" y="50" class="cell-class">.kbd-bg · .kbd-text</text>
+
+    <!-- single-letter -->
+    <g transform="translate(60, 110)">
+      <rect x="0" y="0" width="20" height="20" rx="3" class="kbd-bg"/>
+      <text x="10" y="14" class="kbd-text" text-anchor="middle">A</text>
+      <text x="10" y="44" class="cell-meta" text-anchor="middle">A</text>
+    </g>
+
+    <g transform="translate(120, 110)">
+      <rect x="0" y="0" width="20" height="20" rx="3" class="kbd-bg"/>
+      <text x="10" y="14" class="kbd-text" text-anchor="middle">⌘</text>
+      <text x="10" y="44" class="cell-meta" text-anchor="middle">⌘</text>
+    </g>
+
+    <g transform="translate(180, 110)">
+      <rect x="0" y="0" width="20" height="20" rx="3" class="kbd-bg"/>
+      <text x="10" y="14" class="kbd-text" text-anchor="middle">⇧</text>
+      <text x="10" y="44" class="cell-meta" text-anchor="middle">⇧</text>
+    </g>
+
+    <!-- 3-letter -->
+    <g transform="translate(240, 110)">
+      <rect x="0" y="0" width="32" height="20" rx="3" class="kbd-bg"/>
+      <text x="16" y="14" class="kbd-text" text-anchor="middle">Alt</text>
+      <text x="16" y="44" class="cell-meta" text-anchor="middle">Alt (32×20)</text>
+    </g>
+
+    <g transform="translate(312, 110)">
+      <rect x="0" y="0" width="36" height="20" rx="3" class="kbd-bg"/>
+      <text x="18" y="14" class="kbd-text" text-anchor="middle">Esc</text>
+      <text x="18" y="44" class="cell-meta" text-anchor="middle">Esc</text>
+    </g>
+
+    <!-- 5+ -->
+    <g transform="translate(388, 110)">
+      <rect x="0" y="0" width="48" height="20" rx="3" class="kbd-bg"/>
+      <text x="24" y="14" class="kbd-text" text-anchor="middle">Shift</text>
+      <text x="24" y="44" class="cell-meta" text-anchor="middle">Shift (48×20)</text>
+    </g>
+
+    <g transform="translate(476, 110)">
+      <rect x="0" y="0" width="56" height="20" rx="3" class="kbd-bg"/>
+      <text x="28" y="14" class="kbd-text" text-anchor="middle">Enter</text>
+      <text x="28" y="44" class="cell-meta" text-anchor="middle">Enter</text>
+    </g>
+
+    <!-- combo: Cmd + S -->
+    <g transform="translate(572, 110)">
+      <rect x="0" y="0" width="20" height="20" rx="3" class="kbd-bg"/>
+      <text x="10" y="14" class="kbd-text" text-anchor="middle">⌘</text>
+      <text x="34" y="15" font-size="13" fill="#9ca3af" text-anchor="middle">+</text>
+      <rect x="48" y="0" width="20" height="20" rx="3" class="kbd-bg"/>
+      <text x="58" y="14" class="kbd-text" text-anchor="middle">S</text>
+      <text x="34" y="44" class="cell-meta" text-anchor="middle">⌘ + S</text>
+    </g>
+
+    <text x="440" y="200" class="cell-meta" text-anchor="middle">Tip: keep keycaps inline with prose by giving them the same baseline as adjacent text.</text>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/meters.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/meters.svg
@@ -1,0 +1,103 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  meters
+
+  The meter primitive comes in two variants:
+    .badge          → size readout, blue (selection variant)
+    .badge-distance → distance / measurement readout, red (workbench red)
+
+  Both share the .badge-text class for inner text. Drop-shadow filter
+  matches the kit's #badge-shadow for visual consistency.
+
+  Source for the canonical look:
+    editor/grida-canvas-react/viewport/ui/size.tsx
+    editor/grida-canvas-react/viewport/ui/measurement.tsx
+    editor/grida-canvas-react/ui-config.ts (WorkbenchColors)
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 480"
+     width="960"
+     height="480"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg      { fill: #ECECEC; }
+      .doc-heading    { font-size: 24px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub        { font-size: 13px; fill: #6b7280; }
+      .cell-bg        { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .cell-title     { font-size: 13px; fill: #0a0a0a; font-weight: 600; }
+      .cell-class     { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .cell-meta      { font-size: 10px; fill: #9ca3af; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .badge          { fill: #0D99FF; }
+      .badge-distance { fill: #f44336; }
+      .badge-text     { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+    </style>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="480"/>
+
+  <text x="40" y="50" class="doc-heading">Meters</text>
+  <text x="40" y="74" class="doc-sub">Two variants of the same pill: blue size, red distance. Same shape, same .badge-text.</text>
+
+  <!-- Size variant -->
+  <g transform="translate(40, 110)">
+    <rect width="440" height="280" rx="8" class="cell-bg"/>
+    <text x="20" y="30" class="cell-title">Size meter (selection)</text>
+    <text x="20" y="50" class="cell-class">.badge · .badge-text · #badge-shadow</text>
+
+    <g transform="translate(176, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+
+    <g transform="translate(176, 140)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">auto × 120</text>
+    </g>
+
+    <g transform="translate(176, 180)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="60" height="22" rx="4" class="badge"/>
+      <text x="30" y="15" class="badge-text" text-anchor="middle">w × h</text>
+    </g>
+
+    <text x="220" y="240" class="cell-meta" text-anchor="middle">live size readout under selection</text>
+    <text x="220" y="256" class="cell-meta" text-anchor="middle">colour: WorkbenchColors.sky-ish</text>
+  </g>
+
+  <!-- Distance variant -->
+  <g transform="translate(500, 110)">
+    <rect width="420" height="280" rx="8" class="cell-bg"/>
+    <text x="20" y="30" class="cell-title">Distance meter (measurement)</text>
+    <text x="20" y="50" class="cell-class">.badge-distance · .badge-text · #badge-shadow</text>
+
+    <g transform="translate(166, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge-distance"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">120 px</text>
+    </g>
+
+    <g transform="translate(166, 140)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge-distance"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">340 px</text>
+    </g>
+
+    <g transform="translate(166, 180)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="60" height="22" rx="4" class="badge-distance"/>
+      <text x="30" y="15" class="badge-text" text-anchor="middle">45°</text>
+    </g>
+
+    <text x="210" y="240" class="cell-meta" text-anchor="middle">measurement / dimension readout</text>
+    <text x="210" y="256" class="cell-meta" text-anchor="middle">colour: WorkbenchColors.red (#f44336)</text>
+  </g>
+
+  <text x="40" y="430" class="cell-title">Pattern</text>
+  <text x="40" y="456" class="cell-class">&lt;g transform="translate(x, y)" filter="url(#badge-shadow)"&gt;&lt;rect width="W" height="22" rx="4" class="badge[-distance]"/&gt;&lt;text x="W/2" y="15" class="badge-text" text-anchor="middle"&gt;…&lt;/text&gt;&lt;/g&gt;</text>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/primitives.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/primitives.svg
@@ -1,0 +1,350 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  primitives catalog
+
+  Visual reference of every primitive in the kit. Open this file to see
+  what's available before composing a new figure. The CSS classes shown
+  beside each cell are the same names used in template.svg.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 1400"
+     width="960"
+     height="1400"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+      .doc-heading   { font-size: 24px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 13px; fill: #6b7280; }
+      .cell-bg       { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .cell-title    { font-size: 13px; fill: #0a0a0a; font-weight: 600; }
+      .cell-class    { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      /* primitives — same as template.svg */
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle        { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline      { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+      .edge-hot      { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple        { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2      { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+      .cursor        { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+      .cursor-hand   { fill: #ffffff; stroke: #0a0a0a; stroke-width: 1.5; stroke-linejoin: round; }
+      .badge          { fill: #0D99FF; }
+      .badge-distance { fill: #f44336; }
+      .badge-text     { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+      .kbd-bg         { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
+      .kbd-text       { font-size: 11px; fill: #475569; font-weight: 500; letter-spacing: 0.2px; }
+      .handle-circle  { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.5; }
+      .ghost         { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+      .arrow         { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head    { fill: #9ca3af; }
+      .arrow-red     { stroke: #FF3B30; stroke-width: 1.25; fill: none; opacity: 0.85; }
+      .arrow-red-head{ fill: #FF3B30; }
+      .step-bg       { fill: #0a0a0a; }
+      .step-num      { font-size: 11px; fill: #ffffff; font-weight: 700; }
+      .node-text     { font-size: 22px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      /* token swatches */
+      .swatch        { stroke: #e5e5e5; stroke-width: 1; }
+      .swatch-label  { font-size: 11px; fill: #0a0a0a; }
+      .swatch-hex    { font-size: 10px; fill: #6b7280; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+    </style>
+
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="ah-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-red-head"/>
+    </marker>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <g id="anchor-pin">
+      <circle cx="0" cy="0" r="9" fill="#FF3B30" opacity="0.18"/>
+      <circle cx="0" cy="0" r="5.5" fill="#FF3B30"/>
+      <circle cx="0" cy="0" r="2" fill="#ffffff"/>
+    </g>
+
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
+      <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
+    </symbol>
+
+    <g id="ft-handle">
+      <circle cx="0" cy="0" r="7" class="handle-circle"/>
+    </g>
+
+    <symbol id="cursor-pointer" viewBox="0 0 14 18" overflow="visible">
+      <path d="M 1 1 L 1 15 L 5 11.5 L 7.5 17 L 9.5 16 L 7 10.8 L 12 10.8 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-move" viewBox="0 0 24 24" overflow="visible">
+      <path d="M 12 2 L 16 6 L 14 6 L 14 10 L 18 10 L 18 8 L 22 12 L 18 16 L 18 14 L 14 14 L 14 18 L 16 18 L 12 22 L 8 18 L 10 18 L 10 14 L 6 14 L 6 16 L 2 12 L 6 8 L 6 10 L 10 10 L 10 6 L 8 6 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-grab" viewBox="0 0 16 18" overflow="visible">
+      <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M8.6 17.5Q7 17.5 6 17q-1.2-.5-2-1.5t-1.6-2.6L.6 8.2v-1q0-.4.7-.6H2q.4.3.6.7l1.6 2.9.2.2h.3V10l-1-7q-.1-.7.1-1a1 1 0 0 1 1-.5 1 1 0 0 1 1.1 1l1.1 5.2v-6q0-.6.4-1 .3-.3.9-.3a1.2 1.2 0 0 1 1.2 1.2v6l1-5.2a1 1 0 0 1 1-1h.3q.5 0 .8.5l.2 1-.9 5.3 1.2-3.5q.2-.5.5-.7a1 1 0 0 1 1.6.3q.3.3.2.9l-1.2 6.5a8 8 0 0 1-1.8 4.2q-1.4 1.5-4 1.5Z"
+            class="cursor-hand"/>
+    </symbol>
+    <symbol id="cursor-grabbing" viewBox="0 0 14 13" overflow="visible">
+      <path d="M6.71.5q.39 0 .73.2l.09.06a1 1 0 0 1 .43.83v.66q.1.05.18.03l.01-.03v-.01l.16-.54.05-.15a1 1 0 0 1 .82-.63q.59-.1 1.06.27.26.18.38.5.1.3.04.6l-.15.88-.01.1q.04.04.13.04h.05l.24-.39V2.9q.3-.4.76-.46.4-.05.74.14l.1.06q.42.32.43.83 0 .84-.13 1.63-.12.77-.35 1.74l-.05.27a8 8 0 0 1-1.05 2.67q-.7 1.11-1.89 1.67-1.18.56-2.8.56-1.85 0-3.28-.92a6 6 0 0 1-1.96-2.16l-.2-.4A8.5 8.5 0 0 1 .5 4.93c0-.51.11-1 .41-1.36a1.5 1.5 0 0 1 1.06-.58q.28-.02.5.04l.15.05.27.1.05.27.25 1.27.02.07v.01h.01l.03.01.02-.01v-.05L2.75 2.3q-.08-.3.03-.61.11-.32.37-.5.48-.36 1.07-.27.31.04.56.26.19.17.27.39l.05.14.15.53v.01l.01.02.05.01q.07 0 .14-.03v-.66a1 1 0 0 1 .42-.83q.38-.27.83-.26Z"
+            class="cursor-hand"/>
+    </symbol>
+    <symbol id="cursor-rotate" viewBox="0 0 26 24" overflow="visible">
+      <path fill="#000000" fill-rule="evenodd" clip-rule="evenodd"
+            d="M23 15.5h-6.43l2.65-2.79A7.72 7.72 0 0 0 13 9.5a7.72 7.72 0 0 0-6.22 3.21l2.65 2.79H3V8.75l1.74 1.83A10.5 10.5 0 0 1 13 6.5c3.32 0 6.3 1.59 8.26 4.08L23 8.75v6.75Z"/>
+      <path fill="none" stroke="#ffffff" stroke-width="0.75"
+            d="M23 15.88h.38V7.8l-.65.68-1.45 1.52A10.85 10.85 0 0 0 13 6.13c-3.3 0-6.25 1.5-8.28 3.88L3.27 8.5l-.64-.68v8.07h7.67l-.6-.64-2.43-2.55A7.32 7.32 0 0 1 13 9.88c2.3 0 4.36 1.08 5.73 2.8l-2.43 2.56-.6.63H23Z"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="1400"/>
+
+  <text x="40" y="50" class="doc-heading">Primitives catalog</text>
+  <text x="40" y="74" class="doc-sub">Each cell is a standalone primitive. Class names match template.svg.</text>
+
+  <!-- =============== GRID: 3 cols × 3 rows  (cell 280 × 200) =============== -->
+  <!-- column x: 40, 340, 640         row y: 100, 320, 540 -->
+
+  <!-- ─── 1. Selection chrome ─── -->
+  <g transform="translate(40, 100)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Selection chrome</text>
+    <text x="16" y="46" class="cell-class">.sel-outline · .handle · .baseline</text>
+    <g transform="translate(60, 90)">
+      <rect x="0.5" y="0.5" width="159" height="69" class="sel-outline"/>
+      <line x1="0.5" y1="50.5" x2="159.5" y2="50.5" class="baseline"/>
+      <rect x="-3.5" y="-3.5"   width="7" height="7" class="handle"/>
+      <rect x="156.5" y="-3.5"  width="7" height="7" class="handle"/>
+      <rect x="-3.5" y="66.5"   width="7" height="7" class="handle"/>
+      <rect x="156.5" y="66.5"  width="7" height="7" class="handle"/>
+    </g>
+  </g>
+
+  <!-- ─── 2. Size badge ─── -->
+  <g transform="translate(340, 100)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Size badge</text>
+    <text x="16" y="46" class="cell-class">.badge · .badge-text · #badge-shadow</text>
+    <g transform="translate(96, 110)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <!-- ─── 3. Anchor pin ─── -->
+  <g transform="translate(640, 100)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Anchor pin</text>
+    <text x="16" y="46" class="cell-class">use href="#anchor-pin" · #pin-shadow</text>
+    <line x1="40" y1="120" x2="240" y2="120" class="ghost"/>
+    <g transform="translate(140, 120)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <text x="140" y="160" class="cell-class" text-anchor="middle">place via translate(cx, cy)</text>
+  </g>
+
+  <!-- ─── 4. Resize cursor — horizontal ─── -->
+  <g transform="translate(40, 320)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Resize cursor — horizontal</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-h" w=28 h=16</text>
+    <use href="#cursor-h" x="126" y="100" width="28" height="16" filter="url(#cursor-shadow)"/>
+  </g>
+
+  <!-- ─── 5. Resize cursor — vertical ─── -->
+  <g transform="translate(340, 320)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Resize cursor — vertical</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-v" w=16 h=28</text>
+    <use href="#cursor-v" x="132" y="90" width="16" height="28" filter="url(#cursor-shadow)"/>
+  </g>
+
+  <!-- ─── 6. Click ripple ─── -->
+  <g transform="translate(640, 320)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Click ripple</text>
+    <text x="16" y="46" class="cell-class">.ripple · .ripple-2</text>
+    <circle cx="140" cy="115" r="10" class="ripple"/>
+    <circle cx="140" cy="115" r="16" class="ripple-2"/>
+  </g>
+
+  <!-- ─── 7. Hot edge ─── -->
+  <g transform="translate(40, 540)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Hot edge</text>
+    <text x="16" y="46" class="cell-class">.edge-hot</text>
+    <line x1="100" y1="80" x2="100" y2="160" class="edge-hot"/>
+    <line x1="180" y1="80" x2="180" y2="160" class="edge-hot"/>
+    <text x="140" y="180" class="cell-class" text-anchor="middle">target of a gesture</text>
+  </g>
+
+  <!-- ─── 8. Ghost outline ─── -->
+  <g transform="translate(340, 540)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Ghost outline</text>
+    <text x="16" y="46" class="cell-class">.ghost</text>
+    <rect x="60.5" y="80.5" width="159" height="69" class="ghost"/>
+    <text x="140" y="180" class="cell-class" text-anchor="middle">previous bounds</text>
+  </g>
+
+  <!-- ─── 9. Arrows ─── -->
+  <g transform="translate(640, 540)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Arrows</text>
+    <text x="16" y="46" class="cell-class">.arrow · .arrow-red (#ah / #ah-red)</text>
+    <line x1="50" y1="100" x2="220" y2="100" class="arrow" marker-end="url(#ah)"/>
+    <text x="50" y="92" class="cell-class">flow / step</text>
+    <line x1="50" y1="150" x2="220" y2="150" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+    <text x="50" y="142" class="cell-class">motion / change</text>
+  </g>
+
+  <!-- =============== TOKENS ROW =============== -->
+  <text x="40" y="790" class="cell-title">Color tokens</text>
+  <g transform="translate(40, 810)">
+    <rect width="880" height="130" rx="8" class="cell-bg"/>
+
+    <!-- swatches -->
+    <g transform="translate(20, 24)">
+      <rect width="60" height="44" rx="4" fill="#ECECEC" class="swatch"/>
+      <text x="0" y="64" class="swatch-label">canvas bg</text>
+      <text x="0" y="80" class="swatch-hex">#ECECEC</text>
+    </g>
+    <g transform="translate(120, 24)">
+      <rect width="60" height="44" rx="4" fill="#0D99FF"/>
+      <text x="0" y="64" class="swatch-label">selection</text>
+      <text x="0" y="80" class="swatch-hex">#0D99FF</text>
+    </g>
+    <g transform="translate(220, 24)">
+      <rect width="60" height="44" rx="4" fill="#FF3B30"/>
+      <text x="0" y="64" class="swatch-label">hot</text>
+      <text x="0" y="80" class="swatch-hex">#FF3B30</text>
+    </g>
+    <g transform="translate(320, 24)">
+      <rect width="60" height="44" rx="4" fill="#0a0a0a"/>
+      <text x="0" y="64" class="swatch-label">text</text>
+      <text x="0" y="80" class="swatch-hex">#0a0a0a</text>
+    </g>
+    <g transform="translate(420, 24)">
+      <rect width="60" height="44" rx="4" fill="#6b7280"/>
+      <text x="0" y="64" class="swatch-label">caption</text>
+      <text x="0" y="80" class="swatch-hex">#6b7280</text>
+    </g>
+    <g transform="translate(520, 24)">
+      <rect width="60" height="44" rx="4" fill="#b5b5b5"/>
+      <text x="0" y="64" class="swatch-label">ghost</text>
+      <text x="0" y="80" class="swatch-hex">#b5b5b5</text>
+    </g>
+    <g transform="translate(620, 24)">
+      <rect width="60" height="44" rx="4" fill="#9ca3af"/>
+      <text x="0" y="64" class="swatch-label">arrow</text>
+      <text x="0" y="80" class="swatch-hex">#9ca3af</text>
+    </g>
+    <g transform="translate(720, 24)">
+      <rect width="60" height="44" rx="4" fill="#ffffff" class="swatch"/>
+      <text x="0" y="64" class="swatch-label">handle / panel</text>
+      <text x="0" y="80" class="swatch-hex">#ffffff</text>
+    </g>
+  </g>
+
+  <!-- =============== ROW 4 (new V1 primitives) =============== -->
+  <text x="40" y="990" class="cell-title">More primitives</text>
+
+  <!-- ─── Distance meter (red badge variant) ─── -->
+  <g transform="translate(40, 1010)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Distance meter</text>
+    <text x="16" y="46" class="cell-class">.badge-distance · .badge-text</text>
+    <g transform="translate(96, 110)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge-distance"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">120 px</text>
+    </g>
+    <text x="140" y="172" class="cell-class" text-anchor="middle">measurement / distance variant</text>
+  </g>
+
+  <!-- ─── Keycap ─── -->
+  <g transform="translate(340, 1010)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Keycap</text>
+    <text x="16" y="46" class="cell-class">.kbd-bg · .kbd-text</text>
+    <g transform="translate(124, 100)">
+      <rect x="0" y="0" width="32" height="20" rx="3" class="kbd-bg"/>
+      <text x="16" y="14" class="kbd-text" text-anchor="middle">Alt</text>
+    </g>
+    <g transform="translate(166, 100)">
+      <rect x="0" y="0" width="48" height="20" rx="3" class="kbd-bg"/>
+      <text x="24" y="14" class="kbd-text" text-anchor="middle">Shift</text>
+    </g>
+    <text x="140" y="172" class="cell-class" text-anchor="middle">modifier-key pill (kbd-style)</text>
+  </g>
+
+  <!-- ─── Free-transform handle (circle variant) ─── -->
+  <g transform="translate(640, 1010)">
+    <rect width="280" height="200" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Free-transform handle</text>
+    <text x="16" y="46" class="cell-class">use href="#ft-handle" · .handle-circle</text>
+    <!-- show against a faint selection corner so the role is obvious -->
+    <rect x="80.5" y="80.5" width="120" height="60" class="sel-outline" opacity="0.5"/>
+    <g transform="translate(80, 80)"><use href="#ft-handle"/></g>
+    <g transform="translate(200, 80)"><use href="#ft-handle"/></g>
+    <g transform="translate(80, 140)"><use href="#ft-handle"/></g>
+    <g transform="translate(200, 140)"><use href="#ft-handle"/></g>
+    <text x="140" y="172" class="cell-class" text-anchor="middle">circle variant of .handle</text>
+  </g>
+
+  <!-- =============== ROW 5 (cursor family) =============== -->
+  <g transform="translate(40, 1230)">
+    <rect width="880" height="150" rx="8" class="cell-bg"/>
+    <text x="16" y="28" class="cell-title">Cursors</text>
+    <text x="16" y="46" class="cell-class">use href="#cursor-pointer | move | grab | grabbing | rotate | h | v"</text>
+
+    <!-- 7 cursors in a row, evenly spaced -->
+    <g transform="translate(60, 90)">
+      <use href="#cursor-pointer" x="0" y="-12" width="14" height="18" filter="url(#cursor-shadow)"/>
+      <text x="7" y="36" class="cell-class" text-anchor="middle">pointer</text>
+    </g>
+    <g transform="translate(180, 90)">
+      <use href="#cursor-move" x="-12" y="-12" width="24" height="24" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">move</text>
+    </g>
+    <g transform="translate(300, 90)">
+      <use href="#cursor-grab" x="-11" y="-11" width="22" height="22" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">grab</text>
+    </g>
+    <g transform="translate(420, 90)">
+      <use href="#cursor-grabbing" x="-11" y="-11" width="22" height="22" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">grabbing</text>
+    </g>
+    <g transform="translate(540, 90)">
+      <use href="#cursor-rotate" x="-13" y="-12" width="26" height="24" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">rotate</text>
+    </g>
+    <g transform="translate(680, 90)">
+      <use href="#cursor-h" x="-14" y="-8" width="28" height="16" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">h-resize</text>
+    </g>
+    <g transform="translate(800, 90)">
+      <use href="#cursor-v" x="-8" y="-14" width="16" height="28" filter="url(#cursor-shadow)"/>
+      <text x="0" y="36" class="cell-class" text-anchor="middle">v-resize</text>
+    </g>
+  </g>
+</svg>

--- a/.agents/skills/canvas-docs-svg-kit/snippets/template.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/template.svg
@@ -191,6 +191,18 @@
             class="cursor-hand"/>
     </symbol>
 
+    <!-- Crosshair (solid plus, arms meet at centre) — CSS `cursor: crosshair`.
+         Used for vector drawing / point picking. Hot spot is (10, 10). -->
+    <symbol id="cursor-crosshair" viewBox="0 0 20 20" overflow="visible">
+      <path d="M 9 0 H 11 V 9 H 20 V 11 H 11 V 20 H 9 V 11 H 0 V 9 H 9 Z" class="cursor"/>
+    </symbol>
+
+    <!-- Text (I-beam) — CSS `cursor: text`.
+         Hot spot is the centre (4, 10). -->
+    <symbol id="cursor-text" viewBox="0 0 8 20" overflow="visible">
+      <path d="M 0 0 H 8 V 2 H 5 V 18 H 8 V 20 H 0 V 18 H 3 V 2 H 0 Z" class="cursor"/>
+    </symbol>
+
     <!-- Rotation (curved double-arrow).
          Lifted from editor/components/cursor/cursor-data.ts  (template_rotate_svg, angle=0).
          Use with transform="rotate(θ, 13, 12)" on the <use> wrapper to orient it. -->

--- a/.agents/skills/canvas-docs-svg-kit/snippets/template.svg
+++ b/.agents/skills/canvas-docs-svg-kit/snippets/template.svg
@@ -1,0 +1,282 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!--
+  canvas-docs-svg-kit  ·  starter template
+
+  Copy this file as a starting point for a new docs figure. All tokens,
+  filters, markers, and reusable defs are wired up. Compose your figure
+  inside the "YOUR FIGURE HERE" region.
+
+  KEEP the @generated-by comment above and the <metadata> element below
+  in every figure produced from this template. Both are required by the
+  kit's watermark contract — see SKILL.md.
+
+  Output: 960 × 960 viewport. Inline <style> only. No external <use>.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 960"
+     width="960"
+     height="960"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      /* ============================================================
+         CANVAS / TYPOGRAPHY TOKENS
+         ============================================================ */
+      .canvas-bg     { fill: #ECECEC; }
+
+      .doc-heading   { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 14px; fill: #6b7280; }
+      .col-title     { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label    { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption       { font-size: 13px; fill: #6b7280; }
+      .label-mono    { font-size: 14px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      /* ============================================================
+         SELECTION CHROME (matches editor selection look)
+         ============================================================ */
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle        { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline      { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      /* ============================================================
+         GESTURE / INTERACTION
+         ============================================================ */
+      .edge-hot      { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple        { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2      { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+      .cursor        { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+      /* hand cursors (grab / grabbing) — white interior + thick black outline,
+         matching the macOS Tahoe convention. Distinct from .cursor so the
+         silhouette reads on any background. */
+      .cursor-hand   { fill: #ffffff; stroke: #0a0a0a; stroke-width: 1.5; stroke-linejoin: round; }
+
+      /* ============================================================
+         METER BADGE  (variants: size = blue, distance = red)
+           - size:     selection-blue, used for live w × h readouts
+           - distance: workbench-red (#f44336), used for measurement readouts
+         Same shape; shared `.badge-text` for the inner text.
+         Source: editor/grida-canvas-react/ui-config.ts (WorkbenchColors)
+         ============================================================ */
+      .badge          { fill: #0D99FF; }                /* size variant */
+      .badge-distance { fill: #f44336; }                /* distance / measurement variant */
+      .badge-text     { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+
+      /* ============================================================
+         KEYCAP  (modifier-key pill, kbd-style)
+         Source: editor/components/ui/kbd.tsx
+           bg-muted, text-muted-foreground, h-5, min-w-5, px-1, rounded-sm, text-xs
+         ============================================================ */
+      .kbd-bg         { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
+      .kbd-text       { font-size: 11px; fill: #475569; font-weight: 500; letter-spacing: 0.2px; }
+
+      /* ============================================================
+         TRANSFORM HANDLE — circle variant (free-transform grip)
+         Source: editor/grida-canvas-react/viewport/ui/surface-image-editor.tsx
+           "rounded-full border-2", w-4 h-4, cursor-grab
+         ============================================================ */
+      .handle-circle  { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.5; }
+
+      /* ============================================================
+         GHOST / PIN TRACE  (showing previous bounds)
+         ============================================================ */
+      .ghost         { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+      .pin-line      { stroke: #FF3B30; stroke-width: 1; stroke-dasharray: 3 3; opacity: 0.6; }
+
+      /* ============================================================
+         ARROWS
+         ============================================================ */
+      .arrow         { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head    { fill: #9ca3af; }
+      .arrow-red     { stroke: #FF3B30; stroke-width: 1.25; fill: none; opacity: 0.85; }
+      .arrow-red-head{ fill: #FF3B30; }
+
+      /* ============================================================
+         NODE TEXT  (text rendered inside a sample node)
+         ============================================================ */
+      .node-text     { font-size: 26px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      /* ============================================================
+         LEGEND CARD
+         ============================================================ */
+      .legend-box    { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+
+      /* ============================================================
+         STEP NUMBER PILL
+         ============================================================ */
+      .step-bg       { fill: #0a0a0a; }
+      .step-num      { font-size: 11px; fill: #ffffff; font-weight: 700; }
+    </style>
+
+    <!-- ARROW MARKERS -->
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="ah-red" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-red-head"/>
+    </marker>
+
+    <!-- DROP SHADOWS -->
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- ANCHOR PIN
+         Plain <g> (NOT a <symbol> with shifted viewBox) so that
+         translate(cx, cy) places the dot's centre exactly on (cx, cy). -->
+    <g id="anchor-pin">
+      <circle cx="0" cy="0" r="9" fill="#FF3B30" opacity="0.18"/>
+      <circle cx="0" cy="0" r="5.5" fill="#FF3B30"/>
+      <circle cx="0" cy="0" r="2" fill="#ffffff"/>
+    </g>
+
+    <!-- ROTATION HANDLE  (circle variant of .handle)
+         Plain <g>, place via <g transform="translate(cx,cy)"><use href="#ft-handle"/></g>
+         so the dot's centre lands exactly on (cx, cy). -->
+    <g id="ft-handle">
+      <circle cx="0" cy="0" r="7" class="handle-circle"/>
+    </g>
+
+    <!-- CURSORS
+         All cursors use the .cursor class (black fill + white outline).
+         Aim: placed with <use href="#cursor-X" x="tip-hotspot-adjusted-x" y="..." width="..." height="..."/>
+         For the axis/arrow cursors the viewBox origin is the tip; for hand cursors the hotspot is the centre. -->
+
+    <!-- Resize cursors (used at hot edges) -->
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+    <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
+      <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
+    </symbol>
+
+    <!-- Standard pointer (arrow tip at top-left, 0,0 hotspot) -->
+    <symbol id="cursor-pointer" viewBox="0 0 14 18" overflow="visible">
+      <path d="M 1 1 L 1 15 L 5 11.5 L 7.5 17 L 9.5 16 L 7 10.8 L 12 10.8 Z" class="cursor"/>
+    </symbol>
+
+    <!-- 4-direction move -->
+    <symbol id="cursor-move" viewBox="0 0 24 24" overflow="visible">
+      <path d="M 12 2 L 16 6 L 14 6 L 14 10 L 18 10 L 18 8 L 22 12 L 18 16 L 18 14 L 14 14 L 14 18 L 16 18 L 12 22 L 8 18 L 10 18 L 10 14 L 6 14 L 6 16 L 2 12 L 6 8 L 6 10 L 10 10 L 10 6 L 8 6 Z" class="cursor"/>
+    </symbol>
+
+    <!-- Open hand (grab) — macOS Tahoe-style hand silhouette.
+         White interior, thick black outline. -->
+    <symbol id="cursor-grab" viewBox="0 0 16 18" overflow="visible">
+      <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M8.6 17.5Q7 17.5 6 17q-1.2-.5-2-1.5t-1.6-2.6L.6 8.2v-1q0-.4.7-.6H2q.4.3.6.7l1.6 2.9.2.2h.3V10l-1-7q-.1-.7.1-1a1 1 0 0 1 1-.5 1 1 0 0 1 1.1 1l1.1 5.2v-6q0-.6.4-1 .3-.3.9-.3a1.2 1.2 0 0 1 1.2 1.2v6l1-5.2a1 1 0 0 1 1-1h.3q.5 0 .8.5l.2 1-.9 5.3 1.2-3.5q.2-.5.5-.7a1 1 0 0 1 1.6.3q.3.3.2.9l-1.2 6.5a8 8 0 0 1-1.8 4.2q-1.4 1.5-4 1.5Z"
+            class="cursor-hand"/>
+    </symbol>
+
+    <!-- Closed hand (grabbing) — macOS Tahoe-style closed fist. -->
+    <symbol id="cursor-grabbing" viewBox="0 0 14 13" overflow="visible">
+      <path d="M6.71.5q.39 0 .73.2l.09.06a1 1 0 0 1 .43.83v.66q.1.05.18.03l.01-.03v-.01l.16-.54.05-.15a1 1 0 0 1 .82-.63q.59-.1 1.06.27.26.18.38.5.1.3.04.6l-.15.88-.01.1q.04.04.13.04h.05l.24-.39V2.9q.3-.4.76-.46.4-.05.74.14l.1.06q.42.32.43.83 0 .84-.13 1.63-.12.77-.35 1.74l-.05.27a8 8 0 0 1-1.05 2.67q-.7 1.11-1.89 1.67-1.18.56-2.8.56-1.85 0-3.28-.92a6 6 0 0 1-1.96-2.16l-.2-.4A8.5 8.5 0 0 1 .5 4.93c0-.51.11-1 .41-1.36a1.5 1.5 0 0 1 1.06-.58q.28-.02.5.04l.15.05.27.1.05.27.25 1.27.02.07v.01h.01l.03.01.02-.01v-.05L2.75 2.3q-.08-.3.03-.61.11-.32.37-.5.48-.36 1.07-.27.31.04.56.26.19.17.27.39l.05.14.15.53v.01l.01.02.05.01q.07 0 .14-.03v-.66a1 1 0 0 1 .42-.83q.38-.27.83-.26Z"
+            class="cursor-hand"/>
+    </symbol>
+
+    <!-- Rotation (curved double-arrow).
+         Lifted from editor/components/cursor/cursor-data.ts  (template_rotate_svg, angle=0).
+         Use with transform="rotate(θ, 13, 12)" on the <use> wrapper to orient it. -->
+    <symbol id="cursor-rotate" viewBox="0 0 26 24" overflow="visible">
+      <path fill="#000000" fill-rule="evenodd" clip-rule="evenodd"
+            d="M23 15.5h-6.43l2.65-2.79A7.72 7.72 0 0 0 13 9.5a7.72 7.72 0 0 0-6.22 3.21l2.65 2.79H3V8.75l1.74 1.83A10.5 10.5 0 0 1 13 6.5c3.32 0 6.3 1.59 8.26 4.08L23 8.75v6.75Z"/>
+      <path fill="none" stroke="#ffffff" stroke-width="0.75"
+            d="M23 15.88h.38V7.8l-.65.68-1.45 1.52A10.85 10.85 0 0 0 13 6.13c-3.3 0-6.25 1.5-8.28 3.88L3.27 8.5l-.64-.68v8.07h7.67l-.6-.64-2.43-2.55A7.32 7.32 0 0 1 13 9.88c2.3 0 4.36 1.08 5.73 2.8l-2.43 2.56-.6.63H23Z"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <!-- ============================================================
+       YOUR FIGURE HERE
+       Heading
+       ============================================================ -->
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Figure title</text>
+  <text x="480" y="86" class="doc-sub" text-anchor="middle">Optional one-line subtitle.</text>
+
+  <!-- Compose the figure below.
+
+       Quick-start patterns:
+
+       ┌─ Selection chrome (place inside a <g transform="translate(x,y)">) ─┐
+       │   <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+       │   <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+       │   <rect x="-3.5" y="-3.5"   width="7" height="7" class="handle"/>
+       │   <rect x="276.5" y="-3.5"  width="7" height="7" class="handle"/>
+       │   <rect x="-3.5" y="86.5"   width="7" height="7" class="handle"/>
+       │   <rect x="276.5" y="86.5"  width="7" height="7" class="handle"/>
+       └────────────────────────────────────────────────────────────────────┘
+
+       ┌─ Size badge ─┐
+       │   <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+       │     <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+       │     <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+       │   </g>
+       └──────────────┘
+
+       ┌─ Anchor pin (centre lands exactly on cx, cy) ─┐
+       │   <g transform="translate(140, 45)" filter="url(#pin-shadow)">
+       │     <use href="#anchor-pin"/>
+       │   </g>
+       └────────────────────────────────────────────────┘
+
+       ┌─ Resize cursor at hot edge ─┐
+       │   <use href="#cursor-h" x="-32" y="52" width="28" height="16" filter="url(#cursor-shadow)"/>
+       └─────────────────────────────┘
+
+       ┌─ Click ripple ─┐
+       │   <circle cx="0" cy="60" r="10" class="ripple"/>
+       │   <circle cx="0" cy="60" r="16" class="ripple-2"/>
+       └────────────────┘
+
+       ┌─ Distance meter (red variant of size badge) ─┐
+       │   <g transform="translate(280, 200)" filter="url(#badge-shadow)">
+       │     <rect x="0" y="0" width="74" height="20" rx="4" class="badge-distance"/>
+       │     <text x="37" y="14" class="badge-text" text-anchor="middle">120 px</text>
+       │   </g>
+       └──────────────────────────────────────────────┘
+
+       ┌─ Keycap (modifier-key pill, kbd-style) ─┐
+       │   <g transform="translate(400, 300)">
+       │     <rect x="0" y="0" width="32" height="20" rx="3" class="kbd-bg"/>
+       │     <text x="16" y="14" class="kbd-text" text-anchor="middle">Alt</text>
+       │   </g>
+       └────────────────────────────────────────────┘
+
+       ┌─ Free-transform handle (circle) ─┐
+       │   <g transform="translate(140, 45)">
+       │     <use href="#ft-handle"/>
+       │   </g>
+       └────────────────────────────┘
+
+       ┌─ Cursors (pointer / move / grab / grabbing / rotate) ─┐
+       │   <use href="#cursor-pointer"   x="100" y="100" width="14" height="18" filter="url(#cursor-shadow)"/>
+       │   <use href="#cursor-move"      x="200" y="100" width="24" height="24" filter="url(#cursor-shadow)"/>
+       │   <use href="#cursor-grab"      x="300" y="100" width="22" height="22" filter="url(#cursor-shadow)"/>
+       │   <use href="#cursor-grabbing"  x="400" y="100" width="22" height="22" filter="url(#cursor-shadow)"/>
+       │   <use href="#cursor-rotate"    x="500" y="100" width="26" height="24" filter="url(#cursor-shadow)"/>
+       │   ::: For an angled rotate cursor, wrap in a rotated group:
+       │   <g transform="translate(500, 200) rotate(45)">
+       │     <use href="#cursor-rotate" x="-13" y="-12" width="26" height="24" filter="url(#cursor-shadow)"/>
+       │   </g>
+       └────────────────────────────────────────────────────────┘
+  -->
+
+</svg>

--- a/.agents/skills/canvas-user-docs/SKILL.md
+++ b/.agents/skills/canvas-user-docs/SKILL.md
@@ -110,6 +110,12 @@ For workflows, before/after, or relationships a screenshot can't show.
 - WebP preferred, SVG for vector diagrams
 - Annotations: red (#FF3B30) circles/arrows, 2px stroke, 1-3 callouts max
 
+For SVG figures specifically — gestures, alignment, before/after diagrams that
+recreate canvas UI — use the **`canvas-docs-svg-kit`** skill. It provides a
+starter template, a primitives catalog (selection chrome, size badges, anchor
+pins, resize cursors, ripples), and finished examples to crib from. Saves you
+from re-deriving stroke widths, colors, and the half-pixel alignment tricks.
+
 ## Pre-Publish Checklist
 
 - `title` and `description` in frontmatter

--- a/docs/editor/features/feat-text-node-auto-size.md
+++ b/docs/editor/features/feat-text-node-auto-size.md
@@ -27,11 +27,11 @@ stays put. The opposite side moves in.
 
 ![Left-aligned text keeps its left edge fixed; center-aligned text keeps its center; right-aligned text keeps its right edge.](../resources/text-node-auto-size-alignment.svg)
 
-| Text alignment   | What stays fixed     | What moves    |
-| ---------------- | -------------------- | ------------- |
-| Left / top       | Left or top edge     | Opposite edge |
-| Center / middle  | Center of the axis   | Both edges    |
-| Right / bottom   | Right or bottom edge | Opposite edge |
+| Text alignment  | What stays fixed     | What moves    |
+| --------------- | -------------------- | ------------- |
+| Left / top      | Left or top edge     | Opposite edge |
+| Center / middle | Center of the axis   | Both edges    |
+| Right / bottom  | Right or bottom edge | Opposite edge |
 
 This means the text appears to stay in place while the bounding box
 collapses around it, instead of jumping to a new position.

--- a/docs/editor/features/feat-text-node-auto-size.md
+++ b/docs/editor/features/feat-text-node-auto-size.md
@@ -1,9 +1,46 @@
+---
+title: Text node auto size
+description: Reset a text node's width or height to auto by double-clicking its edge.
+format: md
+---
+
 # Text node auto size
 
-Double-click a text node's edge to reset its dimensions to `auto`.
+Text nodes can be sized **fixed** (a width/height you set explicitly) or
+**auto** (the node hugs the rendered text). You can switch any edge back to
+auto without opening the inspector — just double-click that edge.
 
-- Double-click the left or right edge to set the width to `auto`.
-- Double-click the top or bottom edge to set the height to `auto`.
-- Alignment is preserved: when the text is right, center, or bottom
-  aligned, the node's position shifts so the alignment point stays fixed
-  after auto sizing.
+## How to use
+
+![Double-click the left or right edge to set width to auto; double-click the top or bottom edge to set height to auto.](../resources/text-node-auto-size-edges.svg)
+
+- Double-click the **left** or **right** edge to set **width** to `auto`.
+- Double-click the **top** or **bottom** edge to set **height** to `auto`.
+
+The double-click only resets the axis you clicked. The other axis keeps
+whatever size it had — fixed or auto.
+
+## Alignment is preserved
+
+When the node shrinks to fit, the side that matches the text alignment
+stays put. The opposite side moves in.
+
+![Left-aligned text keeps its left edge fixed; center-aligned text keeps its center; right-aligned text keeps its right edge.](../resources/text-node-auto-size-alignment.svg)
+
+| Text alignment   | What stays fixed     | What moves    |
+| ---------------- | -------------------- | ------------- |
+| Left / top       | Left or top edge     | Opposite edge |
+| Center / middle  | Center of the axis   | Both edges    |
+| Right / bottom   | Right or bottom edge | Opposite edge |
+
+This means the text appears to stay in place while the bounding box
+collapses around it, instead of jumping to a new position.
+
+## When to use it
+
+- After typing into a fixed-size text node that ended up with extra
+  whitespace around the content.
+- After pasting text that was longer than the original node, leaving the
+  height padded out.
+- Any time you want the node to track the text again without re-typing
+  values into the inspector.

--- a/docs/editor/features/surface-image-editor.md
+++ b/docs/editor/features/surface-image-editor.md
@@ -10,6 +10,8 @@ The surface image editor provides on-canvas controls for repositioning image pai
 
 ## Interaction model
 
+![Image-edit overlay showing the translucent polygon that traces a rotated image paint, with three labelled gestures: drag-to-translate inside the polygon, a hot rail along one side for scaling, and a corner handle for rotation.](../resources/surface-image-editor-overlay.svg)
+
 The overlay exposes three groups of controls:
 
 - **Translate** – dragging anywhere inside the highlighted polygon offsets the paint. Movement is resolved in the paint’s local coordinate system so the image follows the pointer even when rotated.

--- a/docs/editor/features/vector-network-editor.md
+++ b/docs/editor/features/vector-network-editor.md
@@ -2,6 +2,8 @@
 
 When hovering a straight segment in the vector editor, a preview point appears at the middle of the segment. Pressing and dragging on this preview splits the segment by inserting a new vertex at the midpoint and immediately begins a drag gesture for that vertex.
 
+![Three-panel diagram of midpoint projection: (1) hovering a straight segment shows a hollow midpoint preview ring; (2) pressing inserts a new selected vertex at the midpoint, splitting the segment in two; (3) the same pointer-down continues as a drag, pulling the new vertex away from its original midpoint position.](../resources/vector-network-editor-midpoint-projection.svg)
+
 - Midpoint preview only appears on straight segments.
 - Pointer down on the preview inserts the vertex and selects it.
 - Dragging continues without releasing the pointer.

--- a/docs/editor/features/vector-network-measurement.md
+++ b/docs/editor/features/vector-network-measurement.md
@@ -17,6 +17,8 @@ The feature activates when you:
 
 It uses the same visual system as regular measurements: guide lines, auxiliary lines, and distance labels showing top/right/bottom/left spacing.
 
+![Holding Alt while hovering a Bezier segment of a vector network displays axis-aligned X and Y distances from the selected vertex (A) to the parametric point under the cursor on the hovered curve (B), drawn as red guide lines with distance badges and dashed alignment helpers.](../resources/vector-network-measurement-alt-hover.svg)
+
 ### Measurement Triggers
 
 - **Segment hover**: When hovering over a curve segment, measures from selection to the parametric point on the curve

--- a/docs/editor/resources/surface-image-editor-overlay.svg
+++ b/docs/editor/resources/surface-image-editor-overlay.svg
@@ -1,0 +1,276 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 960"
+     width="960"
+     height="960"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+
+      .doc-heading   { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 14px; fill: #6b7280; }
+      .col-title     { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label    { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption       { font-size: 13px; fill: #6b7280; }
+      .label-mono    { font-size: 13px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle        { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+
+      .edge-hot      { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple        { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2      { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+      .cursor        { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+
+      .ghost         { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+      .arrow         { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head    { fill: #9ca3af; }
+      .arrow-red     { stroke: #FF3B30; stroke-width: 1.5; fill: none; opacity: 0.9; }
+      .arrow-red-head{ fill: #FF3B30; }
+
+      .legend-box    { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+
+      /* --- Locally invented for this figure --- */
+
+      /* Node frame: the (non-text) shape that owns the image paint */
+      .node-frame    { fill: #ffffff; stroke: #d4d4d4; stroke-width: 1; }
+
+      /* Image paint stand-in: a soft gray fill with a faint photo grid.
+         A real image isn't available; we evoke "an image" with a gradient. */
+      .img-fill      { fill: url(#imgGradient); }
+
+      /* Image-edit polygon overlay: translucent stroke that traces the
+         transformed image bounds — distinct from selection chrome. */
+      .img-poly      { fill: rgba(13, 153, 255, 0.06); stroke: #0D99FF; stroke-width: 1.25; stroke-dasharray: none; }
+
+      /* Scale rail (one of four invisible-but-hot edges) */
+      .img-rail      { stroke: #FF3B30; stroke-width: 3; opacity: 0.85; stroke-linecap: round; }
+
+      /* Rotation arc + handle ring */
+      .rot-arc       { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.85; stroke-dasharray: 3 3; }
+      .rot-handle    { fill: #ffffff; stroke: #FF3B30; stroke-width: 1.5; }
+
+      /* Translate move-cursor marker */
+      .move-glyph    { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+
+      /* Callout pill */
+      .callout-bg    { fill: #0a0a0a; }
+      .callout-text  { font-size: 11px; fill: #ffffff; font-weight: 600; letter-spacing: 0.3px; text-transform: uppercase; }
+    </style>
+
+    <linearGradient id="imgGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#cbd5e1"/>
+      <stop offset="50%" stop-color="#94a3b8"/>
+      <stop offset="100%" stop-color="#64748b"/>
+    </linearGradient>
+
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="ah-red" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-red-head"/>
+    </marker>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+
+    <!-- 4-direction move glyph (locally invented) -->
+    <symbol id="cursor-move" viewBox="-12 -12 24 24" overflow="visible">
+      <path d="M 0 -10 L 4 -6 L 1.5 -6 L 1.5 -1.5 L 6 -1.5 L 6 -4 L 10 0 L 6 4 L 6 1.5 L 1.5 1.5 L 1.5 6 L 4 6 L 0 10 L -4 6 L -1.5 6 L -1.5 1.5 L -6 1.5 L -6 4 L -10 0 L -6 -4 L -6 -1.5 L -1.5 -1.5 L -1.5 -6 L -4 -6 Z" class="move-glyph"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <!-- Heading -->
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Image-edit overlay</text>
+  <text x="480" y="86" class="doc-sub" text-anchor="middle">Double-click an image-bearing node to enter paint/image mode. Three gestures act on the same overlay.</text>
+
+  <!-- =====================================================
+       MAIN STAGE
+       Node centred at (480, 500), 360 wide × 260 tall, no rotation.
+       Image paint inside it, transformed by rotation+scale: visualised
+       as a parallelogram (the polygon overlay) tilted ~15°.
+       ===================================================== -->
+
+  <!-- The host node (a non-text shape with an image fill) -->
+  <g transform="translate(300, 360)">
+    <rect class="node-frame" x="0.5" y="0.5" width="359" height="259" rx="2"/>
+
+    <!-- Clip the image paint to the node bounds -->
+    <clipPath id="nodeClip">
+      <rect x="0" y="0" width="360" height="260" rx="2"/>
+    </clipPath>
+
+    <!-- Image paint (rotated ~12° about the node centre) -->
+    <g clip-path="url(#nodeClip)">
+      <g transform="rotate(12 180 130)">
+        <rect class="img-fill" x="-40" y="20" width="440" height="220"/>
+        <!-- Subtle grid lines to suggest "an image" -->
+        <g stroke="#ffffff" stroke-width="0.75" opacity="0.35">
+          <line x1="-40" y1="75"  x2="400" y2="75"/>
+          <line x1="-40" y1="130" x2="400" y2="130"/>
+          <line x1="-40" y1="185" x2="400" y2="185"/>
+          <line x1="70"  y1="20"  x2="70"  y2="240"/>
+          <line x1="180" y1="20"  x2="180" y2="240"/>
+          <line x1="290" y1="20"  x2="290" y2="240"/>
+        </g>
+      </g>
+    </g>
+
+    <!-- =====================================================
+         OVERLAY: traces the transformed image bounds.
+         The image rect (-40, 20, 440, 220) rotated 12° clockwise
+         about its centre (180, 130).
+
+         cos(12°)=0.97815, sin(12°)=0.20791
+         SVG rotate(θ) about (cx,cy) applies:
+           X = (x-cx)cos - (y-cy)sin + cx
+           Y = (x-cx)sin + (y-cy)cos + cy
+
+         A = (-40, 20)   -> ( -12.3,  -23.3 )
+         B = ( 400, 20)  -> (  418.1,  68.1 )
+         C = ( 400, 240) -> (  372.3, 283.3 )
+         D = ( -40, 240) -> (  -58.1, 191.9 )
+         ===================================================== -->
+    <polygon class="img-poly"
+             points="-12.3,-23.3 418.1,68.1 372.3,283.3 -58.1,191.9"/>
+
+    <!-- ============= TRANSLATE: hit area inside polygon ============= -->
+    <!-- 4-direction cursor near polygon centre -->
+    <g transform="translate(180, 130)" filter="url(#cursor-shadow)">
+      <use href="#cursor-move" width="24" height="24" x="-12" y="-12"/>
+    </g>
+    <!-- Translation arrow showing direction (starts outside cursor glyph) -->
+    <line x1="195" y1="142" x2="250" y2="180"
+          class="arrow-red" marker-end="url(#ah-red)"/>
+
+    <!-- ============= SCALE: hot rail on right edge ============= -->
+    <!-- Right edge of the polygon = B (418.1, 68.1) → C (372.3, 283.3).
+         Inset 14px from each end so the rail does not run through the
+         corner rotate handles. Direction unit vector ≈ (-0.208, 0.978). -->
+    <line x1="415.2" y1="81.8" x2="375.2" y2="269.6" class="img-rail"/>
+    <!-- Resize cursor centred on rail midpoint, perpendicular to the edge.
+         Edge midpoint: (395.2, 175.7). Edge angle = 102°; perpendicular = 12°. -->
+    <g transform="translate(395.2 175.7) rotate(12)" filter="url(#cursor-shadow)">
+      <use href="#cursor-h" x="-14" y="-8" width="28" height="16"/>
+    </g>
+
+    <!-- ============= ROTATE: corner handle at top-right (B) ============= -->
+    <!-- Dashed arc bulging outside corner B, radius 18 -->
+    <path class="rot-arc"
+          d="M 431.8 54.0 A 18 18 0 0 1 433.7 81.6"/>
+    <!-- Handle ring exactly on corner B -->
+    <g transform="translate(418.1 68.1)" filter="url(#pin-shadow)">
+      <circle r="7" class="rot-handle"/>
+    </g>
+
+    <!-- ============= RESTING CORNER HANDLES ============= -->
+    <g transform="translate(-12.3 -23.3)" filter="url(#pin-shadow)">
+      <circle r="5" class="rot-handle"/>
+    </g>
+    <g transform="translate(372.3 283.3)" filter="url(#pin-shadow)">
+      <circle r="5" class="rot-handle"/>
+    </g>
+    <g transform="translate(-58.1 191.9)" filter="url(#pin-shadow)">
+      <circle r="5" class="rot-handle"/>
+    </g>
+  </g>
+
+  <!-- =====================================================
+       CALLOUTS — three labels pointing at the three gestures.
+       Stage local origin: (300, 360).  World coords below.
+       ===================================================== -->
+
+  <!-- Translate callout (left) -->
+  <g>
+    <line x1="220" y1="490" x2="455" y2="490" class="arrow"/>
+    <g transform="translate(80, 478)">
+      <rect class="callout-bg" width="135" height="22" rx="11"/>
+      <text x="67.5" y="15" class="callout-text" text-anchor="middle">1 · Translate</text>
+    </g>
+    <text x="80" y="520" class="caption">Drag inside the polygon.</text>
+    <text x="80" y="538" class="caption">Offset is resolved in the</text>
+    <text x="80" y="556" class="caption">paint's local axes.</text>
+  </g>
+
+  <!-- Scale callout (right) -->
+  <g>
+    <line x1="780" y1="535" x2="700" y2="535" class="arrow"/>
+    <g transform="translate(782, 524)">
+      <rect class="callout-bg" width="118" height="22" rx="11"/>
+      <text x="59" y="15" class="callout-text" text-anchor="middle">2 · Scale</text>
+    </g>
+    <text x="782" y="566" class="caption">Drag a side rail. The</text>
+    <text x="782" y="584" class="caption">opposite edge stays fixed.</text>
+  </g>
+
+  <!-- Rotate callout (top-right) -->
+  <g>
+    <line x1="755" y1="395" x2="722" y2="425" class="arrow"/>
+    <g transform="translate(755, 365)">
+      <rect class="callout-bg" width="125" height="22" rx="11"/>
+      <text x="62.5" y="15" class="callout-text" text-anchor="middle">3 · Rotate</text>
+    </g>
+    <text x="755" y="409" class="caption">Drag a corner handle.</text>
+    <text x="755" y="427" class="caption">Rotation pivots around</text>
+    <text x="755" y="445" class="caption">the polygon centre.</text>
+  </g>
+
+  <!-- =====================================================
+       LEGEND CARD
+       ===================================================== -->
+  <g transform="translate(80, 760)">
+    <rect class="legend-box" width="800" height="140" rx="8"/>
+
+    <text x="20" y="32" class="col-title">Overlay anatomy</text>
+
+    <!-- Row 1: polygon -->
+    <polygon class="img-poly" points="20,55 110,55 105,85 15,85"/>
+    <text x="125" y="70" class="label-mono">image polygon</text>
+    <text x="125" y="86" class="caption">Traces the transformed image bounds.</text>
+
+    <!-- Row 2: rail -->
+    <line x1="20" y1="108" x2="105" y2="108" class="img-rail"/>
+    <text x="125" y="112" class="label-mono">scale rail</text>
+    <text x="125" y="128" class="caption">Invisible at rest; hot under the pointer.</text>
+
+    <!-- Right column: rotate handle -->
+    <g transform="translate(450, 70)">
+      <circle r="7" class="rot-handle"/>
+    </g>
+    <text x="470" y="75" class="label-mono">rotate handle</text>
+    <text x="470" y="91" class="caption">Corner ring; pivots around polygon centre.</text>
+
+    <!-- Right column: move glyph -->
+    <g transform="translate(450, 115)">
+      <use href="#cursor-move" width="20" height="20" x="-10" y="-10"/>
+    </g>
+    <text x="470" y="112" class="label-mono">translate area</text>
+    <text x="470" y="128" class="caption">Anywhere inside the polygon.</text>
+  </g>
+</svg>

--- a/docs/editor/resources/text-node-auto-size-alignment.svg
+++ b/docs/editor/resources/text-node-auto-size-alignment.svg
@@ -1,0 +1,291 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg { fill: #ECECEC; }
+
+      .doc-heading { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub { font-size: 14px; fill: #6b7280; }
+      .col-title { font-size: 16px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption { font-size: 13px; fill: #6b7280; }
+      .label-mono { font-size: 12px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .sel-outline { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      .ghost { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+
+      .pin-line { stroke: #FF3B30; stroke-width: 1; stroke-dasharray: 3 3; opacity: 0.6; }
+
+      .badge { fill: #0D99FF; }
+      .badge-text { font-size: 10px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+
+      .node-text { font-size: 22px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      .arrow { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head { fill: #9ca3af; }
+      .arrow-red { stroke: #FF3B30; stroke-width: 1.25; fill: none; opacity: 0.85; }
+      .arrow-red-head { fill: #FF3B30; }
+
+      .legend-box { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+    </style>
+
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <marker id="ah-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-red-head"/>
+    </marker>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.22"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <filter id="pin-shadow" x="-200%" y="-200%" width="500%" height="500%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+      <feOffset dx="0" dy="0.5" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- Anchor pin: drawn so that (cx, cy) is the literal anchor point.
+         No <symbol> indirection — placed directly with translate(). -->
+    <g id="anchor-pin">
+      <circle cx="0" cy="0" r="9" fill="#FF3B30" opacity="0.18"/>
+      <circle cx="0" cy="0" r="5.5" fill="#FF3B30"/>
+      <circle cx="0" cy="0" r="2" fill="#ffffff"/>
+    </g>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <text x="480" y="58" class="doc-heading" text-anchor="middle">Alignment is preserved</text>
+  <text x="480" y="84" class="doc-sub" text-anchor="middle">The anchor side stays fixed. The opposite side moves in.</text>
+
+  <!-- column dividers -->
+  <line x1="320" y1="120" x2="320" y2="780" stroke="#dcdcdc" stroke-width="1"/>
+  <line x1="640" y1="120" x2="640" y2="780" stroke="#dcdcdc" stroke-width="1"/>
+
+  <!-- =============================================================
+       Geometry plan (per column, inside the group transform):
+         BEFORE box: 280 × 90  at (0, 0)..(280, 90)   ← y-center = 45
+         AFTER  box: 140 × 90, position depends on alignment
+                     LEFT   :   0..140
+                     CENTER :  70..210  (centered on x=140)
+                     RIGHT  : 140..280  (right edge stays at 280)
+       Anchor pin center (in box-local coords):
+         LEFT   : (  0, 45)
+         CENTER : (140, 45)
+         RIGHT  : (280, 45)
+       Pin is a <g> placed via translate(cx, cy), so position is exact.
+     ============================================================= -->
+
+  <!-- ============================================================ -->
+  <!-- LEFT-aligned                                                 -->
+  <!-- ============================================================ -->
+  <text x="160" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="160" y="172" class="col-title" text-anchor="middle">Left</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(20, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="14" y="56" class="node-text">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor on left edge, vertically centered -->
+    <g transform="translate(0, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="160" y1="365" x2="160" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER -->
+  <g transform="translate(20, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="0.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="14" y="56" class="node-text">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="139.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still on left edge -->
+    <g transform="translate(0, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="0" y1="-12" x2="0" y2="102" class="pin-line"/>
+
+    <!-- inward arrow on the moving (right) edge: from old right (280) toward new right (140) -->
+    <line x1="270" y1="45" x2="148" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(33, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="160" y="650" class="caption" text-anchor="middle">Left edge stays put.</text>
+  <text x="160" y="670" class="caption" text-anchor="middle">Right edge moves in.</text>
+
+  <!-- ============================================================ -->
+  <!-- CENTER-aligned                                               -->
+  <!-- ============================================================ -->
+  <text x="480" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="480" y="172" class="col-title" text-anchor="middle">Center</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(340, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="140" y="56" class="node-text" text-anchor="middle">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor at center -->
+    <g transform="translate(140, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="480" y1="365" x2="480" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: new box 70..210, centered on x=140 -->
+  <g transform="translate(340, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="70.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="140" y="56" class="node-text" text-anchor="middle">Hello world</text>
+    <line x1="70.5" y1="64.5" x2="209.5" y2="64.5" class="baseline"/>
+    <rect x="66.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="206.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="66.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="206.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still at center -->
+    <g transform="translate(140, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="140" y1="-12" x2="140" y2="102" class="pin-line"/>
+
+    <!-- both edges move inward -->
+    <line x1="10" y1="45" x2="62" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+    <line x1="270" y1="45" x2="218" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="480" y="650" class="caption" text-anchor="middle">Center stays put.</text>
+  <text x="480" y="670" class="caption" text-anchor="middle">Both edges move inward.</text>
+
+  <!-- ============================================================ -->
+  <!-- RIGHT-aligned                                                -->
+  <!-- ============================================================ -->
+  <text x="800" y="148" class="step-label" text-anchor="middle">Text aligned</text>
+  <text x="800" y="172" class="col-title" text-anchor="middle">Right</text>
+
+  <!-- BEFORE -->
+  <g transform="translate(660, 220)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="sel-outline"/>
+    <text x="266" y="56" class="node-text" text-anchor="end">Hello world</text>
+    <line x1="0.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- anchor on right edge -->
+    <g transform="translate(280, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+
+    <g transform="translate(103, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">280 × 90</text>
+    </g>
+  </g>
+
+  <line x1="800" y1="365" x2="800" y2="412" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: new box 140..280 -->
+  <g transform="translate(660, 432)">
+    <rect x="0.5" y="0.5" width="279" height="89" class="ghost"/>
+    <rect x="140.5" y="0.5" width="139" height="89" class="sel-outline"/>
+    <text x="266" y="56" class="node-text" text-anchor="end">Hello world</text>
+    <line x1="140.5" y1="64.5" x2="279.5" y2="64.5" class="baseline"/>
+    <rect x="136.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="136.5" y="86.5" width="7" height="7" class="handle"/>
+    <rect x="276.5" y="86.5" width="7" height="7" class="handle"/>
+
+    <!-- pin still on right edge -->
+    <g transform="translate(280, 45)" filter="url(#pin-shadow)">
+      <use href="#anchor-pin"/>
+    </g>
+    <line x1="280" y1="-12" x2="280" y2="102" class="pin-line"/>
+
+    <!-- inward arrow on the moving (left) edge -->
+    <line x1="10" y1="45" x2="132" y2="45" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+
+    <g transform="translate(173, 100)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="74" height="20" rx="4" class="badge"/>
+      <text x="37" y="14" class="badge-text" text-anchor="middle">auto × 90</text>
+    </g>
+  </g>
+
+  <text x="800" y="650" class="caption" text-anchor="middle">Right edge stays put.</text>
+  <text x="800" y="670" class="caption" text-anchor="middle">Left edge moves in.</text>
+
+  <!-- ============================================================ -->
+  <!-- legend                                                       -->
+  <!-- ============================================================ -->
+  <g transform="translate(140, 800)">
+    <rect x="0" y="0" width="680" height="120" rx="10" class="legend-box"/>
+
+    <g transform="translate(54, 42)">
+      <use href="#anchor-pin"/>
+      <text x="22" y="5" class="caption">Anchor — the side that stays fixed</text>
+    </g>
+
+    <g transform="translate(40, 80)">
+      <rect x="0" y="-6" width="42" height="12" class="ghost"/>
+      <text x="54" y="3" class="caption">Original bounds before auto sizing</text>
+    </g>
+
+    <g transform="translate(390, 42)">
+      <line x1="0" y1="0" x2="32" y2="0" class="arrow-red" marker-end="url(#ah-red)" stroke-dasharray="3 2"/>
+      <text x="46" y="5" class="caption">Edge that moves inward</text>
+    </g>
+
+    <g transform="translate(390, 80)">
+      <rect x="0" y="-8" width="56" height="16" rx="4" class="badge"/>
+      <text x="28" y="4" class="badge-text" text-anchor="middle">w × h</text>
+      <text x="68" y="3" class="caption">Live size readout</text>
+    </g>
+  </g>
+</svg>

--- a/docs/editor/resources/text-node-auto-size-edges.svg
+++ b/docs/editor/resources/text-node-auto-size-edges.svg
@@ -1,0 +1,239 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg { fill: #ECECEC; }
+      .panel { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+
+      .doc-heading { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .col-title { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .caption { font-size: 14px; fill: #6b7280; }
+      .label-mono { font-size: 14px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+      .step-num { font-size: 11px; fill: #ffffff; font-weight: 700; font-family: 'SF Pro Text', sans-serif; }
+      .step-bg { fill: #0a0a0a; }
+      .step-label { font-size: 12px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+
+      /* selection chrome — thin, crisp */
+      .sel-outline { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      /* hot edge — animated double-click target */
+      .edge-hot { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2 { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+
+      /* size readout badge */
+      .badge { fill: #0D99FF; }
+      .badge-text { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.2px; }
+
+      /* cursor icon */
+      .cursor { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+
+      .node-text { font-size: 26px; fill: #0a0a0a; letter-spacing: -0.3px; }
+
+      .arrow { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head { fill: #9ca3af; }
+
+      .legend-box { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+    </style>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1" result="offset"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- horizontal resize cursor (↔) -->
+    <symbol id="cursor-h" viewBox="0 0 28 16" overflow="visible">
+      <path d="M 4 8 L 9 4 L 9 6.5 L 19 6.5 L 19 4 L 24 8 L 19 12 L 19 9.5 L 9 9.5 L 9 12 Z" class="cursor"/>
+    </symbol>
+    <!-- vertical resize cursor (↕) -->
+    <symbol id="cursor-v" viewBox="0 0 16 28" overflow="visible">
+      <path d="M 8 4 L 4 9 L 6.5 9 L 6.5 19 L 4 19 L 8 24 L 12 19 L 9.5 19 L 9.5 9 L 12 9 Z" class="cursor"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Double-click an edge to reset size to auto</text>
+  <text x="480" y="86" class="caption" text-anchor="middle">The axis you click resets. The other axis stays put.</text>
+
+  <!-- ============================================================ -->
+  <!-- LEFT column: width auto                                      -->
+  <!-- ============================================================ -->
+  <g transform="translate(60, 130)">
+    <text x="200" y="20" class="step-label" text-anchor="middle">Left or right edge</text>
+    <text x="200" y="44" class="col-title" text-anchor="middle">resets <tspan class="label-mono">width</tspan> to auto</text>
+  </g>
+
+  <!-- BEFORE: oversized width text node -->
+  <g transform="translate(80, 220)">
+    <!-- selection outline (crisp at .5) -->
+    <rect x="0.5" y="0.5" width="359" height="119" class="sel-outline"/>
+    <!-- text -->
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <!-- baseline guide -->
+    <line x1="0.5" y1="84.5" x2="359.5" y2="84.5" class="baseline"/>
+    <!-- corner handles 8x8 centred on corners -->
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="356.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="116.5" width="7" height="7" class="handle"/>
+    <rect x="356.5" y="116.5" width="7" height="7" class="handle"/>
+
+    <!-- hot edges -->
+    <line x1="0.5" y1="0" x2="0.5" y2="120" class="edge-hot"/>
+    <line x1="359.5" y1="0" x2="359.5" y2="120" class="edge-hot"/>
+
+    <!-- click ripple on left edge -->
+    <circle cx="0.5" cy="60" r="10" class="ripple"/>
+    <circle cx="0.5" cy="60" r="16" class="ripple-2"/>
+    <!-- click ripple on right edge -->
+    <circle cx="359.5" cy="60" r="10" class="ripple"/>
+    <circle cx="359.5" cy="60" r="16" class="ripple-2"/>
+
+    <!-- resize cursors at hot edges -->
+    <use href="#cursor-h" x="-32" y="52" width="28" height="16" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-h" x="364" y="52" width="28" height="16" filter="url(#cursor-shadow)"/>
+
+    <!-- size badge centred under selection -->
+    <g transform="translate(136, 132)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">360 × 120</text>
+    </g>
+
+    <!-- step number -->
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">1</text>
+    </g>
+  </g>
+
+  <!-- arrow down -->
+  <line x1="260" y1="394" x2="260" y2="448" class="arrow" marker-end="url(#ah)"/>
+
+  <!-- AFTER: width hugs the text -->
+  <g transform="translate(140, 470)">
+    <rect x="0.5" y="0.5" width="159" height="119" class="sel-outline"/>
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <line x1="0.5" y1="84.5" x2="159.5" y2="84.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="156.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="116.5" width="7" height="7" class="handle"/>
+    <rect x="156.5" y="116.5" width="7" height="7" class="handle"/>
+
+    <g transform="translate(36, 132)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">auto × 120</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">2</text>
+    </g>
+  </g>
+
+  <!-- ============================================================ -->
+  <!-- RIGHT column: height auto                                    -->
+  <!-- ============================================================ -->
+  <g transform="translate(540, 130)">
+    <text x="200" y="20" class="step-label" text-anchor="middle">Top or bottom edge</text>
+    <text x="200" y="44" class="col-title" text-anchor="middle">resets <tspan class="label-mono">height</tspan> to auto</text>
+  </g>
+
+  <!-- BEFORE: oversized height text node -->
+  <g transform="translate(580, 200)">
+    <rect x="0.5" y="0.5" width="259" height="199" class="sel-outline"/>
+    <text x="14" y="74" class="node-text">Hello world</text>
+    <line x1="0.5" y1="84.5" x2="259.5" y2="84.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="196.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="196.5" width="7" height="7" class="handle"/>
+
+    <!-- hot top & bottom edges -->
+    <line x1="0" y1="0.5" x2="260" y2="0.5" class="edge-hot"/>
+    <line x1="0" y1="199.5" x2="260" y2="199.5" class="edge-hot"/>
+
+    <!-- ripples -->
+    <circle cx="130" cy="0.5" r="10" class="ripple"/>
+    <circle cx="130" cy="0.5" r="16" class="ripple-2"/>
+    <circle cx="130" cy="199.5" r="10" class="ripple"/>
+    <circle cx="130" cy="199.5" r="16" class="ripple-2"/>
+
+    <!-- resize cursors -->
+    <use href="#cursor-v" x="122" y="-32" width="16" height="28" filter="url(#cursor-shadow)"/>
+    <use href="#cursor-v" x="122" y="204" width="16" height="28" filter="url(#cursor-shadow)"/>
+
+    <g transform="translate(86, 212)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">260 × 200</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">1</text>
+    </g>
+  </g>
+
+  <line x1="710" y1="478" x2="710" y2="528" class="arrow" marker-end="url(#ah)"/>
+
+  <g transform="translate(580, 550)">
+    <rect x="0.5" y="0.5" width="259" height="49" class="sel-outline"/>
+    <text x="14" y="36" class="node-text">Hello world</text>
+    <line x1="0.5" y1="46.5" x2="259.5" y2="46.5" class="baseline"/>
+    <rect x="-3.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="-3.5" width="7" height="7" class="handle"/>
+    <rect x="-3.5" y="46.5" width="7" height="7" class="handle"/>
+    <rect x="256.5" y="46.5" width="7" height="7" class="handle"/>
+
+    <g transform="translate(86, 62)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="88" height="22" rx="4" class="badge"/>
+      <text x="44" y="15" class="badge-text" text-anchor="middle">260 × auto</text>
+    </g>
+
+    <g transform="translate(-26, -8)">
+      <circle cx="0" cy="0" r="11" class="step-bg"/>
+      <text x="0" y="4" class="step-num" text-anchor="middle">2</text>
+    </g>
+  </g>
+
+  <!-- ============================================================ -->
+  <!-- legend                                                       -->
+  <!-- ============================================================ -->
+  <g transform="translate(140, 800)">
+    <rect x="0" y="0" width="680" height="120" rx="10" class="legend-box"/>
+
+    <g transform="translate(40, 40)">
+      <line x1="0" y1="6" x2="28" y2="6" class="edge-hot"/>
+      <circle cx="14" cy="6" r="6" class="ripple"/>
+      <text x="46" y="11" class="caption">Hot edge — your double-click target</text>
+    </g>
+
+    <g transform="translate(40, 78)">
+      <use href="#cursor-h" x="0" y="-2" width="22" height="14"/>
+      <text x="36" y="11" class="caption">Resize cursor appears on hover</text>
+    </g>
+
+    <g transform="translate(390, 40)">
+      <rect x="0" y="-6" width="64" height="22" rx="4" class="badge"/>
+      <text x="32" y="10" class="badge-text" text-anchor="middle">w × h</text>
+      <text x="76" y="11" class="caption">Live size readout</text>
+    </g>
+
+    <g transform="translate(390, 78)">
+      <rect x="-3.5" y="2.5" width="7" height="7" class="handle"/>
+      <text x="20" y="11" class="caption">Selection corner handle</text>
+    </g>
+  </g>
+</svg>

--- a/docs/editor/resources/vector-network-editor-midpoint-projection.svg
+++ b/docs/editor/resources/vector-network-editor-midpoint-projection.svg
@@ -1,0 +1,234 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 960"
+     width="960"
+     height="960"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+
+      .doc-heading   { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 14px; fill: #6b7280; }
+      .col-title     { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label    { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption       { font-size: 13px; fill: #6b7280; }
+      .label-mono    { font-size: 13px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      /* selection chrome */
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .baseline      { stroke: #0D99FF; stroke-width: 0.5; opacity: 0.55; shape-rendering: crispEdges; }
+
+      /* gesture / interaction */
+      .edge-hot      { stroke: #FF3B30; stroke-width: 2; }
+      .ripple        { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2      { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+      .cursor        { fill: #0a0a0a; stroke: #ffffff; stroke-width: 1.25; stroke-linejoin: round; }
+
+      .ghost         { fill: none; stroke: #b5b5b5; stroke-width: 1; stroke-dasharray: 3 3; shape-rendering: crispEdges; }
+
+      .arrow         { stroke: #9ca3af; stroke-width: 1.25; fill: none; }
+      .arrow-head    { fill: #9ca3af; }
+
+      .legend-box    { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+      .panel-bg      { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; shape-rendering: crispEdges; }
+
+      .step-bg       { fill: #0a0a0a; }
+      .step-num      { font-size: 11px; fill: #ffffff; font-weight: 700; }
+
+      /* ---- INVENTED LOCALLY (not in kit v1) ----
+         Vector-network-specific glyphs: anchor vertices (square handles
+         like Figma/Illustrator), straight segment strokes, midpoint
+         preview indicator, and a committed midpoint vertex. */
+      .vn-segment      { stroke: #0D99FF; stroke-width: 1.5; fill: none; }
+      .vn-segment-soft { stroke: #0D99FF; stroke-width: 1.25; fill: none; opacity: 0.55; }
+      .vn-vertex       { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.25; }
+      .vn-vertex-sel   { fill: #0D99FF; stroke: #ffffff; stroke-width: 1.25; }
+
+      /* midpoint preview: hollow ring on hover */
+      .vn-mid-preview-ring { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.25; opacity: 0.95; }
+      .vn-mid-preview-dot  { fill: #0D99FF; opacity: 0.4; }
+    </style>
+
+    <!-- ARROW MARKERS -->
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"/>
+    </marker>
+
+    <!-- SHADOW FILTERS -->
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="vn-vertex-shadow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="0.8"/>
+      <feOffset dx="0" dy="0.5" result="o"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.35"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- CROSSHAIR CURSOR — matches CSS cursor: crosshair used by the
+         vector editor while drawing/picking points. Hot spot at centre (10,10). -->
+    <symbol id="cursor-crosshair" viewBox="0 0 20 20" overflow="visible">
+      <path d="M 9 0 H 11 V 9 H 20 V 11 H 11 V 20 H 9 V 11 H 0 V 9 H 9 Z"
+            class="cursor"/>
+    </symbol>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <!-- HEADING -->
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Midpoint projection on a straight segment</text>
+  <text x="480" y="86" class="doc-sub" text-anchor="middle">Hovering a straight segment previews a midpoint; pressing it inserts a vertex and begins a drag.</text>
+
+  <!-- =========== THREE PANELS =========== -->
+  <!-- Panel layout: 3 columns × 280 wide + 2 × 20 gaps = 880, centred
+       in 960 with 40px margins. Panels at x=40, 340, 640. -->
+
+  <!-- ─── PANEL 1: HOVER (preview) ─── -->
+  <g transform="translate(40, 130)">
+    <rect x="0.5" y="0.5" width="279" height="559" rx="10" class="panel-bg"/>
+
+    <!-- step label + title -->
+    <g transform="translate(20, 32)">
+      <rect x="0" y="-12" width="18" height="18" rx="4" class="step-bg"/>
+      <text x="9" y="1" class="step-num" text-anchor="middle">1</text>
+      <text x="28" y="2" class="step-label">Hover</text>
+    </g>
+    <text x="20" y="68" class="col-title">Preview appears</text>
+    <text x="20" y="90" class="caption">Pointer over a straight segment.</text>
+
+    <g transform="translate(20, 130)">
+      <!-- segment line -->
+      <line x1="40" y1="100" x2="220" y2="250" class="vn-segment"/>
+      <!-- endpoints (circle vertex handles) -->
+      <circle cx="40" cy="100" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+      <circle cx="220" cy="250" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- midpoint preview (hollow ring, smaller than vertex) -->
+      <!-- midpoint of (40,100)-(220,250) = (130, 175) -->
+      <circle cx="130" cy="175" r="5" class="vn-mid-preview-ring" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- crosshair hovering near midpoint (hotspot offset so the ring stays visible) -->
+      <use href="#cursor-crosshair" x="136" y="175" width="20" height="20" filter="url(#cursor-shadow)"/>
+    </g>
+  </g>
+
+  <!-- ─── PANEL 2: PRESS (insert + select) ─── -->
+  <g transform="translate(340, 130)">
+    <rect x="0.5" y="0.5" width="279" height="559" rx="10" class="panel-bg"/>
+
+    <g transform="translate(20, 32)">
+      <rect x="0" y="-12" width="18" height="18" rx="4" class="step-bg"/>
+      <text x="9" y="1" class="step-num" text-anchor="middle">2</text>
+      <text x="28" y="2" class="step-label">Press</text>
+    </g>
+    <text x="20" y="68" class="col-title">Vertex inserted</text>
+    <text x="20" y="90" class="caption">Pointer-down inserts the vertex.</text>
+
+    <g transform="translate(20, 130)">
+      <!-- segment is now two halves, both straight -->
+      <line x1="40" y1="100" x2="130" y2="175" class="vn-segment"/>
+      <line x1="130" y1="175" x2="220" y2="250" class="vn-segment"/>
+
+      <!-- endpoints -->
+      <circle cx="40" cy="100" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+      <circle cx="220" cy="250" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- click ripple at the new vertex -->
+      <circle cx="130" cy="175" r="11" class="ripple"/>
+      <circle cx="130" cy="175" r="17" class="ripple-2"/>
+
+      <!-- new midpoint vertex — selected -->
+      <circle cx="130" cy="175" r="4.5" class="vn-vertex-sel" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- crosshair (still down on it) -->
+      <use href="#cursor-crosshair" x="136" y="175" width="20" height="20" filter="url(#cursor-shadow)"/>
+    </g>
+  </g>
+
+  <!-- ─── PANEL 3: DRAG (continue gesture) ─── -->
+  <g transform="translate(640, 130)">
+    <rect x="0.5" y="0.5" width="279" height="559" rx="10" class="panel-bg"/>
+
+    <g transform="translate(20, 32)">
+      <rect x="0" y="-12" width="18" height="18" rx="4" class="step-bg"/>
+      <text x="9" y="1" class="step-num" text-anchor="middle">3</text>
+      <text x="28" y="2" class="step-label">Drag</text>
+    </g>
+    <text x="20" y="68" class="col-title">Translate without release</text>
+    <text x="20" y="90" class="caption">Same pointer-down continues as a drag.</text>
+
+    <g transform="translate(20, 130)">
+      <!-- ghost: original straight segment -->
+      <line x1="40" y1="100" x2="220" y2="250" class="ghost"/>
+
+      <!-- new dragged geometry: both halves follow the moved midpoint -->
+      <!-- moved midpoint: (175, 110) -->
+      <line x1="40" y1="100" x2="175" y2="110" class="vn-segment"/>
+      <line x1="175" y1="110" x2="220" y2="250" class="vn-segment"/>
+
+      <!-- endpoints -->
+      <circle cx="40" cy="100" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+      <circle cx="220" cy="250" r="4" class="vn-vertex" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- moved midpoint vertex (still selected) -->
+      <circle cx="175" cy="110" r="4.5" class="vn-vertex-sel" filter="url(#vn-vertex-shadow)"/>
+
+      <!-- motion arrow from old midpoint to new -->
+      <line x1="135" y1="172" x2="170" y2="115"
+            stroke="#FF3B30" stroke-width="1.5" fill="none"
+            opacity="0.85" stroke-dasharray="3 2"
+            marker-end="url(#ah)"/>
+
+      <!-- crosshair at the dragged position -->
+      <use href="#cursor-crosshair" x="181" y="110" width="20" height="20" filter="url(#cursor-shadow)"/>
+    </g>
+  </g>
+
+  <!-- =========== LEGEND =========== -->
+  <g transform="translate(40, 720)">
+    <rect x="0.5" y="0.5" width="879" height="74" rx="8" class="legend-box"/>
+
+    <!-- vertex -->
+    <g transform="translate(28, 38)">
+      <circle cx="0" cy="0" r="4" class="vn-vertex"/>
+      <text x="16" y="4" class="caption">vertex</text>
+    </g>
+
+    <!-- selected vertex -->
+    <g transform="translate(125, 38)">
+      <circle cx="0" cy="0" r="4.5" class="vn-vertex-sel"/>
+      <text x="16" y="4" class="caption">selected vertex</text>
+    </g>
+
+    <!-- midpoint preview -->
+    <g transform="translate(280, 38)">
+      <circle cx="0" cy="0" r="5" class="vn-mid-preview-ring"/>
+      <text x="14" y="4" class="caption">midpoint preview (hover only)</text>
+    </g>
+
+    <!-- segment -->
+    <g transform="translate(530, 38)">
+      <line x1="0" y1="0" x2="28" y2="0" class="vn-segment"/>
+      <text x="38" y="4" class="caption">segment</text>
+    </g>
+
+    <!-- ghost -->
+    <g transform="translate(640, 38)">
+      <line x1="0" y1="0" x2="28" y2="0" class="ghost"/>
+      <text x="38" y="4" class="caption">previous shape</text>
+    </g>
+
+    <!-- crosshair -->
+    <g transform="translate(790, 38)">
+      <use href="#cursor-crosshair" x="-10" y="-10" width="20" height="20"/>
+      <text x="16" y="4" class="caption">crosshair</text>
+    </g>
+  </g>
+
+</svg>

--- a/docs/editor/resources/vector-network-measurement-alt-hover.svg
+++ b/docs/editor/resources/vector-network-measurement-alt-hover.svg
@@ -1,0 +1,173 @@
+<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 960 960"
+     width="960"
+     height="960"
+     font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <defs>
+    <style>
+      .canvas-bg     { fill: #ECECEC; }
+
+      .doc-heading   { font-size: 26px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.3px; }
+      .doc-sub       { font-size: 14px; fill: #6b7280; }
+      .col-title     { font-size: 18px; fill: #0a0a0a; font-weight: 600; letter-spacing: -0.2px; }
+      .step-label    { font-size: 11px; fill: #6b7280; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; }
+      .caption       { font-size: 13px; fill: #6b7280; }
+      .label-mono    { font-size: 13px; fill: #0a0a0a; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .sel-outline   { fill: none; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+      .handle        { fill: #ffffff; stroke: #0D99FF; stroke-width: 1; shape-rendering: crispEdges; }
+
+      .vector-stroke { fill: none; stroke: #0a0a0a; stroke-width: 1.5; }
+      .vertex-dot    { fill: #ffffff; stroke: #0D99FF; stroke-width: 1.5; }
+      .vertex-sel    { fill: #0D99FF; stroke: #ffffff; stroke-width: 1.5; }
+
+      .edge-hot      { stroke: #FF3B30; stroke-width: 2; shape-rendering: crispEdges; }
+      .ripple        { fill: none; stroke: #FF3B30; stroke-width: 1.25; opacity: 0.6; }
+      .ripple-2      { fill: none; stroke: #FF3B30; stroke-width: 1; opacity: 0.3; }
+
+      .badge         { fill: #0D99FF; }
+      .badge-text    { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+
+      /* INVENTED: measurement-specific tokens (red, distinct from selection blue) */
+      .measure-line  { stroke: #FF3B30; stroke-width: 1.25; shape-rendering: crispEdges; }
+      .measure-aux   { stroke: #FF3B30; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.7; shape-rendering: crispEdges; }
+      .measure-badge { fill: #FF3B30; }
+      .measure-text  { font-size: 11px; fill: #ffffff; font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 600; letter-spacing: 0.3px; }
+
+      /* INVENTED: neutral key-cap pill for the Alt modifier */
+      .keycap-bg     { fill: #ffffff; stroke: #0a0a0a; stroke-width: 1.25; }
+      .keycap-text   { font-size: 12px; fill: #0a0a0a; font-weight: 600; font-family: 'SF Mono', Menlo, Consolas, monospace; }
+
+      .legend-box    { fill: #ffffff; stroke: #e5e5e5; stroke-width: 1; }
+    </style>
+
+    <filter id="badge-shadow" x="-20%" y="-20%" width="140%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.25"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cursor-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+      <feOffset dx="0" dy="1"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.4"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect class="canvas-bg" width="960" height="960"/>
+
+  <!-- Heading -->
+  <text x="480" y="60" class="doc-heading" text-anchor="middle">Alt-hover on a curve to measure</text>
+  <text x="480" y="86" class="doc-sub" text-anchor="middle">Selected vertex (A) to the parametric point under the cursor on the hovered segment (B).</text>
+
+  <!-- ============================================================
+       Main scene — single panel with the vector network
+       ============================================================ -->
+  <g transform="translate(80, 140)">
+    <rect x="0.5" y="0.5" width="799" height="569" rx="10" class="legend-box"/>
+
+    <!-- step label -->
+    <text x="24" y="36" class="step-label">Gesture</text>
+    <text x="24" y="58" class="col-title">Hold Alt, hover the segment</text>
+
+    <!-- key-cap modifier pill -->
+    <g transform="translate(24, 76)">
+      <rect x="0" y="0" width="56" height="26" rx="6" class="keycap-bg"/>
+      <text x="28" y="18" class="keycap-text" text-anchor="middle">Alt</text>
+      <text x="68" y="18" class="caption">held</text>
+    </g>
+
+    <!-- ============================================================
+         Vector network — a simple open path with three vertices
+         and one Bezier curve segment. Coordinates are panel-local.
+         A: selected vertex at (180, 380)
+         B (parametric): point on curve at roughly (520, 280)
+         ============================================================ -->
+
+    <!-- the vector path: V0 (180,380) -> V1 cubic (520,180) -> V2 (700,420) -->
+    <path d="M 180 380 C 280 180, 460 120, 520 280 S 660 460, 700 420"
+          class="vector-stroke"/>
+
+    <!-- ghost / aux measurement lines (axis-aligned distance from A to parametric point) -->
+    <!-- A is (180, 380); B is (520, 280)
+         dx = 340 (horizontal distance), dy = 100 (vertical distance)
+         Right (dx) line at y of A; Top (dy) line at x of B  -->
+
+    <!-- horizontal aux: from A.x to B.x along A.y -->
+    <line x1="180" y1="380" x2="520" y2="380" class="measure-line"/>
+    <!-- vertical aux: from B.y to A.y along B.x -->
+    <line x1="520" y1="280" x2="520" y2="380" class="measure-line"/>
+
+    <!-- Virtual axis-aligned rect has A (180,380) and B (520,280) at
+         opposite corners. Solid L runs through (520,380). Dashed mirror
+         L runs through (180,280), completing the rectangle's other two
+         sides — matches the editor's measurement-guide rendering. -->
+    <line x1="180" y1="380" x2="180" y2="280" class="measure-aux"/>
+    <line x1="180" y1="280" x2="520" y2="280" class="measure-aux"/>
+
+    <!-- distance badges -->
+    <g transform="translate(310, 392)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="62" height="20" rx="4" class="measure-badge"/>
+      <text x="31" y="14" class="measure-text" text-anchor="middle">340 px</text>
+    </g>
+    <g transform="translate(530, 320)" filter="url(#badge-shadow)">
+      <rect x="0" y="0" width="62" height="20" rx="4" class="measure-badge"/>
+      <text x="31" y="14" class="measure-text" text-anchor="middle">100 px</text>
+    </g>
+
+    <!-- A: the selected vertex -->
+    <circle cx="180" cy="380" r="6" class="vertex-sel"/>
+    <text x="180" y="412" class="label-mono" text-anchor="middle">A · selected vertex</text>
+
+    <!-- other (unselected) vertex on the path for context -->
+    <circle cx="700" cy="420" r="5" class="vertex-dot"/>
+    <text x="700" y="446" class="label-mono" text-anchor="middle">vertex</text>
+
+    <!-- B: parametric point on the curve under the cursor.
+         Dot is coloured with the measurement red so it reads as the
+         measurement target, not a selected vertex. -->
+    <circle cx="520" cy="280" r="10" class="ripple"/>
+    <circle cx="520" cy="280" r="16" class="ripple-2"/>
+    <circle cx="520" cy="280" r="5" fill="#FF3B30" stroke="#ffffff" stroke-width="1.5"/>
+    <text x="520" y="246" class="label-mono" text-anchor="middle">B · parametric point</text>
+
+    <!-- crosshair cursor adjacent to B — offset so the hotspot sits beside
+         the parametric point (hover, not click) and B stays visible. -->
+    <g transform="translate(534, 294)" filter="url(#cursor-shadow)">
+      <path d="M 9 0 H 11 V 9 H 20 V 11 H 11 V 20 H 9 V 11 H 0 V 9 H 9 Z"
+            fill="#0a0a0a" stroke="#ffffff" stroke-width="1.25" stroke-linejoin="round"/>
+    </g>
+  </g>
+
+  <!-- ============================================================
+       Legend / read-out below
+       ============================================================ -->
+  <g transform="translate(80, 740)">
+    <rect x="0.5" y="0.5" width="799" height="120" rx="10" class="legend-box"/>
+    <text x="24" y="34" class="step-label">Read-out</text>
+
+    <!-- legend: A swatch -->
+    <g transform="translate(24, 60)">
+      <circle cx="8" cy="8" r="6" class="vertex-sel"/>
+      <text x="24" y="12" class="label-mono">A — source (selected vertex, vector2)</text>
+    </g>
+    <!-- legend: B swatch -->
+    <g transform="translate(24, 88)">
+      <circle cx="8" cy="8" r="5" fill="#FF3B30" stroke="#ffffff" stroke-width="1.5"/>
+      <text x="24" y="12" class="label-mono">B — target (parametric point on hovered curve)</text>
+    </g>
+
+    <!-- legend: red line -->
+    <g transform="translate(420, 60)">
+      <line x1="0" y1="8" x2="32" y2="8" class="measure-line"/>
+      <text x="44" y="12" class="label-mono">axis-aligned distance (X / Y independent)</text>
+    </g>
+    <g transform="translate(420, 88)">
+      <line x1="0" y1="8" x2="32" y2="8" class="measure-aux"/>
+      <text x="44" y="12" class="label-mono">auxiliary alignment guide</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

New agent skill `canvas-docs-svg-kit` — reusable SVG primitives and templates for authoring figures in Grida Canvas user docs (`docs/editor/`).

- **Primitives**: selection chrome, size / distance meters (blue + red), handles (square, free-transform, anchor pin), cursors (pointer, move, grab, grabbing, rotate, h-resize, v-resize), keycaps, ghost outlines, arrows, click ripples.
- **Tokens**: canvas bg, selection, hot, measurement (workbench red), text, caption, typography classes (SF Pro / SF Mono).
- **Starter template** with every CSS class and def pre-wired.
- **Catalogs**: one overview (`primitives.svg`) plus focused per-family files (`cursors.svg`, `meters.svg`, `handles.svg`, `keycap.svg`).
- **Examples**: two finished figures (`text-node-auto-size-edges.svg`, `text-node-auto-size-alignment.svg`).
- **Workflow**: render-then-look loop via `resvg`, watermark contract (`@generated-by` comment + `<metadata>` element) so kit assets are enumerable via grep.

Ground truth for each primitive points back to the editor source (`grida-canvas-react/viewport/**`, `components/ui/kbd.tsx`, `components/cursor/cursor-data.ts`, etc.) — see *Ground truth in the editor* in SKILL.md.

Draft — more work on kit coverage (vector anchors, transform primitives, measurement notation, viewport/spatial) will land as follow-up commits.

## Test plan

- [x] All kit SVGs render cleanly via \`resvg\`
- [x] Grab + grabbing cursors match the macOS Tahoe look (white fill, thick black outline)
- [x] Watermark grep surfaces all kit assets (\`grep -rl "canvas-docs-svg-kit" docs/editor/ .agents/\`)
- [ ] Produce more doc figures to stress-test the kit in practice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Canvas Docs SVG Kit: authoring workflow, strict SVG format rules, self-contained asset guidance, verification checklist, and best-practice pitfalls
  * Linked SVG-kit guidance into custom graphics authoring guidance
  * Expanded text-node auto-size guide with alignment rules and edge double-click behavior
  * Added illustrative images/overlays for surface image editor, vector midpoint interaction, and axis-aligned measurement workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->