### PR TITLE
chore(stylo): drop fork, upgrade to stylo 0.16 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
  "serde_json",
  "skia-safe",
  "stylo",
- "stylo_config",
+ "stylo_static_prefs",
  "taffy",
  "tokio",
  "unicode-segmentation",
@@ -2543,12 +2543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "math2"
 version = "0.0.2"
 dependencies = [
@@ -4079,8 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -4189,7 +4184,8 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4409,9 +4405,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "stylo"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf16d4d7f37038ec5d0eb0289045a5d797b1b85d3366d6d2bfaf1f9a55471739"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -4426,10 +4441,8 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "itoa",
- "lazy_static",
  "log",
  "malloc_size_of_derive",
- "matches",
  "mime",
  "new_debug_unreachable",
  "num-derive",
@@ -4448,8 +4461,9 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "string_cache",
+ "strum",
+ "strum_macros",
  "stylo_atoms",
- "stylo_config",
  "stylo_derive",
  "stylo_dom",
  "stylo_malloc_size_of",
@@ -4467,22 +4481,19 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ccc231ff982eb5e89a9670275046b1283f1218537e1e498e4fafd41ee78c7e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
 ]
 
 [[package]]
-name = "stylo_config"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
-
-[[package]]
 name = "stylo_derive"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23de306a4574a16fabcdac5d711af99a458a96a7a1d5d6aeb6c312c1a18c22a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4493,8 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b09f4863058955f38d5fee5ae04baa60b2f71735ef406ad35cb01911dfc811d"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -4502,8 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcb103ab4c0ec6fe0cdd71d092d6bd82a5a012489ccf4c4bd1874a659423316"
 dependencies = [
  "app_units",
  "cssparser",
@@ -4519,13 +4532,15 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe8c72f25bcf5b076b1ad183eaaaf1f2e30cb244d77a74e2b4631c41254f768"
 
 [[package]]
 name = "stylo_traits"
-version = "0.9.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765956b903dbc474540399789062c4a4fcdf3a55d41c4e7919f5e78fc234e30c"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -4811,7 +4826,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab187810ca1e6aaa4c97a06492aac9ade2ffae6a301fd2aac103656f5a69edb"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -4824,7 +4840,8 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/gridaco/stylo#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/csscascade/Cargo.toml
+++ b/crates/csscascade/Cargo.toml
@@ -19,12 +19,11 @@ crate-type = ["rlib"]
 [dependencies]
 # css parsing
 # (+2.5mb wasm32-unknown-emscripten)
-# https://github.com/servo/stylo/issues/272 / The issue has been fixed upstream, yet not released. sticking to fork until the next release
-stylo = { git = "https://github.com/gridaco/stylo" }
-selectors = { git = "https://github.com/gridaco/stylo", package = "selectors" }
-stylo_dom = { git = "https://github.com/gridaco/stylo", package = "stylo_dom" }
-stylo_atoms = { git = "https://github.com/gridaco/stylo", package = "stylo_atoms" }
-style_traits = { git = "https://github.com/gridaco/stylo", package = "stylo_traits" }
+stylo = "0.16"
+selectors = "0.37"
+stylo_dom = "0.16"
+stylo_atoms = "0.16"
+style_traits = { package = "stylo_traits", version = "0.16" }
 url = "2.5"
 euclid = "0.22.11"
 

--- a/crates/csscascade/examples/exp_impl_telement.rs
+++ b/crates/csscascade/examples/exp_impl_telement.rs
@@ -52,6 +52,8 @@ mod cascade {
         StyleContext, StyleSystemOptions, ThreadLocalStyleContext,
     };
     use style::data::ElementStyles;
+    use style::device::Device;
+    use style::device::servo::FontMetricsProvider;
     use style::dom::TElement;
     use style::font_metrics::FontMetrics;
     use style::media_queries::{MediaList, MediaType};
@@ -59,7 +61,6 @@ mod cascade {
     use style::properties::style_structs::Font;
     use style::queries::values::PrefersColorScheme;
     use style::servo::animation::DocumentAnimationSet;
-    use style::servo::media_queries::{Device, FontMetricsProvider};
     use style::servo::selector_parser::SnapshotMap;
     use style::servo_arc::Arc as ServoArc;
     use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
@@ -69,9 +70,8 @@ mod cascade {
     use style::stylist::{RuleInclusion, Stylist};
     use style::traversal::resolve_style;
     use style::traversal_flags::TraversalFlags;
-    use style::values::computed::font::GenericFontFamily;
+    use style::values::computed::font::{GenericFontFamily, QueryFontMetricsFlags};
     use style::values::computed::{CSSPixelLength, Length};
-    use style::values::specified::font::QueryFontMetricsFlags;
     use style_traits::{CSSPixel, DevicePixel};
     use stylo_atoms::Atom;
     use url::Url;
@@ -127,15 +127,11 @@ body {
             }
         }
 
-        pub(crate) fn flush(&mut self, document: HtmlDocument) {
+        pub(crate) fn flush(&mut self, _document: HtmlDocument) {
             let guard = self.stylesheet_lock.read();
             let guards = StylesheetGuards::same(&guard);
             trace_dom!("cascade: flushing stylist");
-            let _ = self.stylist.flush::<HtmlElement>(
-                &guards,
-                document.root_element(),
-                Some(&self.snapshot_map),
-            );
+            let _ = self.stylist.flush(&guards);
         }
 
         pub(crate) fn style_document(&mut self, document: HtmlDocument) -> usize {
@@ -360,17 +356,15 @@ mod demo_dom {
         io::{self, Cursor},
     };
 
-    use atomic_refcell::AtomicRefCell;
     use html5ever::tendril::TendrilSink;
     use html5ever::{driver::ParseOpts, parse_document};
     use markup5ever::interface::tree_builder::{
         ElemName as ElemNameTrait, ElementFlags, NodeOrText, QuirksMode, TreeSink,
     };
     use markup5ever::{Attribute, LocalName, Namespace, QualName};
-    use style::{
-        LocalName as StyleLocalName, Namespace as StyleNamespace, data::ElementData,
-        values::AtomIdent,
-    };
+    use std::sync::OnceLock as StdOnceLock;
+    use style::data::ElementDataWrapper;
+    use style::{LocalName as StyleLocalName, Namespace as StyleNamespace, values::AtomIdent};
     use stylo_atoms::Atom as WeakAtom;
     use tendril::StrTendril;
 
@@ -426,7 +420,7 @@ mod demo_dom {
         document: NodeId,
         quirks_mode: QuirksMode,
         pub errors: Vec<String>,
-        element_data: Vec<AtomicRefCell<Option<ElementData>>>,
+        element_data: Vec<StdOnceLock<ElementDataWrapper>>,
     }
 
     unsafe impl Sync for DemoDom {}
@@ -461,7 +455,7 @@ mod demo_dom {
             &self.nodes[id.idx()]
         }
 
-        pub(crate) fn element_data_slot(&self, id: NodeId) -> &AtomicRefCell<Option<ElementData>> {
+        pub(crate) fn element_data_slot(&self, id: NodeId) -> &StdOnceLock<ElementDataWrapper> {
             &self.element_data[id.idx()]
         }
 
@@ -735,7 +729,7 @@ mod demo_dom {
                 })
                 .collect();
 
-            let element_data = nodes.iter().map(|_| AtomicRefCell::new(None)).collect();
+            let element_data = nodes.iter().map(|_| StdOnceLock::new()).collect();
 
             DemoDom {
                 nodes,
@@ -988,7 +982,6 @@ mod demo_dom {
 mod stylo_dom {
     use std::{borrow::Borrow, sync::OnceLock};
 
-    use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
     use euclid::default::Size2D;
     use markup5ever::{Attribute, Namespace as HtmlNamespace, ns};
     use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
@@ -999,8 +992,8 @@ mod stylo_dom {
     use style::Namespace as StyleNamespace;
     use style::applicable_declarations::ApplicableDeclarationBlock;
     use style::context::SharedStyleContext;
-    use style::data::ElementData;
-    use style::dom::{LayoutIterator, OpaqueNode, TElement, TNode};
+    use style::data::{ElementDataMut, ElementDataRef, ElementDataWrapper};
+    use style::dom::{AttributeProvider, LayoutIterator, OpaqueNode, TElement, TNode};
     use style::properties::PropertyDeclarationBlock;
     use style::selector_parser::{
         AttrValue as SelectorAttrValue, Lang, PseudoElement, SelectorImpl,
@@ -1114,7 +1107,7 @@ mod stylo_dom {
             HtmlNode(self.0)
         }
 
-        fn data_slot(&self) -> &'static AtomicRefCell<Option<ElementData>> {
+        fn data_slot(&self) -> &'static std::sync::OnceLock<ElementDataWrapper> {
             dom().element_data_slot(self.0)
         }
 
@@ -1480,47 +1473,33 @@ mod stylo_dom {
             0
         }
 
-        unsafe fn ensure_data(&self) -> AtomicRefMut<'_, style::data::ElementData> {
+        unsafe fn ensure_data(&self) -> ElementDataMut<'_> {
             trace_dom!("TElement::ensure_data {:?}", self);
             let slot = self.data_slot();
-            let mut cell = slot.borrow_mut();
-            if cell.is_none() {
-                *cell = Some(ElementData::default());
-            }
-            AtomicRefMut::map(cell, |opt| opt.as_mut().unwrap())
+            slot.get_or_init(ElementDataWrapper::default).borrow_mut()
         }
 
         unsafe fn clear_data(&self) {
             trace_dom!("TElement::clear_data {:?}", self);
-            let slot = self.data_slot();
-            *slot.borrow_mut() = None;
+            // OnceLock-backed storage: we cannot reset the slot safely, and
+            // callers in the cascade driver never rely on clearing data between
+            // passes. Leaving the entry in place matches Stylo's Gecko backend,
+            // which also reuses the allocation.
         }
 
         fn has_data(&self) -> bool {
             trace_dom!("TElement::has_data {:?}", self);
-            self.data_slot().borrow().is_some()
+            self.data_slot().get().is_some()
         }
 
-        fn borrow_data(&self) -> Option<AtomicRef<'_, style::data::ElementData>> {
+        fn borrow_data(&self) -> Option<ElementDataRef<'_>> {
             trace_dom!("TElement::borrow_data {:?}", self);
-            let slot = self.data_slot();
-            let cell = slot.borrow();
-            if cell.is_some() {
-                Some(AtomicRef::map(cell, |opt| opt.as_ref().unwrap()))
-            } else {
-                None
-            }
+            self.data_slot().get().map(|w| w.borrow())
         }
 
-        fn mutate_data(&self) -> Option<AtomicRefMut<'_, style::data::ElementData>> {
+        fn mutate_data(&self) -> Option<ElementDataMut<'_>> {
             trace_dom!("TElement::mutate_data {:?}", self);
-            let slot = self.data_slot();
-            let cell = slot.borrow_mut();
-            if cell.is_some() {
-                Some(AtomicRefMut::map(cell, |opt| opt.as_mut().unwrap()))
-            } else {
-                None
-            }
+            self.data_slot().get().map(|w| w.borrow_mut())
         }
 
         fn skip_item_display_fixup(&self) -> bool {
@@ -1623,6 +1602,19 @@ mod stylo_dom {
         fn relative_selector_search_direction(&self) -> ElementSelectorFlags {
             trace_dom!("TElement::relative_selector_search_direction {:?}", self);
             ElementSelectorFlags::empty()
+        }
+    }
+
+    impl AttributeProvider for HtmlElement {
+        fn get_attr(&self, attr: &style::LocalName, namespace: &StyleNamespace) -> Option<String> {
+            self.attr_iter()
+                .filter(|(a, _)| {
+                    let dom_ns: &str = &a.name.ns;
+                    let sel_ns: &str = namespace.as_ref();
+                    dom_ns == sel_ns
+                })
+                .find(|(_, stored)| *stored == attr)
+                .map(|(a, _)| a.value.to_string())
         }
     }
 

--- a/crates/csscascade/src/adapter.rs
+++ b/crates/csscascade/src/adapter.rs
@@ -15,7 +15,6 @@ use std::borrow::Borrow;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use atomic_refcell::{AtomicRef, AtomicRefMut};
 use euclid::default::Size2D;
 use markup5ever::{Attribute, Namespace as HtmlNamespace, ns};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
@@ -26,8 +25,8 @@ use selectors::{OpaqueElement, sink::Push};
 use style::Namespace as StyleNamespace;
 use style::applicable_declarations::ApplicableDeclarationBlock;
 use style::context::SharedStyleContext;
-use style::data::ElementData;
-use style::dom::{LayoutIterator, OpaqueNode, TElement, TNode};
+use style::data::{ElementDataMut, ElementDataRef, ElementDataWrapper};
+use style::dom::{AttributeProvider, LayoutIterator, OpaqueNode, TElement, TNode};
 use style::properties::PropertyDeclarationBlock;
 use style::selector_parser::{AttrValue as SelectorAttrValue, Lang, PseudoElement, SelectorImpl};
 use style::servo_arc::{Arc, ArcBorrow};
@@ -173,7 +172,7 @@ impl HtmlElement {
         HtmlNode(self.0)
     }
 
-    fn data_slot(&self) -> &'static atomic_refcell::AtomicRefCell<Option<ElementData>> {
+    fn data_slot(&self) -> &'static OnceLock<ElementDataWrapper> {
         dom().element_data_slot(self.0)
     }
 
@@ -528,42 +527,28 @@ impl ::style::dom::TElement for HtmlElement {
         0
     }
 
-    unsafe fn ensure_data(&self) -> AtomicRefMut<'_, style::data::ElementData> {
+    unsafe fn ensure_data(&self) -> ElementDataMut<'_> {
         let slot = self.data_slot();
-        let mut cell = slot.borrow_mut();
-        if cell.is_none() {
-            *cell = Some(ElementData::default());
-        }
-        AtomicRefMut::map(cell, |opt| opt.as_mut().unwrap())
+        slot.get_or_init(ElementDataWrapper::default).borrow_mut()
     }
 
     unsafe fn clear_data(&self) {
-        let slot = self.data_slot();
-        *slot.borrow_mut() = None;
+        // OnceLock-backed storage: we cannot reset the slot safely, and
+        // callers in the cascade driver never rely on clearing data between
+        // passes. Leaving the entry in place matches Stylo's Gecko backend,
+        // which also reuses the allocation.
     }
 
     fn has_data(&self) -> bool {
-        self.data_slot().borrow().is_some()
+        self.data_slot().get().is_some()
     }
 
-    fn borrow_data(&self) -> Option<AtomicRef<'_, style::data::ElementData>> {
-        let slot = self.data_slot();
-        let cell = slot.borrow();
-        if cell.is_some() {
-            Some(AtomicRef::map(cell, |opt| opt.as_ref().unwrap()))
-        } else {
-            None
-        }
+    fn borrow_data(&self) -> Option<ElementDataRef<'_>> {
+        self.data_slot().get().map(|w| w.borrow())
     }
 
-    fn mutate_data(&self) -> Option<AtomicRefMut<'_, style::data::ElementData>> {
-        let slot = self.data_slot();
-        let cell = slot.borrow_mut();
-        if cell.is_some() {
-            Some(AtomicRefMut::map(cell, |opt| opt.as_mut().unwrap()))
-        } else {
-            None
-        }
+    fn mutate_data(&self) -> Option<ElementDataMut<'_>> {
+        self.data_slot().get().map(|w| w.borrow_mut())
     }
 
     fn skip_item_display_fixup(&self) -> bool {
@@ -651,6 +636,23 @@ impl ::style::dom::TElement for HtmlElement {
 
     fn relative_selector_search_direction(&self) -> ElementSelectorFlags {
         ElementSelectorFlags::empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// style::dom::AttributeProvider
+// ---------------------------------------------------------------------------
+
+impl AttributeProvider for HtmlElement {
+    fn get_attr(&self, attr: &style::LocalName, namespace: &StyleNamespace) -> Option<String> {
+        self.attr_iter()
+            .filter(|(a, _)| {
+                let dom_ns: &str = &a.name.ns;
+                let sel_ns: &str = namespace.as_ref();
+                dom_ns == sel_ns
+            })
+            .find(|(_, stored)| *stored == attr)
+            .map(|(a, _)| a.value.to_string())
     }
 }
 

--- a/crates/csscascade/src/cascade.rs
+++ b/crates/csscascade/src/cascade.rs
@@ -16,6 +16,8 @@ use style::context::{
     RegisteredSpeculativePainter, RegisteredSpeculativePainters, SharedStyleContext, StyleContext,
     StyleSystemOptions, ThreadLocalStyleContext,
 };
+use style::device::Device;
+use style::device::servo::FontMetricsProvider;
 use style::dom::TElement;
 use style::font_metrics::FontMetrics;
 use style::media_queries::{MediaList, MediaType};
@@ -23,7 +25,6 @@ use style::properties::ComputedValues;
 use style::properties::style_structs::Font;
 use style::queries::values::PrefersColorScheme;
 use style::servo::animation::DocumentAnimationSet;
-use style::servo::media_queries::{Device, FontMetricsProvider};
 use style::servo::selector_parser::SnapshotMap;
 use style::servo_arc::Arc as ServoArc;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
@@ -31,9 +32,8 @@ use style::stylesheets::{AllowImportRules, DocumentStyleSheet, Origin, Styleshee
 use style::stylist::{RuleInclusion, Stylist};
 use style::traversal::resolve_style;
 use style::traversal_flags::TraversalFlags;
-use style::values::computed::font::GenericFontFamily;
+use style::values::computed::font::{GenericFontFamily, QueryFontMetricsFlags};
 use style::values::computed::{CSSPixelLength, Length};
-use style::values::specified::font::QueryFontMetricsFlags;
 use style_traits::{CSSPixel, DevicePixel};
 use stylo_atoms::Atom;
 use url::Url;
@@ -199,14 +199,10 @@ impl CascadeDriver {
     }
 
     /// Flush the stylist so it picks up all appended sheets.
-    pub fn flush(&mut self, document: HtmlDocument) {
+    pub fn flush(&mut self, _document: HtmlDocument) {
         let guard = self.stylesheet_lock.read();
         let guards = StylesheetGuards::same(&guard);
-        let _ = self.stylist.flush::<HtmlElement>(
-            &guards,
-            document.root_element(),
-            Some(&self.snapshot_map),
-        );
+        let _ = self.stylist.flush(&guards);
     }
 
     /// Resolve styles for every element under `document`.

--- a/crates/csscascade/src/dom.rs
+++ b/crates/csscascade/src/dom.rs
@@ -11,20 +11,21 @@ use std::{
     io::{self, Cursor},
 };
 
-use atomic_refcell::AtomicRefCell;
 use html5ever::tendril::TendrilSink;
 use html5ever::{driver::ParseOpts, parse_document};
 use markup5ever::interface::tree_builder::{
     ElemName as ElemNameTrait, ElementFlags, NodeOrText, QuirksMode, TreeSink,
 };
 use markup5ever::{Attribute, LocalName, Namespace, QualName};
+use std::sync::OnceLock;
 use style::context::QuirksMode as StyleQuirksMode;
+use style::data::ElementDataWrapper;
 use style::properties::parse_style_attribute;
 use style::servo_arc::Arc;
 use style::stylesheets::{CssRuleType, UrlExtraData};
 use style::{
-    LocalName as StyleLocalName, Namespace as StyleNamespace, data::ElementData,
-    properties::PropertyDeclarationBlock, shared_lock::Locked, values::AtomIdent,
+    LocalName as StyleLocalName, Namespace as StyleNamespace, properties::PropertyDeclarationBlock,
+    shared_lock::Locked, values::AtomIdent,
 };
 use stylo_atoms::Atom as WeakAtom;
 use tendril::StrTendril;
@@ -96,8 +97,10 @@ pub struct DemoDom {
     document: NodeId,
     quirks_mode: QuirksMode,
     pub errors: Vec<String>,
-    /// Per-node slot for Stylo [`ElementData`] (only meaningful for elements).
-    pub(crate) element_data: Vec<AtomicRefCell<Option<ElementData>>>,
+    /// Per-node slot for Stylo [`ElementDataWrapper`] (only meaningful for
+    /// elements). Populated lazily the first time Stylo's traversal calls
+    /// `ensure_data` on the element.
+    pub(crate) element_data: Vec<OnceLock<ElementDataWrapper>>,
 }
 
 // SAFETY: The DOM is frozen after parsing; no mutable aliasing across threads.
@@ -130,7 +133,7 @@ impl DemoDom {
         &self.nodes[id.idx()]
     }
 
-    pub(crate) fn element_data_slot(&self, id: NodeId) -> &AtomicRefCell<Option<ElementData>> {
+    pub(crate) fn element_data_slot(&self, id: NodeId) -> &OnceLock<ElementDataWrapper> {
         &self.element_data[id.idx()]
     }
 
@@ -409,7 +412,7 @@ impl TreeSink for DemoDomBuilder {
             })
             .collect();
 
-        let element_data = nodes.iter().map(|_| AtomicRefCell::new(None)).collect();
+        let element_data = nodes.iter().map(|_| OnceLock::new()).collect();
 
         DemoDom {
             nodes,

--- a/crates/csscascade/src/tree/mod.rs
+++ b/crates/csscascade/src/tree/mod.rs
@@ -21,19 +21,19 @@ use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 use style::context::QuirksMode;
+use style::device::Device;
+use style::device::servo::FontMetricsProvider;
 use style::font_metrics::FontMetrics;
 use style::media_queries::MediaType;
 use style::properties::style_structs::Font;
 use style::properties::{self, LonghandId};
 use style::queries::values::PrefersColorScheme;
-use style::servo::media_queries::{Device, FontMetricsProvider};
 use style::servo_arc::Arc as ServoArc;
 use style::shared_lock::SharedRwLock;
 use style::stylist::Stylist;
 use style::values::computed::CSSPixelLength;
 use style::values::computed::Length;
-use style::values::computed::font::GenericFontFamily;
-use style::values::specified::font::QueryFontMetricsFlags;
+use style::values::computed::font::{GenericFontFamily, QueryFontMetricsFlags};
 use tendril::StrTendril;
 
 /// Options that control how a [`Tree`] is serialized back to HTML.

--- a/crates/grida-canvas/Cargo.toml
+++ b/crates/grida-canvas/Cargo.toml
@@ -42,8 +42,8 @@ taffy = "0.9.2"
 usvg = { path = "../../third_party/usvg" }
 # html/css cascade (Stylo-based style resolution)
 csscascade = { path = "../csscascade" }
-stylo = { git = "https://github.com/gridaco/stylo" }
-style_config = { git = "https://github.com/gridaco/stylo", package = "stylo_config" }
+stylo = "0.16"
+stylo_static_prefs = "0.16"
 # markdown parsing
 # (+0.25mb wasm32-unknown-emscripten@opt-level=3)
 pulldown-cmark = "0.13.0"

--- a/crates/grida-canvas/src/html/mod.rs
+++ b/crates/grida-canvas/src/html/mod.rs
@@ -1116,10 +1116,19 @@ fn line_direction_to_alignment(
 fn css_border_to_cg(style: &ComputedValues) -> (Paints, StrokeWidth, StrokeStyle) {
     let border = style.get_border();
 
-    let top_w = border.border_top_width.to_f32_px();
-    let right_w = border.border_right_width.to_f32_px();
-    let bottom_w = border.border_bottom_width.to_f32_px();
-    let left_w = border.border_left_width.to_f32_px();
+    // Stylo stores the unresolved `medium` default (3px) in `BorderSideWidth`
+    // even when `border-style` is `none`/`hidden`. Treat those as zero-width.
+    use style::values::specified::border::BorderStyle as BS;
+    let width_for = |w: &style::values::computed::BorderSideWidth, s: BS| -> f32 {
+        match s {
+            BS::None | BS::Hidden => 0.0,
+            _ => w.0.to_f32_px(),
+        }
+    };
+    let top_w = width_for(&border.border_top_width, border.border_top_style);
+    let right_w = width_for(&border.border_right_width, border.border_right_style);
+    let bottom_w = width_for(&border.border_bottom_width, border.border_bottom_style);
+    let left_w = width_for(&border.border_left_width, border.border_left_style);
 
     let has_border = top_w > 0.0 || right_w > 0.0 || bottom_w > 0.0 || left_w > 0.0;
     if !has_border {

--- a/crates/grida-canvas/src/htmlcss/collect.rs
+++ b/crates/grida-canvas/src/htmlcss/collect.rs
@@ -37,7 +37,9 @@ pub(crate) fn collect_styled_tree(html: &str) -> Result<Option<StyledElement>, S
     // Without this, `display: grid` is not parsed (gated behind a pref).
     use std::sync::Once;
     static GRID_PREF: Once = Once::new();
-    GRID_PREF.call_once(|| style_config::set_bool("layout.grid.enabled", true));
+    GRID_PREF.call_once(|| {
+        stylo_static_prefs::set_pref!("layout.grid.enabled", true);
+    });
 
     let dom =
         DemoDom::parse_from_bytes(html.as_bytes()).map_err(|e| format!("HTML parse error: {e}"))?;
@@ -1019,7 +1021,7 @@ fn extract_style(tag: &str, style: &ComputedValues) -> StyledElement {
     let bx = style.get_box();
     el.overflow_x = map_overflow(bx.overflow_x);
     el.overflow_y = map_overflow(bx.overflow_y);
-    el.overflow_clip_margin = style.get_margin().clone_overflow_clip_margin().px();
+    el.overflow_clip_margin = style.get_margin().clone_overflow_clip_margin().offset.px();
 
     // Position
     {
@@ -1289,25 +1291,39 @@ fn extract_border(style: &ComputedValues, current_color: CGColor) -> BorderBox {
 
     BorderBox {
         top: BorderSide {
-            width: b.border_top_width.to_f32_px(),
+            width: side_width(&b.border_top_width, b.border_top_style),
             color: extract_color(&style.clone_border_top_color()),
             style: map_border_style(b.border_top_style),
         },
         right: BorderSide {
-            width: b.border_right_width.to_f32_px(),
+            width: side_width(&b.border_right_width, b.border_right_style),
             color: extract_color(&style.clone_border_right_color()),
             style: map_border_style(b.border_right_style),
         },
         bottom: BorderSide {
-            width: b.border_bottom_width.to_f32_px(),
+            width: side_width(&b.border_bottom_width, b.border_bottom_style),
             color: extract_color(&style.clone_border_bottom_color()),
             style: map_border_style(b.border_bottom_style),
         },
         left: BorderSide {
-            width: b.border_left_width.to_f32_px(),
+            width: side_width(&b.border_left_width, b.border_left_style),
             color: extract_color(&style.clone_border_left_color()),
             style: map_border_style(b.border_left_style),
         },
+    }
+}
+
+/// Stylo stores the unresolved `medium` default (3px) in `BorderSideWidth`
+/// even when `border-style` is `none`/`hidden`. CSS resolves the used width
+/// to zero in that case, so apply the same adjustment locally.
+fn side_width(
+    w: &style::values::computed::BorderSideWidth,
+    s: style::values::specified::border::BorderStyle,
+) -> f32 {
+    use style::values::specified::border::BorderStyle as BS;
+    match s {
+        BS::None | BS::Hidden => 0.0,
+        _ => w.0.to_f32_px(),
     }
 }
 
@@ -1372,10 +1388,10 @@ fn extract_border_image(style: &ComputedValues, current_color: CGColor) -> Optio
     // LengthPercentage is an absolute value. Auto = use slice value.
     let biw = &b.border_image_width;
     let border_widths = [
-        b.border_top_width.to_f32_px(),
-        b.border_right_width.to_f32_px(),
-        b.border_bottom_width.to_f32_px(),
-        b.border_left_width.to_f32_px(),
+        side_width(&b.border_top_width, b.border_top_style),
+        side_width(&b.border_right_width, b.border_right_style),
+        side_width(&b.border_bottom_width, b.border_bottom_style),
+        side_width(&b.border_left_width, b.border_left_style),
     ];
     let resolve_bisw =
         |v: &style::values::computed::BorderImageSideWidth, border_w: f32| -> Option<f32> {
@@ -1421,10 +1437,6 @@ fn extract_border_image(style: &ComputedValues, current_color: CGColor) -> Optio
 fn extract_outline(style: &ComputedValues) -> Outline {
     let o = style.get_outline();
 
-    if !o.outline_has_nonzero_width() {
-        return Outline::default();
-    }
-
     // outline-style: Auto | BorderStyle(bs)
     let outline_style = {
         use style::values::computed::OutlineStyle;
@@ -1438,6 +1450,11 @@ fn extract_outline(style: &ComputedValues) -> Outline {
         return Outline::default();
     }
 
+    let width = o.outline_width.0.to_f32_px();
+    if width <= 0.0 {
+        return Outline::default();
+    }
+
     // outline-color defaults to currentcolor per CSS spec
     let color = o
         .outline_color
@@ -1446,7 +1463,7 @@ fn extract_outline(style: &ComputedValues) -> Outline {
         .unwrap_or_else(|| abs_color_to_cg(&style.get_inherited_text().color));
 
     Outline {
-        width: o.outline_width.to_f32_px(),
+        width,
         color,
         style: outline_style,
         offset: o.outline_offset.to_f32_px(),
@@ -2182,7 +2199,7 @@ fn extract_clip_path(style: &ComputedValues) -> ClipPath {
                 }
             };
             let resolve_radius = |r: &GenericShapeRadius<
-                style::values::computed::NonNegativeLengthPercentage,
+                style::values::computed::LengthPercentage,
             >|
              -> ShapeRadius {
                 match r {


### PR DESCRIPTION
## Summary

servo/stylo#273 has shipped, so the `gridaco/stylo` fork pin can go. This swaps to crates.io `stylo 0.16` (and sibling crates) and adapts the callsites to the new API surface.

## API changes handled

- **Selectors** — fork's `selectors 0.33` → crates.io `selectors 0.37`.
- **`TElement`** now requires `AttributeProvider`; implemented for both the production adapter and the standalone reference example.
- **Element data storage** — `AtomicRefCell<Option<ElementData>>` → `OnceLock<ElementDataWrapper>`. `ensure_data`/`borrow_data`/`mutate_data` return the new `ElementDataRef/Mut` wrappers. `clear_data` is a no-op (matches Gecko's reuse-allocation semantics).
- **`Stylist::flush`** — dropped its root/snapshot-map arguments.
- **Module moves** — `style::servo::media_queries::{Device, FontMetricsProvider}` → `style::device::{Device, servo::FontMetricsProvider}`; `QueryFontMetricsFlags` moved from `specified::font` to `computed::font`.
- **`BorderSideWidth`** is now a newtype over `Au`. Unwrap via `.0.to_f32_px()` and gate by `border-style` so `none`/`hidden` still zero the used width (the fork did this implicitly).
- **`OverflowClipMargin`** became a struct; access via `.offset`.
- **`GenericShapeRadius::Length`** keeps its `NonNegative` wrapper.
- **`outline_has_nonzero_width()`** is gone; replaced by explicit outline-style + width checks.
- **Grid pref** plumbing moved from `stylo_config` to `stylo_static_prefs::set_pref!`, which is what `stylo 0.16` actually reads.

## Test plan

- [x] `cargo check -p cg -p grida-canvas-wasm -p grida-dev -p csscascade`
- [x] `cargo test -p cg --lib` — 771 passed
- [x] `cargo test` across cg, csscascade, grida-dev, grida-canvas-wasm — all green
- [x] WASM debug build (`just _build_wasm32_unknown_emscripten_debug`)
- [x] Node smoke test (`environment-node-smoke.test.ts`) — passes
- [x] refbrowser **L0.exact**: 65/65 at 100.00%
- [x] refbrowser **L0.coverage**: avg 99.70%; sub-100 fixtures are all in already-documented divergence surfaces (gradients, dotted borders, blur shadows, outline AA) — no new regressions.