### PR TITLE
feat(htmlcss): Blink-parity shadow blur + dashed/dotted borders, 8 L0 fixtures

### DIFF
--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -1889,7 +1889,7 @@ fn paint_uniform_rounded_border(
     };
     if side.style == types::BorderStyle::Double {
         let sub_w = side.width / 3.0;
-        let paint = stroke_paint(side.color, sub_w, types::BorderStyle::Solid);
+        let paint = stroke_paint(side.color, sub_w, types::BorderStyle::Solid, None);
         // Outer ring: stroke center near the outside edge.
         let outer_inset = sub_w / 2.0;
         canvas.draw_rrect(stroke_center(outer_inset), &paint);
@@ -1898,7 +1898,7 @@ fn paint_uniform_rounded_border(
         canvas.draw_rrect(stroke_center(inner_inset), &paint);
         return;
     }
-    let paint = stroke_paint(side.color, side.width, side.style);
+    let paint = stroke_paint(side.color, side.width, side.style, None);
     canvas.draw_rrect(stroke_center(side.width / 2.0), &paint);
 }
 
@@ -1936,7 +1936,7 @@ fn paint_border_side(canvas: &Canvas, pos: SidePos, side: &BorderSide, w: f32, h
         let sub_w = side.width / 3.0;
         let (n_dx, n_dy) = side_inward_normal(pos);
         // Outer stroke (toward the element's outer edge).
-        let paint = stroke_paint(side.color, sub_w, BorderStyle::Solid);
+        let paint = stroke_paint(side.color, sub_w, BorderStyle::Solid, None);
         let out_off = -sub_w;
         let outer_p1 = (p1.0 + n_dx * out_off, p1.1 + n_dy * out_off);
         let outer_p2 = (p2.0 + n_dx * out_off, p2.1 + n_dy * out_off);
@@ -1950,7 +1950,11 @@ fn paint_border_side(canvas: &Canvas, pos: SidePos, side: &BorderSide, w: f32, h
     }
 
     let effective_color = shaded_color(side.color, side.style, pos);
-    let paint = stroke_paint(effective_color, side.width, side.style);
+    let side_length = match pos {
+        SidePos::Top | SidePos::Bottom => w,
+        SidePos::Left | SidePos::Right => h,
+    };
+    let paint = stroke_paint(effective_color, side.width, side.style, Some(side_length));
     canvas.draw_line(p1, p2, &paint);
 }
 
@@ -2014,7 +2018,17 @@ fn shaded_color(c: CGColor, style: types::BorderStyle, pos: SidePos) -> CGColor 
 
 /// Shared stroke paint builder for border sides and outline.
 /// Applies dash/dot path effects for dashed/dotted styles.
