### PR TITLE
htmlcss: promote paint-opacity + box-padding to L0.exact

### DIFF
--- a/.agents/skills/fixtures/SKILL.md
+++ b/.agents/skills/fixtures/SKILL.md
@@ -43,6 +43,13 @@ edge case** that the codebase supports or intends to support. This includes:
   filename alone should tell you what's being tested.
 - **Labeled specimens.** Within a fixture, label each test case with the
   value being exercised so both humans and heuristics can identify regions.
+  Keep labels short, and pin the dimensions of any container holding a
+  label (flex item, grid cell, stretched block) so font-advance-width
+  differences between engines can't leak into box geometry. When a test
+  pipeline offers a text-neutralizing stylesheet (e.g.
+  `fixtures/test-html/_reftest/hide-text.css` for the htmlcss reftests),
+  prefer that over stripping the label — keeping the text helps the next
+  reader understand the fixture.
 - **Match the fixture's subject to the viewport policy.** For refbrowser
   fixtures under `fixtures/test-html/`, **paint / visual-property**
   fixtures should size their root to a preset viewport (via `min-height`)

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -117,7 +117,7 @@ fn paint_box(
 
     if needs_layer {
         let mut layer_paint = Paint::default();
-        layer_paint.set_alpha((style.opacity * 255.0) as u8);
+        layer_paint.set_alpha_f(style.opacity);
         let has_filter = !style.filter.is_empty();
         if has_filter {
             if let Some(filter) = build_filter_chain(&style.filter) {

--- a/fixtures/test-html/L0/box-padding.html
+++ b/fixtures/test-html/L0/box-padding.html
@@ -14,9 +14,10 @@
       }
 
       .label {
+        width: 200px;
+        height: 16px;
         font-size: 11px;
         color: #666;
-        padding-bottom: 4px;
       }
 
       .columns {
@@ -28,14 +29,12 @@
 
       .outer {
         background: #eee;
-        border-radius: 8px;
       }
 
       .inner {
         background: #000;
-        border-radius: 4px;
-        font-size: 12px;
-        color: #fff;
+        width: 80px;
+        height: 24px;
       }
 
       .uniform {
@@ -57,25 +56,25 @@
       <div>
         <div class="label">padding: 24px (uniform)</div>
         <div class="outer uniform">
-          <div class="inner">content</div>
+          <div class="inner"></div>
         </div>
       </div>
       <div>
         <div class="label">padding: 8px 32px (horizontal)</div>
         <div class="outer horizontal">
-          <div class="inner">content</div>
+          <div class="inner"></div>
         </div>
       </div>
       <div>
         <div class="label">padding: 32px 8px (vertical)</div>
         <div class="outer vertical">
-          <div class="inner">content</div>
+          <div class="inner"></div>
         </div>
       </div>
       <div>
         <div class="label">padding: 8px 16px 32px 48px</div>
         <div class="outer asymmetric">
-          <div class="inner">content</div>
+          <div class="inner"></div>
         </div>
       </div>
     </div>

--- a/fixtures/test-html/L0/paint-opacity.html
+++ b/fixtures/test-html/L0/paint-opacity.html
@@ -78,19 +78,19 @@
       <div class="grid">
         <div>
           <div class="label">1.0</div>
-          <div class="box o100">100%</div>
+          <div class="box o100"></div>
         </div>
         <div>
           <div class="label">0.75</div>
-          <div class="box o75">75%</div>
+          <div class="box o75"></div>
         </div>
         <div>
           <div class="label">0.5</div>
-          <div class="box o50">50%</div>
+          <div class="box o50"></div>
         </div>
         <div>
           <div class="label">0.25</div>
-          <div class="box o25">25%</div>
+          <div class="box o25"></div>
         </div>
       </div>
     </div>

--- a/fixtures/test-html/README.md
+++ b/fixtures/test-html/README.md
@@ -123,6 +123,27 @@ sides should now be at identical dimensions.
 layout changes its natural cull, invalidating `viewport.height` in
 the suite. Re-measure and update.
 
+## Captions and labels
+
+Short captions next to each specimen (`"0.75"`, `"padding: 24px"`,
+etc.) are welcome — they help humans reading the fixture identify what
+each region is testing. Two rules:
+
+- **Keep them short.** The caption is not the subject; if it grows
+  long enough to shape the layout it's in the way.
+- **Don't let captions drive layout.** When captions sit inside flex
+  items, grid cells, or stretched blocks, pin the enclosing element's
+  dimensions (`width`, `height`) so font-advance-width differences
+  between Chromium and cg can't leak into box geometry. Otherwise a
+  1px shaping difference in "padding: 24px (uniform)" propagates to
+  every following sibling.
+
+When text is incidental (labels, glyph placeholders, captions), inject
+`_reftest/hide-text.css` via the suite's `extra_css` — it neutralizes
+color, text-shadow, and line-height while preserving advance widths
+and block flow. The suite defaults already pull it in; see
+`.agents/skills/cg-reftest/SKILL.md` for details.
+
 ## Adding a new fixture
 
 1. **Name** — `<domain>-<property>[-<variant>].html`. The filename is

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "../L0/box-padding.html",
-      "viewport": { "width": 600, "height": 222 }
+      "viewport": { "width": 600, "height": 256 }
     },
     { "path": "../L0/paint-background-solid.html" },
     { "path": "../L0/paint-opacity.html" },

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -16,6 +16,11 @@
     {
       "path": "../L0/box-dimensions.html",
       "viewport": { "width": 600, "height": 522 }
-    }
+    },
+    {
+      "path": "../L0/box-padding.html",
+      "viewport": { "width": 600, "height": 256 }
+    },
+    { "path": "../L0/paint-opacity.html" }
   ]
 }


### PR DESCRIPTION
## Summary

Two Chromium-parity promotions for the cg htmlcss renderer, driven through the `dev-cg-htmlcss-feature` 5-phase loop.

### 1. `paint-opacity` — float-native alpha fix

- `crates/grida-canvas/src/htmlcss/paint.rs:120` used `set_alpha((opacity * 255.0) as u8)`. Rust `as u8` truncates toward zero, so opacity values that don't align to u8 boundaries diverged from Blink by 1 unit per channel.
- Example: `opacity: 0.5` on black-over-white yielded `rgb(127,127,127)` in cg vs `rgb(126,126,126)` in Chromium; `0.25` yielded `(191,191,191)` vs `(190,190,190)`.
- Blink's opacity stacking-context layer lands in `SkCanvas::saveLayerAlphaf(bounds, float)` → `SkPaint::setAlphaf`. WebRender similarly carries `f32` end-to-end.
- Fix: swap to `set_alpha_f(style.opacity)`. skia-safe's float-native API maps straight to `SkPaint::setAlphaf`.
- Before: similarity `0.9600` (19,200 / 480,000 diff pixels). After: **`1.0000` (0 / 480,000)**.

### 2. `box-padding` — fixture stabilization (no code change)

The 912-pixel divergence on box-padding was entirely fixture noise, not a renderer bug. Three anti-patterns from the skill:

- `.outer { border-radius: 8px }` / `.inner { border-radius: 4px }` — decoration unrelated to the padding subject; removed.
- `.inner` content was font-shaped text `"content"`; its advance width varied ~1px between engines and propagated to outer block width via stretch. Replaced with explicit `width: 80px; height: 24px`.
- `.label` was auto-sized by text advance width, driving flex-item `max-content` width, which then drove `.outer` stretch width. Pinned with `.label { width: 200px; height: 16px }`.

Before: similarity `0.9932` (912 / 133,200 diff pixels). After: **`1.0000` (0 / 153,600)**. No cg code change needed.

### 3. Suite promotions

- `fixtures/test-html/suites/L0.exact.json` now gates three fixtures at `floor: 1.0`, `threshold: 0`, `aa: false`:
  - `box-dimensions` (pre-existing)
  - `box-padding` (new — this PR)
  - `paint-opacity` (new — this PR)
- `paint-opacity.html` also strips inner text from its opacity boxes (text-under-opacity-layer hits a second-order Chromium compositing path, even with `color: transparent`).
- `box-padding` viewport bumped from 222 → 256 to match the new natural document height after the label width change.

## Test plan

- [x] `cargo check -p cg -p grida-canvas-wasm -p grida-dev` clean
- [x] `cargo test -p cg --lib htmlcss` passes (149/149, including the pre-existing `test_render_opacity`)
- [x] `just fmt` clean; lefthook pre-commit (oxfmt + cargo-fmt + clippy) passes
- [x] Chromium reftest via `@grida/reftest` shows `L0.exact` at floor=1.0 for all three fixtures after the change
- [x] Before/after diff PNGs reviewed per-row for the sub-1.0 residuals (opacity 0.5 box confirmed 126→126 matching Chromium; 0.75 confirmed no residual)

## Follow-ups

- Separate chip was flagged during this work: `@grida/reftest compare` CLI silently drops `--threshold` and `--json` flags (defaults win regardless of CLI arg). Library path works correctly. Small bug, separate PR.
- `paint-border-radius` (0.9894) and `paint-background-solid` (0.9792) remain in `L0.coverage`; next candidates for future iterations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opacity handling for layered rendering to preserve full-float transparency for smoother, more accurate visuals.

* **Tests**
  * Updated and added visual test fixtures and viewport settings; adjusted padding examples and removed displayed percentage text from opacity demos.

* **Documentation**
  * Added guidance on captions and labels for test fixtures to prevent incidental text from affecting layout and standardize authoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->