### PR TITLE
feat(vercel): skip blog and viewer builds when no deps changed

### DIFF
--- a/apps/blog/skip-build.sh
+++ b/apps/blog/skip-build.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Decide whether the blog build can be skipped for the current commit range.
+#
+# Exit 0 → no changed file is part of the blog site's declared dependency
+#          tree; safe to skip the build.
+# Exit non-zero → at least one change is in a dep (or we couldn't tell).
+#
+# Same shape as editor/skip-build.sh — tool-agnostic, usable wherever a CI
+# runner can branch on an exit code (Vercel ignoreCommand, GitHub Actions).
+# The script itself knows nothing about the host.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# DEPS — repo-relative patterns of paths the blog build consumes.
+#
+# The blog is a self-contained Docusaurus project under apps/blog. Content
+# lives inside apps/blog/blog/ — nothing else in the workspace is pulled in
+# (no workspace:* deps).
+#
+# Pattern syntax (gitignore-like, evaluated by bash `case`):
+#   "/foo"      → root-anchored: matches "foo" at repo root only
+#   "foo/"      → directory subtree (the dir and everything inside)
+#   "foo/bar"   → exact path match
+#   "*.md"      → bash glob, matches anywhere in the tree
+# ---------------------------------------------------------------------------
+DEPS=(
+  # the Docusaurus project itself (includes content under apps/blog/blog/)
+  "apps/blog/"
+
+  # build orchestration at the repo root
+  "/package.json"
+  "/pnpm-workspace.yaml"
+  "/pnpm-lock.yaml"
+  "/turbo.json"
+)
+
+is_dep() {
+  local f="$1" p
+  for p in "${DEPS[@]}"; do
+    case "$p" in
+      /*)
+        case "$f" in "${p#/}") return 0 ;; esac
+        ;;
+      */)
+        case "$f" in "$p"*) return 0 ;; esac
+        ;;
+      *)
+        # shellcheck disable=SC2254
+        case "$f" in $p) return 0 ;; esac
+        ;;
+    esac
+  done
+  return 1
+}
+
+BASE="${PREVIOUS_SHA:-${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}}"
+
+if ! CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null); then
+  echo "[skip-build] could not diff against $BASE — building."
+  exit 1
+fi
+
+if [ -z "$CHANGED" ]; then
+  echo "[skip-build] empty diff against $BASE — building."
+  exit 1
+fi
+
+DEP_HITS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  is_dep "$f" && DEP_HITS+=("$f")
+done <<< "$CHANGED"
+
+if [ ${#DEP_HITS[@]} -eq 0 ]; then
+  echo "[skip-build] no changes in blog build deps — skipping."
+  echo "$CHANGED" | sed 's/^/  /'
+  exit 0
+fi
+
+echo "[skip-build] changes touch blog build deps — building."
+printf '  %s\n' "${DEP_HITS[@]}"
+exit 1

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash skip-build.sh"
+}

--- a/apps/viewer/skip-build.sh
+++ b/apps/viewer/skip-build.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Decide whether the viewer build can be skipped for the current commit range.
+#
+# Exit 0 → no changed file is part of the viewer app's declared dependency
+#          tree; safe to skip the build.
+# Exit non-zero → at least one change is in a dep (or we couldn't tell).
+#
+# Same shape as editor/skip-build.sh — tool-agnostic, usable wherever a CI
+# runner can branch on an exit code (Vercel ignoreCommand, GitHub Actions).
+# The script itself knows nothing about the host.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# DEPS — repo-relative patterns of paths the viewer build consumes.
+#
+# The viewer is a self-contained Next.js app under apps/viewer with no
+# workspace:* deps — nothing else in the monorepo is pulled in at build time.
+#
+# Pattern syntax (gitignore-like, evaluated by bash `case`):
+#   "/foo"      → root-anchored: matches "foo" at repo root only
+#   "foo/"      → directory subtree (the dir and everything inside)
+#   "foo/bar"   → exact path match
+#   "*.md"      → bash glob, matches anywhere in the tree
+# ---------------------------------------------------------------------------
+DEPS=(
+  # the Next.js app itself
+  "apps/viewer/"
+
+  # build orchestration at the repo root
+  "/package.json"
+  "/pnpm-workspace.yaml"
+  "/pnpm-lock.yaml"
+  "/turbo.json"
+)
+
+is_dep() {
+  local f="$1" p
+  for p in "${DEPS[@]}"; do
+    case "$p" in
+      /*)
+        case "$f" in "${p#/}") return 0 ;; esac
+        ;;
+      */)
+        case "$f" in "$p"*) return 0 ;; esac
+        ;;
+      *)
+        # shellcheck disable=SC2254
+        case "$f" in $p) return 0 ;; esac
+        ;;
+    esac
+  done
+  return 1
+}
+
+BASE="${PREVIOUS_SHA:-${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}}"
+
+if ! CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null); then
+  echo "[skip-build] could not diff against $BASE — building."
+  exit 1
+fi
+
+if [ -z "$CHANGED" ]; then
+  echo "[skip-build] empty diff against $BASE — building."
+  exit 1
+fi
+
+DEP_HITS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  is_dep "$f" && DEP_HITS+=("$f")
+done <<< "$CHANGED"
+
+if [ ${#DEP_HITS[@]} -eq 0 ]; then
+  echo "[skip-build] no changes in viewer build deps — skipping."
+  echo "$CHANGED" | sed 's/^/  /'
+  exit 0
+fi
+
+echo "[skip-build] changes touch viewer build deps — building."
+printf '  %s\n' "${DEP_HITS[@]}"
+exit 1

--- a/apps/viewer/vercel.json
+++ b/apps/viewer/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash skip-build.sh"
+}


### PR DESCRIPTION
## Summary

Extends the `vercel.json` + `skip-build.sh` pattern from [#710](https://github.com/gridaco/grida/pull/710) (editor) and [b3063baae](https://github.com/gridaco/grida/commit/b3063baae) (docs) to the remaining two Vercel-deployed apps:

- `apps/blog/` — Docusaurus
- `apps/viewer/` — Next.js

Each app gets:

- `vercel.json` with `ignoreCommand: bash skip-build.sh`
- `skip-build.sh` — same tool-agnostic shape as the editor/docs scripts

## Allowlists

Both apps are self-contained with **no `workspace:*` deps**, so each allowlist is just the app dir plus the repo-root build orchestration files:

```
apps/blog/   |  apps/viewer/
/package.json
/pnpm-workspace.yaml
/pnpm-lock.yaml
/turbo.json
```

If/when either app starts pulling in `@grida/*` or `@app/*` packages, the allowlist needs to grow — the comment at the top of each script calls this out.

## Verified

Tested against recent commits — all classifications correct:

| Commit | Touches | blog | viewer |
|---|---|---|---|
| `b3063baae` | `apps/docs/**` | SKIP ✓ | SKIP ✓ |
| `400eebad6` | `editor/**` | SKIP ✓ | SKIP ✓ |
| `e445c119d` | `apps/blog/**` + lockfile | BUILD ✓ | BUILD ✓ (lockfile) |
| `813542b17` | `apps/blog/**` + `apps/viewer/**` | BUILD ✓ | BUILD ✓ |
| `fd7c8f7f2` | lockfile + `apps/viewer/**` | BUILD ✓ (lockfile) | BUILD ✓ |
| `2fc305b31` | lockfile + `turbo.json` | BUILD ✓ | BUILD ✓ |

## Test plan

- [ ] Merge and observe one deploy of each project: confirm Vercel logs show `[skip-build]` line and the expected verdict
- [ ] Land an unrelated commit (e.g. `editor/**` or `apps/docs/**`); confirm both blog and viewer deploys are skipped
- [ ] Land a commit touching `apps/blog/**` or `apps/viewer/**`; confirm that project deploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added build optimization configuration for blog and viewer applications. Builds will now be conditionally skipped based on changed files, improving deployment efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/713)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->