### PR TITLE
ci(desktop): drop hardcoded pnpm@9.15.4, align desktop on pnpm@10.24.0

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -52,5 +52,5 @@
     "typescript": "^6",
     "vite": "^8.0.8"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Summary

Publish Desktop App workflow ([run 26167062660](https://github.com/gridaco/grida/actions/runs/26167062660)) failed at the **Setup pnpm** step:

```
Error: Multiple versions of pnpm specified:
  - version 9.15.4 in the GitHub Action config with the key "version"
  - version pnpm@10.24.0 in the package.json with the key "packageManager"
```

`pnpm/action-setup@v4` validates the hardcoded `with.version` against `packageManager` from `package.json` and aborts on mismatch. The repo root migrated to pnpm 10.24.0 at some point; the desktop workflow had a stale `version: 9.15.4` from the pnpm 9 era and was never refreshed (it wasn't being exercised — macOS row was commented out until #726).

## Changes

- Drop hardcoded `version: 9.15.4` from `pnpm/action-setup@v4` in [`.github/workflows/realease-desktop-app.yml`](https://github.com/gridaco/grida/blob/worktree-fix-pnpm-version-conflict/.github/workflows/realease-desktop-app.yml). action-setup now picks up the pnpm version from `packageManager`.
- Bump `desktop/package.json` `packageManager` from `pnpm@10.10.0` → `pnpm@10.24.0` to match root, so the workflow installs one coherent version and pnpm doesn't complain when running inside `desktop/`.

## Test plan

- [x] Locally: `rm -rf desktop/node_modules && cd desktop && pnpm install --frozen-lockfile` clean on pnpm 10.24.0 with the existing lockfile (7.6s)
- [x] Native modules (`macos-alias`, `electron`, `fs-xattr`) all built — confirms the `onlyBuiltDependencies` allowlist from #726 still works under the bumped version
- [ ] After merge: re-trigger `Publish Desktop App` workflow; Setup pnpm should pass and the pipeline should reach the publish step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application build tooling configuration with pnpm package manager version updates for improved consistency in the development and deployment pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->