### PR TITLE
feat(htmlcss): inline-block siblings via Taffy flex-wrap emulation

### DIFF
--- a/crates/grida-canvas/src/htmlcss/collect.rs
+++ b/crates/grida-canvas/src/htmlcss/collect.rs
@@ -432,8 +432,16 @@ fn collect_element_with_counter(
 
                     // Widgets with intrinsic sizes need their own Taffy node
                     // for sizing to work — don't flatten them into inline groups.
-                    let is_inline = child.display == types::Display::Inline
-                        || child.display == types::Display::InlineBlock;
+                    // Same for inline-block with explicit sizing: its width/height
+                    // would be lost inside the inline path. Layout later emulates
+                    // inline-block flow by mapping the parent to Taffy flex-wrap
+                    // when all of its element children are inline-block.
+                    let inline_block_with_size = child.display == types::Display::InlineBlock
+                        && (child.width != types::CssLength::Auto
+                            || child.height != types::CssLength::Auto);
+                    let is_inline = (child.display == types::Display::Inline
+                        || child.display == types::Display::InlineBlock)
+                        && !inline_block_with_size;
                     if is_inline && !child.widget.is_widget() && child.replaced.is_none() {
                         collect_inline_items(&child, &mut pending_inline);
                     } else {

--- a/crates/grida-canvas/src/htmlcss/layout.rs
+++ b/crates/grida-canvas/src/htmlcss/layout.rs
@@ -126,6 +126,19 @@ fn build_taffy_node(
         apply_replaced_intrinsic_size(&mut style, replaced, images);
     }
 
+    // Emulate inline-block sibling flow via Taffy flex-wrap. Taffy has no
+    // inline formatting context, so a block container holding only
+    // inline-block siblings would otherwise stack them vertically. Only
+    // apply when ≥2 inline-block element children exist and no text or
+    // non-inline-block elements would be misrouted through flex.
+    if style.display == taffy::Display::Block && should_emulate_inline_block_container(el) {
+        style.display = taffy::Display::Flex;
+        style.flex_wrap = taffy::FlexWrap::Wrap;
+        // Override default `stretch` so inline-blocks keep their
+        // own block-size instead of filling the container's line height.
+        style.align_items = Some(taffy::AlignItems::Start);
+    }
+
     // Build child nodes
     let mut child_ids: Vec<TaffyNodeId> = Vec::new();
 
@@ -174,6 +187,26 @@ fn build_taffy_node(
     }
 
     taffy.new_with_children(style, &child_ids).unwrap()
+}
+
+/// Returns true when `el` should lay out its children as a horizontal
+/// flex-wrap row to emulate inline-block flow. Only safe when the
+/// container holds ≥2 inline-block element siblings and no text or
+/// non-inline-block element children (those would require a real inline
+/// formatting context to mix with inline-blocks correctly).
+fn should_emulate_inline_block_container(el: &StyledElement) -> bool {
+    let mut inline_block_count = 0usize;
+    for child in &el.children {
+        match child {
+            StyledNode::Element(child_el) => match child_el.display {
+                types::Display::InlineBlock => inline_block_count += 1,
+                types::Display::None => {}
+                _ => return false,
+            },
+            StyledNode::Text(_) | StyledNode::InlineGroup(_) => return false,
+        }
+    }
+    inline_block_count >= 2
 }
 
 /// Taffy context for text/inline leaf nodes. Stores inline items so the

--- a/fixtures/test-html/L0/layout-display-inline-block.html
+++ b/fixtures/test-html/L0/layout-display-inline-block.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Layout: display: inline-block</title>
+    <style>
+      html,
+      body {
+        min-height: 800px;
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #fff;
+      }
+
+      .row {
+        font-size: 0;
+      }
+
+      .box {
+        display: inline-block;
+        width: 80px;
+        height: 80px;
+        vertical-align: top;
+      }
+
+      .a {
+        background: #c00;
+      }
+      .b {
+        background: #0a0;
+      }
+      .c {
+        background: #05f;
+      }
+      .d {
+        background: #fa0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="row">
+      <div class="box a"></div>
+      <div class="box b"></div>
+      <div class="box c"></div>
+      <div class="box d"></div>
+    </div>
+  </body>
+</html>

--- a/fixtures/test-html/suites/L0.exact.json
+++ b/fixtures/test-html/suites/L0.exact.json
@@ -85,6 +85,7 @@
     { "path": "../L0/paint-border-style-dashed.html" },
     { "path": "../L0/paint-filter-drop-shadow.html" },
     { "path": "../L0/paint-transform-matrix.html" },
-    { "path": "../L0/paint-filter-blur.html" }
+    { "path": "../L0/paint-filter-blur.html" },
+    { "path": "../L0/layout-display-inline-block.html" }
   ]
 }


### PR DESCRIPTION
## Summary

Sub-PR for #690 — lands the first of the four tier-0 WPT primitives (`display: inline-block`).

Taffy has no inline formatting context, so a block container holding `display: inline-block` siblings previously either stacked them vertically (when preserved as elements) or dropped their width/height (when flattened into an `InlineGroup`). Both broke the WPT ref pattern where ≥2 explicit-size inline-blocks should sit side-by-side.

- [crates/grida-canvas/src/htmlcss/collect.rs](../blob/claude/dazzling-dirac-3b738f/crates/grida-canvas/src/htmlcss/collect.rs) — preserve inline-block as an element when it has explicit width or height; don't flatten into the inline path.
- [crates/grida-canvas/src/htmlcss/layout.rs](../blob/claude/dazzling-dirac-3b738f/crates/grida-canvas/src/htmlcss/layout.rs) — at Taffy-style time, detect containers whose element children are all inline-block (≥2, no text or other block children) and switch the container to `Flex + flex-wrap: wrap + align-items: start`.

## Impact on WPT refs

Unlocks refs that rely on inline-block for horizontal layout: ~37% of css-flexbox refs, ~30% of css-position refs (per `~/Desktop/grida-wpt/ref-primitives-inventory.md`).

## Gate

- L0.exact: **65/65 at 100.00%** (was 64/64). `gate.floor=1.0`, `threshold=0`, `aa=true` unchanged.
- New fixture: `fixtures/test-html/L0/layout-display-inline-block.html` (paint-style, four equal-size blocks laid out via `font-size:0` parent to kill inter-element whitespace).

## Tier-0 primitives — remaining work

The loop also audited priorities 2–4; here's what they need before they can be pursued:

| Priority | Status | Gating issue |
|---|---|---|
| 2. Inline `<svg>` | deferred | Separate subject — needs DOM→SVG serialization + `usvg::Tree` wiring + Skia paint. |
| 3. `float` | blocked upstream | Taffy 0.9.2 has no float property. Needs a custom layout pass outside Taffy. |
| 4. `writing-mode: vertical-*` | blocked upstream | stylo's `layout.writing-mode.enabled` pref is missing from `stylo_static_prefs/src/lib.rs` and defaults to `false`; declarations are rejected at parse time and never reach `ComputedStyle::clone_writing_mode()`. Needs a cross-repo patch to [gridaco/stylo](https://github.com/gridaco/stylo). |

## Test plan

- [x] `cargo build -p grida_wpt --release`
- [x] `cargo clippy --no-deps -- -D warnings`
- [x] `cargo test -p cg`
- [x] L0.exact full run: 65 fixtures at 100.00%, min=100.00%, max=100.00%
- [x] No new fixture regressions (all previously-listed L0.exact entries still at 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)