### PR TITLE
feat(ai): expand agent model catalog and add gpt-image-2

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -55,7 +55,7 @@ Per 1M tokens.
 | Name                                              | Input  | Cache Write | Cache Read | Output  |
 | ------------------------------------------------- | ------ | ----------- | ---------- | ------- |
 | GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | $0.20  | —           | $0.02      | $1.25   |
-| GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | $0.75  | —           | $0.07      | $4.50   |
+| GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | $0.75  | —           | $0.075     | $4.50   |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Opus 4.7 (`anthropic/claude-opus-4.7`)     | $5.00  | $6.25       | $0.50      | $25.00  |
 | GPT-5.5 (`openai/gpt-5.5`)                        | $5.00  | —           | $0.50      | $30.00  |
@@ -123,17 +123,17 @@ Flat per-image pricing.
 
 ### Image Sizes
 
-| Model              | Min Size  | Max Size  | Aspect Ratios |
-| ------------------ | --------- | --------- | ------------- |
-| GPT Image 2        | —         | 3840x3840 | up to 3:1     |
-| GPT Image 1.5      | 1024x1024 | 1536x1536 | 1:1, 2:3, 3:2 |
-| GPT Image Mini     | 1024x1024 | 1536x1536 | 1:1, 2:3, 3:2 |
-| Gemini Flash Image | —         | 1536x1536 | Flexible      |
-| Gemini Pro Image   | —         | 1536x1536 | Flexible      |
-| Flux 2 Pro         | 256x256   | 1440x1440 | Flexible      |
-| Flux Kontext Max   | —         | 1820x1820 | Flexible      |
-| Flux Kontext Pro   | —         | 1820x1820 | Flexible      |
-| Flux Pro 1.1       | 256x256   | 1440x1440 | Flexible      |
+| Model              | Min Size  | Max Size                         | Aspect Ratios |
+| ------------------ | --------- | -------------------------------- | ------------- |
+| GPT Image 2        | —         | edges ≤ 3840 px, ≤ 8.3M px total | up to 3:1     |
+| GPT Image 1.5      | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
+| GPT Image Mini     | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
+| Gemini Flash Image | —         | 1536x1536                        | Flexible      |
+| Gemini Pro Image   | —         | 1536x1536                        | Flexible      |
+| Flux 2 Pro         | 256x256   | 1440x1440                        | Flexible      |
+| Flux Kontext Max   | —         | 1820x1820                        | Flexible      |
+| Flux Kontext Pro   | —         | 1820x1820                        | Flexible      |
+| Flux Pro 1.1       | 256x256   | 1440x1440                        | Flexible      |
 
 ## Image Tools
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -13,9 +13,9 @@ All models are routed through the [Vercel AI Gateway](https://vercel.com/docs/ai
 
 Free users receive a **$1.00 monthly budget** (rolling 30-day window). Each AI operation deducts the model's cost from the budget.
 
-## Text Models
+## Agent Models
 
-Text models power chat, content generation, summarization, and agentic features in the editor.
+Agent models power chat, content generation, summarization, code, tool use, and agentic features in the editor.
 
 Models are organized into **tiers** based on capability and cost:
 
@@ -33,9 +33,9 @@ Models are organized into **tiers** based on capability and cost:
 | `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | 400K    | 128K       | $0.20          | $1.25           |
 | `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | 400K    | 128K       | $0.75          | $4.50           |
 | `pro`  | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | 1M      | 128K       | $3.00          | $15.00          |
-| `max`  | Claude Opus 4.6 (`anthropic/claude-opus-4.6`)     | 1M      | 128K       | $5.00          | $25.00          |
+| `max`  | Claude Opus 4.7 (`anthropic/claude-opus-4.7`)     | 1M      | 128K       | $5.00          | $25.00          |
 
-All text models support **multimodal** inputs (text + images).
+All tier models support **multimodal** inputs (text + images).
 
 ### Cache Pricing
 
@@ -48,29 +48,58 @@ All tiers support prompt caching, which reduces cost for repeated context:
 | `pro`  | $0.30               | $3.75                |
 | `max`  | $0.50               | $6.25                |
 
+### All Models
+
+Per 1M tokens.
+
+| Name                                              | Input  | Cache Write | Cache Read | Output  |
+| ------------------------------------------------- | ------ | ----------- | ---------- | ------- |
+| GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | $0.20  | —           | $0.02      | $1.25   |
+| GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | $0.75  | —           | $0.07      | $4.50   |
+| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Opus 4.7 (`anthropic/claude-opus-4.7`)     | $5.00  | $6.25       | $0.50      | $25.00  |
+| GPT-5.5 (`openai/gpt-5.5`)                        | $5.00  | —           | $0.50      | $30.00  |
+| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                | $30.00 | —           | —          | $180.00 |
+
 ## Image Generation Models
 
 Image models power the image generation features in the editor. Pricing varies by provider — some charge per image (flat or tiered by quality/size), others charge per token.
 
 ### OpenAI
 
-Per-image pricing, tiered by quality and output size.
+OpenAI image models are billed per output token. The tables below show the published per-image equivalents for popular sizes; arbitrary in-envelope sizes are billed by the underlying token rates.
 
-**GPT Image 1.5** (`openai/gpt-image-1.5`)
+**GPT Image 2** (`openai/gpt-image-2`)
+
+Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · image cached $2.00 · output $30.00`
 
 | Quality | 1024x1024 | 1024x1536 | 1536x1024 |
 | ------- | --------- | --------- | --------- |
-| Low     | $0.009    | $0.013    | $0.013    |
-| Medium  | $0.034    | $0.050    | $0.050    |
-| High    | $0.133    | $0.200    | $0.200    |
+| Low     | $0.006    | $0.005    | $0.005    |
+| Medium  | $0.053    | $0.041    | $0.041    |
+| High    | $0.211    | $0.165    | $0.165    |
+
+GPT Image 2 also accepts arbitrary resolutions (multiples of 16, edges ≤ 3840 px, aspect ratio ≤ 3:1, total pixels in 655,360 – 8,294,400). Cost for non-standard sizes is computed from output token count.
 
 **GPT Image Mini** (`openai/gpt-image-1-mini`)
+
+Per 1M tokens: `text input $2.00 · text cached $0.20 · image input $2.50 · image cached $0.25 · output $8.00`
 
 | Quality | 1024x1024 | 1024x1536 | 1536x1024 |
 | ------- | --------- | --------- | --------- |
 | Low     | $0.005    | $0.006    | $0.006    |
 | Medium  | $0.011    | $0.015    | $0.015    |
 | High    | $0.036    | $0.052    | $0.052    |
+
+**GPT Image 1.5** (`openai/gpt-image-1.5`) — _deprecated, superseded by GPT Image 2_
+
+Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · image cached $2.00 · output $32.00`
+
+| Quality | 1024x1024 | 1024x1536 | 1536x1024 |
+| ------- | --------- | --------- | --------- |
+| Low     | $0.009    | $0.013    | $0.013    |
+| Medium  | $0.034    | $0.050    | $0.050    |
+| High    | $0.133    | $0.200    | $0.200    |
 
 ### Google
 
@@ -96,6 +125,7 @@ Flat per-image pricing.
 
 | Model              | Min Size  | Max Size  | Aspect Ratios |
 | ------------------ | --------- | --------- | ------------- |
+| GPT Image 2        | —         | 3840x3840 | up to 3:1     |
 | GPT Image 1.5      | 1024x1024 | 1536x1536 | 1:1, 2:3, 3:2 |
 | GPT Image Mini     | 1024x1024 | 1536x1536 | 1:1, 2:3, 3:2 |
 | Gemini Flash Image | —         | 1536x1536 | Flexible      |

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -381,8 +381,13 @@ function TextModelRow({ tier, spec }: { tier: ModelTier; spec: ModelSpec }) {
   );
 }
 
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 3,
+});
+
 function fmtCost(value: number | undefined): string {
-  return value === undefined ? "—" : `$${value.toFixed(2)}`;
+  return value === undefined ? "—" : `$${usdFormatter.format(value)}`;
 }
 
 function CatalogRow({ spec }: { spec: ModelSpec }) {

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -2,6 +2,13 @@ import type { FC } from "react";
 import type { Metadata } from "next";
 import ai from "@/lib/ai";
 import {
+  models as textModels,
+  catalog as textCatalog,
+  type CatalogId,
+  type ModelSpec,
+  type ModelTier,
+} from "@/lib/ai/models";
+import {
   Card,
   CardContent,
   CardDescription,
@@ -75,8 +82,8 @@ function dimLabel(model: AITypes.image.ImageModelCard) {
   if (model.sizes?.length) {
     return model.sizes.map(([w, h, r]) => `${w}x${h} (${r})`).join(", ");
   }
-  if (model.max_width > 0) {
-    return `Up to ${model.max_width}x${model.max_height}`;
+  if (model.constraints?.max_edge) {
+    return `Up to ${model.constraints.max_edge}x${model.constraints.max_edge}`;
   }
   return "Flexible";
 }
@@ -112,6 +119,28 @@ function PricingBadge({
   }
 }
 
+function TokenRates({ rates }: { rates: AITypes.image.PerTokenRates }) {
+  const rows: [string, number][] = [["Text input", rates.input]];
+  if (rates.cached_input !== undefined)
+    rows.push(["Text input (cached)", rates.cached_input]);
+  if (rates.image_input !== undefined)
+    rows.push(["Image input", rates.image_input]);
+  if (rates.cached_image_input !== undefined)
+    rows.push(["Image input (cached)", rates.cached_image_input]);
+  rows.push(["Output", rates.output]);
+  return (
+    <div className="space-y-0.5 text-xs">
+      <p className="text-muted-foreground mb-1">Per 1M tokens</p>
+      {rows.map(([label, price]) => (
+        <div key={label} className="flex justify-between">
+          <span className="text-muted-foreground">{label}</span>
+          <span className="font-mono text-foreground">${price.toFixed(2)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function PricingDetail({
   pricing,
 }: {
@@ -137,32 +166,40 @@ function PricingDetail({
         qualities.set(quality, list);
       }
       return (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-20 px-0">Quality</TableHead>
-              <TableHead className="px-0">Size</TableHead>
-              <TableHead className="text-right px-0">Price</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {[...qualities.entries()].map(([quality, sizes]) =>
-              sizes.map(([size, price], i) => (
-                <TableRow key={`${quality}/${size}`} className="border-0">
-                  <TableCell className="py-1 px-0 capitalize text-muted-foreground">
-                    {i === 0 ? quality : ""}
-                  </TableCell>
-                  <TableCell className="py-1 px-0 font-mono text-xs text-muted-foreground">
-                    {size}
-                  </TableCell>
-                  <TableCell className="py-1 px-0 text-right font-mono">
-                    ${price.toFixed(3)}
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+        <div className="space-y-3">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-20 px-0">Quality</TableHead>
+                <TableHead className="px-0">Size</TableHead>
+                <TableHead className="text-right px-0">Price</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[...qualities.entries()].map(([quality, sizes]) =>
+                sizes.map(([size, price], i) => (
+                  <TableRow key={`${quality}/${size}`} className="border-0">
+                    <TableCell className="py-1 px-0 capitalize text-muted-foreground">
+                      {i === 0 ? quality : ""}
+                    </TableCell>
+                    <TableCell className="py-1 px-0 font-mono text-xs text-muted-foreground">
+                      {size}
+                    </TableCell>
+                    <TableCell className="py-1 px-0 text-right font-mono">
+                      ${price.toFixed(3)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+          {pricing.tokens && (
+            <>
+              <Separator />
+              <TokenRates rates={pricing.tokens} />
+            </>
+          )}
+        </div>
       );
     }
     case "per_token":
@@ -182,6 +219,49 @@ function PricingDetail({
         </div>
       );
   }
+}
+
+function ConstraintsDetail({
+  constraints,
+}: {
+  constraints: AITypes.image.ImageSizeConstraints;
+}) {
+  const rows: [string, string][] = [];
+  if (constraints.max_edge !== undefined) {
+    const min = constraints.min_edge ?? 0;
+    rows.push([
+      "Edge",
+      min > 0
+        ? `${min}–${constraints.max_edge} px`
+        : `≤ ${constraints.max_edge} px`,
+    ]);
+  }
+  if (constraints.step !== undefined) {
+    rows.push(["Step", `multiples of ${constraints.step} px`]);
+  }
+  if (
+    constraints.min_pixels !== undefined ||
+    constraints.max_pixels !== undefined
+  ) {
+    const min = constraints.min_pixels?.toLocaleString() ?? "0";
+    const max = constraints.max_pixels?.toLocaleString() ?? "—";
+    rows.push(["Pixels", `${min}–${max}`]);
+  }
+  if (constraints.aspect_ratio?.max !== undefined) {
+    rows.push(["Aspect ratio", `up to ${constraints.aspect_ratio.max}:1`]);
+  }
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-0.5 text-xs">
+      <p className="text-muted-foreground mb-1">Constraints</p>
+      {rows.map(([label, value]) => (
+        <div key={label} className="flex justify-between">
+          <span className="text-muted-foreground">{label}</span>
+          <span className="font-mono text-foreground">{value}</span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 // ── Card ─────────────────────────────────────────────────────────────────────
@@ -210,6 +290,14 @@ function ModelCard({ model }: { model: AITypes.image.ImageModelCard }) {
         {/* Pricing */}
         <PricingDetail pricing={model.pricing} />
 
+        {/* Constraints */}
+        {model.constraints && (
+          <>
+            <Separator />
+            <ConstraintsDetail constraints={model.constraints} />
+          </>
+        )}
+
         {/* Specs */}
         <div className="mt-auto space-y-2 text-xs text-muted-foreground">
           <div className="flex justify-between">
@@ -217,8 +305,8 @@ function ModelCard({ model }: { model: AITypes.image.ImageModelCard }) {
             <span className="font-mono text-foreground">
               {model.sizes?.length
                 ? `${model.sizes.length} presets`
-                : model.max_width > 0
-                  ? `up to ${model.max_width}x${model.max_height}`
+                : model.constraints?.max_edge
+                  ? `up to ${model.constraints.max_edge}x${model.constraints.max_edge}`
                   : "Flexible"}
             </span>
           </div>
@@ -226,9 +314,184 @@ function ModelCard({ model }: { model: AITypes.image.ImageModelCard }) {
             <span>Model ID</span>
             <code className="text-foreground">{model.id}</code>
           </div>
+          {model.deprecated && (
+            <div className="flex justify-between">
+              <span>Status</span>
+              <Badge variant="outline" className="text-xs h-4 font-normal">
+                Deprecated
+              </Badge>
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+// ── Text models ─────────────────────────────────────────────────────────────
+
+function vendorOf(modelId: string): string {
+  return modelId.includes("/") ? modelId.split("/")[0] : "openai";
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return `${n}`;
+}
+
+function TextModelRow({ tier, spec }: { tier: ModelTier; spec: ModelSpec }) {
+  const vendor = vendorOf(spec.id);
+  const Logo = Logos[vendor];
+  return (
+    <TableRow>
+      <TableCell>
+        <Badge variant="secondary" className="capitalize font-mono text-xs">
+          {tier}
+        </Badge>
+      </TableCell>
+      <TableCell className="font-medium">
+        <div className="flex items-center gap-2">
+          {Logo && <Logo className="size-4 shrink-0" />}
+          <div>
+            <div className="font-medium">{spec.label}</div>
+            <code className="text-xs text-muted-foreground">{spec.id}</code>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell font-mono text-xs">
+        {fmtTokens(spec.contextWindow)}
+      </TableCell>
+      <TableCell className="hidden md:table-cell font-mono text-xs">
+        {fmtTokens(spec.outputLimit)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.input)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.cacheWrite)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.cacheRead)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.output)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function fmtCost(value: number | undefined): string {
+  return value === undefined ? "—" : `$${value.toFixed(2)}`;
+}
+
+function CatalogRow({ spec }: { spec: ModelSpec }) {
+  const vendor = vendorOf(spec.id);
+  const Logo = Logos[vendor];
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        <div className="flex items-center gap-2">
+          {Logo && <Logo className="size-4 shrink-0" />}
+          <div>
+            <div className="font-medium">{spec.label}</div>
+            <code className="text-xs text-muted-foreground">{spec.id}</code>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.input)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.cacheWrite)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.cacheRead)}
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs">
+        {fmtCost(spec.cost.output)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function CatalogSection() {
+  const entries = Object.entries(textCatalog) as [CatalogId, ModelSpec][];
+  if (entries.length === 0) return null;
+  return (
+    <div className="container mx-auto px-4 pb-12">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold tracking-tight mb-1">
+          All Models
+        </h3>
+        <p className="text-xs text-muted-foreground">Per 1M tokens.</p>
+      </div>
+      <div className="rounded-lg border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/40">
+              <TableHead className="w-[260px]">Name</TableHead>
+              <TableHead className="text-right">Input</TableHead>
+              <TableHead className="text-right">Cache Write</TableHead>
+              <TableHead className="text-right">Cache Read</TableHead>
+              <TableHead className="text-right">Output</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map(([id, spec]) => (
+              <CatalogRow key={id} spec={spec} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function TextModelsSection() {
+  const tiers = Object.entries(textModels) as [ModelTier, ModelSpec][];
+  return (
+    <>
+      {/* Hero */}
+      <div className="container px-4 pt-16 pb-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">Agent Models</h1>
+        <p className="text-base text-muted-foreground max-w-xl">
+          Models powering agentic features in the editor — chat, code, tool use,
+          and reasoning. Tiered models are included in the free budget;
+          everything else is available metered at provider rates.
+        </p>
+      </div>
+
+      {/* Tier table */}
+      <div className="container mx-auto px-4 pb-12">
+        <p className="text-xs text-muted-foreground mb-2">
+          Cost columns are USD per 1M tokens.
+        </p>
+        <div className="rounded-lg border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-muted/40">
+                <TableHead className="w-[100px]">Tier</TableHead>
+                <TableHead className="w-[260px]">Model</TableHead>
+                <TableHead className="hidden md:table-cell">Context</TableHead>
+                <TableHead className="hidden md:table-cell">
+                  Output limit
+                </TableHead>
+                <TableHead className="text-right">Input</TableHead>
+                <TableHead className="text-right">Cache Write</TableHead>
+                <TableHead className="text-right">Cache Read</TableHead>
+                <TableHead className="text-right">Output</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tiers.map(([tier, spec]) => (
+                <TextModelRow key={tier} tier={tier} spec={spec} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
   );
 }
 
@@ -240,6 +503,12 @@ export default function AIModelsCatalogPage() {
   return (
     <main className="min-h-screen">
       <Header className="relative top-0 z-50" />
+
+      <TextModelsSection />
+
+      <CatalogSection />
+
+      <Separator />
 
       {/* Hero */}
       <div className="container px-4 pt-16 pb-10">

--- a/editor/lib/ai/ai.ts
+++ b/editor/lib/ai/ai.ts
@@ -650,10 +650,8 @@ export namespace ai {
           [1024, 1536, "2:3"],
           [1536, 1024, "3:2"],
         ],
-        constraints: {
-          min_edge: 1024,
-          max_edge: 1536,
-        },
+        // Preset-only — provider rejects arbitrary sizes.
+        constraints: null,
         // https://developers.openai.com/api/docs/models/gpt-image-1.5
         pricing: {
           type: "per_image_tiered",
@@ -699,10 +697,8 @@ export namespace ai {
           [1024, 1536, "2:3"],
           [1536, 1024, "3:2"],
         ],
-        constraints: {
-          min_edge: 1024,
-          max_edge: 1536,
-        },
+        // Preset-only — provider rejects arbitrary sizes.
+        constraints: null,
         // https://developers.openai.com/api/docs/models/gpt-image-1-mini
         pricing: {
           type: "per_image_tiered",

--- a/editor/lib/ai/ai.ts
+++ b/editor/lib/ai/ai.ts
@@ -363,6 +363,7 @@ export namespace ai {
      */
     export type ImageModelId =
       // OpenAI
+      | "openai/gpt-image-2"
       | "openai/gpt-image-1.5"
       | "openai/gpt-image-1-mini"
       // Google (multimodal LLMs with image output)
@@ -386,6 +387,39 @@ export namespace ai {
     // ── Pricing ───────────────────────────────────────────────────────
 
     /**
+     * Per-token rate sheet, in USD per **1 million** tokens.
+     *
+     * The authoritative pricing unit for token-billed models. For
+     * tiered/flat per-image pricing, the same provider often publishes
+     * an equivalent token-based meter — store it here so that arbitrary
+     * sizes (outside the tiered map) can be priced exactly.
+     *
+     * Providers that distinguish text-input vs image-input modalities
+     * (e.g. OpenAI image models) populate both `input` and `image_input`,
+     * each with its own optional cached counterpart. Models that bill all
+     * inputs uniformly (e.g. Google Gemini) leave the image-side fields
+     * unset.
+     */
+    export type PerTokenRates = {
+      /** USD per 1M text input tokens. */
+      input: number;
+      /** USD per 1M cached text input tokens. */
+      cached_input?: number;
+      /** USD per 1M image input tokens (edits/refs). */
+      image_input?: number;
+      /** USD per 1M cached image input tokens. */
+      cached_image_input?: number;
+      /**
+       * USD per 1M output tokens.
+       *
+       * For image models this is the image-output rate. Some providers
+       * publish a separate text-output rate for multimodal flows; that's
+       * out of scope for this spec.
+       */
+      output: number;
+    };
+
+    /**
      * Per-image pricing with quality × size tiers (e.g. OpenAI).
      *
      * Values from the provider's official pricing page.
@@ -394,6 +428,16 @@ export namespace ai {
       type: "per_image_tiered";
       /** USD per image, keyed by `"quality/WxH"` (e.g. `"medium/1024x1024"`). */
       tiers: Record<string, number>;
+      /**
+       * Authoritative underlying per-token rates.
+       *
+       * `tiers` covers the provider's published per-image equivalents for
+       * popular sizes; arbitrary in-envelope sizes (see
+       * {@link ImageSizeConstraints}) are billed by token count using
+       * these rates. Always present when the provider documents a token
+       * meter for the model.
+       */
+      tokens?: PerTokenRates;
     };
 
     /**
@@ -407,16 +451,9 @@ export namespace ai {
 
     /**
      * Per-token pricing (e.g. Google Gemini image models).
-     *
-     * Values are USD per **1 million** tokens, matching the convention
-     * in `lib/ai/models.ts`.
      */
-    export type PerTokenPricing = {
+    export type PerTokenPricing = PerTokenRates & {
       type: "per_token";
-      /** USD per 1M input tokens. */
-      input: number;
-      /** USD per 1M output tokens. */
-      output: number;
     };
 
     /**
@@ -429,6 +466,55 @@ export namespace ai {
       | PerImageTieredPricing
       | PerImageFlatPricing
       | PerTokenPricing;
+
+    // ── Size constraints ──────────────────────────────────────────────
+
+    /**
+     * Continuous size constraints for an image model.
+     *
+     * Models accept arbitrary widths and heights within these bounds.
+     * Use alongside (or instead of) `sizes` (discrete presets):
+     *
+     * - **Presets only** — fixed-size models (legacy OpenAI image).
+     * - **Constraints only** — fully flexible (Flux, Gemini).
+     * - **Both** — `gpt-image-2`: documented preset prices plus arbitrary
+     *   sizes within the engine's pixel/aspect envelope.
+     *
+     * **Validation precedence.** When both `sizes` (presets) and
+     * `constraints` are present on a card, `constraints` is the
+     * authoritative validator: a request must satisfy every constraint
+     * field. `sizes` is a UI hint and a pricing-tier anchor — off-preset
+     * but in-envelope requests are valid, but their cost falls back to
+     * the nearest priced tier (see `PerImageTieredPricing`).
+     *
+     * All bounds are inclusive. Omit a field when the provider does not
+     * document that constraint.
+     */
+    export type ImageSizeConstraints = {
+      /**
+       * Pixel quantization. Width and height must be multiples of `step`.
+       * Default `1` (no quantization).
+       *
+       * @example 16 // gpt-image-2
+       */
+      step?: number;
+      /** Per-edge bounds, in px. Applies symmetrically to width and height. */
+      min_edge?: number;
+      max_edge?: number;
+      /** Total pixel-count bounds (`width × height`). */
+      min_pixels?: number;
+      max_pixels?: number;
+      /**
+       * Aspect-ratio bounds, expressed as the long edge over the short
+       * edge (always `>= 1`). Applies in either orientation.
+       *
+       * @example { max: 3 } // up to 3:1
+       */
+      aspect_ratio?: {
+        min?: number;
+        max?: number;
+      };
+    };
 
     // ── Card types ────────────────────────────────────────────────────
 
@@ -452,11 +538,14 @@ export namespace ai {
       styles: string[] | null;
       speed_label: SpeedLabel;
       speed_max: string;
-      min_width: number;
-      max_width: number;
-      min_height: number;
-      max_height: number;
+      /** Discrete preset sizes (UI suggestions and pricing-tier anchors). */
       sizes: SizeSpec[] | null;
+      /**
+       * Continuous size constraints for arbitrary dimensions.
+       * Authoritative for input validation when present (see
+       * {@link ImageSizeConstraints}).
+       */
+      constraints: ImageSizeConstraints | null;
       /** Real provider pricing data. */
       pricing: ImageModelPricing;
       /**
@@ -491,13 +580,13 @@ export namespace ai {
       // -----------------------------------------------------------------
       // OpenAI
       // -----------------------------------------------------------------
-      // https://developers.openai.com/api/docs/models/gpt-image-1.5
-      "openai/gpt-image-1.5": {
-        id: "openai/gpt-image-1.5",
-        label: "GPT Image 1.5",
+      // https://developers.openai.com/api/docs/models/gpt-image-2
+      "openai/gpt-image-2": {
+        id: "openai/gpt-image-2",
+        label: "GPT Image 2",
         deprecated: false,
         short_description:
-          "State-of-the-art image generation with better instruction following",
+          "State-of-the-art image generation and editing with flexible resolutions",
         vendor: "openai",
         provider: "gateway",
         speed_label: "medium",
@@ -508,10 +597,63 @@ export namespace ai {
           [1024, 1536, "2:3"],
           [1536, 1024, "3:2"],
         ],
-        min_width: 1024,
-        max_width: 1536,
-        min_height: 1024,
-        max_height: 1536,
+        constraints: {
+          step: 16,
+          max_edge: 3840,
+          min_pixels: 655_360,
+          max_pixels: 8_294_400,
+          aspect_ratio: { max: 3 },
+        },
+        // https://developers.openai.com/api/docs/models/gpt-image-2
+        pricing: {
+          type: "per_image_tiered",
+          tiers: {
+            "low/1024x1024": 0.006,
+            "low/1024x1536": 0.005,
+            "low/1536x1024": 0.005,
+            "medium/1024x1024": 0.053,
+            "medium/1024x1536": 0.041,
+            "medium/1536x1024": 0.041,
+            "high/1024x1024": 0.211,
+            "high/1024x1536": 0.165,
+            "high/1536x1024": 0.165,
+          },
+          tokens: {
+            input: 5.0,
+            cached_input: 1.25,
+            image_input: 8.0,
+            cached_image_input: 2.0,
+            output: 30.0,
+          },
+        },
+        avg_cost_usd: 0.053, // medium/1024x1024
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // https://developers.openai.com/api/docs/models/gpt-image-1.5
+      "openai/gpt-image-1.5": {
+        id: "openai/gpt-image-1.5",
+        label: "GPT Image 1.5",
+        deprecated: true,
+        short_description:
+          "Previous-generation image model. Superseded by GPT Image 2.",
+        vendor: "openai",
+        provider: "gateway",
+        speed_label: "medium",
+        speed_max: "1m",
+        styles: null,
+        sizes: [
+          [1024, 1024, "1:1"],
+          [1024, 1536, "2:3"],
+          [1536, 1024, "3:2"],
+        ],
+        constraints: {
+          min_edge: 1024,
+          max_edge: 1536,
+        },
         // https://developers.openai.com/api/docs/models/gpt-image-1.5
         pricing: {
           type: "per_image_tiered",
@@ -525,6 +667,13 @@ export namespace ai {
             "high/1024x1024": 0.133,
             "high/1024x1536": 0.2,
             "high/1536x1024": 0.2,
+          },
+          tokens: {
+            input: 5.0,
+            cached_input: 1.25,
+            image_input: 8.0,
+            cached_image_input: 2.0,
+            output: 32.0,
           },
         },
         avg_cost_usd: 0.034, // medium/1024x1024
@@ -550,10 +699,10 @@ export namespace ai {
           [1024, 1536, "2:3"],
           [1536, 1024, "3:2"],
         ],
-        min_width: 1024,
-        max_width: 1536,
-        min_height: 1024,
-        max_height: 1536,
+        constraints: {
+          min_edge: 1024,
+          max_edge: 1536,
+        },
         // https://developers.openai.com/api/docs/models/gpt-image-1-mini
         pricing: {
           type: "per_image_tiered",
@@ -567,6 +716,13 @@ export namespace ai {
             "high/1024x1024": 0.036,
             "high/1024x1536": 0.052,
             "high/1536x1024": 0.052,
+          },
+          tokens: {
+            input: 2.0,
+            cached_input: 0.2,
+            image_input: 2.5,
+            cached_image_input: 0.25,
+            output: 8.0,
           },
         },
         avg_cost_usd: 0.011, // medium/1024x1024
@@ -593,10 +749,7 @@ export namespace ai {
         speed_max: "15s",
         styles: null,
         sizes: null,
-        min_width: 0,
-        max_width: 1536,
-        min_height: 0,
-        max_height: 1536,
+        constraints: { max_edge: 1536 },
         pricing: { type: "per_token", input: 0.5, output: 3.0 },
         avg_cost_usd: 0.004, // conservative per-image estimate for budget
         default: {
@@ -619,10 +772,7 @@ export namespace ai {
         speed_max: "30s",
         styles: null,
         sizes: null,
-        min_width: 0,
-        max_width: 1536,
-        min_height: 0,
-        max_height: 1536,
+        constraints: { max_edge: 1536 },
         pricing: { type: "per_token", input: 2.0, output: 12.0 },
         avg_cost_usd: 0.015, // conservative per-image estimate for budget
         default: {
@@ -648,10 +798,7 @@ export namespace ai {
         speed_max: "30s",
         styles: null,
         sizes: null,
-        min_width: 256,
-        max_width: 1440,
-        min_height: 256,
-        max_height: 1440,
+        constraints: { min_edge: 256, max_edge: 1440 },
         pricing: { type: "per_image_flat", usd: 0.06 },
         avg_cost_usd: 0.06,
         default: {
@@ -672,10 +819,7 @@ export namespace ai {
         speed_max: "30s",
         styles: null,
         sizes: null,
-        min_width: 0,
-        min_height: 0,
-        max_width: 1820,
-        max_height: 1820,
+        constraints: { max_edge: 1820 },
         pricing: { type: "per_image_flat", usd: 0.08 },
         avg_cost_usd: 0.08,
         default: {
@@ -695,10 +839,7 @@ export namespace ai {
         speed_max: "20s",
         styles: null,
         sizes: null,
-        min_width: 0,
-        min_height: 0,
-        max_width: 1820,
-        max_height: 1820,
+        constraints: { max_edge: 1820 },
         pricing: { type: "per_image_flat", usd: 0.05 },
         avg_cost_usd: 0.05,
         default: {
@@ -719,10 +860,7 @@ export namespace ai {
         speed_max: "30s",
         styles: null,
         sizes: null,
-        min_width: 256,
-        max_width: 1440,
-        min_height: 256,
-        max_height: 1440,
+        constraints: { min_edge: 256, max_edge: 1440 },
         pricing: { type: "per_image_flat", usd: 0.04 },
         avg_cost_usd: 0.04,
         default: {

--- a/editor/lib/ai/models.ts
+++ b/editor/lib/ai/models.ts
@@ -79,14 +79,18 @@ export interface ModelSpec {
 }
 
 // ---------------------------------------------------------------------------
-// Current model assignments — edit here when bumping models
+// Catalog — every model the editor knows about
+//
+// Single source of truth. Tiered models (see `tierAssignments` below) are
+// included in the free budget; everything else is opt-in and billed as
+// metered at the provider's published per-token rates.
 //
 // All values from https://models.dev/api.json
 // To look up: python .tools/model_info.py <model_id>
 // ---------------------------------------------------------------------------
 
-const specs = {
-  nano: {
+const catalogSpecs = {
+  "openai/gpt-5.4-nano": {
     id: "openai/gpt-5.4-nano",
     label: "GPT-5.4 Nano",
     multimodal: true,
@@ -94,7 +98,7 @@ const specs = {
     outputLimit: 128_000,
     cost: { input: 0.2, output: 1.25, cacheRead: 0.02 },
   },
-  mini: {
+  "openai/gpt-5.4-mini": {
     id: "openai/gpt-5.4-mini",
     label: "GPT-5.4 Mini",
     multimodal: true,
@@ -102,7 +106,23 @@ const specs = {
     outputLimit: 128_000,
     cost: { input: 0.75, output: 4.5, cacheRead: 0.075 },
   },
-  pro: {
+  "openai/gpt-5.5": {
+    id: "openai/gpt-5.5",
+    label: "GPT-5.5",
+    multimodal: true,
+    contextWindow: 1_050_000,
+    outputLimit: 128_000,
+    cost: { input: 5, output: 30, cacheRead: 0.5 },
+  },
+  "openai/gpt-5.5-pro": {
+    id: "openai/gpt-5.5-pro",
+    label: "GPT-5.5 Pro",
+    multimodal: true,
+    contextWindow: 1_050_000,
+    outputLimit: 128_000,
+    cost: { input: 30, output: 180 },
+  },
+  "anthropic/claude-sonnet-4.6": {
     id: "anthropic/claude-sonnet-4.6",
     label: "Claude Sonnet 4.6",
     multimodal: true,
@@ -110,22 +130,64 @@ const specs = {
     outputLimit: 128_000,
     cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   },
-  max: {
-    id: "anthropic/claude-opus-4.6",
-    label: "Claude Opus 4.6",
+  "anthropic/claude-opus-4.7": {
+    id: "anthropic/claude-opus-4.7",
+    label: "Claude Opus 4.7",
     multimodal: true,
     contextWindow: 1_000_000,
     outputLimit: 128_000,
     cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   },
-} as const satisfies Record<ModelTier, ModelSpec>;
+} as const satisfies Record<string, ModelSpec>;
+
+export type CatalogId = keyof typeof catalogSpecs;
+
+// ---------------------------------------------------------------------------
+// Tier assignments — which catalog entry powers each tier
+//
+// Edit here when bumping a tier to a different catalog model.
+// ---------------------------------------------------------------------------
+
+const tierAssignments = {
+  nano: "openai/gpt-5.4-nano",
+  mini: "openai/gpt-5.4-mini",
+  pro: "anthropic/claude-sonnet-4.6",
+  max: "anthropic/claude-opus-4.7",
+} as const satisfies Record<ModelTier, CatalogId>;
+
+const specs: Record<ModelTier, ModelSpec> = {
+  nano: catalogSpecs[tierAssignments.nano],
+  mini: catalogSpecs[tierAssignments.mini],
+  pro: catalogSpecs[tierAssignments.pro],
+  max: catalogSpecs[tierAssignments.max],
+};
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Read-only map of tier → model spec. */
+/** Read-only map of tier → model spec (resolved from the catalog). */
 export const models: Record<ModelTier, ModelSpec> = specs;
+
+/** Read-only map of catalog model ID → spec. Includes tier and metered models. */
+export const catalog: Record<CatalogId, ModelSpec> = catalogSpecs;
+
+/** Read-only map of tier → catalog model ID. */
+export const tiers: Record<ModelTier, CatalogId> = tierAssignments;
+
+/**
+ * Returns the tier (if any) that currently uses the given catalog model.
+ * `undefined` for metered-only models.
+ */
+export function tierOf(catalogId: CatalogId): ModelTier | undefined {
+  for (const [tier, id] of Object.entries(tierAssignments) as [
+    ModelTier,
+    CatalogId,
+  ][]) {
+    if (id === catalogId) return tier;
+  }
+  return undefined;
+}
 
 /**
  * Look up a model spec by model ID.
@@ -137,7 +199,7 @@ export const models: Record<ModelTier, ModelSpec> = specs;
  *   snapshot date to the model ID in their API responses)
  */
 export function modelSpecById(modelId: string): ModelSpec | undefined {
-  for (const spec of Object.values(specs)) {
+  for (const spec of Object.values(catalogSpecs)) {
     // Exact match (gateway format)
     if (spec.id === modelId) return spec;
 


### PR DESCRIPTION
## Summary

- **Image models:** Add `openai/gpt-image-2` as the new OpenAI flagship (3-tier per-image pricing + per-token rates); mark `gpt-image-1.5` deprecated; keep `gpt-image-1-mini` active.
- **Agent models:** Bump `max` tier from `claude-opus-4.6` → `claude-opus-4.7` (identical pricing/limits). Restructure `lib/ai/models.ts` so a flat `catalogSpecs` map is the single source of truth and tiers reference it by ID. Add `gpt-5.5` and `gpt-5.5-pro` as opt-in metered catalog entries.
- **Spec types:** Add `ImageSizeConstraints` (step / min_edge / max_edge / min_pixels / max_pixels / aspect_ratio) and migrate every image model to it; drop flat min/max_width/height. Add `PerTokenRates` with text/cached + image/cached_image breakdown, attached as the authoritative meter under tiered OpenAI image pricing.
- **`/ai/models` page:** Rename Text Models → Agent Models. Split tier table into per-column Input / Cache Write / Cache Read / Output. Add an "All Models" table that consumes the full catalog. Add token-rate and constraints panels to image model cards. Surface `deprecated` flag.

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified locally)
- [ ] `pnpm oxlint` clean on touched files (verified locally — 0 warnings, 0 errors)
- [ ] `just fmt` clean (verified locally; oxfmt + cargo fmt no-op on commit)
- [ ] Visit `/ai/models`:
  - [ ] "Agent Models" hero renders; tier table has 8 columns (Tier, Model, Context, Output limit, Input, Cache Write, Cache Read, Output) with `—` for missing cache rates
  - [ ] "All Models" table lists all 6 catalog entries (`gpt-5.4-nano/mini`, `gpt-5.5`, `gpt-5.5-pro`, `claude-sonnet-4.6`, `claude-opus-4.7`)
  - [ ] "Image Models" section shows `GPT Image 2` (active) above `GPT Image 1.5` (deprecated badge); cards include Constraints panel and Per-1M-tokens rates
- [ ] Spot-check pricing accuracy against [OpenAI pricing page](https://developers.openai.com/api/docs/pricing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.5, GPT-5.5 Pro, and GPT Image 2 to the model lineup.
  * Max-tier model updated to Claude Opus 4.7.

* **Updates**
  * Documentation now frames “Agent Models” (chat/agentic capabilities) and offers an “All Models” token-based pricing table.
  * Image generation section reorganized; Image 2 added with updated size/quality limits and pricing; deprecated older image models.
* **UX**
  * Catalog and model displays updated to show improved constraint and token-rate formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->