### PR TITLE
fix: unblock fresh-clone editor boot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,15 @@
 
 ---
 
-First, clone the repo with git submodules (optional. using Github Desktop will automatically clone the submodules for you)
+First, clone the repo with git submodules (required for canvas/WASM builds; GitHub Desktop clones submodules automatically).
 
 ```bash
 # clone the repo
 git clone --recurse-submodules https://github.com/gridaco/grida
 cd grida
+
+# or, if you already cloned without --recurse-submodules
+git submodule update --init
 
 # setup node & package manager
 nvm use

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Docs: [@grida/refig](https://grida.co/docs/packages/@grida/refig)
 
 ## Quickstart (monorepo)
 
-**Requirements:** Node.js **22+**, pnpm **10+**
+**Requirements:** Node.js **24+**, pnpm **10+**
 
 ```bash
 pnpm install

--- a/editor/.env.example
+++ b/editor/.env.example
@@ -25,7 +25,7 @@ NEXT_PUBLIC_SUPABASE_URL_RR_AP_NORTHEAST_2=...
 # [insiders config]
 # flag to use unsafe sandbox (set 1 to enable)
 NEXT_PUBLIC_GRIDA_UNSAFE_DEVELOPER_SANDBOX='0'
-NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL='http://localhost:4020/dist' # set to use locally served wasm (dev)
+# NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL='http://localhost:4020/dist' # opt-in: use locally served wasm (requires `just build canvas wasm && just serve canvas wasm`). Leave unset to fetch the published wasm from unpkg.
 NEXT_PUBLIC_GRIDA_WASM_VERBOSE='0' # set 1 to inspect (log) the wasm api
 NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH='1'
 NEXT_PUBLIC_GRIDA_LOCALHOST_REGION="us-west-1"

