### PR TITLE
ci(desktop): bump macOS runner macos-15 → macos-26

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -24,7 +24,7 @@ jobs:
           - name: windows
             image: windows-latest
           - name: macos-apple-silicon
-            image: macos-15
+            image: macos-26
     runs-on: ${{ matrix.os.image }}
     env:
       HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}


### PR DESCRIPTION
## Summary

Previous run [26167995147](https://github.com/gridaco/grida/actions/runs/26167995147/job/76977463044) on \`macos-15\` (Sequoia) failed at the DMG-creation step with a flaky \`hdiutil\` race:

\`\`\`
hdiutil: convert failed - Resource temporarily unavailable
Error: Command failed: hdiutil convert ... -format UDZO -imagekey zlib-level=9 -o .../Grida.dmg
\`\`\`

The \`.app\` was signed and notarized successfully; only the final DMG compression step crashed. \`EAGAIN\` here means the kernel was still finalizing the source \`.dmg\` when \`hdiutil convert\` tried to read it — an intermittent issue on \`macos-15\` runners.

## Change

Bump runner image: \`macos-15\` → \`macos-26\` (Tahoe). One-line edit in [\`.github/workflows/realease-desktop-app.yml\`](https://github.com/gridaco/grida/blob/worktree-bump-macos-runner-26/.github/workflows/realease-desktop-app.yml#L27).

\`macos-26\` is GA on GitHub Actions and is what opencode's publish workflow uses. Newer image + different toolchain versions; reasonable chance the flake doesn't repro.

## Test plan

- [ ] After merge, re-trigger \`Publish Desktop App\`. Should reach the publish step on macOS.
- [ ] If \`hdiutil\` flakes again on macos-26, the next fallback is to drop \`MakerDMG\` from \`forge.config.ts\` and ship \`.zip\`-only (autoupdate doesn't need the DMG).

## Notes

- Notary quota was already consumed by the failed run; this PR doesn't avoid that.
- Public log audit from the prior run: all 6 Apple secrets correctly masked by GitHub Actions auto-redaction (\`***\` everywhere, including inside file paths). Safe to leave logs public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build runner configuration for the desktop application release workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->