### PR TITLE
feat(keygen): add CRON_SECRET generator

### DIFF
--- a/editor/app/(tools)/tools/keygen/_page.tsx
+++ b/editor/app/(tools)/tools/keygen/_page.tsx
@@ -27,6 +27,7 @@ type ScenarioId =
   | "webhook"
   | "jwt-hs256"
   | "session"
+  | "cron-secret"
   | "jwt-keypair"
   | "aes-256-gcm"
   | "xchacha20-poly1305"
@@ -45,6 +46,7 @@ type Scenario = {
   defaultEncoding?: Encoding;
   envKeys?: string[];
   headerKey?: string;
+  headerValuePrefix?: string;
   jsonKey?: string;
   supportedFormats: CopyFormat[];
   panelDescription: string[];
@@ -87,6 +89,7 @@ type QuickPickId =
   | "webhook"
   | "jwt-hs256"
   | "session"
+  | "cron-secret"
   | "aes-256-gcm"
   | "xchacha20-poly1305";
 
@@ -127,6 +130,14 @@ const QUICK_PICKS: QuickPickSpec[] = [
   {
     id: "session",
     title: "Session secret",
+    count: 3,
+    layout: "list",
+    bytes: 32,
+    encoding: "base64url",
+  },
+  {
+    id: "cron-secret",
+    title: "CRON_SECRET",
     count: 3,
     layout: "list",
     bytes: 32,
@@ -271,6 +282,40 @@ const token = jwt.sign({ sub: userId }, secret, {
       "Generate a session secret for cookie signing and server side session storage.",
   },
   {
+    id: "cron-secret",
+    title: "Vercel CRON_SECRET Generator",
+    shortTitle: "CRON_SECRET",
+    whenToUse:
+      "Use to authenticate Vercel Cron, Upstash QStash, or GitHub Actions cron requests.",
+    defaultLine: "Default: 32 bytes, base64url.",
+    kind: "bytes",
+    defaultBytes: 32,
+    strongBytes: 64,
+    defaultEncoding: "base64url",
+    envKeys: ["CRON_SECRET"],
+    headerKey: "Authorization",
+    headerValuePrefix: "Bearer ",
+    jsonKey: "cronSecret",
+    supportedFormats: ["plain", "env", "header", "json"],
+    panelDescription: [
+      "Bearer token for protecting scheduled job endpoints.",
+      "Vercel Cron sends it as Authorization: Bearer <CRON_SECRET>.",
+    ],
+    safetyNote: "Anyone with this secret can trigger your cron endpoints.",
+    howToUse: `// app/api/cron/route.ts
+export async function GET(req: Request) {
+  const auth = req.headers.get("authorization");
+  if (auth !== \`Bearer \${process.env.CRON_SECRET}\`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  // run scheduled job
+  return Response.json({ ok: true });
+}`,
+    anchorId: "vercel-cron-secret-generator",
+    seoDescription:
+      "Generate a CRON_SECRET to authenticate Vercel Cron, Upstash QStash, or GitHub Actions cron requests via the Authorization header.",
+  },
+  {
     id: "jwt-keypair",
     title: "JWT Keypair Generator (RS256 / ES256)",
     shortTitle: "JWT keypair",
@@ -403,6 +448,11 @@ const FAQ_ITEMS = [
       "AES-256-GCM and XChaCha20-Poly1305 keys: should I use 32 or 64 bytes?",
     answer:
       "Use 32 bytes. AES-256 and XChaCha20-Poly1305 require 256-bit (32-byte) keys. If you need to derive keys from longer secrets, use a KDF (like HKDF/scrypt/Argon2) instead of passing a 64-byte value directly as a cipher key.",
+  },
+  {
+    question: "What is CRON_SECRET and how do I use it with Vercel Cron?",
+    answer:
+      'CRON_SECRET is a shared bearer token that protects scheduled job endpoints from public invocation. Set it as an environment variable, and Vercel Cron will send it as "Authorization: Bearer <CRON_SECRET>" on each request. Verify the header in your route handler and reject anything that doesn\'t match. 32 random bytes (base64url) is a strong default.',
   },
   {
     question: "HS256 vs RS256 vs ES256 for JWT: which should I use?",
@@ -546,7 +596,8 @@ function buildSingleValueOutput({
 
   if (format === "header") {
     const headerKey = scenario.headerKey ?? "x-secret";
-    return `${headerKey}: ${value}`;
+    const prefix = scenario.headerValuePrefix ?? "";
+    return `${headerKey}: ${prefix}${value}`;
   }
 
   const jsonKey = scenario.jsonKey ?? "secret";

--- a/editor/app/(tools)/tools/keygen/page.tsx
+++ b/editor/app/(tools)/tools/keygen/page.tsx
@@ -6,14 +6,14 @@ import ServerSecretGeneratorTool from "./_page";
 export const metadata: Metadata = {
   title: "Keygen (Server Secret Generator)",
   description:
-    "Generate secure server secrets locally: S2S API keys, webhook signing secrets, JWT keys, session secrets, encryption keys, and PKCE.",
+    "Generate secure server secrets locally: S2S API keys, webhook secrets, JWT, session, CRON_SECRET, encryption keys, and PKCE.",
   keywords:
-    "keygen, server secret generator, s2s api key, webhook signing secret, jwt secret, session secret, aes-256-gcm key, xchacha20-poly1305 key, pkce",
+    "keygen, server secret generator, s2s api key, webhook signing secret, jwt secret, session secret, cron_secret, vercel cron secret, aes-256-gcm key, xchacha20-poly1305 key, pkce",
   category: "Developer Tools",
   openGraph: {
     title: "Keygen (Server Secret Generator)",
     description:
-      "Generate secure server secrets locally: S2S API keys, webhook signing secrets, JWT keys, session secrets, encryption keys, and PKCE.",
+      "Generate secure server secrets locally: S2S API keys, webhook secrets, JWT, session, CRON_SECRET, encryption keys, and PKCE.",
     type: "website",
     url: "https://grida.co/tools/keygen",
   },


### PR DESCRIPTION
## Summary

- Add a dedicated **CRON_SECRET** scenario to the Keygen tool (`/tools/keygen`) covering Vercel Cron, Upstash QStash, and GitHub Actions cron handlers.
- Extend the Header copy format with an optional `headerValuePrefix` so CRON_SECRET emits `Authorization: Bearer <value>` cleanly while every other preset stays unchanged.
- Update page metadata, FAQ, and the SEO anchor section so the new preset is discoverable in search and from the FAQ JSON-LD.

## Details

**New scenario `cron-secret`**
- 32-byte base64url default (64B strong), env key `CRON_SECRET`.
- Quick-pick card placed right after Session secret.
- Anchor section `#vercel-cron-secret-generator` with FAQ entry covering "What is CRON_SECRET and how do I use it with Vercel Cron?".
- "How to use" snippet shows an App Router cron route handler verifying `Authorization: Bearer ${process.env.CRON_SECRET}`.

**Header format**
- Added `headerValuePrefix?: string` to `Scenario` and threaded it through `buildSingleValueOutput`. CRON_SECRET sets `"Bearer "`; every other scenario behaves exactly as before.

**SEO** (followed `/seo` skill checklist)
- `description` and `openGraph.description` updated to mention CRON_SECRET while staying under 160 characters.
- `keywords` extended with `cron_secret, vercel cron secret`.
- Page metadata title unchanged; FAQ entry is automatically included in the existing `FAQPage` JSON-LD via the shared `FAQ_ITEMS` array.
- Anchor section follows the existing pattern so the in-page link from each card resolves to a crawlable section with `seoDescription`.

## Test plan

- [x] `/tools/keygen` returns 200 in local dev
- [x] Quick Picks shows new CRON_SECRET card in expected position (between Session secret and AES-256-GCM)
- [x] "Vercel CRON_SECRET Generator" card link resolves to `#vercel-cron-secret-generator`
- [x] Generate button on the CRON_SECRET card populates the generator panel
- [x] Header copy format produces `Authorization: Bearer <token>`
- [x] .env copy format produces `CRON_SECRET="<token>"`
- [x] Other scenarios' Header output unchanged (no `Bearer ` prefix)
- [ ] Visual review of the new card and panel in a deployed preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating Vercel CRON_SECRET with base64url formatting and multiple output formats.
  * Added header value prefix option for secret output customization.

* **Documentation**
  * Extended FAQ with guidance on using CRON_SECRET with Vercel Cron via the Authorization header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/715)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->