### PR TITLE
feat(pricing): add billing guide, FAQ, and clean up features table

### DIFF
--- a/docs/platform/billing.mdx
+++ b/docs/platform/billing.mdx
@@ -1,0 +1,229 @@
+---
+title: How Grida billing works
+description: A plain-English guide to Grida's plans, AI credits, and billing. No legalese.
+sidebar_label: Billing
+sidebar_position: 1
+---
+
+# How Grida billing works
+
+This page explains how Grida charges you, how AI credits work, and what to expect on your bill. If you have a specific question, jump to the [Common questions](#common-questions) at the bottom.
+
+> Heads up: specific dollar amounts on this page (plan price, monthly credit allotment, top-up range) can change as we tune things. We'll update this doc when they do.
+
+## Plans
+
+Grida has two plans today.
+
+| Plan | Price                   | Monthly AI credit                  |
+| ---- | ----------------------- | ---------------------------------- |
+| Free | $0                      | $0.50 (shared by everyone in your org) |
+| Pro  | **$20 per user / month** | **$15 per user**, pooled across your team |
+
+Pro is the only paid tier right now. An annual plan is on the roadmap but not available yet.
+
+The Pro price breaks down like this, per user: $5 keeps the lights on (servers, storage, support), and the other $15 lands in your team's shared AI credit pool. **There is no separate "Team" plan — Pro is per-seat from day one.** A solo user is just a 1-seat Pro subscription. A 5-person team is a 5-seat Pro subscription that pays $100/month and gets $75 of pooled credit.
+
+> Heads up: AI credit pools at the **organization** level, not per individual. If your team has 3 Pro seats, the $45 pool is shared — anyone on the team can spend any of it. This matches how Cursor Teams, Linear, and most peer products work.
+
+## How AI credits work
+
+Every AI feature in Grida — generating an image, generating audio, and so on — costs credit. Your balance drops by exactly what we paid the model provider for that call.
+
+A few things to know:
+
+- **AI is sold at cost.** We don't mark it up. If a provider charges us $0.04 for an image, you pay $0.04.
+- **Monthly credit doesn't roll over.** Whatever's left of your $0.50 (Free) or $15 (Pro) at the end of your billing period is gone. This is how monthly plans normally work — same idea as Vercel, v0, Linear, or Cursor.
+- **Top-up credit never expires.** If you bought $25 of credit and only used $3, the other $22 stays in your account. Even if you cancel Pro and come back next year, it's still there.
+- **Monthly credit is spent first.** Because monthly credit is about to expire, we burn it before touching your top-up balance. That way your top-ups stick around as long as possible.
+
+### The $0.25 minimum balance
+
+If your balance drops below **$0.25**, AI calls are blocked until you top up or your monthly credit refreshes.
+
+This is a safety floor. No AI feature in Grida today costs more than $0.25 per call, so the floor guarantees no single call can drive you into the negative. You're never going to get a surprise bill from one expensive request.
+
+If we add models in the future that cost more per call (video, for instance), we'll raise the floor for those features and clearly mark it.
+
+## Top-ups
+
+When your monthly credit runs out, you have two choices: wait for the next month, or buy more credit on demand.
+
+A top-up is a one-time purchase. You pick any amount between **$5 and $1000** and that exact amount lands in your balance.
+
+Card processors take a small fee on every transaction. We pass that through transparently — we don't pad it or absorb it into the credit you receive. So if you top up $25:
+
+- You receive **$25.00** of credit.
+- Your card is charged about **$25.73** ($25.00 + roughly 2.9% + $0.30 for the processor).
+
+Both numbers are shown on the checkout page and on your receipt before you confirm. Nothing surprising.
+
+Top-up credit never expires.
+
+## What happens when you run out
+
+If your balance hits the $0.25 floor:
+
+- AI features pause.
+- Everything else keeps working — saving, editing, designing, exporting, all of it. Only the AI buttons stop responding.
+- You can either wait for next month's credit to land, or top up.
+
+We will never charge your card to "cover" an AI call. You only ever spend credit you've already paid for or that came with your plan.
+
+## What happens if your card fails
+
+This section is Pro-only. Free users have nothing to renew.
+
+Each month we try to charge your card for the $20 Pro renewal. If the charge fails (expired card, insufficient funds, anything), here's what happens:
+
+- **Pro pauses immediately.** Not in 24 hours, not after a 7-day grace period — the same minute the charge fails.
+- **Your $15 monthly credit is suspended** until the card succeeds.
+- **Top-up credit keeps working.** You bought it, you own it. Use it whenever.
+- **We retry the card automatically** a handful of times over the next two weeks. The moment a retry succeeds, Pro turns back on and the monthly credit lands.
+- You can update your card any time from the billing settings page. As soon as the new card succeeds, you're back.
+
+> Good to know: while Pro is paused for non-payment, you do **not** drop down to the Free $0.50 monthly credit. A pause is a "payment broken" state, not a downgrade. To return to Free properly (and get the $0.50 monthly), you need to actually cancel Pro.
+
+## Working with a team
+
+If your organization has more than one person, Pro charges per seat — but everyone shares the same credit pool, the same way Cursor Teams or Linear handle it.
+
+A few things to know:
+
+- **Every member of a Pro org is a paid seat.** Each seat is $20/month and contributes $15 to the shared pool. The owner counts as a seat too.
+- **Inviting someone to your org adds a seat.** Their cost is prorated for the rest of the current period — e.g., adding Bob halfway through the month adds about $10 to your next invoice.
+- **Removing someone from your org removes their seat next period.** The current period's credit pool is unaffected (it was already paid for and minted at the start of the period). Stripe issues a small prorated credit for the unused portion of their seat.
+- **Pending invitations don't count as seats.** A seat starts costing only when the person accepts and joins the org.
+- **Free orgs can have multiple members.** They all share one $0.50 monthly credit pool — same total whether your org has 1 person or 5. If you need more credit, upgrade to Pro and seats scale automatically.
+- **Only the org owner can manage seats and billing** today. Member-role permissions are coming.
+
+> Good to know: a "Team plan" as a separate product doesn't exist. Pro is per-seat from day one. You don't have to "upgrade to Team" to add a teammate — you just invite them, and the next invoice reflects the new seat count.
+
+## Cancel anytime
+
+You can cancel Pro from your account settings at any time, no questions asked.
+
+When you cancel:
+
+- You keep Pro and the current month's credit until the end of the period you've already paid for.
+- After that, you switch to Free and start getting $0.50 of credit each month (shared across the org if you have multiple members).
+- Any top-up credit you have stays in your account.
+
+There's nothing to "downgrade" manually. Cancellation handles it.
+
+## Examples
+
+Three quick walkthroughs to make this concrete.
+
+### Maya is on Free
+
+Maya has $0.50 of credit at the start of the month.
+
+- She generates 5 images at $0.04 each → spends $0.20. Balance: $0.30.
+- She generates an audio clip at $0.04 → balance: $0.26.
+- She tries one more image. Blocked — she's below the $0.25 floor.
+
+She waits a week. The new month rolls over. Her balance refreshes to $0.50 and she's back in business.
+
+### Jordan upgrades to Pro (solo)
+
+Jordan is the only person in their org. Upgrading to Pro buys 1 seat — $20/month, $15 of monthly AI credit.
+
+Jordan generates a lot of images and a lot of audio tracks throughout the month. Late one night, the balance is at $0.20 — blocked by the floor.
+
+Jordan tops up $25.
+
+- The card is charged about **$25.73** (the $25 top-up plus the processor fee).
+- Jordan's balance becomes **$25.20**.
+
+Jordan keeps working. When the next month begins, $15 of fresh Pro credit lands on top of whatever top-up credit is still left.
+
+### Priya's team upgrades
+
+Priya runs a 4-person design team on Free. They share $0.50/month — clearly not enough for the kind of AI work they want to do.
+
+Priya upgrades the org to Pro from the billing settings.
+
+- The seat count is set automatically to **4** (everyone currently in the org).
+- The first invoice is **$80** (4 × $20).
+- The team's credit pool jumps to **$60/month** (4 × $15), shared across all 4 people. Anyone on the team can spend any of it.
+
+A week later, they invite a fifth person.
+
+- Bob accepts the invitation. Stripe charges a **prorated $15** for the rest of the period.
+- The seat count is now 5. Next month's pool will be **$75** (5 × $15).
+
+A month later, someone leaves the team. Priya removes them.
+
+- The seat count drops to 4. Stripe issues a **prorated credit** of about $10 to the next invoice.
+- The current month's $75 pool is unchanged (it was already paid for and minted at the start of the period).
+- Next month's pool will be **$60**.
+
+### Sam's card fails
+
+Sam is Pro and has $25.00 in top-up credit sitting in the account.
+
+The monthly Pro renewal hits Sam's card. The charge fails (expired card).
+
+- Pro pauses. Sam's $15 monthly credit is suspended.
+- Sam's $25 top-up credit keeps working — Sam can still use AI features against that balance.
+
+Three days later, the card is renewed and the next retry succeeds.
+
+- Pro resumes immediately.
+- The next monthly $15 lands on schedule on Sam's normal renewal date.
+
+## Common questions
+
+**Do my unused monthly credits roll over?**
+No. Monthly credit (Free or Pro) resets each billing period. This is how all monthly plans work.
+
+**What about credits I bought as a top-up?**
+Top-up credit never expires. It stays in your balance until you spend it, even if you cancel Pro and come back later.
+
+**Can I get a refund?**
+See the [refund policy](/support/refund-policy). The short version: we'll work with you on accidental top-ups and obvious billing errors.
+
+**What happens if I cancel Pro mid-month?**
+You keep Pro and your remaining monthly credit until the end of the period you've already paid for. After that, you're on Free. Top-ups stay.
+
+**Why is there a $0.25 minimum balance?**
+So no single AI call can ever take you negative. It's a safety floor, not a fee.
+
+**Are AI prices marked up?**
+No. We charge you exactly what the model provider charges us. We make our money on the $5 base difference in the Pro plan, not on AI usage.
+
+**Can I see how much I've used?**
+Yes — your billing settings show your current balance, what was spent this month, and a per-call history.
+
+**What payment methods do you accept?**
+Major credit and debit cards. Apple Pay and Google Pay where supported by your browser.
+
+**Do you charge tax?**
+We collect VAT/GST/sales tax where the law requires it, based on your billing address. Tax (if any) is shown on the checkout page before you confirm and itemized on your receipt.
+
+**I run a team — how does pricing work?**
+Pro is per-seat: $20 per user per month. Every member of your org is a seat, including the owner. Adding a member adds a seat (prorated); removing one removes it. AI credit is shared across the team — a 5-seat Pro org has a $75/month pool that any member can spend from. There's no separate "Team plan" — Pro is the team product.
+
+**Is the credit really shared, or is each person locked to $15?**
+Shared. We pool it at the org level so a teammate's heavy week doesn't stop yours, and an admin's spending doesn't strand junior team members. If you need stricter per-user controls, that's on the roadmap.
+
+**Who can manage billing for a team?**
+The org owner today. Member-role permissions (admin, billing-only, etc.) are coming.
+
+**Is there an annual plan?**
+Not yet. We'll add one once Pro has settled.
+
+**What if a model's price changes?**
+Providers occasionally adjust their prices. When they do, we update what we charge you to match. We never charge you more than we pay the provider.
+
+**Can I top up with crypto / wire / invoice?**
+Not in v1. Card payments only for now.
+
+## Anything else?
+
+- [Refund policy](/support/refund-policy)
+- [Terms and conditions](/support/terms-and-conditions)
+- [Privacy policy](/support/privacy-policy)
+
+Still stuck? Email [support@grida.co](mailto:support@grida.co) and a real human will get back to you.

--- a/editor/app/(www)/(pricing)/pricing/_sections/faq.tsx
+++ b/editor/app/(www)/(pricing)/pricing/_sections/faq.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import Link from "next/link";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+const faqs: { question: string; answer: React.ReactNode }[] = [
+  {
+    question: "How do AI credits work?",
+    answer: (
+      <>
+        Each plan includes a monthly AI credit — $0.50 on Free,{" "}
+        <strong>$15 per seat</strong> on Pro. AI features draw from this balance
+        at the model provider&apos;s cost; we never mark up AI usage. Unused
+        monthly credit resets at the start of the next billing period.{" "}
+        <Link
+          href="/docs/platform/billing"
+          className="underline underline-offset-4"
+        >
+          Read the full guide
+        </Link>
+        .
+      </>
+    ),
+  },
+  {
+    question: "Can I buy credit ahead of time?",
+    answer:
+      "Yes. You can top up at any time, in any amount from $5 to $1000. The amount you pick is exactly what lands in your balance — the card processor's fee is added on top of the charge and shown clearly at checkout. Top-up credit never expires, even if you cancel Pro and come back later.",
+  },
+  {
+    question: "What happens when I run out of credit?",
+    answer:
+      "AI features pause until your monthly credit refreshes or you top up. Saving, editing, exporting — everything else in Grida keeps working. We never charge your card automatically to cover an AI call.",
+  },
+  {
+    question: "Are AI prices marked up?",
+    answer:
+      "No. We charge you exactly what the model provider charges us. Our margin lives in the base plan ($5 of every $20 Pro plan), not in AI usage. When provider prices change, we update what we charge to match.",
+  },
+  {
+    question: "What happens if I cancel?",
+    answer:
+      "You keep Pro and the current month's credit until the end of the period you've already paid for. After that, you switch to Free and start receiving $0.50 of credit each month. Any top-up credit you have stays in your account.",
+  },
+  {
+    question: "How does pricing work for teams?",
+    answer:
+      "Pro is per-seat — $20 per user per month — and there is no separate 'Team plan.' A solo user is just a 1-seat Pro subscription. A 5-person team is 5 seats: $100/month with $75 of pooled AI credit that anyone on the team can spend. Adding a member is prorated; removing one credits the next invoice. The owner counts as a seat.",
+  },
+];
+
+export default function PricingFAQ() {
+  return (
+    <div className="w-full max-w-3xl mx-auto">
+      <h2 className="text-4xl font-semibold text-center mb-8">
+        Frequently asked questions
+      </h2>
+      <Accordion type="multiple" className="w-full">
+        {faqs.map((faq, index) => (
+          <AccordionItem key={index} value={`item-${index}`}>
+            <AccordionTrigger>{faq.question}</AccordionTrigger>
+            <AccordionContent className="text-muted-foreground">
+              {faq.answer}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+      <p className="text-center text-sm text-muted-foreground mt-12">
+        For the full breakdown — examples, edge cases, and policies — see the{" "}
+        <Link
+          href="/docs/platform/billing"
+          className="underline underline-offset-4 text-foreground"
+        >
+          billing guide
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/editor/app/(www)/(pricing)/pricing/page.tsx
+++ b/editor/app/(www)/(pricing)/pricing/page.tsx
@@ -2,6 +2,7 @@ import { Pricing } from "@/www/pricing/pricing";
 import Header from "@/www/header";
 import FooterWithCTA from "@/www/footer-with-cta";
 import { Section } from "@/www/ui/section";
+import PricingFAQ from "./_sections/faq";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -16,6 +17,9 @@ export default function WWWPricingPage() {
       <div className="h-40" />
       <Section container>
         <Pricing />
+      </Section>
+      <Section container className="mt-32">
+        <PricingFAQ />
       </Section>
       <div className="h-96" />
       <FooterWithCTA />

--- a/editor/www/data/pricing.ts
+++ b/editor/www/data/pricing.ts
@@ -3,10 +3,9 @@ type Pricing = {
   highlight: PricingCategory;
   integrations: PricingCategory;
   storage: PricingCategory;
-  support: PricingCategory;
-  ticketing: PricingCategory;
   commerce: PricingCategory;
   channels: PricingCategory;
+  support: PricingCategory;
   commingsoon: PricingCategory;
 };
 
@@ -47,7 +46,7 @@ export const pricing: Pricing = {
         usage_based: false,
       },
       {
-        title: "Generated Image License",
+        title: "Generated Media License",
         plans: {
           free: "Public (CC0)",
           pro: "Full ownership",
@@ -67,20 +66,10 @@ export const pricing: Pricing = {
         usage_based: false,
       },
       {
-        title: "Credits Rollover",
-        plans: {
-          free: false,
-          pro: true,
-          team: true,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
-      {
         title: "Buy extra credits",
         plans: {
           free: false,
-          pro: false,
+          pro: true,
           team: true,
           enterprise: true,
         },
@@ -182,45 +171,20 @@ export const pricing: Pricing = {
         usage_based: false,
       },
       {
-        title: "Advanced Analytics",
+        title: "Simulator",
         plans: {
           free: false,
           pro: false,
-          team: true,
+          team: false,
           enterprise: true,
         },
-        usage_based: false,
+        usage_based: true,
       },
       {
         title: "Remove branding from Sites",
         plans: {
           free: false,
           pro: true,
-          team: true,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
-    ],
-  },
-  support: {
-    title: "Support",
-    features: [
-      {
-        title: "Community Support",
-        plans: {
-          free: true,
-          pro: true,
-          team: true,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
-      {
-        title: "Live chat support",
-        plans: {
-          free: false,
-          pro: false,
           team: true,
           enterprise: true,
         },
@@ -257,26 +221,6 @@ export const pricing: Pricing = {
     title: "Integrations",
     features: [
       {
-        title: "Connect to Google sheets",
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
-      {
-        title: "Connect to Notion Database",
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise: true,
-        },
-        usage_based: false,
-      },
-      {
         title: "Custom Domain",
         plans: {
           free: false,
@@ -298,43 +242,6 @@ export const pricing: Pricing = {
       },
     ],
   },
-  ticketing: {
-    title: "Ticketing",
-    features: [
-      {
-        title: "Concurrent Users",
-        plans: {
-          free: "Up to 50 concurrencies",
-          pro: "Up to 100 concurrencies",
-          team: "Up to 250 concurrencies",
-          enterprise:
-            "250 concurrencies included. then $100 / 500 concurrencies",
-        },
-        usage_based: true,
-      },
-      {
-        title: "Dedicated Servers for High demand",
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise:
-            "$3,000 initially. then $2,500 per 10,000 concurrencies (may vary)",
-        },
-        usage_based: true,
-      },
-      {
-        title: "Simulator",
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise: true,
-        },
-        usage_based: true,
-      },
-    ],
-  },
   commerce: {
     title: "Commerce",
     features: [
@@ -345,26 +252,6 @@ export const pricing: Pricing = {
           pro: "No additional fee",
           team: "No additional fee",
           enterprise: "No additional fee",
-        },
-        usage_based: false,
-      },
-      {
-        title: "Payments with Toss (for 🇰🇷)",
-        plans: {
-          free: false,
-          pro: false,
-          team: "Contact Sales",
-          enterprise: "Contact Sales",
-        },
-        usage_based: false,
-      },
-      {
-        title: "Ticketing for Events",
-        plans: {
-          free: false,
-          pro: false,
-          team: true,
-          enterprise: true,
         },
         usage_based: false,
       },
@@ -403,10 +290,15 @@ export const pricing: Pricing = {
         },
         usage_based: false,
       },
+    ],
+  },
+  support: {
+    title: "Support",
+    features: [
       {
-        title: "WhatsApp Notifications",
+        title: "Community Support",
         plans: {
-          free: false,
+          free: true,
           pro: true,
           team: true,
           enterprise: true,
@@ -414,12 +306,12 @@ export const pricing: Pricing = {
         usage_based: false,
       },
       {
-        title: "KakaoTalk Notifications (for 🇰🇷)",
+        title: "Live chat support",
         plans: {
           free: false,
           pro: false,
-          team: false,
-          enterprise: "Contact Sales",
+          team: true,
+          enterprise: true,
         },
         usage_based: false,
       },

--- a/editor/www/pricing/pricing-comparison-table.tsx
+++ b/editor/www/pricing/pricing-comparison-table.tsx
@@ -17,7 +17,6 @@ import {
   PlugZapIcon,
   ShoppingBagIcon,
   SparklesIcon,
-  TicketIcon,
 } from "lucide-react";
 
 function PricingMobileHeader({
@@ -67,7 +66,7 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
   return (
     <div
       id="compare-plans"
-      className="sm:pb-18 container relative top-48 mx-auto px-0 pb-16 md:pb-16 lg:px-16 xl:px-20"
+      className="sm:pb-18 container relative mt-48 mx-auto px-0 pb-16 md:pb-16 lg:px-16 xl:px-20"
     >
       {/* <!-- xs to lg --> */}
       <div className="lg:hidden">
@@ -128,11 +127,6 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
               icon={<ShoppingBagIcon className="size-4" />}
             />
             <PricingTableRowMobile
-              category={pricing.ticketing}
-              plan={"free"}
-              icon={<TicketIcon className="size-4" />}
-            />
-            <PricingTableRowMobile
               category={pricing.channels}
               plan={"free"}
               icon={<MessageCircleIcon className="size-4" />}
@@ -177,11 +171,6 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
               category={pricing.commerce}
               plan={"pro"}
               icon={<ShoppingBagIcon className="size-4" />}
-            />
-            <PricingTableRowMobile
-              category={pricing.ticketing}
-              plan={"pro"}
-              icon={<TicketIcon className="size-4" />}
             />
             <PricingTableRowMobile
               category={pricing.channels}
@@ -230,11 +219,6 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
               icon={<ShoppingBagIcon className="size-4" />}
             />
             <PricingTableRowMobile
-              category={pricing.ticketing}
-              plan={"team"}
-              icon={<TicketIcon className="size-4" />}
-            />
-            <PricingTableRowMobile
               category={pricing.channels}
               plan={"team"}
               icon={<MessageCircleIcon className="size-4" />}
@@ -276,11 +260,6 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
               category={pricing.commerce}
               plan={"enterprise"}
               icon={<ShoppingBagIcon className="size-4" />}
-            />
-            <PricingTableRowMobile
-              category={pricing.ticketing}
-              plan={"enterprise"}
-              icon={<TicketIcon className="size-4" />}
             />
             <PricingTableRowMobile
               category={pricing.channels}
@@ -378,19 +357,14 @@ const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
               sectionId="commerce"
             />
             <PricingTableRowDesktop
-              category={pricing.ticketing}
-              icon={<TicketIcon className="size-4" />}
-              sectionId="ticketing"
+              category={pricing.channels}
+              icon={<MessageCircleIcon className="size-4" />}
+              sectionId="channels"
             />
             <PricingTableRowDesktop
               category={pricing.support}
               icon={<MessageCircleQuestionIcon className="size-4" />}
               sectionId="support"
-            />
-            <PricingTableRowDesktop
-              category={pricing.channels}
-              icon={<MessageCircleIcon className="size-4" />}
-              sectionId="channels"
             />
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Add user-facing billing guide at `docs/platform/billing.mdx` covering plans, AI credits, $0.25 floor, top-ups, per-seat Pro, and team credit pooling
- Add FAQ section to `/pricing` linking to the billing guide
- Clean up the comparison features table — remove legacy/dishonest rows, drop the Ticketing category, move Simulator under Forms, gate "Buy extra credits" from Pro, rename "Generated Image License" → "Generated Media License", reorder so Support is the last section

## Test plan
- [ ] `/pricing` renders without layout collapse on desktop and mobile
- [ ] FAQ accordion expands/collapses; links navigate to `/docs/platform/billing`
- [ ] `/docs/platform/billing` renders cleanly under docs sidebar
- [ ] No broken references to the removed `pricing.ticketing` category