### PR TITLE
skills: convert cg-htmlcss-feature prompt to a skill

### DIFF
--- a/.agents/skills/cg-htmlcss-feature/SKILL.md
+++ b/.agents/skills/cg-htmlcss-feature/SKILL.md
@@ -1,18 +1,26 @@
-# cg-htmlcss — feature loop prompt
+---
+name: cg-htmlcss-feature
+description: >
+  Drive a single CSS feature end-to-end in the cg htmlcss renderer using a
+  five-phase loop: audit, ground (spec + Blink/stylo prior art), fixture,
+  implement, verify. Use when the user explicitly asks for a full feature
+  cycle on an htmlcss property (e.g. "full loop on border-radius", "bring
+  <property> to Chromium parity"). Not for small fixes or paper-cuts — this
+  is an opt-in conductor over /research, /fixtures, /cg-reftest with strict
+  gate policy (L0.exact at floor 1.0, threshold 0, aa off). Relevant paths:
+  crates/grida-canvas/src/htmlcss/, fixtures/test-html/L0/,
+  fixtures/test-html/suites/L0.exact.json, fixtures/test-html/suites/L0.coverage.json.
+---
 
-**What this is.** A pastable prompt template for driving a single CSS
-feature forward in the cg htmlcss renderer. Paste the template at the
-bottom into a new task; the reference above it is context an agent
-can read to follow the loop honestly.
+# cg-htmlcss — feature loop
 
-**Why this is a prompt and not a skill.** The 5-phase loop is
-deliberately heavy — audit + ground + fixture + implement + verify.
-It's overkill for small fixes, and it's already a conductor over
-`/research`, `/fixtures`, `/cg-reftest`, which auto-trigger correctly
-on their own. Opt-in invocation is right: paste it when you want the
-full cycle; skip it for paper-cuts.
+**What this is.** A heavy, opt-in loop for driving a single CSS feature
+forward in the cg htmlcss renderer. Load this skill when the user asks
+for a full feature cycle; skip it for small fixes. The loop is a
+conductor over `/research`, `/fixtures`, and `/cg-reftest` — they
+auto-trigger on their own for narrower work.
 
-**Lifecycle.** Expect this file to grow as new divergence patterns
+**Lifecycle.** Expect this skill to grow as new divergence patterns
 surface. It will likely go stale in parts once htmlcss hits
 Chromium-parity on L0/L1; treat the _phase structure_ as durable and
 the _property-specific callouts_ as advisory.
@@ -245,7 +253,7 @@ upstream is advisory; verify is the truth.
   fixture here is "we know about this case and intend to fix it."
   Promoting to exact is "we now match Blink."
 
-Automation rules downstream of this prompt (CI gating, auto-merge,
+Automation rules downstream of this skill (CI gating, auto-merge,
 etc.) must assert on the `report.json` emitted by `@grida/reftest`
 and **not** on free-text agent assertions. The agent's job is to
 drive the loop; the report is the contract.
@@ -291,7 +299,7 @@ without the conversation.
 
 ```text
 Drive the htmlcss feature loop for: <property or behavior>.
-Follow .agents/prompts/cg-htmlcss-feature.md.
+Follow the cg-htmlcss-feature skill (.agents/skills/cg-htmlcss-feature/SKILL.md).
 
 Scope:
 - Feature:    <e.g. `border-radius` percentage values>

--- a/.agents/skills/dev-cg-htmlcss-feature/SKILL.md
+++ b/.agents/skills/dev-cg-htmlcss-feature/SKILL.md
@@ -1,24 +1,18 @@
 ---
-name: cg-htmlcss-feature
+name: dev-cg-htmlcss-feature
 description: >
-  Drive a single CSS feature end-to-end in the cg htmlcss renderer using a
-  five-phase loop: audit, ground (spec + Blink/stylo prior art), fixture,
-  implement, verify. Use when the user explicitly asks for a full feature
-  cycle on an htmlcss property (e.g. "full loop on border-radius", "bring
-  <property> to Chromium parity"). Not for small fixes or paper-cuts — this
-  is an opt-in conductor over /research, /fixtures, /cg-reftest with strict
-  gate policy (L0.exact at floor 1.0, threshold 0, aa off). Relevant paths:
-  crates/grida-canvas/src/htmlcss/, fixtures/test-html/L0/,
-  fixtures/test-html/suites/L0.exact.json, fixtures/test-html/suites/L0.coverage.json.
+  Manual-invocation only. Five-phase feature loop (audit → ground →
+  fixture → implement → verify) for driving a single CSS feature to
+  Chromium parity in the cg htmlcss renderer.
 ---
 
 # cg-htmlcss — feature loop
 
-**What this is.** A heavy, opt-in loop for driving a single CSS feature
-forward in the cg htmlcss renderer. Load this skill when the user asks
-for a full feature cycle; skip it for small fixes. The loop is a
-conductor over `/research`, `/fixtures`, and `/cg-reftest` — they
-auto-trigger on their own for narrower work.
+**What this is.** A heavy, manually-invoked loop for driving a single
+CSS feature forward in the cg htmlcss renderer. Do not auto-trigger;
+load only when the user explicitly runs it. The loop is a conductor
+over `/research`, `/fixtures`, and `/cg-reftest` — those auto-trigger
+on their own for narrower work.
 
 **Lifecycle.** Expect this skill to grow as new divergence patterns
 surface. It will likely go stale in parts once htmlcss hits
@@ -299,7 +293,7 @@ without the conversation.
 
 ```text
 Drive the htmlcss feature loop for: <property or behavior>.
-Follow the cg-htmlcss-feature skill (.agents/skills/cg-htmlcss-feature/SKILL.md).
+Follow the dev-cg-htmlcss-feature skill (.agents/skills/dev-cg-htmlcss-feature/SKILL.md).
 
 Scope:
 - Feature:    <e.g. `border-radius` percentage values>


### PR DESCRIPTION
## Summary

- Move `.agents/prompts/cg-htmlcss-feature.md` → `.agents/skills/cg-htmlcss-feature/SKILL.md` with proper frontmatter.
- Remove the `.agents/prompts/` directory entirely.

## Why

The `.agents/` convention adopted by Vercel/Next.js and read by opencode (and Claude-Code-compatible tooling) only standardizes **`.agents/skills/`**. There is no portable `.agents/prompts/` slot — no agent runtime discovers that path. Keeping the prompt there meant it wasn't reachable as a `/cg-htmlcss-feature` invocation anywhere.

Non-skill reusable prompts (i.e. \"commands\") have tool-specific homes (`.claude/commands/`, `.opencode/commands/`) and no portable cross-tool location, so folding this into the skill system is the cleanest fix.

Opt-in behavior is preserved via the skill `description`: it instructs agents to load only when the user explicitly asks for a full feature cycle (\"full loop on <property>\", \"bring <property> to Chromium parity\"), not on every htmlcss edit.

## Test plan

- [ ] `.agents/skills/cg-htmlcss-feature/SKILL.md` exists with valid YAML frontmatter.
- [ ] `.agents/prompts/` is gone.
- [ ] Skill is auto-listed by Claude Code / opencode when loaded into a session (shows up under the `/` menu as `cg-htmlcss-feature`).
- [ ] No remaining references to `.agents/prompts/cg-htmlcss-feature.md` outside the file itself (the template block inside SKILL.md now points to the new path).