### PR TITLE
ci(desktop): sign + notarize macOS, gate release behind environment

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -5,26 +5,30 @@ name: Publish Desktop App
 
 on:
   workflow_dispatch:
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  APPLE_ID: ${{ secrets.APPLE_ID }}
-  APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    inputs:
+      prerelease:
+        description: "Publish as prerelease (autoupdate skips prereleases by default)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
+    environment: release
     strategy:
+      fail-fast: false
       matrix:
         os:
           - name: linux
             image: ubuntu-latest
           - name: windows
             image: windows-latest
-
-          # - name: macos-apple-silicon
-          #   image: macos-15
+          - name: macos-apple-silicon
+            image: macos-15
     runs-on: ${{ matrix.os.image }}
+    env:
+      HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}
+      HAS_NOTARIZE: ${{ secrets.APPLE_API_KEY_P8 != '' }}
     defaults:
       run:
         working-directory: ./desktop
@@ -54,14 +58,47 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Import Apple signing certificate
+        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' }}
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          keychain: build
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Stage App Store Connect API key
+        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_NOTARIZE == 'true' }}
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          DIR="$RUNNER_TEMP/keys"
+          mkdir -p "$DIR"
+          KEY_PATH="$DIR/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Publish App (Windows)
         if: ${{ matrix.os.name == 'windows' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: pnpm run publish:prerelease --arch="x64"
 
       - name: Publish App (Linux)
         if: ${{ matrix.os.name == 'linux' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: pnpm run publish:prerelease --arch="x64,arm64"
 
       - name: Publish App (MacOS)
         if: ${{ matrix.os.name == 'macos-apple-silicon' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: pnpm run publish:prerelease --arch="x64,arm64"

--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -27,8 +27,8 @@ jobs:
             image: macos-15
     runs-on: ${{ matrix.os.image }}
     env:
-      HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}
-      HAS_NOTARIZE: ${{ secrets.APPLE_API_KEY_P8 != '' }}
+      HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
+      HAS_NOTARIZE: ${{ secrets.APPLE_API_KEY_P8 != '' && secrets.APPLE_API_KEY_ID != '' && secrets.APPLE_API_ISSUER != '' }}
     defaults:
       run:
         working-directory: ./desktop
@@ -94,7 +94,7 @@ jobs:
         run: pnpm run publish:prerelease --arch="x64,arm64"
 
       - name: Publish App (MacOS)
-        if: ${{ matrix.os.name == 'macos-apple-silicon' }}
+        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' && env.HAS_NOTARIZE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRERELEASE: ${{ inputs.prerelease }}

--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -11,6 +11,7 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import * as dotenv from "dotenv";
+import path from "node:path";
 
 // cli flags
 const IS_INSIDERS = process.argv.includes("--insiders");
@@ -27,6 +28,36 @@ const productName = IS_INSIDERS ? "Grida Insiders" : "Grida";
 const appBundleId = IS_INSIDERS ? "co.grida.insiders" : "co.grida.desktop";
 const icon = IS_INSIDERS ? "./images/insiders/icon" : "./images/icon";
 
+const signingIdentity = process.env.APPLE_SIGNING_IDENTITY;
+const entitlementsPath = path.join(
+  __dirname,
+  "build",
+  "entitlements.mac.plist"
+);
+
+const osxSign = signingIdentity
+  ? {
+      identity: signingIdentity,
+      optionsForFile: () => ({
+        hardenedRuntime: true,
+        entitlements: entitlementsPath,
+        "entitlements-inherit": entitlementsPath,
+        "gatekeeper-assess": false,
+      }),
+    }
+  : undefined;
+
+const osxNotarize =
+  process.env.APPLE_API_KEY &&
+  process.env.APPLE_API_KEY_ID &&
+  process.env.APPLE_API_ISSUER
+    ? {
+        appleApiKey: process.env.APPLE_API_KEY,
+        appleApiKeyId: process.env.APPLE_API_KEY_ID,
+        appleApiIssuer: process.env.APPLE_API_ISSUER,
+      }
+    : undefined;
+
 const config: ForgeConfig = {
   packagerConfig: {
     extraResource: [
@@ -38,12 +69,8 @@ const config: ForgeConfig = {
     asar: true,
     appBundleId: appBundleId,
     icon: icon,
-    osxSign: {},
-    osxNotarize: {
-      appleId: process.env.APPLE_ID ?? "",
-      appleIdPassword: process.env.APPLE_PASSWORD ?? "",
-      teamId: process.env.APPLE_TEAM_ID ?? "",
-    },
+    osxSign,
+    osxNotarize,
     win32metadata: {
       CompanyName: "Grida Inc.",
     },
@@ -148,7 +175,7 @@ const config: ForgeConfig = {
           owner: "gridaco",
           name: "grida",
         },
-        prerelease: true,
+        prerelease: process.env.PRERELEASE === "true",
       },
     },
   ],

--- a/desktop/pnpm-workspace.yaml
+++ b/desktop/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - .
+onlyBuiltDependencies:
+  - electron
+  - electron-winstaller
+  - fs-xattr
+  - macos-alias

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -29,7 +29,7 @@ app.commandLine.appendSwitch("disable-async-dns");
 app.commandLine.appendSwitch("js-flags", "--expose-gc");
 // #endregion chrome flags
 
-updateElectronApp();
+updateElectronApp({ notifyUser: true });
 
 app.setName("Grida");
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/docs/contributing/desktop-release.md
+++ b/docs/contributing/desktop-release.md
@@ -58,7 +58,7 @@ To promote a prerelease to stable: edit the GitHub Release in the UI and uncheck
 
 Secrets (all 6 env-scoped, not repo-wide):
 
-```
+```text
 APPLE_CERTIFICATE_P12         base64 of the .p12
 APPLE_CERTIFICATE_PASSWORD    .p12 export password
 APPLE_SIGNING_IDENTITY        "Developer ID Application: <Name> (TEAMID)" (no quotes)

--- a/docs/contributing/desktop-release.md
+++ b/docs/contributing/desktop-release.md
@@ -1,0 +1,160 @@
+---
+format: md
+---
+
+# Contributing to Grida | Desktop release
+
+Runbook for cutting desktop releases — macOS / Windows / Linux signed, notarized, autoupdating via [`update.electronjs.org`](https://github.com/electron/update.electronjs.org). Target audience: maintainers with `release` environment approver rights.
+
+> Triggering the workflow does **not** ship anything until an approver clicks "Approve and deploy" in the [`release` environment](https://github.com/gridaco/grida/settings/environments) gate.
+
+---
+
+## Cutting a release
+
+1. **Bump the version.** Edit [`desktop/package.json`](https://github.com/gridaco/grida/blob/main/desktop/package.json) `"version"` and commit on `main`. Plain semver only (`0.2.0`, not `desktop-v0.2.0`) — the autoupdate feed runs `semver.valid()` on the tag and silently skips anything else. Don't reuse an existing tag.
+
+2. **Trigger the workflow.**
+
+   ```sh
+   gh workflow run realease-desktop-app.yml -R gridaco/grida -f prerelease=false
+   ```
+
+   Or via UI: **Actions → Publish Desktop App → Run workflow**.
+
+3. **Approve in the environment gate.** Each platform job (mac/win/linux) pauses at the `release` environment. Open the run in Actions and click "Review deployments → Approve and deploy."
+
+4. **Verify.** When the run finishes, the GitHub Release page has `Grida-darwin-arm64-<version>.zip`, `Grida-darwin-x64-<version>.zip`, the `.dmg` siblings, Windows `.exe` + nupkg, and Linux `.deb` / `.rpm`. Confirm the feed serves it:
+
+   ```sh
+   BASE=https://update.electronjs.org/gridaco/grida/darwin-arm64
+   curl -s -w "\n%{http_code}\n" "$BASE/0.0.0"
+   # WANT: 200 + JSON pointing at the new .zip
+
+   curl -s -o /dev/null -w "%{http_code}\n" "$BASE/<just-released-version>"
+   # WANT: 204 (no update — correct)
+   ```
+
+   If the old-client request returns 204, either the release is marked prerelease or the tag isn't valid semver. See [Troubleshooting](#troubleshooting).
+
+## Cutting a prerelease
+
+Same as above but with `-f prerelease=true`. The release shows up on GitHub Releases marked as a prerelease and `update.electronjs.org` **skips it for installed users** — prereleases are for manual download / testing only. Useful when you want a build out for QA without auto-shipping it to everyone.
+
+To promote a prerelease to stable: edit the GitHub Release in the UI and uncheck "Set as a pre-release." The feed will pick it up on the next poll (~6h default).
+
+---
+
+## What lives where
+
+| Concern                       | File / location                                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Workflow                      | [`.github/workflows/realease-desktop-app.yml`](https://github.com/gridaco/grida/blob/main/.github/workflows/realease-desktop-app.yml) |
+| Build + signing config        | [`desktop/forge.config.ts`](https://github.com/gridaco/grida/blob/main/desktop/forge.config.ts)                                       |
+| Hardened-runtime entitlements | [`desktop/build/entitlements.mac.plist`](https://github.com/gridaco/grida/blob/main/desktop/build/entitlements.mac.plist)             |
+| In-app updater wiring         | [`desktop/src/main.ts`](https://github.com/gridaco/grida/blob/main/desktop/src/main.ts) — `updateElectronApp({ notifyUser: true })`   |
+| pnpm native-module allowlist  | [`desktop/pnpm-workspace.yaml`](https://github.com/gridaco/grida/blob/main/desktop/pnpm-workspace.yaml) — `onlyBuiltDependencies`     |
+| Apple secrets                 | `release` environment on `gridaco/grida` — `gh secret list --env release --repo gridaco/grida`                                        |
+
+Secrets (all 6 env-scoped, not repo-wide):
+
+```
+APPLE_CERTIFICATE_P12         base64 of the .p12
+APPLE_CERTIFICATE_PASSWORD    .p12 export password
+APPLE_SIGNING_IDENTITY        "Developer ID Application: <Name> (TEAMID)" (no quotes)
+APPLE_API_KEY_P8              raw .p8 PEM contents
+APPLE_API_KEY_ID              10-char Key ID (also in .p8 filename)
+APPLE_API_ISSUER              Issuer UUID — App Store Connect → Integrations
+```
+
+Rotating any of these is a `gh secret set <NAME> --env release --repo gridaco/grida` away. The code reads from env vars only — no code changes needed when secrets rotate.
+
+---
+
+## Hard constraints
+
+These are silent footguns. Pinned, do not change without a plan:
+
+- **`appBundleId: "co.grida.desktop"`** in `forge.config.ts`. Changing it strands every installed user (Squirrel won't apply updates across bundle-id boundaries). Insiders use `co.grida.insiders` — separate track on purpose.
+- **Plain semver tags.** `update.electronjs.org` skips tags that don't pass `semver.valid()`. No `desktop-v…` or other prefixes.
+- **`hardenedRuntime: true`** in `osxSign.optionsForFile`. Required for notarization; required for the entitlements plist to apply.
+- **`onlyBuiltDependencies` in `pnpm-workspace.yaml`** (not `package.json`). pnpm 10 silently disables native module builds without it; in pnpm 10, when both files exist, only the workspace file's list is consulted. Removing it breaks the DMG maker (`Cannot find module '../build/Release/volume.node'`).
+
+---
+
+## Troubleshooting
+
+**`update.electronjs.org` returns 204 for an old client → feed not serving the new release.**
+
+1. Release marked prerelease — uncheck in the UI or re-publish with `prerelease=false`.
+2. Tag not valid semver — re-tag with a valid version.
+3. No asset matching `<platform>-<arch>` (e.g. `darwin-arm64`) on the release. Check artifact filenames in forge `makers` config.
+
+**Workflow logs: `Cannot find module '../build/Release/volume.node'`**
+`onlyBuiltDependencies` is missing or in the wrong file. Must be in `desktop/pnpm-workspace.yaml`, not `desktop/package.json`. See [Hard constraints](#hard-constraints).
+
+**Workflow logs: `Error parsing workflow file ... HTTP 422` on `workflow_dispatch`.**
+A step `if:` references `${{ secrets.* }}` directly — not allowed. Map secrets to job-level `env:` booleans (`HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}`) and gate on `env.HAS_SIGNING == 'true'`.
+
+**Notarization rejects the upload (`The signature does not include a secure timestamp` or similar).**
+Hardened runtime not enabled, or entitlements plist not applied. Check `forge.config.ts` `osxSign.optionsForFile` returns `hardenedRuntime: true` and points at [`build/entitlements.mac.plist`](https://github.com/gridaco/grida/blob/main/desktop/build/entitlements.mac.plist).
+
+**Squirrel error in user logs: `Code signature at URL ... did not pass validation`.**
+The downloaded update's signature doesn't satisfy the installed app's Designated Requirement. Most likely the Team ID changed — see [Apple credential rotation](#apple-credential-rotation). For the existing fleet, a manual reinstall is the only path forward.
+
+---
+
+## Local end-to-end test (when changing release config)
+
+When editing `forge.config.ts`, `entitlements.mac.plist`, the workflow, or the pnpm allowlist — run a full local signed+notarized build before merging. Catches the same failures CI would hit without burning the notary quota or polluting the Releases tab.
+
+Assumes you have the cert and API key under `~/.applesecrets/` (or wherever; adjust paths).
+
+```sh
+# Temp keychain — mirrors what apple-actions/import-codesign-certs does in CI
+KEYCHAIN="$TMPDIR/grida-build.keychain-db"
+KCPASS="$(uuidgen)"
+security create-keychain -p "$KCPASS" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
+security import ~/.applesecrets/certificate.p12 \
+  -P "$(tr -d '\n' < ~/.applesecrets/p12password)" \
+  -A -t cert -f pkcs12 -k "$KEYCHAIN" >/dev/null
+security set-key-partition-list -S apple-tool:,apple: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
+EXISTING="$(security list-keychains -d user | tr -d '"' | xargs)"
+security list-keychains -d user -s "$KEYCHAIN" $EXISTING
+
+# Env (forge reads these)
+export APPLE_SIGNING_IDENTITY="$(tr -d '"\n' < ~/.applesecrets/codesigning-identity-string-with-quotes)"
+export APPLE_API_KEY="$HOME/.applesecrets/AuthKey_XXXXXXXXXX.p8"
+export APPLE_API_KEY_ID="XXXXXXXXXX"
+export APPLE_API_ISSUER="<uuid>"
+
+# Build — does NOT publish
+cd desktop && pnpm make --arch=arm64
+
+# Verify the .app
+APP="out/Grida-darwin-arm64/Grida.app"
+codesign --verify --deep --strict --verbose=2 "$APP"   # valid on disk + satisfies DR
+spctl -a -vvv -t install "$APP"                        # accepted + source=Notarized Developer ID
+xcrun stapler validate "$APP"                          # "validate action worked"
+
+# Cleanup
+security list-keychains -d user -s $EXISTING
+security delete-keychain "$KEYCHAIN"
+```
+
+Notarization takes 1–5 minutes. Forge calls `notarytool` and waits.
+
+> `pnpm make` builds locally only. `pnpm run publish:prerelease` pushes to GitHub Releases — **don't run that locally.** Releases go through the workflow.
+
+---
+
+## Apple credential rotation
+
+The 6 secrets above are independent of code. Rotating a cert, switching the App Store Connect API key, or moving to a different Apple Developer account is a `gh secret set` for each value. No code changes.
+
+> [!WARNING]
+> If the new cert has a **different Team ID** from the previous one, autoupdate breaks for existing installs: Squirrel.Mac validates each update against the installed app's Designated Requirement (which includes Team ID), the check fails, the update is silently rejected. Existing users keep working on their last build with the old Team ID but stop receiving updates — they must manually re-download from grida.co to get on the new track.
+>
+> If a Team ID change is planned: add an in-app banner ("this version stopped receiving updates, please reinstall") _before_ you rotate, so existing users see your messaging while still on the old build. `appBundleId` is independent of Team ID and stays stable across rotations.


### PR DESCRIPTION
## Summary

- Wires macOS code signing and notarization in the desktop release pipeline (was commented out / shipping unsigned).
- Switches notarization to the App Store Connect API key (`.p8`) form, replacing Apple ID + app-specific password.
- Puts the release workflow behind a new `release` GitHub Environment with required reviewers — triggering doesn't ship until an approver clicks through.
- Adds a `prerelease` workflow_dispatch input so canary builds don't auto-ship to installed users via `update.electronjs.org`.
- Fixes pnpm 10 silently skipping native module builds (`macos-alias`, `fs-xattr`, `electron`) with `--frozen-lockfile` — would have broken the DMG maker step in CI exactly where it broke locally.
- Adds runbook at [`docs/contributing/desktop-release.md`](https://github.com/gridaco/grida/blob/feature/hopeful-brattain-e0bac6/docs/contributing/desktop-release.md).

## What this preserves

- **Same-repo unified release** (opencode-shaped). No separate releases repo; all desktop artifacts attach to the same `gridaco/grida` GitHub Release.
- **Free `update.electronjs.org` feed.** No custom update server. Plain semver tags (required by the feed's `semver.valid()` check).
- **electron-forge.** No migration to electron-builder.

## Out-of-band setup completed (not in repo)

- `release` GitHub Environment created with `softmarshmallow` as required reviewer.
- 6 secrets uploaded to the environment: `APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`.

## Test plan

- [x] `pnpm typecheck` passes in `desktop/`
- [x] Local `pnpm make --arch=arm64` builds clean (.zip + .dmg)
- [x] `codesign --verify --deep --strict`: valid on disk, satisfies DR
- [x] `flags=0x10000(runtime)`: hardened runtime applied
- [x] `spctl -a -t install`: accepted, source=Notarized Developer ID
- [x] `xcrun stapler validate`: ticket stapled
- [x] `gh secret list --env release --repo gridaco/grida`: all 6 present
- [ ] First dispatched workflow run after merge — requires bumping `desktop/package.json` version off `0.0.1` (current value collides with existing tag)
- [ ] Post-release verify: `curl https://update.electronjs.org/gridaco/grida/darwin-arm64/0.0.0` returns 200 + JSON pointing at the new `.zip`

## Reviewer notes

- The Team ID baked into the first signed build is `A5K7JMXG3Z` (personal Developer ID for Woojoo Jung). Future switch to an organization team will require existing users to manually reinstall — Squirrel.Mac rejects updates across Team ID boundaries. See the "Apple credential rotation" callout in the runbook.
- Workflow filename typo (`realease-`) left alone to avoid breaking external references; harmless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow control for prerelease desktop app builds and added Apple Silicon publishing support.

* **Improvements**
  * Conditional macOS signing/notarization flow for stronger, more flexible release signing.
  * Updated macOS entitlements to support required execution behaviors.
  * Limited native dependency build set for more reliable builds.
  * Enabled user notifications for app updates.

* **Documentation**
  * Added a detailed desktop release runbook and troubleshooting guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->