### PR TITLE
feat(vercel): skip editor builds when no deps changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,5 +235,8 @@ __pycache__/
 .claude/scheduled_tasks.lock
 CLAUDE.local.md
 
+# Local-only cherry-pick / snapshot scratch
+/.tmp/
+
 # Local-only tracking docs
 /TODO.md

--- a/editor/skip-build.sh
+++ b/editor/skip-build.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Decide whether the editor build can be skipped for the current commit range.
+#
+# Exit 0 → no changed file is part of the editor's declared dependency tree;
+#          safe to skip the build.
+# Exit non-zero → at least one change is in a dep (or we couldn't tell).
+#
+# Tool-agnostic: usable wherever a CI runner can branch on an exit code
+# (Vercel ignoreCommand, GitHub Actions, etc.). The script itself knows
+# nothing about the host.
+#
+# Strategy: ALLOWLIST of known build dependencies, derived from
+# pnpm-workspace.yaml + editor/package.json (workspace:* deps) + turbo.json.
+# An entry MISSING from this list means real changes won't trigger a deploy
+# — keep it correct as the workspace topology evolves.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# DEPS — repo-relative patterns of paths the editor build consumes.
+#
+# Pattern syntax (gitignore-like, evaluated by bash `case`):
+#   "/foo"      → root-anchored: matches "foo" at repo root only
+#                 e.g. "/package.json" excludes "apps/x/package.json"
+#   "foo/"      → directory subtree (the dir and everything inside)
+#                 e.g. "packages/" matches "packages/grida-bitmap/src/x.ts"
+#   "foo/bar"   → exact path match
+#   "*.md"      → bash glob, matches anywhere in the tree
+#
+# Add or remove entries freely. Order does not matter.
+# ---------------------------------------------------------------------------
+DEPS=(
+  # workspace packages consumed by the editor (direct or transitive)
+  "editor/"
+  "database/"             # @app/database
+  "packages/"             # most @grida/* deps
+  "crates/grida-canvas-wasm/"  # @grida/canvas-wasm (lives under crates/)
+
+  # build orchestration at the repo root
+  "/package.json"
+  "/pnpm-workspace.yaml"
+  "/pnpm-lock.yaml"
+  "/turbo.json"
+)
+
+is_dep() {
+  local f="$1" p
+  for p in "${DEPS[@]}"; do
+    case "$p" in
+      /*)
+        # root-anchored exact
+        case "$f" in "${p#/}") return 0 ;; esac
+        ;;
+      */)
+        # directory subtree (prefix match)
+        case "$f" in "$p"*) return 0 ;; esac
+        ;;
+      *)
+        # glob (right-hand side intentionally unquoted)
+        # shellcheck disable=SC2254
+        case "$f" in $p) return 0 ;; esac
+        ;;
+    esac
+  done
+  return 1
+}
+
+# Compare against the previous deployed/built SHA when the host provides one
+# (Vercel sets VERCEL_GIT_PREVIOUS_SHA), otherwise fall back to the parent
+# commit. If neither resolves, build to be safe.
+BASE="${PREVIOUS_SHA:-${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}}"
+
+if ! CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null); then
+  echo "[skip-build] could not diff against $BASE — building."
+  exit 1
+fi
+
+if [ -z "$CHANGED" ]; then
+  echo "[skip-build] empty diff against $BASE — building."
+  exit 1
+fi
+
+DEP_HITS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  is_dep "$f" && DEP_HITS+=("$f")
+done <<< "$CHANGED"
+
+if [ ${#DEP_HITS[@]} -eq 0 ]; then
+  echo "[skip-build] no changes in editor build deps — skipping."
+  echo "$CHANGED" | sed 's/^/  /'
+  exit 0
+fi
+
+echo "[skip-build] changes touch editor build deps — building."
+printf '  %s\n' "${DEP_HITS[@]}"
+exit 1

--- a/editor/vercel.json
+++ b/editor/vercel.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json"
+}

--- a/editor/vercel.json
+++ b/editor/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash skip-build.sh"
 }


### PR DESCRIPTION
## Summary

- Add `editor/vercel.json` with `ignoreCommand: bash skip-build.sh`
- Add `editor/skip-build.sh` — tool-agnostic build-skip script (Vercel ignoreCommand-compatible; reusable from GitHub Actions etc.)
- Allowlist of editor build deps derived from `pnpm-workspace.yaml`, editor's `workspace:*` deps, and `turbo.json`

## Behavior

Skips the deploy when the diff (`VERCEL_GIT_PREVIOUS_SHA..HEAD`, falling back to `HEAD^..HEAD`) touches **nothing** in:

```
editor/                       # the app
database/                     # @app/database
packages/                     # @grida/* (most)
crates/grida-canvas-wasm/     # @grida/canvas-wasm (lives under crates/)
/package.json
/pnpm-workspace.yaml
/pnpm-lock.yaml
/turbo.json
```

Anything else triggers a normal build. On any error (shallow clone, bad ref, etc.), it builds — fail-safe defaults to deploying.

### Pattern syntax (gitignore-like)

| Pattern | Meaning |
|---|---|
| `foo/` | directory subtree |
| `/foo` | root-anchored exact |
| `foo/bar` | exact path |
| `*.md` | bash glob, anywhere |

## Why allowlist (not denylist)

For a build, the dep set is bounded and declarable (workspace + turbo). An allowlist miss = real change skipped (correctness bug, user-visible); a denylist miss = wasted build. Allowlist is tighter and more principled here. The risk of a miss is mitigated because new deps require a `workspace:*` entry in `editor/package.json`, which itself is in the allowlist.

## Verified

Tested against real recent commits — all classifications correct:

| Commit | Touches | Verdict |
|---|---|---|
| `60b903ef6` | `.gitignore` | SKIP ✓ |
| `7e59da513` | `editor/vercel.json` | BUILD ✓ |
| `7852e25ae` | `editor/.../upgrade/_view.tsx` | BUILD ✓ |
| `bc59656eb` | `supabase/migrations/*.sql` | SKIP ✓ |
| `9aeef5ac7` | `editor/lib/billing/index.ts` | BUILD ✓ |
| `f1b70a600` | `justfile` + `supabase/{migrations,schemas}/` | SKIP ✓ |

## Test plan

- [ ] Merge and observe one deploy: confirm Vercel logs show `[skip-build]` line and the expected build/skip verdict
- [ ] Land a docs-only or `supabase/`-only follow-up commit; confirm the editor deploy is skipped
- [ ] Land a normal `editor/**` commit; confirm the editor deploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` configuration to exclude development-only temporary directories from version control.
  * Enhanced CI/CD pipeline performance with intelligent build optimization: Editor builds are now intelligently skipped when only files unrelated to editor functionality are modified, reducing unnecessary build executions and accelerating development velocity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->