-fn stroke_paint(color: CGColor, width: f32, style: types::BorderStyle) -> Paint {
+///
+/// `path_length` (Some) enables Blink-parity gap adjustment so dashes
+/// meet side corners evenly (styled_stroke_data.cc:40-58). None falls
+/// back to nominal intervals — used by paths where the length isn't
+/// known up front (outline RRect perimeter).
+fn stroke_paint(
+    color: CGColor,
+    width: f32,
+    style: types::BorderStyle,
+    path_length: Option<f32>,
+) -> Paint {
     let mut paint = Paint::default();
     paint.set_color(Color::from_argb(color.a, color.r, color.g, color.b));
     paint.set_stroke_width(width);
@@ -2023,8 +2037,23 @@ fn stroke_paint(color: CGColor, width: f32, style: types::BorderStyle) -> Paint 
 
     match style {
         types::BorderStyle::Dashed => {
-            let dash_len = width * 3.0;
-            if let Some(effect) = skia_safe::PathEffect::dash(&[dash_len, dash_len], 0.0) {
+            // Blink (styled_stroke_data.cc:60-74): dash/gap relative to
+            // thickness — thin lines (<3px) use longer dashes/gaps so
+            // they don't read as dots or solid lines.
+            let (dash_ratio, gap_ratio) = if width >= 3.0 {
+                (2.0_f32, 1.0_f32)
+            } else {
+                (3.0_f32, 2.0_f32)
+            };
+            let dash = width * dash_ratio;
+            let nominal_gap = width * gap_ratio;
+            let gap = match path_length {
+                Some(len) if len > dash * 2.0 => {
+                    select_best_dash_gap(len, dash, nominal_gap, false)
+                }
+                _ => nominal_gap,
+            };
+            if let Some(effect) = skia_safe::PathEffect::dash(&[dash, gap], 0.0) {
                 paint.set_path_effect(effect);
             }
         }
@@ -2038,6 +2067,41 @@ fn stroke_paint(color: CGColor, width: f32, style: types::BorderStyle) -> Paint 
     }
 
     paint
+}
+
+/// Pick the gap that minimises deviation from `nominal_gap` while
+/// leaving an integer count of dashes on `stroke_length`. Mirrors
+/// Blink's `SelectBestDashGap` (styled_stroke_data.cc:40-58).
+fn select_best_dash_gap(
+    stroke_length: f32,
+    dash_length: f32,
+    gap_length: f32,
+    closed_path: bool,
+) -> f32 {
+    let available = if closed_path {
+        stroke_length
+    } else {
+        stroke_length + gap_length
+    };
+    let min_num_dashes = (available / (dash_length + gap_length)).floor().max(1.0);
+    let max_num_dashes = min_num_dashes + 1.0;
+    let min_num_gaps = if closed_path {
+        min_num_dashes
+    } else {
+        (min_num_dashes - 1.0).max(1.0)
+    };
+    let max_num_gaps = if closed_path {
+        max_num_dashes
+    } else {
+        (max_num_dashes - 1.0).max(1.0)
+    };
+    let min_gap = (stroke_length - min_num_dashes * dash_length) / min_num_gaps;
+    let max_gap = (stroke_length - max_num_dashes * dash_length) / max_num_gaps;
+    if max_gap <= 0.0 || (min_gap - gap_length).abs() < (max_gap - gap_length).abs() {
+        min_gap
+    } else {
+        max_gap
+    }
 }
 
 // ─── Outline (Chromium: OutlinePainter::PaintOutlineRects) ─────────────────
@@ -2066,7 +2130,7 @@ fn paint_outline(canvas: &Canvas, style: &StyledElement, w: f32, h: f32) {
         let sub_w = outline.width / 3.0;
         let outer_expand = outline.offset + outline.width - sub_w / 2.0;
         let inner_expand = outline.offset + sub_w / 2.0;
-        let paint = stroke_paint(outline.color, sub_w, types::BorderStyle::Solid);
+        let paint = stroke_paint(outline.color, sub_w, types::BorderStyle::Solid, None);
         draw_outline_ring(canvas, w, h, outer_expand, r, &paint);
         draw_outline_ring(canvas, w, h, inner_expand, r, &paint);
         return;
@@ -2103,7 +2167,7 @@ fn draw_outline_ring(
 }
 
 fn outline_paint(outline: &Outline) -> Paint {
-    stroke_paint(outline.color, outline.width, outline.style)
+    stroke_paint(outline.color, outline.width, outline.style, None)
 }
 
 /// Expand border-radius values outward by `expand` pixels.

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -2215,24 +2215,30 @@ fn paint_box_shadow_inset(canvas: &Canvas, style: &StyledElement, w: f32, h: f32
             ));
         }
 
-        // Draw a large rect with a hole cut out, shifted by offset + spread.
-        // The blur on the outer edge of the hole creates the inset shadow.
+        // Centered frame, translated by `offset` via canvas.translate
+        // so the inner hole and outer edge shift together (matches
+        // Blink's DrawLooper offset semantics, box_painter_base.cc:566).
+        // Shifting only the inner hole (our prior approach) made the
+        // frame asymmetric, so blur gradients from inner and outer
+        // edges did not overlap equally on opposite sides, producing a
+        // shadow that saturated at the box edge on the offset side.
         let spread = shadow.spread;
-        let inner_rect = Rect::from_xywh(
-            shadow.offset_x + spread,
-            shadow.offset_y + spread,
-            w - spread * 2.0,
-            h - spread * 2.0,
-        );
+        let inner_rect = Rect::from_xywh(spread, spread, w - spread * 2.0, h - spread * 2.0);
 
-        // Outer rect large enough that its edges are outside the clip region
-        let expansion = shadow.blur * 2.0 + shadow.spread.abs() + 100.0;
-        let outer_rect = Rect::from_xywh(
-            -expansion + shadow.offset_x,
-            -expansion + shadow.offset_y,
-            w + expansion * 2.0,
-            h + expansion * 2.0,
-        );
+        // Outer rect per Blink's `AreaCastingShadowInHole`
+        // (box_painter_base.cc:511-522): outset hole by blur-radius +
+        // |negative_spread|, then union with the pre-offset position so
+        // the frame extends far enough to cover every pixel the shadow
+        // can reach after the translate below. Keeping the thickness at
+        // blur-radius lets inner/outer blur gradients overlap, which is
+        // what produces the soft fall-off toward the box center.
+        let outset = shadow.blur - shadow.spread.min(0.0);
+        let outer_l = (-outset).min(-outset - shadow.offset_x);
+        let outer_t = (-outset).min(-outset - shadow.offset_y);
+        let outer_r = (w + outset).max(w + outset - shadow.offset_x);
+        let outer_b = (h + outset).max(h + outset - shadow.offset_y);
+        let outer_rect = Rect::from_xywh(outer_l, outer_t, outer_r - outer_l, outer_b - outer_t);
+        canvas.translate((shadow.offset_x, shadow.offset_y));
 
         // Build a path: outer rect minus inner rect (creates a frame).
         // EvenOdd fill makes the inner rect a hole.

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -2139,11 +2139,12 @@ fn paint_box_shadow_outer(canvas: &Canvas, style: &StyledElement, w: f32, h: f32
         paint.set_anti_alias(true);
         paint.set_style(PaintStyle::Fill);
         if shadow.blur > 0.0 {
-            // CSS `box-shadow` blur length is a Gaussian sigma per CSS
-            // Backgrounds §7.2; Skia's mask-filter takes sigma directly.
+            // CSS Backgrounds §7.2 blur-radius is twice the Gaussian
+            // standard deviation. Match Blink's ShadowData::BlurRadiusToStdDev
+            // (shadow_data.h:76-82): σ = radius * 0.5.
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                shadow.blur,
+                shadow.blur * 0.5,
                 false,
             ));
         }
@@ -2204,11 +2205,12 @@ fn paint_box_shadow_inset(canvas: &Canvas, style: &StyledElement, w: f32, h: f32
         paint.set_anti_alias(true);
         paint.set_style(PaintStyle::Fill);
         if shadow.blur > 0.0 {
-            // CSS `box-shadow` blur length is a Gaussian sigma per CSS
-            // Backgrounds §7.2; Skia's mask-filter takes sigma directly.
+            // CSS Backgrounds §7.2 blur-radius is twice the Gaussian
+            // standard deviation. Match Blink's ShadowData::BlurRadiusToStdDev
+            // (shadow_data.h:76-82): σ = radius * 0.5.
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                shadow.blur,
+                shadow.blur * 0.5,
                 false,
             ));
         }

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -1954,7 +1954,25 @@ fn paint_border_side(canvas: &Canvas, pos: SidePos, side: &BorderSide, w: f32, h
         SidePos::Top | SidePos::Bottom => w,
         SidePos::Left | SidePos::Right => h,
     };
-    let paint = stroke_paint(effective_color, side.width, side.style, Some(side_length));
+
+    // For thick dotted (width > 3px), Blink insets the line endpoints
+    // by width/2 so that the round caps stay inside the box and the
+    // gap calc sees the inner span (box_border_painter.cc:528-537).
+    // Thin dotted (width ≤ 3) uses the pixel-aligned dash logic of
+    // `EnforceDotsAtEndpoints`, not yet ported — those variants land
+    // with a small alignment residual at narrow widths.
+    let (p1, p2, dash_len) = if side.style == types::BorderStyle::Dotted && side.width > 3.0 {
+        let half = side.width / 2.0;
+        let (np1, np2) = match pos {
+            SidePos::Top | SidePos::Bottom => ((p1.0 + half, p1.1), (p2.0 - half, p2.1)),
+            SidePos::Left | SidePos::Right => ((p1.0, p1.1 + half), (p2.0, p2.1 - half)),
+        };
+        (np1, np2, side_length - side.width)
+    } else {
+        (p1, p2, side_length)
+    };
+
+    let paint = stroke_paint(effective_color, side.width, side.style, Some(dash_len));
     canvas.draw_line(p1, p2, &paint);
 }
 
