### PR TITLE
ci(desktop) [DO NOT MERGE]: drop x64 darwin build to dodge parallel-arch DMG bugs

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -99,4 +99,4 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: pnpm run publish:prerelease --arch="x64,arm64"
+        run: pnpm run publish:prerelease --arch="arm64"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.2-arm64-test.1",
+  "version": "0.0.1",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.1",
+  "version": "0.0.2-arm64-test.1",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],


### PR DESCRIPTION
**This PR is for CI verification only — do NOT merge as-is** (contains a test version bump). Once verified, the workflow change will land in a clean PR.

## Hypothesis

Both DMG failure modes we've seen are **parallel-arch races**:

| Failure | Hit on |
|---|---|
| `hdiutil convert failed - Resource temporarily unavailable` (EAGAIN, filesystem contention) | runs [#26167995147](https://github.com/gridaco/grida/actions/runs/26167995147), [#26169048761](https://github.com/gridaco/grida/actions/runs/26169048761) |
| `Target already exists` from appdmg ([electron/forge#3517](https://github.com/electron/forge/issues/3517), known unfixed) | run [#26170073770](https://github.com/gridaco/grida/actions/runs/26170073770) |

PR #730's sync hook mitigated the EAGAIN but exposed the next layer. With only one arch, neither race can fire.

## Change

```diff
- run: pnpm run publish:prerelease --arch="x64,arm64"
+ run: pnpm run publish:prerelease --arch="arm64"
```

That's it. DMG maker stays. Macos-26 runner stays.

## Tradeoff

Intel Mac users can't install or autoupdate. In 2026, Apple-Silicon share dominates and our audience for a 0.x.x technical-preview canvas tool skews heavily to that cohort. We can add Intel back later when telemetry shows demand — either as a universal binary or as a serialized second `pnpm make` invocation that avoids the parallel race.

## Verify

```sh
gh workflow run realease-desktop-app.yml -R gridaco/grida \
  --ref worktree-arm64-only-darwin-build -f prerelease=true
```

Lands on a clearly-test prerelease tag `0.0.2-arm64-test.1`. `update.electronjs.org` skips prereleases by default, so existing users aren't affected.

If the macOS job completes through to publish:
- Close this PR
- Open a clean PR with just the workflow change (no test version bump)
- Delete the `0.0.2-arm64-test.1` release + tag

If it fails:
- Fall back to dropping `MakerDMG`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Desktop app release now publishes arm64 architecture exclusively
  * Desktop app version updated to `0.0.2-arm64-test.1`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->