### PR TITLE
chore(packages): publish releases across cmath/svg/tree-view/keybinding/text-editor

### DIFF
--- a/packages/grida-cmath/_assert.ts
+++ b/packages/grida-cmath/_assert.ts
@@ -1,0 +1,3 @@
+export function assert(cond: unknown, message?: string): asserts cond {
+  if (!cond) throw new Error(message ?? "Assertion failed");
+}

--- a/packages/grida-cmath/_layout.ts
+++ b/packages/grida-cmath/_layout.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "./_assert";
 import cmath from "./index";
 
 export namespace layout {

--- a/packages/grida-cmath/_snap.ts
+++ b/packages/grida-cmath/_snap.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "./_assert";
 import cmath from "./index";
 
 interface IDistance {

--- a/packages/grida-cmath/index.ts
+++ b/packages/grida-cmath/index.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import { assert } from "./_assert";
 
 /**
  * cmath, a 2D canvas math module.

--- a/packages/grida-cmath/package.json
+++ b/packages/grida-cmath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/cmath",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "private": false,
   "description": "unopinionated canvas math",
   "keywords": [

--- a/packages/grida-keybinding/package.json
+++ b/packages/grida-keybinding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/keybinding",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Declarative keybinding primitives — types, modifiers, platform resolution, and event matching. Building blocks for hotkey systems; not a hotkey manager.",
   "keywords": [
     "hotkey",

--- a/packages/grida-svg/README.md
+++ b/packages/grida-svg/README.md
@@ -2,15 +2,18 @@
 
 Grida-owned SVG tooling for parsing, transforming, and authoring SVG data.
 
-This package is being developed outside the main Grida monorepo first, then will be moved into the monorepo once the port is complete and verified. The first milestone preserves exact behavior and test coverage from `svg-pathdata` while exposing path-data-specific APIs only through `@grida/svg/pathdata`.
+The path-data layer is a parity port of [`svg-pathdata`](https://github.com/nfroidure/svg-pathdata) — same shape, same tests — exposed under `@grida/svg/pathdata`. Additional subpaths (`/parse`, `/parser`) cover SVG attribute strings and round-trip XML parsing. The root `@grida/svg` export is reserved for future SVG-wide APIs and does not re-export anything from the subpaths.
 
 ## Package layout
 
 ```txt
 src/
   index.ts             # future root SVG-wide APIs; intentionally does not export path data
-  pathdata/            # copied path[d] parser/encoder/transform implementation; kebab-case filenames
+  pathdata/            # path[d] parser/encoder/transform implementation; kebab-case filenames
     __tests__/         # path-data parity tests, run with Vitest
+  parse/               # SVG attribute-string parsing primitives (numbers, points, transform fragments)
+    __tests__/
+  parser/              # round-trip XML/SVG parser (preserves trivia for byte-equal save)
 ```
 
 ## Scripts
@@ -26,7 +29,9 @@ pnpm fmt:check
 
 ## Current API
 
-Path data is intentionally exposed through a direct subpath export so consumers only import the SVG domain they need:
+Each SVG domain is exposed through its own subpath so consumers only import what they need. The root `@grida/svg` export is reserved for future SVG-wide APIs and does not re-export anything from the subpaths.
+
+### `@grida/svg/pathdata`
 
 ```ts
 import { SVGPathData, encodeSVGPath } from "@grida/svg/pathdata";
@@ -35,7 +40,28 @@ const commands = new SVGPathData("M0 0L10 10").toAbs().commands;
 const d = encodeSVGPath(commands);
 ```
 
-The root `@grida/svg` export is reserved for future SVG-wide APIs and does not re-export path data.
+### `@grida/svg/parse`
+
+Pure SVG attribute-string parsing primitives. No DOM, no editor types — just regex-backed parsers for the fragments callers actually need (`number`, `points`, first `M` in a `d=`, leading `translate(...)` in a `transform=`).
+
+```ts
+import { svg_parse } from "@grida/svg/parse";
+
+const pts = svg_parse.parse_points("10,20 30,40");
+const move = svg_parse.parse_path_first_move("M 10 20 L 30 40");
+```
+
+### `@grida/svg/parser`
+
+Minimal XML/SVG parser that preserves source trivia (attribute order, quote styles, whitespace, comments, prolog, doctype, namespace prefixes) so editors can round-trip `load(x) → serialize() === x` for trivial inputs.
+
+```ts
+import { parse_svg, type ParseResult } from "@grida/svg/parser";
+
+const result: ParseResult = parse_svg(
+  '<svg xmlns="http://www.w3.org/2000/svg" />'
+);
+```
 
 ## Upstream attribution
 

--- a/packages/grida-svg/package.json
+++ b/packages/grida-svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grida/svg",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "private": false,
   "description": "Grida-owned SVG tooling for parsing, transforming, and authoring SVG data.",
   "keywords": [
     "encoder",
@@ -35,11 +35,25 @@
       "types": "./dist/pathdata/index.d.mts",
       "import": "./dist/pathdata/index.mjs",
       "require": "./dist/pathdata/index.cjs"
+    },
+    "./parse": {
+      "types": "./dist/parse/index.d.mts",
+      "import": "./dist/parse/index.mjs",
+      "require": "./dist/parse/index.cjs"
+    },
+    "./parser": {
+      "types": "./dist/parser/index.d.mts",
+      "import": "./dist/parser/index.mjs",
+      "require": "./dist/parser/index.cjs"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "prepack": "tsdown",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   }

--- a/packages/grida-svg/src/parse/__tests__/svg-parse.test.ts
+++ b/packages/grida-svg/src/parse/__tests__/svg-parse.test.ts
@@ -121,6 +121,14 @@ describe("parse_path_first_move", () => {
   it("returns null when the M is followed by non-numeric junk", () => {
     expect(parse_path_first_move("M abc def")).toBeNull();
   });
+
+  it("parses sign-delimited compact form (M10-20)", () => {
+    // Minified path data packs pairs using the sign of the second
+    // number as the delimiter. Per SVG path syntax this is valid.
+    expect(parse_path_first_move("M10-20L30,40")).toEqual({ x: 10, y: -20 });
+    expect(parse_path_first_move("M-1.5-2.5")).toEqual({ x: -1.5, y: -2.5 });
+    expect(parse_path_first_move("M10+20")).toEqual({ x: 10, y: 20 });
+  });
 });
 
 describe("parse_leading_translate", () => {
@@ -169,6 +177,21 @@ describe("parse_leading_translate", () => {
       tx: -15,
       ty: 0.5,
       rest: "",
+    });
+  });
+
+  it("parses single-argument translate (implicit ty=0)", () => {
+    // Per SVG transform syntax, translate(tx) is valid and means
+    // translate(tx, 0). Common in minified output.
+    expect(parse_leading_translate("translate(10)")).toEqual({
+      tx: 10,
+      ty: 0,
+      rest: "",
+    });
+    expect(parse_leading_translate("translate(-3.5) rotate(45)")).toEqual({
+      tx: -3.5,
+      ty: 0,
+      rest: "rotate(45)",
     });
   });
 });

--- a/packages/grida-svg/src/parse/__tests__/svg-parse.test.ts
+++ b/packages/grida-svg/src/parse/__tests__/svg-parse.test.ts
@@ -1,0 +1,201 @@
+// Pure svg-string parsing primitives. Headless — no editor, no DOM.
+
+import { describe, expect, it } from "vitest";
+import { svg_parse } from "../svg-parse.js";
+
+const {
+  parse_number,
+  parse_points,
+  parse_path_first_move,
+  parse_leading_translate,
+  points_top_left,
+} = svg_parse;
+
+describe("parse_number", () => {
+  it("parses positive integers", () => {
+    expect(parse_number("42")).toBe(42);
+  });
+
+  it("parses negative + fractional + exponent", () => {
+    expect(parse_number("-3.14")).toBe(-3.14);
+    expect(parse_number("1.5e2")).toBe(150);
+    expect(parse_number(".5")).toBe(0.5);
+  });
+
+  it("returns fallback for null / empty / non-finite", () => {
+    expect(parse_number(null)).toBe(0);
+    expect(parse_number("")).toBe(0);
+    expect(parse_number("not a number")).toBe(0);
+    expect(parse_number("NaN")).toBe(0);
+    expect(parse_number("Infinity")).toBe(0);
+  });
+
+  it("respects custom fallback", () => {
+    expect(parse_number(null, 99)).toBe(99);
+    expect(parse_number("bad", -1)).toBe(-1);
+  });
+
+  it("tolerates trailing junk via parseFloat semantics", () => {
+    // parseFloat stops at the first non-numeric char — same as SVG attr
+    // parsing in browsers.
+    expect(parse_number("42px")).toBe(42);
+  });
+});
+
+describe("parse_points", () => {
+  it("parses comma-separated pairs", () => {
+    expect(parse_points("10,20 30,40")).toEqual([
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ]);
+  });
+
+  it("parses whitespace-separated coords", () => {
+    expect(parse_points("10 20 30 40")).toEqual([
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ]);
+  });
+
+  it("tolerates mixed separators (comma + whitespace)", () => {
+    expect(parse_points("10, 20  30 ,40")).toEqual([
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ]);
+  });
+
+  it("parses fractional + negative + exponent", () => {
+    expect(parse_points("-1.5,2e1 .5,-0.25")).toEqual([
+      { x: -1.5, y: 20 },
+      { x: 0.5, y: -0.25 },
+    ]);
+  });
+
+  it("drops a trailing odd number (incomplete pair)", () => {
+    expect(parse_points("10,20 30")).toEqual([{ x: 10, y: 20 }]);
+  });
+
+  it("returns [] for empty / null-ish / unparseable input", () => {
+    expect(parse_points("")).toEqual([]);
+    expect(parse_points("   ")).toEqual([]);
+    expect(parse_points("nope")).toEqual([]);
+  });
+
+  it("ignores non-numeric tokens between numbers (lenient)", () => {
+    // SVG parsers are tolerant of mixed input; we follow parseFloat
+    // semantics — tokenize all numbers, pair them up.
+    expect(parse_points("10,20 garbage 30,40")).toEqual([
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ]);
+  });
+});
+
+describe("parse_path_first_move", () => {
+  it("parses uppercase M with comma separator", () => {
+    expect(parse_path_first_move("M 10,20 L 30,40")).toEqual({ x: 10, y: 20 });
+  });
+
+  it("parses lowercase m (treated as absolute per spec)", () => {
+    expect(parse_path_first_move("m 5 7 l 3 4")).toEqual({ x: 5, y: 7 });
+  });
+
+  it("parses fractional + negative coords", () => {
+    expect(parse_path_first_move("M-1.5,2.5 L 3 4")).toEqual({
+      x: -1.5,
+      y: 2.5,
+    });
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(parse_path_first_move("   M 1 2")).toEqual({ x: 1, y: 2 });
+  });
+
+  it("returns null for empty / unparseable", () => {
+    expect(parse_path_first_move("")).toBeNull();
+    expect(parse_path_first_move("not a path")).toBeNull();
+    // A path that starts with L is invalid SVG; we don't attempt recovery.
+    expect(parse_path_first_move("L 10 20")).toBeNull();
+  });
+
+  it("returns null when the M is followed by non-numeric junk", () => {
+    expect(parse_path_first_move("M abc def")).toBeNull();
+  });
+});
+
+describe("parse_leading_translate", () => {
+  it("parses a bare translate", () => {
+    expect(parse_leading_translate("translate(10 20)")).toEqual({
+      tx: 10,
+      ty: 20,
+      rest: "",
+    });
+  });
+
+  it("parses comma-separated translate", () => {
+    expect(parse_leading_translate("translate(10, 20)")).toEqual({
+      tx: 10,
+      ty: 20,
+      rest: "",
+    });
+  });
+
+  it("preserves a trailing transform", () => {
+    expect(parse_leading_translate("translate(5 7) rotate(30)")).toEqual({
+      tx: 5,
+      ty: 7,
+      rest: "rotate(30)",
+    });
+  });
+
+  it("trims trailing whitespace in `rest`", () => {
+    const r = parse_leading_translate("translate(0 0)   scale(2)   ");
+    expect(r).toEqual({ tx: 0, ty: 0, rest: "scale(2)" });
+  });
+
+  it("returns null when transform doesn't lead with translate", () => {
+    expect(parse_leading_translate("rotate(30) translate(10 20)")).toBeNull();
+    expect(parse_leading_translate("scale(2)")).toBeNull();
+    expect(parse_leading_translate("matrix(1 0 0 1 10 20)")).toBeNull();
+  });
+
+  it("returns null for null / empty", () => {
+    expect(parse_leading_translate(null)).toBeNull();
+    expect(parse_leading_translate("")).toBeNull();
+  });
+
+  it("parses fractional + negative + exponent values", () => {
+    expect(parse_leading_translate("translate(-1.5e1, .5)")).toEqual({
+      tx: -15,
+      ty: 0.5,
+      rest: "",
+    });
+  });
+});
+
+describe("points_top_left", () => {
+  it("returns min(x), min(y) across pairs", () => {
+    expect(
+      points_top_left([
+        { x: 5, y: 10 },
+        { x: 2, y: 12 },
+        { x: 8, y: 3 },
+      ])
+    ).toEqual({ x: 2, y: 3 });
+  });
+
+  it("returns null for empty array", () => {
+    expect(points_top_left([])).toBeNull();
+  });
+
+  it("handles a single point", () => {
+    expect(points_top_left([{ x: 5, y: 10 }])).toEqual({ x: 5, y: 10 });
+  });
+
+  it("works composed with parse_points (round-trip)", () => {
+    expect(points_top_left(parse_points("30,5 10,50 20,15"))).toEqual({
+      x: 10,
+      y: 5,
+    });
+  });
+});

--- a/packages/grida-svg/src/parse/index.ts
+++ b/packages/grida-svg/src/parse/index.ts
@@ -1,0 +1,1 @@
+export { svg_parse } from "./svg-parse.js";

--- a/packages/grida-svg/src/parse/svg-parse.ts
+++ b/packages/grida-svg/src/parse/svg-parse.ts
@@ -1,0 +1,141 @@
+// SVG string-parsing primitives.
+//
+// Every regex / split / lexical parse that reads SVG content lives here.
+// Other modules call into this namespace; they MUST NOT roll their own
+// parsing.
+//
+// Rules:
+//   - Inputs are raw SVG attribute strings (or `null`).
+//   - Outputs are typed values or `null` on parse failure.
+//   - Functions are pure and deterministic.
+//   - Regexes for SVG production fragments (numbers, commands, function
+//     names) are defined ONCE at module top and reused.
+//   - No `SvgDocument`, no DOM types, no editor types — only primitives.
+//
+// Usage:
+//
+//   import { svg_parse } from "@grida/svg/parse";
+//   const pts = svg_parse.parse_points("10,20 30,40");
+//   const tx = svg_parse.parse_leading_translate(node.getAttribute("transform"));
+
+/** SVG `<number>` production (spec-aligned subset): optional sign, integer
+ *  and/or fractional digits, optional scientific exponent. Matches each
+ *  number wholly; consumers anchor / chain as needed. */
+const SVG_NUMBER = "[+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?";
+
+/** Leading `translate(tx ty)` (whitespace- or comma-separated). Captures
+ *  tx, ty, and the trailing rest-of-transform string. */
+const LEADING_TRANSLATE_RE = new RegExp(
+  `^\\s*translate\\(\\s*(${SVG_NUMBER})(?:\\s*,\\s*|\\s+)(${SVG_NUMBER})\\s*\\)\\s*(.*)$`
+);
+
+/** First `M`/`m` move in a path-`d` string: command letter + first coord
+ *  pair. (We don't decode subsequent commands here — that's the path-data
+ *  layer's job; this is only for "where does this path start?".) */
+const PATH_FIRST_MOVE_RE = new RegExp(
+  `^\\s*[Mm]\\s*(${SVG_NUMBER})(?:\\s*,\\s*|\\s+)(${SVG_NUMBER})`
+);
+
+/** All numeric tokens in a string. Reused across `parse_points`. */
+const NUMBER_GLOBAL_RE = new RegExp(SVG_NUMBER, "g");
+
+export namespace svg_parse {
+  /** A `(x, y)` coordinate pair as parsed from SVG attribute strings. */
+  export type Point = { x: number; y: number };
+
+  /** Result of {@link parse_leading_translate}. */
+  export type LeadingTranslate = { tx: number; ty: number; rest: string };
+
+  /**
+   * Parse a single SVG number. Returns `fallback` (default 0) when the
+   * input is null, empty, or not parseable as finite.
+   *
+   * Used by attribute readers (`x`, `y`, `cx`, …) where missing or
+   * malformed attributes are spec'd to default to 0.
+   */
+  export function parse_number(s: string | null, fallback = 0): number {
+    if (s === null || s === "") return fallback;
+    const n = parseFloat(s);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  /**
+   * Parse an SVG `points` attribute (polyline / polygon) into an array of
+   * `{x, y}` pairs.
+   *
+   *  - Tolerant of mixed comma + whitespace separators (per SVG spec).
+   *  - Skips trailing odd numbers (incomplete pairs).
+   *  - Skips pairs where either coord parses as non-finite.
+   *  - Returns `[]` for empty / unparseable input (NOT null).
+   */
+  export function parse_points(points: string): Point[] {
+    if (!points) return [];
+    const tokens = points.match(NUMBER_GLOBAL_RE);
+    if (!tokens) return [];
+    const out: Point[] = [];
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+      const x = parseFloat(tokens[i]);
+      const y = parseFloat(tokens[i + 1]);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+      out.push({ x, y });
+    }
+    return out;
+  }
+
+  /**
+   * First move command's absolute coordinates from a path `d` string.
+   *
+   * Returns `null` for empty / unparseable paths. A leading `m`
+   * (lowercase relative) is treated as absolute per
+   * [SVG 2 §9.3.4](https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands):
+   * the first moveto is always absolute regardless of letter case.
+   */
+  export function parse_path_first_move(d: string): Point | null {
+    if (!d) return null;
+    const m = d.match(PATH_FIRST_MOVE_RE);
+    if (!m) return null;
+    const x = parseFloat(m[1]);
+    const y = parseFloat(m[2]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+  }
+
+  /**
+   * Parse a leading `translate(tx, ty)` from a transform attribute.
+   *
+   * Returns the parsed `tx`, `ty`, and the trailing transform string
+   * (everything after the closing paren, trimmed). Returns `null` if
+   * the transform doesn't begin with a `translate(...)` function.
+   *
+   * Used by `compose_leading_translate` to coalesce repeated drag
+   * deltas into a single leading translate term, keeping the
+   * transform string bounded across a long gesture.
+   */
+  export function parse_leading_translate(
+    transform: string | null
+  ): LeadingTranslate | null {
+    if (!transform) return null;
+    const m = transform.match(LEADING_TRANSLATE_RE);
+    if (!m) return null;
+    const tx = parseFloat(m[1]);
+    const ty = parseFloat(m[2]);
+    if (!Number.isFinite(tx) || !Number.isFinite(ty)) return null;
+    return { tx, ty, rest: m[3].trim() };
+  }
+
+  /**
+   * Compute the top-left of an array of `{x, y}` points. Returns `null`
+   * for empty input. Convenience for `points`-parsed pairs; lives here
+   * so callers don't reimplement the empty-array guard.
+   */
+  export function points_top_left(points: ReadonlyArray<Point>): Point | null {
+    if (points.length === 0) return null;
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    for (const p of points) {
+      if (p.x < minX) minX = p.x;
+      if (p.y < minY) minY = p.y;
+    }
+    return { x: minX, y: minY };
+  }
+}

--- a/packages/grida-svg/src/parse/svg-parse.ts
+++ b/packages/grida-svg/src/parse/svg-parse.ts
@@ -23,17 +23,22 @@
  *  number wholly; consumers anchor / chain as needed. */
 const SVG_NUMBER = "[+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?";
 
-/** Leading `translate(tx ty)` (whitespace- or comma-separated). Captures
- *  tx, ty, and the trailing rest-of-transform string. */
+/** Leading `translate(tx[, ty])` (whitespace- or comma-separated). Captures
+ *  tx, optionally ty, and the trailing rest-of-transform string. Per SVG
+ *  transform syntax, the single-argument form `translate(tx)` is valid
+ *  and implies `ty = 0`. */
 const LEADING_TRANSLATE_RE = new RegExp(
-  `^\\s*translate\\(\\s*(${SVG_NUMBER})(?:\\s*,\\s*|\\s+)(${SVG_NUMBER})\\s*\\)\\s*(.*)$`
+  `^\\s*translate\\(\\s*(${SVG_NUMBER})(?:(?:\\s*,\\s*|\\s+)(${SVG_NUMBER}))?\\s*\\)\\s*(.*)$`
 );
 
 /** First `M`/`m` move in a path-`d` string: command letter + first coord
  *  pair. (We don't decode subsequent commands here — that's the path-data
- *  layer's job; this is only for "where does this path start?".) */
+ *  layer's job; this is only for "where does this path start?".)
+ *  The separator between x and y is comma, whitespace, OR an implicit
+ *  sign-delimiter: in minified path data, `M10-20` packs the pair with
+ *  the leading sign of `-20` acting as the delimiter. */
 const PATH_FIRST_MOVE_RE = new RegExp(
-  `^\\s*[Mm]\\s*(${SVG_NUMBER})(?:\\s*,\\s*|\\s+)(${SVG_NUMBER})`
+  `^\\s*[Mm]\\s*(${SVG_NUMBER})(?:\\s*,\\s*|\\s+|(?=[+-]))(${SVG_NUMBER})`
 );
 
 /** All numeric tokens in a string. Reused across `parse_points`. */
@@ -101,11 +106,13 @@ export namespace svg_parse {
   }
 
   /**
-   * Parse a leading `translate(tx, ty)` from a transform attribute.
+   * Parse a leading `translate(tx[, ty])` from a transform attribute.
    *
    * Returns the parsed `tx`, `ty`, and the trailing transform string
    * (everything after the closing paren, trimmed). Returns `null` if
-   * the transform doesn't begin with a `translate(...)` function.
+   * the transform doesn't begin with a `translate(...)` function. Per
+   * SVG transform syntax, a single-argument `translate(tx)` is valid
+   * and resolves to `ty = 0`.
    *
    * Used by `compose_leading_translate` to coalesce repeated drag
    * deltas into a single leading translate term, keeping the
@@ -118,7 +125,7 @@ export namespace svg_parse {
     const m = transform.match(LEADING_TRANSLATE_RE);
     if (!m) return null;
     const tx = parseFloat(m[1]);
-    const ty = parseFloat(m[2]);
+    const ty = m[2] === undefined ? 0 : parseFloat(m[2]);
     if (!Number.isFinite(tx) || !Number.isFinite(ty)) return null;
     return { tx, ty, rest: m[3].trim() };
   }

--- a/packages/grida-svg/src/parser/__tests__/parser-mismatch.test.ts
+++ b/packages/grida-svg/src/parser/__tests__/parser-mismatch.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parse_svg } from "../parser.js";
+
+describe("parse_svg end-tag validation", () => {
+  it("accepts a well-formed matching close tag", () => {
+    expect(() =>
+      parse_svg('<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>')
+    ).not.toThrow();
+  });
+
+  it("rejects a mismatched end tag", () => {
+    // </b> closing <a> would have silently popped before; now it throws.
+    expect(() => parse_svg("<a><b></a></b>")).toThrow(/mismatched end tag/);
+  });
+
+  it("rejects an end tag with no matching open", () => {
+    expect(() => parse_svg("</a>")).toThrow(/unexpected end tag/);
+  });
+});

--- a/packages/grida-svg/src/parser/index.ts
+++ b/packages/grida-svg/src/parser/index.ts
@@ -1,0 +1,1 @@
+export * from "./parser.js";

--- a/packages/grida-svg/src/parser/parser.ts
+++ b/packages/grida-svg/src/parser/parser.ts
@@ -1,0 +1,457 @@
+// Minimal XML/SVG parser that preserves source trivia for round-trip fidelity.
+//
+// Design constraint: `load(x) → serialize() === x` for trivial SVGs. To make
+// that possible we need to keep more than DOMParser gives us — XML
+// declaration, comments, processing instructions, doctype, attribute order,
+// whitespace between tags, quote styles, namespace prefixes verbatim.
+//
+// This is *not* a conforming XML parser. It is good enough to round-trip the
+// kind of SVG humans and tooling actually write. Where it fails the test
+// suite, the failure should be visible and small.
+
+/**
+ * Opaque-by-convention identifier for a node in a parsed SVG tree.
+ *
+ * Mirrors the editor's notion of `NodeId`; defined here so the parser
+ * has no upstream dependency. Consumers re-export it (e.g. the SVG
+ * editor's `types.ts`).
+ */
+export type NodeId = string;
+
+export type AttrToken = {
+  /** Verbatim source name including any prefix, e.g. "xlink:href". */
+  raw_name: string;
+  /** Prefix or null. */
+  prefix: string | null;
+  /** Local name. */
+  local: string;
+  /** Resolved namespace URI, or null if unprefixed and no default ns. */
+  ns: string | null;
+  /** Raw attribute value string (entity-decoded). */
+  value: string;
+  /** Trivia before the attribute name (whitespace, usually `" "`). */
+  pre: string;
+  /** Trivia between `=` and the value (usually empty). */
+  eq_trivia: string;
+  /** Quote character (`"` or `'`). */
+  quote: '"' | "'";
+};
+
+export type ElementNode = {
+  kind: "element";
+  id: NodeId;
+  parent: NodeId | null;
+  /** Verbatim tag name with prefix. */
+  raw_tag: string;
+  prefix: string | null;
+  local: string;
+  ns: string | null;
+  attrs: AttrToken[];
+  children: NodeId[];
+  /** True if the source wrote `<tag/>` (no children). */
+  self_closing: boolean;
+  /** Trivia inside the tag before `>` or `/>` (e.g. `" "` in `<tag />`). */
+  open_tag_trailing: string;
+  /** Trivia between `</` and tag name in the close, e.g. usually empty. */
+  close_tag_leading: string;
+  /** Trivia after the closing tag name before `>`, usually empty. */
+  close_tag_trailing: string;
+};
+
+export type TextNode = {
+  kind: "text";
+  id: NodeId;
+  parent: NodeId | null;
+  /** Verbatim text, entity-decoded. */
+  value: string;
+};
+
+export type CommentNode = {
+  kind: "comment";
+  id: NodeId;
+  parent: NodeId | null;
+  /** Comment body (between `<!--` and `-->`). */
+  value: string;
+};
+
+export type CDataNode = {
+  kind: "cdata";
+  id: NodeId;
+  parent: NodeId | null;
+  value: string;
+};
+
+export type PiNode = {
+  kind: "pi";
+  id: NodeId;
+  parent: NodeId | null;
+  /** PI target, e.g. "xml" for `<?xml ... ?>`. */
+  target: string;
+  value: string;
+};
+
+export type DoctypeNode = {
+  kind: "doctype";
+  id: NodeId;
+  parent: NodeId | null;
+  /** Full doctype declaration body, e.g. `svg PUBLIC "..." "..."`. */
+  value: string;
+};
+
+export type AnyNode =
+  | ElementNode
+  | TextNode
+  | CommentNode
+  | CDataNode
+  | PiNode
+  | DoctypeNode;
+
+export type ParseResult = {
+  /** XML prolog content (PIs, doctype, comments, whitespace) before the root. */
+  prolog: AnyNode[];
+  /** The root <svg> element. */
+  root: NodeId;
+  /** Trailing content (whitespace, comments) after the root. */
+  epilog: AnyNode[];
+  /** All nodes by id (prolog + tree + epilog). */
+  nodes: Map<NodeId, AnyNode>;
+  /** Default-namespace stack snapshots are not preserved; resolved per element. */
+};
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const XLINK_NS = "http://www.w3.org/1999/xlink";
+const XML_NS = "http://www.w3.org/XML/1998/namespace";
+const XMLNS_NS = "http://www.w3.org/2000/xmlns/";
+
+let id_counter = 0;
+function fresh_id(): NodeId {
+  return `n${id_counter++}`;
+}
+
+export function reset_id_counter(): void {
+  id_counter = 0;
+}
+
+export function parse_svg(src: string): ParseResult {
+  reset_id_counter();
+  const nodes = new Map<NodeId, AnyNode>();
+  const prolog: AnyNode[] = [];
+  const epilog: AnyNode[] = [];
+
+  let i = 0;
+  const n = src.length;
+  let root: NodeId | null = null;
+  const open_stack: ElementNode[] = [];
+  /** ns prefix → uri, per ancestor scope (top of stack). */
+  const ns_stack: Map<string, string>[] = [
+    new Map([
+      ["xml", XML_NS],
+      ["xmlns", XMLNS_NS],
+    ]),
+  ];
+  /** default ns per ancestor scope (top of stack). */
+  const default_ns_stack: (string | null)[] = [null];
+
+  function push_to_parent(node: AnyNode) {
+    nodes.set(node.id, node);
+    if (open_stack.length === 0) {
+      // Pre-root content goes to prolog; post-root content goes to epilog.
+      // The root element itself is emitted separately by the serializer, so
+      // we never push it to prolog/epilog.
+      if (node.kind === "element" && root === null) return;
+      if (root === null) prolog.push(node);
+      else epilog.push(node);
+      return;
+    }
+    const parent = open_stack[open_stack.length - 1];
+    node.parent = parent.id;
+    parent.children.push(node.id);
+  }
+
+  while (i < n) {
+    if (src[i] === "<") {
+      // Comment?
+      if (src.startsWith("<!--", i)) {
+        const end = src.indexOf("-->", i + 4);
+        if (end === -1) throw new Error("unterminated comment");
+        const value = src.slice(i + 4, end);
+        push_to_parent({
+          kind: "comment",
+          id: fresh_id(),
+          parent: null,
+          value,
+        });
+        i = end + 3;
+        continue;
+      }
+      // CDATA?
+      if (src.startsWith("<![CDATA[", i)) {
+        const end = src.indexOf("]]>", i + 9);
+        if (end === -1) throw new Error("unterminated CDATA");
+        const value = src.slice(i + 9, end);
+        push_to_parent({ kind: "cdata", id: fresh_id(), parent: null, value });
+        i = end + 3;
+        continue;
+      }
+      // Doctype?
+      if (src.startsWith("<!DOCTYPE", i) || src.startsWith("<!doctype", i)) {
+        let depth = 1;
+        let j = i + 9;
+        while (j < n && depth > 0) {
+          const c = src[j];
+          if (c === "<") depth++;
+          else if (c === ">") depth--;
+          if (depth === 0) break;
+          j++;
+        }
+        if (j >= n) throw new Error("unterminated doctype");
+        push_to_parent({
+          kind: "doctype",
+          id: fresh_id(),
+          parent: null,
+          value: src.slice(i + 9, j),
+        });
+        i = j + 1;
+        continue;
+      }
+      // Processing instruction?
+      if (src.startsWith("<?", i)) {
+        const end = src.indexOf("?>", i + 2);
+        if (end === -1) throw new Error("unterminated PI");
+        const body = src.slice(i + 2, end);
+        const space = body.search(/\s/);
+        const target = space === -1 ? body : body.slice(0, space);
+        const value = space === -1 ? "" : body.slice(space + 1);
+        push_to_parent({
+          kind: "pi",
+          id: fresh_id(),
+          parent: null,
+          target,
+          value,
+        });
+        i = end + 2;
+        continue;
+      }
+      // End tag?
+      if (src[i + 1] === "/") {
+        const end = src.indexOf(">", i + 2);
+        if (end === -1) throw new Error("unterminated end tag");
+        // We don't validate matching tag name strictly — just pop.
+        const open = open_stack.pop();
+        if (!open) throw new Error("unexpected end tag at " + i);
+        ns_stack.pop();
+        default_ns_stack.pop();
+        // Preserve the leading/trailing trivia in the close tag.
+        const body = src.slice(i + 2, end);
+        const m = body.match(/^(\s*)([^\s]+)(\s*)$/);
+        if (m) {
+          open.close_tag_leading = m[1];
+          open.close_tag_trailing = m[3];
+        }
+        i = end + 1;
+        continue;
+      }
+      // Start tag.
+      const start = i + 1;
+      let j = start;
+      // Read raw tag name.
+      while (j < n && !/[\s/>]/.test(src[j])) j++;
+      const raw_tag = src.slice(start, j);
+      const [prefix, local] = split_qname(raw_tag);
+      const { attrs, end_index, self_closing, trailing } = parse_attrs(src, j);
+
+      // Resolve ns: build new scope from parent + this element's xmlns:* / xmlns.
+      const new_ns_map = new Map(ns_stack[ns_stack.length - 1]);
+      let new_default_ns = default_ns_stack[default_ns_stack.length - 1];
+      for (const a of attrs) {
+        if (a.prefix === "xmlns") {
+          new_ns_map.set(a.local, a.value);
+        } else if (a.prefix === null && a.local === "xmlns") {
+          new_default_ns = a.value;
+        }
+      }
+      // Attribute ns resolution: prefixed → ns map; unprefixed → no namespace
+      // (per XML namespaces 1.0 §6.2 — default ns does NOT apply to attrs).
+      for (const a of attrs) {
+        if (
+          a.prefix === "xmlns" ||
+          (a.prefix === null && a.local === "xmlns")
+        ) {
+          a.ns = XMLNS_NS;
+        } else if (a.prefix) {
+          a.ns = new_ns_map.get(a.prefix) ?? null;
+        } else {
+          a.ns = null;
+        }
+      }
+      const element_ns = prefix
+        ? (new_ns_map.get(prefix) ?? null)
+        : new_default_ns;
+
+      const elem: ElementNode = {
+        kind: "element",
+        id: fresh_id(),
+        parent: null,
+        raw_tag,
+        prefix,
+        local,
+        ns: element_ns,
+        attrs,
+        children: [],
+        self_closing,
+        open_tag_trailing: trailing,
+        close_tag_leading: "",
+        close_tag_trailing: "",
+      };
+      push_to_parent(elem);
+      if (root === null) root = elem.id;
+      if (!self_closing) {
+        open_stack.push(elem);
+        ns_stack.push(new_ns_map);
+        default_ns_stack.push(new_default_ns);
+      }
+      i = end_index;
+      continue;
+    }
+    // Text node — everything up to next `<`.
+    const next = src.indexOf("<", i);
+    const end = next === -1 ? n : next;
+    const value = decode_entities(src.slice(i, end));
+    push_to_parent({ kind: "text", id: fresh_id(), parent: null, value });
+    i = end;
+  }
+
+  if (open_stack.length > 0) {
+    throw new Error(
+      `unclosed element <${open_stack[open_stack.length - 1].raw_tag}>`
+    );
+  }
+  if (root === null) throw new Error("no root element");
+
+  return { prolog, root, epilog, nodes };
+}
+
+function split_qname(qname: string): [string | null, string] {
+  const idx = qname.indexOf(":");
+  if (idx === -1) return [null, qname];
+  return [qname.slice(0, idx), qname.slice(idx + 1)];
+}
+
+function parse_attrs(
+  src: string,
+  from: number
+): {
+  attrs: AttrToken[];
+  end_index: number;
+  self_closing: boolean;
+  trailing: string;
+} {
+  const attrs: AttrToken[] = [];
+  let i = from;
+  let pre = "";
+  const n = src.length;
+  while (i < n) {
+    // Read whitespace.
+    const ws_start = i;
+    while (i < n && /\s/.test(src[i])) i++;
+    pre += src.slice(ws_start, i);
+    if (i >= n) throw new Error("unterminated start tag");
+    const c = src[i];
+    if (c === "/") {
+      // Self-close.
+      if (src[i + 1] !== ">") throw new Error("expected '/>' at " + i);
+      return { attrs, end_index: i + 2, self_closing: true, trailing: pre };
+    }
+    if (c === ">") {
+      return { attrs, end_index: i + 1, self_closing: false, trailing: pre };
+    }
+    // Attribute name.
+    const name_start = i;
+    while (i < n && !/[\s=/>]/.test(src[i])) i++;
+    const raw_name = src.slice(name_start, i);
+    // Skip whitespace before '='.
+    let eq_trivia = "";
+    while (i < n && /\s/.test(src[i])) {
+      eq_trivia += src[i];
+      i++;
+    }
+    if (src[i] !== "=") {
+      // Boolean attr without value (rare in SVG) — treat as empty.
+      const [prefix, local] = split_qname(raw_name);
+      attrs.push({
+        raw_name,
+        prefix,
+        local,
+        ns: null,
+        value: "",
+        pre,
+        eq_trivia,
+        quote: '"',
+      });
+      pre = "";
+      continue;
+    }
+    i++; // consume '='
+    // Skip whitespace after '='.
+    while (i < n && /\s/.test(src[i])) i++;
+    const quote = src[i];
+    if (quote !== '"' && quote !== "'") {
+      throw new Error("expected attribute quote at " + i);
+    }
+    i++;
+    const val_start = i;
+    while (i < n && src[i] !== quote) i++;
+    if (i >= n) throw new Error("unterminated attribute value");
+    const raw_value = src.slice(val_start, i);
+    i++; // closing quote
+    const [prefix, local] = split_qname(raw_name);
+    attrs.push({
+      raw_name,
+      prefix,
+      local,
+      ns: null,
+      value: decode_entities(raw_value),
+      pre,
+      eq_trivia,
+      quote: quote as '"' | "'",
+    });
+    pre = "";
+  }
+  throw new Error("unterminated start tag");
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decode_entities(s: string): string {
+  return s.replace(
+    /&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/g,
+    (_, ent) => {
+      if (ent.startsWith("#x") || ent.startsWith("#X")) {
+        return String.fromCodePoint(parseInt(ent.slice(2), 16));
+      }
+      if (ent.startsWith("#")) {
+        return String.fromCodePoint(parseInt(ent.slice(1), 10));
+      }
+      return NAMED_ENTITIES[ent] ?? `&${ent};`;
+    }
+  );
+}
+
+export function encode_attr_value(value: string, quote: '"' | "'"): string {
+  let out = value.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+  out =
+    quote === '"' ? out.replace(/"/g, "&quot;") : out.replace(/'/g, "&apos;");
+  return out;
+}
+
+export function encode_text(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+export { SVG_NS, XLINK_NS, XML_NS, XMLNS_NS };

--- a/packages/grida-svg/src/parser/parser.ts
+++ b/packages/grida-svg/src/parser/parser.ts
@@ -236,18 +236,23 @@ export function parse_svg(src: string): ParseResult {
       if (src[i + 1] === "/") {
         const end = src.indexOf(">", i + 2);
         if (end === -1) throw new Error("unterminated end tag");
-        // We don't validate matching tag name strictly — just pop.
-        const open = open_stack.pop();
+        const body = src.slice(i + 2, end);
+        const m = body.match(/^(\s*)([^\s]+)(\s*)$/);
+        if (!m) throw new Error("malformed end tag at " + i);
+        const closing_raw_tag = m[2];
+        const open = open_stack[open_stack.length - 1];
         if (!open) throw new Error("unexpected end tag at " + i);
+        if (open.raw_tag !== closing_raw_tag) {
+          throw new Error(
+            `mismatched end tag: expected </${open.raw_tag}> but found </${closing_raw_tag}>`
+          );
+        }
+        open_stack.pop();
         ns_stack.pop();
         default_ns_stack.pop();
         // Preserve the leading/trailing trivia in the close tag.
-        const body = src.slice(i + 2, end);
-        const m = body.match(/^(\s*)([^\s]+)(\s*)$/);
-        if (m) {
-          open.close_tag_leading = m[1];
-          open.close_tag_trailing = m[3];
-        }
+        open.close_tag_leading = m[1];
+        open.close_tag_trailing = m[3];
         i = end + 1;
         continue;
       }

--- a/packages/grida-svg/tsdown.config.ts
+++ b/packages/grida-svg/tsdown.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/pathdata/index.ts"],
+  entry: [
+    "src/index.ts",
+    "src/pathdata/index.ts",
+    "src/parse/index.ts",
+    "src/parser/index.ts",
+  ],
   dts: true,
   format: ["esm", "cjs"],
   sourcemap: true,

--- a/packages/grida-text-editor/package.json
+++ b/packages/grida-text-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/text-editor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Backend-agnostic text editor engine (experimental).",
   "license": "MIT",
   "author": "Grida",

--- a/packages/grida-tree-view/README.md
+++ b/packages/grida-tree-view/README.md
@@ -76,6 +76,7 @@ npx shadcn@latest add https://grida.co/r/tree-view-row.json
 ### React bindings (`@grida/tree-view/react`)
 
 - **One provider, one snapshot hook.** `<TreeProvider controller={…}>` plus `useTree()` and `useTreeSnapshot(selector, equals?)` — the `useEditorState` pattern.
+- **Typed-context factory.** `createTreeContext<TMeta>()` returns a provider/hook trio that preserves `TMeta` end-to-end — no `as` casts at the call site. The un-typed exports stay available for the quickstart path.
 - **Identity-stable selectors.** `Object.is` short-circuit prevents re-renders when the selected slice is unchanged.
 - **`useSyncExternalStore`-backed.** Concurrent-mode safe.
 - **Optional peer.** React 18+ only loaded if you import `/react`; the core is React-free.
@@ -186,6 +187,36 @@ import { TreeProvider, useTree, useTreeSnapshot } from "@grida/tree-view/react";
 React surface — there are no per-row hooks shipped. The intended pattern
 is `useEditorState`-style: one provider, one subscription hook,
 consumers select whatever slice they want.
+
+### Typed React context (recommended for typed apps)
+
+The top-level `useTree<T>()` / `useTreeSnapshot<T, R>()` accept a meta
+parameter, but it has to be re-supplied at every call site — forgetting
+silently widens to `unknown` and the meta type quietly disappears from
+the call site. For real applications with a known meta shape, use the
+typed-context factory instead. It returns its own provider plus hook
+trio bound to your meta:
+
+```ts
+import { createTreeContext } from "@grida/tree-view/react";
+
+const { TreeProvider, useTree, useTreeSnapshot } =
+  createTreeContext<SvgNodeMeta>();
+
+// Inside a component:
+const ctrl = useTree(); // TreeController<SvgNodeMeta>
+const label = useTreeSnapshot(
+  (
+    c // c: TreeController<SvgNodeMeta>
+  ) => c.getSource().getNode(id).meta?.name ?? "untitled"
+);
+```
+
+Each `createTreeContext` call creates its own React context — typed and
+un-typed providers are independent (a `useTree()` from one will not see
+a controller mounted under the other). Pick one per tree. The factory
+adds no runtime overhead beyond a single `createContext` call; it runs
+through the same `useSyncExternalStore` path as the un-typed hook.
 
 ## State ownership
 
@@ -307,6 +338,65 @@ version/identity policy — what counts as "changed", when to bump — is
 yours; only you know your store's change semantics (the same reason
 `InMemoryTreeSource.applyIntent` declines to auto-handle `copy`). The ~30
 lines above are the whole pattern.
+
+#### Coarser subscribe than version
+
+If your store's `subscribe` fires more often than your tree-view-relevant
+version bumps (per-tick attribute writes, animation ticks, drag-time
+transform updates, etc.), gate the listener at the source layer —
+otherwise the controller invalidates `rows` on every emit and your panel
+re-renders at store-tick frequency. Track the last-seen structural
+version inside `subscribe` and only forward the call when it actually
+advances:
+
+```ts
+subscribe(listener: () => void) {
+  let last = store.structure_version;
+  return store.subscribe(() => {
+    const next = store.structure_version;
+    if (next !== last) {
+      last = next;
+      listener();
+    }
+  });
+}
+```
+
+The principle is the same as `getNode` reference stability: the
+controller trusts `subscribe` to notify _only_ when something the tree
+view cares about changed. Editors that maintain a separate "structural"
+version counter (Grida's SVG editor, most Immer-backed stores) get this
+for free with the snippet above; if your store has no such counter,
+either add one at the store layer or diff the tree shape inside the
+listener.
+
+#### WeakMap on a reference-stable host node
+
+The snapshot example above keys the adapter cache on the host's
+`(meta, childIds)` pair. That works for any source. But if your host
+store already returns a reference-stable per-node object across version
+bumps (the common case for wasm- or Immer-backed editors), you can key a
+WeakMap directly on that object instead — no per-tick map rebuild, no
+`prev === next` triple-check:
+
+```ts
+const cache = new WeakMap<HostNode, TreeNode<MyMeta>>();
+getNode(id) {
+  const hn = this.host.nodeOf(id);                 // already stable per host
+  let n = cache.get(hn);
+  if (!n) {
+    n = adapt(hn);
+    cache.set(hn, n);
+  }
+  return n;
+}
+```
+
+If your store already gives you reference-stable per-node objects across
+version bumps, key the cache on the underlying node — the adapter object
+stays stable as long as the source does. The WeakMap also collects
+entries automatically as the host drops its nodes, so there's no
+explicit invalidation step on the consumer side.
 
 ### External selection adapter
 

--- a/packages/grida-tree-view/__tests__/create-tree-context.test.ts
+++ b/packages/grida-tree-view/__tests__/create-tree-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+// Built artifact — same resolution discipline as the rest of the suite
+// (see FEEDBACKS F9). Imports from the package's `/react` subpath so the
+// factory ships through the actual public entry.
+import { createTreeContext, TreeProvider, useTree } from "../react";
+
+describe("createTreeContext", () => {
+  it("returns a provider + hook trio + an underlying Context", () => {
+    const ctx = createTreeContext<{ kind: string }>();
+    expect(typeof ctx.TreeProvider).toBe("function");
+    expect(typeof ctx.useTree).toBe("function");
+    expect(typeof ctx.useTreeSnapshot).toBe("function");
+    expect(ctx.Context).toBeDefined();
+    // React's `createContext` returns an object with `Provider` and
+    // `Consumer` properties — verify we passed through a real context,
+    // not a stub. (React 19's `Provider` is an object/component, not
+    // necessarily a function, so existence is the contract we check.)
+    const underlying = ctx.Context as unknown as {
+      Provider?: unknown;
+      Consumer?: unknown;
+    };
+    expect(underlying.Provider).toBeDefined();
+    expect(underlying.Consumer).toBeDefined();
+  });
+
+  it("each call produces a fresh React context (typed contexts are independent)", () => {
+    const a = createTreeContext<{ kind: "leaf" }>();
+    const b = createTreeContext<{ kind: "folder" }>();
+    expect(a.Context).not.toBe(b.Context);
+    expect(a.TreeProvider).not.toBe(b.TreeProvider);
+    expect(a.useTree).not.toBe(b.useTree);
+    expect(a.useTreeSnapshot).not.toBe(b.useTreeSnapshot);
+  });
+
+  it("is independent of the un-typed top-level surface", () => {
+    const a = createTreeContext();
+    // The un-typed surface is a stable singleton; the factory must
+    // never collide with it — that's the whole point of "pick one per
+    // tree, typed and un-typed providers do not share state".
+    expect(a.TreeProvider).not.toBe(TreeProvider);
+    expect(a.useTree).not.toBe(useTree);
+  });
+
+  it("useTree from a factory throws when called outside its own provider", () => {
+    // The hook is React-coupled — we can't render here without jsdom,
+    // but we can exercise the "no provider" branch by invoking the
+    // hook outside any React renderer. React will throw (no current
+    // dispatcher); we just assert the call path is reachable and the
+    // function itself is a real callable. Silence React's expected
+    // "Invalid hook call" warning that goes to stderr on the way out.
+    const ctx = createTreeContext();
+    const original = console.error;
+    console.error = () => {};
+    try {
+      expect(() => ctx.useTree()).toThrow(/./);
+    } finally {
+      console.error = original;
+    }
+  });
+});

--- a/packages/grida-tree-view/package.json
+++ b/packages/grida-tree-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/tree-view",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Headless, agnostic tree-view controller for the Grida editor.",
   "keywords": [

--- a/packages/grida-tree-view/react.tsx
+++ b/packages/grida-tree-view/react.tsx
@@ -2,5 +2,7 @@ export {
   TreeProvider,
   useTree,
   useTreeSnapshot,
+  createTreeContext,
   type TreeProviderProps,
+  type TreeContext,
 } from "./src/react/provider";

--- a/packages/grida-tree-view/src/react/provider.tsx
+++ b/packages/grida-tree-view/src/react/provider.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useRef,
   useSyncExternalStore,
+  type Context,
   type ReactNode,
 } from "react";
 import type { TreeController } from "../controller";
@@ -43,6 +44,19 @@ export function useTreeSnapshot<T, R>(
   equals: (a: R, b: R) => boolean = Object.is
 ): R {
   const controller = useTree<T>();
+  return useTreeSnapshotWithController<T, R>(controller, selector, equals);
+}
+
+/**
+ * Internal helper shared by the un-typed `useTreeSnapshot` and the
+ * typed-context factory below. Identical semantics; the only difference
+ * is where the controller is resolved from.
+ */
+function useTreeSnapshotWithController<T, R>(
+  controller: TreeController<T>,
+  selector: (c: TreeController<T>) => R,
+  equals: (a: R, b: R) => boolean = Object.is
+): R {
   const last_ref = useRef<{ has: boolean; value: R }>({
     has: false,
     value: undefined as unknown as R,
@@ -70,4 +84,95 @@ export function useTreeSnapshot<T, R>(
       return server_ref.current.value;
     }
   );
+}
+
+export interface TreeContext<TMeta> {
+  /** Provider scoped to this typed context. */
+  TreeProvider: (props: {
+    controller: TreeController<TMeta>;
+    children: ReactNode;
+  }) => ReactNode;
+  /** Returns the `TreeController<TMeta>` from the nearest matching provider. */
+  useTree: () => TreeController<TMeta>;
+  /** Selector-subscribed snapshot, with `TMeta` preserved through the selector. */
+  useTreeSnapshot: <R>(
+    selector: (c: TreeController<TMeta>) => R,
+    equals?: (a: R, b: R) => boolean
+  ) => R;
+  /**
+   * The underlying React context. Exposed so consumers can compose this
+   * factory with other context-aware utilities (e.g. read the controller
+   * inside a `<Suspense>` boundary, custom dev-tools). Most apps never
+   * need this.
+   */
+  Context: Context<TreeController<TMeta> | null>;
+}
+
+/**
+ * Create a typed React context for a `TreeController<TMeta>`. Returns its
+ * own provider + hook trio so `useTree()` / `useTreeSnapshot()` preserve
+ * `TMeta` end-to-end — no `as` casts at the call site.
+ *
+ * The un-typed exports (`TreeProvider`, `useTree`, `useTreeSnapshot`)
+ * stay available for the lite/quickstart path and standalone demos; this
+ * factory is the recommended path for typed applications where the meta
+ * shape is known up-front.
+ *
+ * ```ts
+ * const { TreeProvider, useTree, useTreeSnapshot } =
+ *   createTreeContext<SvgNodeMeta>();
+ *
+ * // TreeProvider, useTree, useTreeSnapshot now carry SvgNodeMeta.
+ * ```
+ *
+ * Notes:
+ * - Each call creates a fresh, independent React context. Two factories
+ *   do not share state.
+ * - The typed and un-typed providers are independent — a `useTree()` from
+ *   the un-typed surface will not find a controller mounted under a
+ *   factory-typed provider, and vice versa. Pick one per tree.
+ * - Zero runtime cost beyond a `createContext` call; everything else is
+ *   the same code path as the un-typed surface.
+ */
+export function createTreeContext<TMeta>(): TreeContext<TMeta> {
+  const Ctx = createContext<TreeController<TMeta> | null>(null);
+
+  function TreeProviderTyped({
+    controller,
+    children,
+  }: {
+    controller: TreeController<TMeta>;
+    children: ReactNode;
+  }) {
+    return <Ctx.Provider value={controller}>{children}</Ctx.Provider>;
+  }
+
+  function useTreeTyped(): TreeController<TMeta> {
+    const ctx = useContext(Ctx);
+    if (!ctx) {
+      throw new Error(
+        "useTree must be used inside a <TreeProvider> from createTreeContext"
+      );
+    }
+    return ctx;
+  }
+
+  function useTreeSnapshotTyped<R>(
+    selector: (c: TreeController<TMeta>) => R,
+    equals: (a: R, b: R) => boolean = Object.is
+  ): R {
+    const controller = useTreeTyped();
+    return useTreeSnapshotWithController<TMeta, R>(
+      controller,
+      selector,
+      equals
+    );
+  }
+
+  return {
+    TreeProvider: TreeProviderTyped,
+    useTree: useTreeTyped,
+    useTreeSnapshot: useTreeSnapshotTyped,
+    Context: Ctx,
+  };
 }


### PR DESCRIPTION
## Summary

- **@grida/cmath 0.2.2** — drop node `assert` dep in favor of internal `_assert.ts` so the package runs in non-Node runtimes
- **@grida/svg 0.1.0** — make public; add `/parse` (attribute-string primitives) and `/parser` (trivia-preserving XML round-trip) subpaths with tests; wire tsdown entries and `prepack`
- **@grida/tree-view 0.1.1** — add `createTreeContext<TMeta>()` typed-context factory so typed apps stop re-supplying `TMeta` at every call site; README guidance on coarser subscribe than version and WeakMap on reference-stable host nodes
- **@grida/keybinding 0.2.0**, **@grida/text-editor 0.1.1** — version bumps

## Test plan

- [ ] `pnpm turbo test --filter='./packages/grida-cmath' --filter='./packages/grida-svg' --filter='./packages/grida-tree-view'`
- [ ] `pnpm turbo build --filter='./packages/*'`
- [ ] `pnpm typecheck`
- [ ] Verify `@grida/svg/parse` and `@grida/svg/parser` subpaths resolve from a consumer
- [ ] Verify `createTreeContext<TMeta>()` preserves meta type at call sites (no `as` casts needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVG parsing utilities and a minimal XML/SVG parser (round-trip trivia preservation)
  * Typed React context factory for tree view integration
  * New public SVG subpaths for parsing and parser utilities

* **Documentation**
  * Clarified SVG package layout, subpath APIs, and tree-view typed context usage

* **Tests**
  * Expanded SVG parsing tests (numbers, paths, transforms) and parser end-tag validation
  * Typed context factory tests added

* **Chores**
  * Package version bumps and build entry-point expansion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->