### PR TITLE
ci(desktop) [DO NOT MERGE]: try preMake sync hook to dodge hdiutil race

### DIFF
--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -84,7 +84,18 @@ const config: ForgeConfig = {
     appCategoryType: "public.app-category.developer-tools",
   },
   rebuildConfig: {},
-  hooks: {},
+  hooks: {
+    // Workaround for `hdiutil: convert failed - Resource temporarily unavailable`
+    // on GitHub macOS runners. Flushing pending writes from the package step
+    // before the DMG maker reads the source image reduces the I/O race window.
+    // See: https://discourse.cmake.org/t/macos-hdiutil-packaging-on-github-actions-can-fail-if-prepackage-scripts-are-used/14990
+    preMake: async () => {
+      if (process.platform !== "darwin") return;
+      const { execFileSync } = await import("node:child_process");
+      execFileSync("sync");
+      await new Promise((r) => setTimeout(r, 2000));
+    },
+  },
   makers: [
     new MakerSquirrel((arch) => {
       const version = process.env.npm_package_version;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.1",
+  "version": "0.0.2-dmg-test.1",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],


### PR DESCRIPTION
**This PR is for CI verification only — do NOT merge.**

## Purpose

PRs [#729](https://github.com/gridaco/grida/pull/729) (runner bump macos-15 → macos-26) didn't fix the deterministic `hdiutil convert failed - Resource temporarily unavailable` error. This PR layers a speculative `preMake` sync hook on top to see if flushing pending I/O before the DMG maker dodges the race.

## What's here

Two commits on top of `main`:

1. `e78d187a6` — `macos-15 → macos-26` (already in [#729](https://github.com/gridaco/grida/pull/729))
2. `243c04a30` — new: `preMake` sync hook in [`desktop/forge.config.ts`](https://github.com/gridaco/grida/blob/worktree-dmg-sync-hook-test/desktop/forge.config.ts), plus bumping `desktop/package.json` to `0.0.2-dmg-test.1` so this run lands on a clearly-test prerelease tag separate from `0.0.1` production.

## Verification path

Trigger the workflow on this branch with `prerelease=true`:

```sh
gh workflow run realease-desktop-app.yml -R gridaco/grida --ref worktree-dmg-sync-hook-test -f prerelease=true
```

`update.electronjs.org` skips prereleases by default, so no installed user gets this build. Approve in the `release` environment gate. If the macOS job completes through to publish, the hook works and we cherry-pick the sync hook (without the version bump) into a clean PR. If it fails again, we close this and fall back to dropping `MakerDMG`.

## Cleanup

Regardless of outcome, after the test run:
- Delete the `0.0.2-dmg-test.1` release + tag on GitHub.
- This PR gets closed (not merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a macOS DMG creation race condition to improve installation reliability.

* **Chores**
  * Bumped app version to 0.0.2-dmg-test.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->