--- a/editor/app/(www)/(home)/_home/content-1.tsx
+++ b/editor/app/(www)/(home)/_home/content-1.tsx
@@ -78,15 +78,15 @@ export default function Content1() {
       </Carousel>
       {/* body */}
       <div className="min-h-96 h-[300px] sm:h-[400px] md:h-[600px] lg:h-[800px] w-full flex items-start justify-center">
-        <BigImageContainer key={index} {...img} alt={categories[index]} />
+        {img && (
+          <BigImageContainer key={index} src={img} alt={categories[index]} />
+        )}
       </div>
     </div>
   );
 }
 
 function BigImageContainer({
-  width,
-  height,
   alt = "",
   ...props
 }: React.ComponentProps<typeof Image>) {
@@ -97,7 +97,7 @@ function BigImageContainer({
       animate={{ opacity: 1 }}
       transition={{ duration: 1 }}
     >
-      <Image {...props} width={width} height={height} alt={alt} />
+      <Image {...props} alt={alt} />
     </motion.div>
   );
 }

--- a/editor/grida-canvas-react-starter-kit/starterkit-loading/loading.tsx
+++ b/editor/grida-canvas-react-starter-kit/starterkit-loading/loading.tsx
@@ -197,18 +197,17 @@ export function FullscreenLoadingOverlay({
   errmsg,
 }: FullscreenLoadingOverlayProps) {
   const [showOverlay, setShowOverlay] = useState(true);
-  const [startTime, setStartTime] = useState<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (loading) {
-      setStartTime(Date.now());
+      startTimeRef.current = Date.now();
       setShowOverlay(true);
-    } else if (startTime) {
-      const elapsed = Date.now() - startTime;
+    } else if (startTimeRef.current) {
+      const elapsed = Date.now() - startTimeRef.current;
       const remaining = Math.max(0, minDuration - elapsed);
 
       if (remaining > 0) {
-        // Wait for minimum duration before hiding
         const timer = setTimeout(() => {
           setShowOverlay(false);
         }, remaining);
@@ -218,7 +217,7 @@ export function FullscreenLoadingOverlay({
         setShowOverlay(false);
       }
     }
-  }, [loading, minDuration, startTime]);
+  }, [loading, minDuration]);
 
   return (
     <AnimatePresence mode="wait" onExitComplete={onExitComplete}>

--- a/editor/grida-canvas/backends/wasm-locate-file.ts
+++ b/editor/grida-canvas/backends/wasm-locate-file.ts
@@ -9,8 +9,6 @@ export default function locateFile(...args: Args) {
   const [path, version] = args;
   if (process.env.NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL) {
     return `${process.env.NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL}/${path}`;
-  } else if (process.env.NODE_ENV === "development") {
-    return `http://localhost:4020/dist/${path}`;
   } else {
     return `https://unpkg.com/@grida/canvas-wasm@${version}/dist/${path}`;
   }


### PR DESCRIPTION
## Summary

I ran through a fresh-worktree setup of the editor and hit three things that block any contributor's first click after `pnpm install && pnpm dev:editor`. Fixing them here, plus the two doc mismatches I tripped on.

## What changed

### `/canvas` now boots on a clean clone
`editor/grida-canvas/backends/wasm-locate-file.ts` hardcoded `http://localhost:4020/dist/` as the dev fallback. That URL is only served by `just serve canvas wasm` after `just build canvas wasm` — which pulls emsdk, requires ninja, and takes ~10 min on first run. Result: a fresh checkout's `/canvas` loaded a progress bar forever with no UI error, no console error, no 404 (I only found the URL via `performance.getEntriesByType('resource')`).

Now: in dev, if `NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL` is set, use it; otherwise fall through to the unpkg-published wasm (same path prod already uses). Canvas-engine devs who want local wasm still set the env var — `.env.example` now has it commented out and labeled as an opt-in override.

### Landing page no longer throws on every load
Two separate bugs, both on `/`:

- `FullscreenLoadingOverlay` in `grida-canvas-react-starter-kit/starterkit-loading/loading.tsx:204` had `startTime` in the effect's dep array while also being set inside the effect — infinite `setState`-in-`useEffect` loop, showing up as `Maximum update depth exceeded` on every home render. Switched `startTime` to `useRef`; semantics preserved (latch on enter, read on exit).
- `content-1.tsx` (the carousel on the home page) spread a `StaticImageData` import via `{...img}` before the carousel had picked an index, rendering `<Image src={undefined} />` on first paint (empty-`src` + "Image missing required src" warnings), and then leaked `blurWidth`/`blurHeight` DOM attrs ("React does not recognize the blurWidth prop" warnings). Guarded the initial render and pass `src={img}` so Next owns the blur bookkeeping.

### Docs
- `README.md`: Node **22+** → **24+** to match `.nvmrc` (`v24.14.0`) and `engines.node` (`>=24.0.0`).
- `CONTRIBUTING.md`: the submodule clone step was labeled "optional" but it's required for any canvas/WASM build (`third_party/externals/emsdk`). Reworded, added the `git submodule update --init` recovery command for folks who already cloned without `--recurse-submodules`.

## Verification

- `pnpm turbo typecheck --filter=editor` → 28/28 pass (editor rebuilt, not cached).
- `pnpm oxlint` on all changed TS → 0 warnings, 0 errors.
- Runtime: booted the editor fresh, loaded `/` (no red overlay, 0 errors in console), loaded `/canvas` and confirmed the wasm fetch URL is now `https://unpkg.com/@grida/canvas-wasm@<ver>/dist/grida_canvas_wasm.wasm` and the editor UI renders fully without any local rust/emsdk toolchain.

## Reviewer notes

- The wasm-locate-file change is behavior-preserving for anyone whose `.env` already sets `NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL` (the shipped example did). The only change-in-behavior case is a dev who had the var unset — they now get the published wasm in dev instead of a 404.
- Not fixed here (out of scope):
  - The Turbopack "multiple lockfiles" warning is worktree-specific and doesn't fire on a normal clone.
  - `/playground/canvas` isn't a real route (the Canvas Playground card on `/playground` links to `/canvas`) — no code or docs referenced the phantom path.

## Test plan

- [ ] On a fresh clone: `pnpm install && cp editor/.env.example editor/.env && pnpm dev:editor`, open `/` (no red overlay, clean console) and `/canvas` (editor loads with wasm from unpkg, no local build needed).
- [ ] With `NEXT_PUBLIC_GRIDA_WASM_DEV_SERVE_URL=http://localhost:4020/dist` set and `just serve canvas wasm` running, `/canvas` still loads the locally served wasm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with required submodule cloning instructions for canvas/WASM builds
  * Updated minimum Node.js version requirement to 24+ in system requirements

* **Bug Fixes**
  * Fixed conditional image rendering on home page

* **Chores**
  * Updated WASM development server configuration defaults
  * Optimized loading overlay rendering performance to reduce unnecessary updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->