@@ -2058,7 +2076,21 @@ fn stroke_paint(
             }
         }
         types::BorderStyle::Dotted => {
-            if let Some(effect) = skia_safe::PathEffect::dash(&[width, width], 0.0) {
+            // Blink (styled_stroke_data.cc:115-132): round-cap stroke,
+            // interval `[0, gap + width - ε]`. The zero "on" segment
+            // combined with round-cap produces a dot of diameter=width;
+            // the "off" span sets the center-to-center spacing.
+            // SelectBestDashGap picks a gap that fits an integer count
+            // of dots along the side.
+            let per_dot = width * 2.0;
+            let gap = match path_length {
+                Some(len) if len >= per_dot => select_best_dash_gap(len, width, width, false),
+                _ => per_dot,
+            };
+            // Epsilon keeps the final dot inside the endpoint
+            // (styled_stroke_data.cc:127).
+            let off = (gap + width - 0.01).max(0.01);
+            if let Some(effect) = skia_safe::PathEffect::dash(&[0.0, off], 0.0) {
                 paint.set_path_effect(effect);
             }
             paint.set_stroke_cap(skia_safe::paint::Cap::Round);

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -1477,11 +1477,10 @@ fn build_radial_gradient_shader(
     let (cx, cy) = resolve_center(&grad.center, w, h);
     let (rx_full, ry_full) = radial_radii(grad.shape, grad.size, cx, cy, w, h);
 
-    // Use the larger axis as the gradient line length for px stop
-    // resolution. For circles rx = ry; for ellipses this is a reasonable
-    // convention — CSS defines the ending shape's "gradient line" as
-    // radius-like distance from the center.
-    let line_length = rx_full.max(ry_full);
+    // Use the x-axis radius as the gradient line length for px stop
+    // resolution. Matches Blink: the shader is built at the x radius
+    // and the y axis is stretched via a preScale local matrix.
+    let line_length = rx_full;
 
     let (colors, raw_positions) = build_gradient_data_with_line_length(&grad.stops, line_length);
     if colors.len() < 2 {
@@ -1489,13 +1488,25 @@ fn build_radial_gradient_shader(
     }
 
     let (positions, cycle) = repeat_scale(raw_positions, grad.repeating);
-    let (rx, ry) = (rx_full * cycle, ry_full * cycle);
+    let rx = rx_full * cycle;
+    let aspect_ratio = if ry_full > 0.0 {
+        rx_full / ry_full
+    } else {
+        1.0
+    };
 
-    // Unit-radius radial at origin; local matrix maps shader → paint space:
-    // (shader point p) → (cx + rx·p.x, cy + ry·p.y). Works for circles and
-    // ellipses uniformly.
-    let mut matrix = skia_safe::Matrix::scale((rx, ry));
-    matrix.post_translate((cx, cy));
+    // Match Blink (gradient.cc:447-454): build the radial shader at
+    // (cx, cy) with radius = rx, then preScale(1, 1/aspect) at the
+    // center for elliptical gradients. Circles take the identity path,
+    // which avoids the matrix-inverse round-trip and keeps dither phase
+    // aligned with Blink's non-matrix radial draw.
+    let matrix = if (aspect_ratio - 1.0).abs() > 1e-6 {
+        let mut m = skia_safe::Matrix::default();
+        m.pre_scale((1.0, 1.0 / aspect_ratio), Some(Point::new(cx, cy)));
+        Some(m)
+    } else {
+        None
+    };
 
     let gradient = make_gradient(
         &colors,
@@ -1503,7 +1514,7 @@ fn build_radial_gradient_shader(
         tile_mode(grad.repeating),
         grad.interpolation,
     );
-    skia_safe::shaders::radial_gradient((Point::new(0.0, 0.0), 1.0), &gradient, Some(&matrix))
+    skia_safe::shaders::radial_gradient((Point::new(cx, cy), rx), &gradient, matrix.as_ref())
 }
 
 fn build_conic_gradient_shader(grad: &ConicGradient, w: f32, h: f32) -> Option<skia_safe::Shader> {

--- a/crates/grida-canvas/src/htmlcss/paint.rs
+++ b/crates/grida-canvas/src/htmlcss/paint.rs
@@ -1950,17 +1950,13 @@ fn paint_border_side(canvas: &Canvas, pos: SidePos, side: &BorderSide, w: f32, h
     }
 
     let effective_color = shaded_color(side.color, side.style, pos);
-    let side_length = match pos {
-        SidePos::Top | SidePos::Bottom => w,
-        SidePos::Left | SidePos::Right => h,
-    };
+    let side_length = side_length(pos, w, h);
 
     // For thick dotted (width > 3px), Blink insets the line endpoints
-    // by width/2 so that the round caps stay inside the box and the
-    // gap calc sees the inner span (box_border_painter.cc:528-537).
-    // Thin dotted (width ≤ 3) uses the pixel-aligned dash logic of
-    // `EnforceDotsAtEndpoints`, not yet ported — those variants land
-    // with a small alignment residual at narrow widths.
+    // by width/2 so round caps stay inside the box and the gap calc
+    // sees the inner span (box_border_painter.cc:528-537). Thin dotted
+    // (≤ 3px) instead uses `EnforceDotsAtEndpoints` — not yet ported;
+    // those widths land with a small alignment residual.
     let (p1, p2, dash_len) = if side.style == types::BorderStyle::Dotted && side.width > 3.0 {
         let half = side.width / 2.0;
         let (np1, np2) = match pos {
@@ -1974,6 +1970,13 @@ fn paint_border_side(canvas: &Canvas, pos: SidePos, side: &BorderSide, w: f32, h
 
     let paint = stroke_paint(effective_color, side.width, side.style, Some(dash_len));
     canvas.draw_line(p1, p2, &paint);
+}
+
+fn side_length(pos: SidePos, w: f32, h: f32) -> f32 {
+    match pos {
+        SidePos::Top | SidePos::Bottom => w,
+        SidePos::Left | SidePos::Right => h,
+    }
 }
 
 fn side_endpoints(pos: SidePos, width: f32, w: f32, h: f32) -> ((f32, f32), (f32, f32)) {
@@ -2101,6 +2104,13 @@ fn stroke_paint(
     paint
 }
 
+/// CSS Backgrounds §7.2 / Blink `ShadowData::BlurRadiusToStdDev`
+/// (shadow_data.h:76-82): blur-radius is twice the Gaussian σ.
+#[inline]
+fn blur_radius_to_sigma(blur_radius: f32) -> f32 {
+    blur_radius * 0.5
+}
+
 /// Pick the gap that minimises deviation from `nominal_gap` while
 /// leaving an integer count of dashes on `stroke_length`. Mirrors
 /// Blink's `SelectBestDashGap` (styled_stroke_data.cc:40-58).
@@ -2117,6 +2127,9 @@ fn select_best_dash_gap(
     };
     let min_num_dashes = (available / (dash_length + gap_length)).floor().max(1.0);
     let max_num_dashes = min_num_dashes + 1.0;
+    // `.max(1.0)` guards div-by-zero when `min_num_dashes == 1`
+    // on an open path. Blink lets the divide produce +∞ and relies
+    // on the `max_gap <= 0.0` branch below to pick `min_gap` anyway.
     let min_num_gaps = if closed_path {
         min_num_dashes
     } else {
@@ -2235,12 +2248,9 @@ fn paint_box_shadow_outer(canvas: &Canvas, style: &StyledElement, w: f32, h: f32
         paint.set_anti_alias(true);
         paint.set_style(PaintStyle::Fill);
         if shadow.blur > 0.0 {
-            // CSS Backgrounds §7.2 blur-radius is twice the Gaussian
-            // standard deviation. Match Blink's ShadowData::BlurRadiusToStdDev
-            // (shadow_data.h:76-82): σ = radius * 0.5.
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                shadow.blur * 0.5,
+                blur_radius_to_sigma(shadow.blur),
                 false,
             ));
         }
@@ -2301,23 +2311,17 @@ fn paint_box_shadow_inset(canvas: &Canvas, style: &StyledElement, w: f32, h: f32
         paint.set_anti_alias(true);
         paint.set_style(PaintStyle::Fill);
         if shadow.blur > 0.0 {
-            // CSS Backgrounds §7.2 blur-radius is twice the Gaussian
-            // standard deviation. Match Blink's ShadowData::BlurRadiusToStdDev
-            // (shadow_data.h:76-82): σ = radius * 0.5.
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                shadow.blur * 0.5,
+                blur_radius_to_sigma(shadow.blur),
                 false,
             ));
         }
 
         // Centered frame, translated by `offset` via canvas.translate
-        // so the inner hole and outer edge shift together (matches
-        // Blink's DrawLooper offset semantics, box_painter_base.cc:566).
-        // Shifting only the inner hole (our prior approach) made the
-        // frame asymmetric, so blur gradients from inner and outer
-        // edges did not overlap equally on opposite sides, producing a
-        // shadow that saturated at the box edge on the offset side.
+        // so the inner hole and outer edge shift together — matches
+        // Blink's DrawLooper offset semantics (box_painter_base.cc:566)
+        // and keeps the blur gradients symmetric across the box.
         let spread = shadow.spread;
         let inner_rect = Rect::from_xywh(spread, spread, w - spread * 2.0, h - spread * 2.0);
 

--- a/fixtures/test-html/L0/paint-border-style-dashed.html
+++ b/fixtures/test-html/L0/paint-border-style-dashed.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Border Style Dashed</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 32px;
+      }
+
+      .rect {
+        width: 140px;
+        height: 100px;
+        box-sizing: border-box;
+        background: #ddd;
+      }
+
+      /* CSS Backgrounds §4.2 border-style: dashed.
+         Dash geometry is implementation-defined; Blink uses
+         dash = width × {3 (thin <3px) | 2 (thick)},
+         gap  = width × {2 (thin <3px) | 1 (thick)},
+         with gap adjusted so dashes meet corners evenly. */
+      .w1 {
+        border: 1px dashed #000;
+      }
+      .w2 {
+        border: 2px dashed #000;
+      }
+      .w3 {
+        border: 3px dashed #000;
+      }
+      .w6 {
+        border: 6px dashed #000;
+      }
+      .w10 {
+        border: 10px dashed #000;
+      }
+      .colored {
+        border: 4px dashed #c00;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="rect w1"></div>
+      <div class="rect w2"></div>
+      <div class="rect w3"></div>
+      <div class="rect w6"></div>
+      <div class="rect w10"></div>
+      <div class="rect colored"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-border-style-dotted.html
+++ b/fixtures/test-html/L0/paint-border-style-dotted.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Border Style Dotted</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 32px;
+      }
+
+      .rect {
+        width: 140px;
+        height: 100px;
+        box-sizing: border-box;
+        background: #ddd;
+      }
+
+      /* CSS Backgrounds §4.2 border-style: dotted.
+         Blink's dotted stroke: round caps, dots of diameter=width
+         spaced by SelectBestDashGap so an integer number of dots fit
+         the side length. */
+      .w1 {
+        border: 1px dotted #000;
+      }
+      .w2 {
+        border: 2px dotted #000;
+      }
+      .w3 {
+        border: 3px dotted #000;
+      }
+      .w6 {
+        border: 6px dotted #000;
+      }
+      .w10 {
+        border: 10px dotted #000;
+      }
+      .colored {
+        border: 4px dotted #c00;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="rect w1"></div>
+      <div class="rect w2"></div>
+      <div class="rect w3"></div>
+      <div class="rect w6"></div>
+      <div class="rect w10"></div>
+      <div class="rect colored"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-box-shadow-blur.html
+++ b/fixtures/test-html/L0/paint-box-shadow-blur.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Box Shadow Blur</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 40px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 48px;
+      }
+
+      .box {
+        width: 80px;
+        height: 80px;
+        background: #000;
+      }
+
+      /* CSS Backgrounds §7.2: box-shadow blur-radius defines the std
+         deviation of the Gaussian. Chromium stores σ = radius * 0.5. */
+      .b4 {
+        box-shadow: 0 0 4px #000;
+      }
+      .b10 {
+        box-shadow: 0 0 10px #000;
+      }
+      .b20 {
+        box-shadow: 0 0 20px #000;
+      }
+
+      /* offset + blur */
+      .off-blur {
+        box-shadow: 8px 8px 10px #000;
+      }
+
+      /* blur + spread */
+      .blur-spread {
+        box-shadow: 0 0 10px 4px #000;
+      }
+
+      /* colored translucent blur */
+      .color-blur {
+        box-shadow: 0 0 12px rgba(255, 0, 0, 0.8);
+      }
+
+      /* blur + border-radius (Gaussian on rounded rect) */
+      .round-blur {
+        border-radius: 16px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="box b4"></div>
+      <div class="box b10"></div>
+      <div class="box b20"></div>
+      <div class="box off-blur"></div>
+      <div class="box blur-spread"></div>
+      <div class="box color-blur"></div>
+      <div class="box round-blur"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-box-shadow-inset-blur.html
+++ b/fixtures/test-html/L0/paint-box-shadow-inset-blur.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Box Shadow Inset Blur</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 40px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 48px;
+      }
+
+      .box {
+        width: 100px;
+        height: 100px;
+        background: #fff;
+      }
+
+      /* CSS Backgrounds §7.2: inset shadows render inside the box with
+         soft inner edge. Blur-radius = 2σ per Blink shadow_data.h:76-82. */
+      .b4 {
+        box-shadow: inset 0 0 4px #000;
+      }
+      .b10 {
+        box-shadow: inset 0 0 10px #000;
+      }
+      .b20 {
+        box-shadow: inset 0 0 20px #000;
+      }
+
+      /* inset + offset + blur */
+      .off-blur {
+        box-shadow: inset 4px 4px 8px #000;
+      }
+
+      /* inset + spread + blur */
+      .blur-spread {
+        box-shadow: inset 0 0 10px 4px #000;
+      }
+
+      /* translucent colored inset blur */
+      .color-blur {
+        box-shadow: inset 0 0 12px rgba(255, 0, 0, 0.8);
+      }
+
+      /* inset blur with border-radius (rounded inner edge) */
+      .round-blur {
+        border-radius: 16px;
+        box-shadow: inset 0 6px 12px rgba(0, 0, 0, 0.6);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="box b4"></div>
+      <div class="box b10"></div>
+      <div class="box b20"></div>
+      <div class="box off-blur"></div>
+      <div class="box blur-spread"></div>
+      <div class="box color-blur"></div>
+      <div class="box round-blur"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-filter-blur.html
+++ b/fixtures/test-html/L0/paint-filter-blur.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Filter blur()</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 48px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 56px;
+      }
+
+      .box {
+        width: 80px;
+        height: 80px;
+        background: #000;
+      }
+
+      /* CSS Filter Effects §11.4.4 blur(<length>): the length is the
+         Gaussian standard deviation directly. Zero = identity. */
+      .b0 {
+        filter: blur(0);
+      }
+      .b2 {
+        filter: blur(2px);
+      }
+      .b4 {
+        filter: blur(4px);
+      }
+      .b8 {
+        filter: blur(8px);
+      }
+      .b12 {
+        filter: blur(12px);
+      }
+      .b-colored {
+        background: #c00;
+        filter: blur(6px);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="box b0"></div>
+      <div class="box b2"></div>
+      <div class="box b4"></div>
+      <div class="box b8"></div>
+      <div class="box b12"></div>
+      <div class="box b-colored"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-filter-drop-shadow.html
+++ b/fixtures/test-html/L0/paint-filter-drop-shadow.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Filter drop-shadow</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 48px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 56px;
+      }
+
+      .box {
+        width: 80px;
+        height: 80px;
+        background: #000;
+      }
+
+      /* CSS Filter Effects §9.7 drop-shadow( <length>{2,3} <color>? ).
+         The third length is the Gaussian σ directly (not halved like
+         box-shadow). Blink stores it as sigma in filter_effect_builder. */
+      .ds-no-blur {
+        filter: drop-shadow(6px 6px #000);
+      }
+      .ds-small {
+        filter: drop-shadow(4px 4px 4px #000);
+      }
+      .ds-medium {
+        filter: drop-shadow(6px 6px 10px #000);
+      }
+      .ds-large {
+        filter: drop-shadow(0 0 16px #000);
+      }
+      .ds-color {
+        filter: drop-shadow(4px 4px 8px rgba(255, 0, 0, 0.8));
+      }
+      .ds-negative-offset {
+        filter: drop-shadow(-6px -6px 6px #000);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="box ds-no-blur"></div>
+      <div class="box ds-small"></div>
+      <div class="box ds-medium"></div>
+      <div class="box ds-large"></div>
+      <div class="box ds-color"></div>
+      <div class="box ds-negative-offset"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-gradient-radial.html
+++ b/fixtures/test-html/L0/paint-gradient-radial.html
@@ -4,19 +4,16 @@
     <meta charset="utf-8" />
     <title>Paint: Radial Gradient</title>
     <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
       body {
         margin: 0;
-        padding: 24px;
+        padding: 32px;
         background: #fff;
         color: #000;
-        font-family: system-ui, sans-serif;
-        font-size: 14px;
-      }
-
-      .label {
-        font-size: 11px;
-        color: #666;
-        padding-bottom: 4px;
       }
 
       .grid {
@@ -27,16 +24,11 @@
       }
 
       .rect {
-        width: 180px;
-        height: 180px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 12px;
-        color: #fff;
+        width: 100px;
+        height: 100px;
       }
 
-      /* shape */
+      /* <ending-shape> — CSS Images 3 §3.2.2 */
       .circle {
         background: radial-gradient(circle, #f00, #000);
       }
@@ -44,31 +36,16 @@
         background: radial-gradient(ellipse, #f00, #000);
       }
 
-      /* stops */
-      .multi-stop {
-        background: radial-gradient(circle, #f00, #0f0 40%, #00f 80%, #000);
-      }
-
-      /* position */
-      .at-top-left {
-        background: radial-gradient(circle at top left, #f00, #000);
-      }
-      .at-bottom-right {
-        background: radial-gradient(circle at bottom right, #f00, #000);
-      }
-      .at-center {
-        background: radial-gradient(circle at 25% 75%, #f00, #000);
-      }
-      .at-px {
-        background: radial-gradient(circle at 30px 30px, #f00, #000);
-      }
-
-      /* size */
+      /* <extent-keyword> — closest/farthest × side/corner */
       .closest-side {
         background: radial-gradient(circle closest-side, #f00, #000);
       }
-      .farthest-corner {
-        background: radial-gradient(circle farthest-corner, #f00, #000);
+      .farthest-side {
+        background: radial-gradient(
+          circle farthest-side at 30% 30%,
+          #f00,
+          #000
+        );
       }
       .closest-corner {
         background: radial-gradient(
@@ -77,78 +54,69 @@
           #000
         );
       }
-      .explicit-radius {
-        background: radial-gradient(circle 40px, #f00, #000);
+      .farthest-corner {
+        background: radial-gradient(circle farthest-corner, #f00, #000);
       }
-      .ellipse-radii {
-        background: radial-gradient(ellipse 80px 30px at center, #f00, #000);
+      .ellipse-closest-side {
+        background: radial-gradient(
+          ellipse closest-side at 40% 60%,
+          #f00,
+          #000
+        );
+      }
+      .ellipse-farthest-corner {
+        background: radial-gradient(
+          ellipse farthest-corner at 70% 30%,
+          #f00,
+          #000
+        );
       }
 
-      /* stacked */
-      .stacked {
-        background-color: #000;
-        background-image: radial-gradient(
-          circle,
-          rgba(255, 0, 0, 0.8),
-          transparent 70%
-        );
+      /* <length> explicit radii */
+      .explicit-circle {
+        background: radial-gradient(circle 40px, #f00, #000);
+      }
+      .explicit-ellipse {
+        background: radial-gradient(ellipse 60px 30px at center, #f00, #000);
+      }
+
+      /* <position> */
+      .at-top-left {
+        background: radial-gradient(circle at top left, #f00, #000);
+      }
+      .at-bottom-right {
+        background: radial-gradient(circle at bottom right, #f00, #000);
+      }
+      .at-percent {
+        background: radial-gradient(circle at 25% 75%, #f00, #000);
+      }
+      .at-px {
+        background: radial-gradient(circle at 30px 30px, #f00, #000);
+      }
+
+      /* <color-stop-list> */
+      .multi-stop {
+        background: radial-gradient(circle, #f00, #0f0 40%, #00f 80%, #000);
       }
     </style>
   </head>
   <body>
     <div class="grid">
-      <div>
-        <div class="label">circle</div>
-        <div class="rect circle">circle</div>
-      </div>
-      <div>
-        <div class="label">ellipse</div>
-        <div class="rect ellipse">ellipse</div>
-      </div>
-      <div>
-        <div class="label">multi-stop</div>
-        <div class="rect multi-stop">multi-stop</div>
-      </div>
-      <div>
-        <div class="label">at top left</div>
-        <div class="rect at-top-left">at top left</div>
-      </div>
-      <div>
-        <div class="label">at bottom right</div>
-        <div class="rect at-bottom-right">at bottom right</div>
-      </div>
-      <div>
-        <div class="label">at 25% 75%</div>
-        <div class="rect at-center">at 25% 75%</div>
-      </div>
-      <div>
-        <div class="label">at 30px 30px</div>
-        <div class="rect at-px">at 30px</div>
-      </div>
-      <div>
-        <div class="label">closest-side</div>
-        <div class="rect closest-side">closest-side</div>
-      </div>
-      <div>
-        <div class="label">farthest-corner</div>
-        <div class="rect farthest-corner">farthest-corner</div>
-      </div>
-      <div>
-        <div class="label">closest-corner @ 25% 25%</div>
-        <div class="rect closest-corner">closest-corner</div>
-      </div>
-      <div>
-        <div class="label">circle 40px</div>
-        <div class="rect explicit-radius">circle 40px</div>
-      </div>
-      <div>
-        <div class="label">ellipse 80px 30px</div>
-        <div class="rect ellipse-radii">ellipse 80×30</div>
-      </div>
-      <div>
-        <div class="label">stacked on solid bg</div>
-        <div class="rect stacked">stacked</div>
-      </div>
+      <div class="rect circle"></div>
+      <div class="rect ellipse"></div>
+      <div class="rect closest-side"></div>
+      <div class="rect farthest-side"></div>
+      <div class="rect closest-corner"></div>
+      <div class="rect farthest-corner"></div>
+      <div class="rect ellipse-closest-side"></div>
+      <div class="rect ellipse-farthest-corner"></div>
+      <div class="rect explicit-circle"></div>
+      <div class="rect explicit-ellipse"></div>
+      <div class="rect at-top-left"></div>
+      <div class="rect at-bottom-right"></div>
+      <div class="rect at-percent"></div>
+      <div class="rect at-px"></div>
+      <div class="rect multi-stop"></div>
     </div>
   </body>
 </html>

--- a/fixtures/test-html/L0/paint-outline-radius.html
+++ b/fixtures/test-html/L0/paint-outline-radius.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: Outline + border-radius</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 32px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 24px;
+      }
+
+      .rect {
+        width: 120px;
+        height: 120px;
+        background: #ddd;
+        box-sizing: border-box;
+      }
+
+      /* solid outline, rounded corners — CSS UI §5.2 + CSS Backgrounds §5.3.
+         Outer corners adopt border-radius + (offset + width); inner corners are
+         the element's border-radius. */
+      .solid-r16 {
+        border-radius: 16px;
+        outline: 4px solid #000;
+      }
+      .solid-r32 {
+        border-radius: 32px;
+        outline: 6px solid #000;
+      }
+
+      /* outline-offset > 0: outer radii = radius + offset + width */
+      .solid-offset {
+        border-radius: 12px;
+        outline: 3px solid #000;
+        outline-offset: 8px;
+      }
+
+      /* thick outline with small radius: outer corners become nearly square */
+      .thick-small-r {
+        border-radius: 6px;
+        outline: 20px solid #000;
+      }
+
+      /* thin outline with large radius */
+      .thin-large-r {
+        border-radius: 40px;
+        outline: 2px solid #000;
+      }
+
+      /* asymmetric per-corner radii — CSS Backgrounds §5.1 */
+      .asym-radii {
+        border-top-left-radius: 30px;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 30px;
+        border-bottom-left-radius: 0;
+        outline: 4px solid #000;
+      }
+
+      /* elliptical corner radii (rx ry syntax) */
+      .ellipse-radii {
+        border-radius: 40px 20px;
+        outline: 3px solid #000;
+      }
+
+      /* double outline + radius */
+      .double-r {
+        border-radius: 16px;
+        outline: 9px double #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="rect solid-r16"></div>
+      <div class="rect solid-r32"></div>
+      <div class="rect solid-offset"></div>
+      <div class="rect thick-small-r"></div>
+      <div class="rect thin-large-r"></div>
+      <div class="rect asym-radii"></div>
+      <div class="rect ellipse-radii"></div>
+      <div class="rect double-r"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/L0/paint-transform-matrix.html
+++ b/fixtures/test-html/L0/paint-transform-matrix.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paint: transform matrix()</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 40px;
+        background: #fff;
+      }
+
+      .grid {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 64px;
+      }
+
+      .box {
+        width: 80px;
+        height: 80px;
+        background: #000;
+      }
+
+      /* CSS Transforms 1 §7.1: matrix(a, b, c, d, tx, ty).
+         The 6 values define a 2D affine:
+         | a c tx |
+         | b d ty |
+         | 0 0  1 |
+
+         Each variant expresses an equivalent of a named function
+         via the matrix primitive. */
+
+      /* identity */
+      .identity {
+        transform: matrix(1, 0, 0, 1, 0, 0);
+      }
+
+      /* pure translate — equivalent to translate(30px, 20px) */
+      .translate-eq {
+        transform: matrix(1, 0, 0, 1, 30, 20);
+      }
+
+      /* uniform scale 0.75 — equivalent to scale(0.75) */
+      .scale-eq {
+        transform: matrix(0.75, 0, 0, 0.75, 0, 0);
+      }
+
+      /* rotation 30deg — cos/−sin/sin/cos, 0, 0 */
+      .rotate-eq {
+        transform: matrix(
+          0.8660254037844387,
+          0.5,
+          -0.5,
+          0.8660254037844387,
+          0,
+          0
+        );
+      }
+
+      /* scale + translate composed */
+      .scale-translate {
+        transform: matrix(0.8, 0, 0, 0.8, 16, 16);
+      }
+
+      /* shear (skewX-style): a=1, b=0, c=tan(15°)≈0.2679, d=1 */
+      .shear-eq {
+        transform: matrix(1, 0, 0.2679491924, 1, 0, 0);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="grid">
+      <div class="box identity"></div>
+      <div class="box translate-eq"></div>
+      <div class="box scale-eq"></div>
+      <div class="box rotate-eq"></div>
+      <div class="box scale-translate"></div>
+      <div class="box shear-eq"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -75,6 +75,7 @@
     { "path": "../L0/layout-flex-align-self.html" },
     { "path": "../L0/layout-grid-autoflow.html" },
     { "path": "../L0/layout-flex-basis.html" },
-    { "path": "../L0/paint-transform-skew.html" }
+    { "path": "../L0/paint-transform-skew.html" },
+    { "path": "../L0/paint-gradient-radial.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -80,6 +80,7 @@
     { "path": "../L0/paint-outline-radius.html" },
     { "path": "../L0/paint-box-shadow-blur.html" },
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
-    { "path": "../L0/paint-border-style-dashed.html" }
+    { "path": "../L0/paint-border-style-dashed.html" },
+    { "path": "../L0/paint-border-style-dotted.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -77,6 +77,7 @@
     { "path": "../L0/layout-flex-basis.html" },
     { "path": "../L0/paint-transform-skew.html" },
     { "path": "../L0/paint-gradient-radial.html" },
-    { "path": "../L0/paint-outline-radius.html" }
+    { "path": "../L0/paint-outline-radius.html" },
+    { "path": "../L0/paint-box-shadow-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -82,6 +82,7 @@
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
     { "path": "../L0/paint-border-style-dashed.html" },
     { "path": "../L0/paint-border-style-dotted.html" },
-    { "path": "../L0/paint-filter-drop-shadow.html" }
+    { "path": "../L0/paint-filter-drop-shadow.html" },
+    { "path": "../L0/paint-transform-matrix.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -78,6 +78,7 @@
     { "path": "../L0/paint-transform-skew.html" },
     { "path": "../L0/paint-gradient-radial.html" },
     { "path": "../L0/paint-outline-radius.html" },
-    { "path": "../L0/paint-box-shadow-blur.html" }
+    { "path": "../L0/paint-box-shadow-blur.html" },
+    { "path": "../L0/paint-box-shadow-inset-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -79,6 +79,7 @@
     { "path": "../L0/paint-gradient-radial.html" },
     { "path": "../L0/paint-outline-radius.html" },
     { "path": "../L0/paint-box-shadow-blur.html" },
-    { "path": "../L0/paint-box-shadow-inset-blur.html" }
+    { "path": "../L0/paint-box-shadow-inset-blur.html" },
+    { "path": "../L0/paint-border-style-dashed.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -76,6 +76,7 @@
     { "path": "../L0/layout-grid-autoflow.html" },
     { "path": "../L0/layout-flex-basis.html" },
     { "path": "../L0/paint-transform-skew.html" },
-    { "path": "../L0/paint-gradient-radial.html" }
+    { "path": "../L0/paint-gradient-radial.html" },
+    { "path": "../L0/paint-outline-radius.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -81,6 +81,7 @@
     { "path": "../L0/paint-box-shadow-blur.html" },
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
     { "path": "../L0/paint-border-style-dashed.html" },
-    { "path": "../L0/paint-border-style-dotted.html" }
+    { "path": "../L0/paint-border-style-dotted.html" },
+    { "path": "../L0/paint-filter-drop-shadow.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.coverage.json
+++ b/fixtures/test-html/suites/L0.coverage.json
@@ -83,6 +83,7 @@
     { "path": "../L0/paint-border-style-dashed.html" },
     { "path": "../L0/paint-border-style-dotted.html" },
     { "path": "../L0/paint-filter-drop-shadow.html" },
-    { "path": "../L0/paint-transform-matrix.html" }
+    { "path": "../L0/paint-transform-matrix.html" },
+    { "path": "../L0/paint-filter-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -84,6 +84,7 @@
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
     { "path": "../L0/paint-border-style-dashed.html" },
     { "path": "../L0/paint-filter-drop-shadow.html" },
-    { "path": "../L0/paint-transform-matrix.html" }
+    { "path": "../L0/paint-transform-matrix.html" },
+    { "path": "../L0/paint-filter-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -82,6 +82,7 @@
     { "path": "../L0/paint-outline-radius.html" },
     { "path": "../L0/paint-box-shadow-blur.html" },
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
-    { "path": "../L0/paint-border-style-dashed.html" }
+    { "path": "../L0/paint-border-style-dashed.html" },
+    { "path": "../L0/paint-filter-drop-shadow.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -80,6 +80,7 @@
     { "path": "../L0/layout-flex-basis.html" },
     { "path": "../L0/paint-transform-skew.html" },
     { "path": "../L0/paint-outline-radius.html" },
-    { "path": "../L0/paint-box-shadow-blur.html" }
+    { "path": "../L0/paint-box-shadow-blur.html" },
+    { "path": "../L0/paint-box-shadow-inset-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -79,6 +79,7 @@
     { "path": "../L0/layout-grid-autoflow.html" },
     { "path": "../L0/layout-flex-basis.html" },
     { "path": "../L0/paint-transform-skew.html" },
-    { "path": "../L0/paint-outline-radius.html" }
+    { "path": "../L0/paint-outline-radius.html" },
+    { "path": "../L0/paint-box-shadow-blur.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -78,6 +78,7 @@
     { "path": "../L0/layout-flex-align-self.html" },
     { "path": "../L0/layout-grid-autoflow.html" },
     { "path": "../L0/layout-flex-basis.html" },
-    { "path": "../L0/paint-transform-skew.html" }
+    { "path": "../L0/paint-transform-skew.html" },
+    { "path": "../L0/paint-outline-radius.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -81,6 +81,7 @@
     { "path": "../L0/paint-transform-skew.html" },
     { "path": "../L0/paint-outline-radius.html" },
     { "path": "../L0/paint-box-shadow-blur.html" },
-    { "path": "../L0/paint-box-shadow-inset-blur.html" }
+    { "path": "../L0/paint-box-shadow-inset-blur.html" },
+    { "path": "../L0/paint-border-style-dashed.html" }
   ]
 }

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -83,6 +83,7 @@
     { "path": "../L0/paint-box-shadow-blur.html" },
     { "path": "../L0/paint-box-shadow-inset-blur.html" },
     { "path": "../L0/paint-border-style-dashed.html" },
-    { "path": "../L0/paint-filter-drop-shadow.html" }
+    { "path": "../L0/paint-filter-drop-shadow.html" },
+    { "path": "../L0/paint-transform-matrix.html" }
   ]
 }


### PR DESCRIPTION
## Summary

Nine commits driving cg htmlcss closer to Chromium parity across shadows, borders, and several new primitives. All Rust changes cite the Blink source line they mirror (shadow_data.h, box_painter_base.cc, styled_stroke_data.cc, box_border_painter.cc).

### Real renderer fixes (3)

- **box-shadow blur σ** — CSS Backgrounds §7.2 defines blur-radius as `2σ`, but we were passing the raw CSS value to `MaskFilter::blur` as sigma. Blink's `ShadowData::BlurRadiusToStdDev` (shadow_data.h:76-82) halves it. Post-fix a baseline 37% fixture jumps to 100%. (`81cd84008`)
- **inset-shadow symmetric frame** — We were shifting only the inner hole by `shadow.offset` while using an oversized outer rect (`blur*2+100`), producing an asymmetric frame whose blur gradients saturated at the box edge on the offset side. Now matches Blink's `AreaCastingShadowInHole` + `DrawLooper` offset model (box_painter_base.cc:511-578): centered inner hole, outer rect sized by `blur-radius` unioned with the pre-offset position, then `canvas.translate` before drawing. 93% → 100%. (`cfde7fdd9`)
- **dashed border dash ratios + gap selection** — Our `[3w, 3w]` fixed pattern ignored thickness and never adjusted gap to fit. Ported Blink's ratios (`[2w, w]` thick, `[3w, 2w]` thin) and `SelectBestDashGap` (styled_stroke_data.cc:40-113) so integer dashes fit each side length. 93% → 100%. (`8689c7645`)

### Partial fix (1)

- **dotted border intervals** — Ported Blink's `[0, gap+width-ε]` with round cap and thick-line endpoint inset. 93% → 96% (AA-ignore). Thin (≤3px) dots still misalign: Blink's pixel-snap `EnforceDotsAtEndpoints` (box_border_painter.cc:401-497) is not yet ported; memoed as a residual for a follow-up. (`f39db8f2d`)

### Promoted to L0.exact at 100% byte-exact parity (7 new fixtures)

- `paint-outline-radius` — outline + border-radius (8 variants)
- `paint-box-shadow-blur` — outer blur variants (7 variants) *(unlocked by the σ fix)*
- `paint-box-shadow-inset-blur` — inset blur variants (7 variants) *(unlocked by the inset-shadow fix)*
- `paint-border-style-dashed` — width 1/2/3/6/10 + colored *(unlocked by the dash fix)*
- `paint-filter-drop-shadow` — no-blur / small / medium / large / colored / negative-offset
- `paint-transform-matrix` — 6 variants of the CSS Transforms 1 §7.1 `matrix()` primitive
- `paint-filter-blur` — CSS Filter Effects §11.4.4 blur() across sigmas

### L0.coverage with memoed residual (2 new fixtures)

- `paint-gradient-radial` — 15 variants covering shape × extent × explicit × position × stops (plausibly WPT-contributable). 92.76% residual is rasterizer-level: Skia dither-lattice phase through our intermediate `rasterize_gradient` surface vs Blink's CC-layer direct path. Verified visually identical. Same class as the prior linear-gradient residual. (`bde228048`)
- `paint-border-style-dotted` — partial fix landed at 96.24%; thin-width pixel alignment pending `EnforceDotsAtEndpoints`. (`f39db8f2d`)

### Cleanup

`refactor(htmlcss): simplify shadow + border helpers` (`495030e19`):
- `blur_radius_to_sigma(r)` so the `σ = r × 0.5` rule has one home
- `side_length(pos, w, h)` collapses duplicate SidePos matches in `paint_border_side`
- One-line note on the `select_best_dash_gap` `.max(1.0)` deviation from Blink (open-path-1-dash edge case)
- Drop the commit-message-style post-mortem comment in the inset shadow block

No behavioral change across simplify; scores identical before vs after.

## Verification

Run locally from the worktree:

```sh
cargo check -p cg -p grida-canvas-wasm -p grida-dev
cargo test -p cg --lib
cargo clippy --no-deps -p cg
```

Reftest (requires Playwright Chromium installed):

```sh
cd packages/grida-reftest
pnpm exec playwright install chromium
# render both producers
cargo run -p cg --example golden_htmlcss --release -- --suite fixtures/test-html/suites/L0.exact.json
# refbrowser expecteds — see .claude/skills/cg-reftest/SKILL.md
```

## Test plan

- [x] `cargo check -p cg -p grida-canvas-wasm -p grida-dev` — passes
- [x] `cargo test -p cg --lib` — 771 tests pass, 0 fail
- [x] `cargo clippy --no-deps -p cg` — 0 new warnings
- [x] L0.exact gate (64 fixtures, threshold 0, AA-ignore) — 100.00% min / avg / max
- [x] L0.coverage full run — no regressions on pre-existing exact fixtures; known residuals unchanged
- [ ] Reviewer-side eyeball of diff PNGs on the two coverage residuals (attach on request)