### PR TITLE
fix(billing): post-#705 follow-ups — backfill + cleanup

### DIFF
--- a/editor/app/(site)/organizations/[organization_name]/settings/billing/upgrade/_view.tsx
+++ b/editor/app/(site)/organizations/[organization_name]/settings/billing/upgrade/_view.tsx
@@ -313,11 +313,6 @@ export default function UpgradeView({
           );
         })}
       </div>
-
-      <p className="text-xs text-muted-foreground mt-4">
-        Test mode: use card <code>4242 4242 4242 4242</code>. After payment,
-        you&apos;ll be redirected back here. Provisioning takes a few seconds.
-      </p>
     </>
   );
 

--- a/supabase/migrations/20260507000000_grida_billing_backfill_provision.sql
+++ b/supabase/migrations/20260507000000_grida_billing_backfill_provision.sql
@@ -1,0 +1,28 @@
+-- Backfill billing provisioning for orgs that pre-date 20260506132900.
+--
+-- The base migration adds an `AFTER INSERT` trigger that calls
+-- `fn_provision_account` to create the `grida_billing.account` and free
+-- `grida_billing.subscription` rows. The trigger only fires on NEW orgs;
+-- pre-existing orgs were left without their billing rows. This blocks
+-- their first checkout because `fn_attach_stripe_customer` (correctly)
+-- refuses to attach a Stripe customer to a non-provisioned account.
+--
+-- Production hit this on org 255: "billing account not provisioned for
+-- organization 255".
+--
+-- Iterate every existing org and call `fn_provision_account` (idempotent:
+-- INSERT … ON CONFLICT DO NOTHING). The guard in fn_attach_stripe_customer
+-- stays loud — once the data is right, that RAISE is the correct behavior
+-- for any future anomaly (deleted row, bypassed trigger, partial restore).
+
+DO $$
+DECLARE
+  rec RECORD;
+  n   integer := 0;
+BEGIN
+  FOR rec IN SELECT id FROM public.organization LOOP
+    PERFORM grida_billing.fn_provision_account(rec.id);
+    n := n + 1;
+  END LOOP;
+  RAISE NOTICE 'grida_billing backfill: provisioned % organizations', n;
+END $$;


### PR DESCRIPTION
Follow-up to #705 (now merged). Two distinct fixes:

## 1. Production hot-fix: backfill billing rows for pre-migration orgs

#705's `20260506132900_grida_billing.sql` adds an `AFTER INSERT` trigger
that calls `fn_provision_account` to create the
`grida_billing.account` and free `grida_billing.subscription` rows for
new organizations. The trigger only fires on **new** orgs — pre-existing
ones never got their billing rows.

This blocked first checkout for any pre-migration org with:

```
Error: resolveOrCreateStripeCustomer attach: billing account not provisioned for organization 255
```

Single-shot data fix in `20260507000000_grida_billing_backfill_provision.sql`:
iterate `public.organization` and call `fn_provision_account` for each.
Idempotent — `fn_provision_account` uses `INSERT … ON CONFLICT DO NOTHING`.

The guard in `fn_attach_stripe_customer` stays loud — once the data is
correct, that `RAISE` is the right behavior for any future anomaly
(deleted row, bypassed trigger, partial restore). Adding self-heal in
the guard's path would silence real signal.

## 2. UX polish: drop dev test-card hint from upgrade page

`Test mode: use card 4242 4242 4242 4242…` was an unguarded footer on the
plan cards — visible in production. The test card number belongs in
[`docs/contributing/billing.md`](https://github.com/gridaco/grida/blob/main/docs/contributing/billing.md)
(where it already lives), not in the customer-facing UI. Other test-mode
copy (the "sandbox" disclaimer at the bottom of /billing) is correctly
gated behind `state.is_test_mode` — this string was the lone unguarded one.

## Test plan

- [x] Apply migration to production: `supabase db push`
- [x] Verify org 255 (and others previously affected) can now reach Stripe Checkout
- [x] Confirm the test-card hint no longer appears on `/organizations/<org>/settings/billing/upgrade`
- [x] Confirm the sandbox disclaimer (gated by `is_test_mode`) still appears in dev / staging where `BILLING_TEST_MODE=true`

## Related

- Builds on #705 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed test mode information from the billing upgrade view.

* **Chores**
  * Added database migration to backfill billing provisioning for existing organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->