### PR TITLE
fix: block submit while file upload is pending

### DIFF
--- a/editor/components/extension/file-upload.tsx
+++ b/editor/components/extension/file-upload.tsx
@@ -404,6 +404,7 @@ export const UploadedFileValue = forwardRef<
           name={name}
           required={required}
           value={value}
+          readOnly
           className={cn("sr-only", className)}
         />
       </>

--- a/editor/components/formfield/file-upload-field/__tests__/file-upload-validation.test.ts
+++ b/editor/components/formfield/file-upload-field/__tests__/file-upload-validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { shouldBlockSubmitForFileUpload } from "../file-upload-validation";
+
+describe("shouldBlockSubmitForFileUpload", () => {
+  test("does not block an untouched optional upload field", () => {
+    expect(
+      shouldBlockSubmitForFileUpload({
+        selectedFilesCount: 0,
+        uploadedFilesCount: 0,
+        isUploading: false,
+      })
+    ).toBe(false);
+  });
+
+  test("blocks when a selected file has not produced an uploaded path yet", () => {
+    expect(
+      shouldBlockSubmitForFileUpload({
+        selectedFilesCount: 1,
+        uploadedFilesCount: 0,
+        isUploading: true,
+      })
+    ).toBe(true);
+  });
+
+  test("allows submit after each selected file has an uploaded path", () => {
+    expect(
+      shouldBlockSubmitForFileUpload({
+        selectedFilesCount: 2,
+        uploadedFilesCount: 2,
+        isUploading: false,
+      })
+    ).toBe(false);
+  });
+
+  test("does not block multipart file uploads", () => {
+    expect(
+      shouldBlockSubmitForFileUpload({
+        isMultipartFile: true,
+        selectedFilesCount: 1,
+        uploadedFilesCount: 0,
+        isUploading: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/editor/components/formfield/file-upload-field/file-upload-field.tsx
+++ b/editor/components/formfield/file-upload-field/file-upload-field.tsx
@@ -97,6 +97,7 @@ export const FileUploadField = ({
     () => data.map((info) => info.path).filter(Boolean) as string[],
     [data]
   );
+  const uploadedFilesValue = uploadedFilesPaths.join(",");
 
   const shouldBlockSubmit = shouldBlockSubmitForFileUpload({
     isMultipartFile,
@@ -112,6 +113,29 @@ export const FileUploadField = ({
   useEffect(() => {
     uploadedFileValueRef.current?.setCustomValidity(validationMessage);
   }, [validationMessage]);
+
+  useEffect(() => {
+    const input = uploadedFileValueRef.current;
+    const form = input?.form;
+
+    if (!input || !form || isMultipartFile) return;
+
+    const handleSubmit = (event: SubmitEvent) => {
+      if (!shouldBlockSubmit) return;
+
+      input.setCustomValidity(validationMessage);
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      input.reportValidity();
+    };
+
+    form.addEventListener("submit", handleSubmit, true);
+
+    return () => {
+      form.removeEventListener("submit", handleSubmit, true);
+    };
+  }, [isMultipartFile, shouldBlockSubmit, validationMessage]);
 
   return (
     <FileUploader
@@ -135,7 +159,7 @@ export const FileUploadField = ({
               ref={uploadedFileValueRef}
               name={name}
               required={required || shouldBlockSubmit}
-              value={uploadedFilesPaths}
+              value={uploadedFilesValue}
             />
           )}
         </>

--- a/editor/components/formfield/file-upload-field/file-upload-field.tsx
+++ b/editor/components/formfield/file-upload-field/file-upload-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect, useRef } from "react";
 import {
   FileUploader,
   FileUploaderTrigger,
@@ -16,6 +16,7 @@ import { DropzoneOptions } from "react-dropzone";
 import { UploadStatus, useFileUploader } from "./use-file-uploader";
 import type { FileUploaderFn } from "./uploader";
 import Image from "next/image";
+import { shouldBlockSubmitForFileUpload } from "./file-upload-validation";
 
 type Accept = {
   [key: string]: string[];
@@ -59,6 +60,8 @@ export const FileUploadField = ({
   onFilesChange,
   isMultipartFile,
 }: FileUploadDropzoneProps) => {
+  const uploadedFileValueRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     if (isMultipartFile) return;
     if (!uploader) {
@@ -69,7 +72,7 @@ export const FileUploadField = ({
   }, [isMultipartFile, uploader]);
 
   const [files, setFiles] = useState<File[]>([]);
-  const { getStatus, data } = useFileUploader({
+  const { getStatus, data, isUploading } = useFileUploader({
     files,
     uploader,
     autoUpload: true,
@@ -95,6 +98,21 @@ export const FileUploadField = ({
     [data]
   );
 
+  const shouldBlockSubmit = shouldBlockSubmitForFileUpload({
+    isMultipartFile,
+    selectedFilesCount: files.length,
+    uploadedFilesCount: uploadedFilesPaths.length,
+    isUploading,
+  });
+
+  const validationMessage = shouldBlockSubmit
+    ? "Please wait for the selected file upload to finish."
+    : "";
+
+  useEffect(() => {
+    uploadedFileValueRef.current?.setCustomValidity(validationMessage);
+  }, [validationMessage]);
+
   return (
     <FileUploader
       value={files}
@@ -114,8 +132,9 @@ export const FileUploadField = ({
           />
           {!isMultipartFile && (
             <UploadedFileValue
+              ref={uploadedFileValueRef}
               name={name}
-              required={required}
+              required={required || shouldBlockSubmit}
               value={uploadedFilesPaths}
             />
           )}

--- a/editor/components/formfield/file-upload-field/file-upload-validation.ts
+++ b/editor/components/formfield/file-upload-field/file-upload-validation.ts
@@ -1,0 +1,11 @@
+export function shouldBlockSubmitForFileUpload(args: {
+  isMultipartFile?: boolean;
+  selectedFilesCount: number;
+  uploadedFilesCount: number;
+  isUploading: boolean;
+}): boolean {
+  if (args.isMultipartFile) return false;
+  if (args.selectedFilesCount === 0) return false;
+
+  return args.isUploading || args.uploadedFilesCount < args.selectedFilesCount;
+}


### PR DESCRIPTION
## Summary
- mark the uploaded-file value input invalid while a selected non-multipart file has not produced an uploaded path
- keep multipart upload behavior unchanged
- add focused validation helper coverage

## Verification
- pnpm --dir editor exec vitest run components/formfield/file-upload-field/__tests__/file-upload-validation.test.ts
- pnpm exec oxfmt --check editor/components/formfield/file-upload-field/file-upload-field.tsx editor/components/formfield/file-upload-field/file-upload-validation.ts editor/components/formfield/file-upload-field/__tests__/file-upload-validation.test.ts
- pnpm exec oxlint editor/components/formfield/file-upload-field/file-upload-field.tsx editor/components/formfield/file-upload-field/file-upload-validation.ts editor/components/formfield/file-upload-field/__tests__/file-upload-validation.test.ts

Note: pnpm --dir editor typecheck currently fails on unrelated missing static image modules under app/(www), app/(site), app/(workbench), and components/stripe.

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forms with file uploads are now reliably blocked from submission until all selected files finish uploading, preventing incomplete uploads.
  * Browser-level validation now enforces the upload-complete requirement.

* **Improvements**
  * File upload field is explicitly non-editable and displays clearer validation state while uploads are in progress.
  * Required validation is applied conditionally based on upload state.

* **Tests**
  * Added tests covering multiple file-upload states and validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->