### PR TITLE
chore(www,ci): drop unsupported mac builds from downloads, template release notes

### DIFF
--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -15,14 +15,14 @@ This is a nightly release of Grida `{{version}}`.
 
 ## Supported builds
 
-| Name    | Platform | x64 | arm64 | makers           | signed | notes                                                              |
-| ------- | -------- | --- | ----- | ---------------- | ------ | ------------------------------------------------------------------ |
-| `Grida` | `darwin` |     | ✓     | `zip`, `dmg`     | ✓      | Apple Silicon only. Rosetta 2 cannot run arm64 binaries on Intel.  |
-| `Grida` | `win32`  | ✓   |       | `exe (squirrel)` |        | x64 only / not signed                                              |
-| `Grida` | `linux`  | ✓   | ✓     | `deb`, `rpm`     |        |                                                                    |
+| Name    | Platform | x64 | arm64 | makers           | signed | notes                                                             |
+| ------- | -------- | --- | ----- | ---------------- | ------ | ----------------------------------------------------------------- |
+| `Grida` | `darwin` |     | ✓     | `zip`, `dmg`     | ✓      | Apple Silicon only. Rosetta 2 cannot run arm64 binaries on Intel. |
+| `Grida` | `win32`  | ✓   |       | `exe (squirrel)` |        | x64 only / not signed                                             |
+| `Grida` | `linux`  | ✓   | ✓     | `deb`, `rpm`     |        |                                                                   |
 
 ## Auto-update
 
 macOS installs receive updates automatically via [`update.electronjs.org`](https://github.com/electron/update.electronjs.org). The running app polls every 6 hours; when a newer release is available, a "Restart to update" prompt appears.
 
-Releases marked **pre-release** on this page are *not* served to existing installs — they're for manual download / testing only.
+Releases marked **pre-release** on this page are _not_ served to existing installs — they're for manual download / testing only.

--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -1,0 +1,28 @@
+# Grida Desktop — Technical Preview
+
+This is a nightly release of Grida `{{version}}`.
+
+- macOS (signed, notarized)
+  - darwin arm64 — Apple Silicon
+  - dmg · zip
+- linux
+  - deb · rpm
+  - arm64 · x64
+- windows (not signed)
+  - x64
+
+[Join Slack](https://grida.co/join-slack) to learn more.
+
+## Supported builds
+
+| Name    | Platform | x64 | arm64 | makers           | signed | notes                                                              |
+| ------- | -------- | --- | ----- | ---------------- | ------ | ------------------------------------------------------------------ |
+| `Grida` | `darwin` |     | ✓     | `zip`, `dmg`     | ✓      | Apple Silicon only. Rosetta 2 cannot run arm64 binaries on Intel.  |
+| `Grida` | `win32`  | ✓   |       | `exe (squirrel)` |        | x64 only / not signed                                              |
+| `Grida` | `linux`  | ✓   | ✓     | `deb`, `rpm`     |        |                                                                    |
+
+## Auto-update
+
+macOS installs receive updates automatically via [`update.electronjs.org`](https://github.com/electron/update.electronjs.org). The running app polls every 6 hours; when a newer release is available, a "Restart to update" prompt appears.
+
+Releases marked **pre-release** on this page are *not* served to existing installs — they're for manual download / testing only.

--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -102,9 +102,11 @@ jobs:
         run: pnpm run publish:prerelease --arch="arm64"
 
       - name: Update release notes from template
-        # Runs once (only on the macOS row) after the release tag has been
-        # created by the publisher. Template at .github/release-notes/desktop.md.
-        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' && env.HAS_NOTARIZE == 'true' }}
+        # Runs once (gated to the linux row, which has no signing-secret
+        # dependency and therefore always runs). The release tag will exist
+        # by this point since linux's publish step ran just above.
+        # Template at .github/release-notes/desktop.md.
+        if: ${{ matrix.os.name == 'linux' }}
         working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -100,3 +100,16 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: pnpm run publish:prerelease --arch="arm64"
+
+      - name: Update release notes from template
+        # Runs once (only on the macOS row) after the release tag has been
+        # created by the publisher. Template at .github/release-notes/desktop.md.
+        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' && env.HAS_NOTARIZE == 'true' }}
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./desktop/package.json').version")
+          TAG="v${VERSION}"
+          BODY=$(sed "s|{{version}}|${VERSION}|g" .github/release-notes/desktop.md)
+          gh release edit "$TAG" --notes "$BODY" --repo gridaco/grida

--- a/editor/app/(www)/(downloads)/downloads/downloads.ts
+++ b/editor/app/(www)/(downloads)/downloads/downloads.ts
@@ -291,10 +291,21 @@ export namespace downloads {
       // GitHub. `getLinks()` resolves 6 assets via separate `getAsset` calls;
       // without this, a single cache miss in `getCachedLinks` would burn
       // 6 unauthenticated requests against the 60/hr/IP limit.
+      //
+      // Failures are memoized as `[]` so the same cap applies on the error
+      // path — otherwise `m_assets` stays null and each of the 6 sequential
+      // getAsset calls retries the API. `getAsset` already handles the
+      // empty-asset case gracefully via its assert+catch, returning null.
+      // A fresh Fetcher is created per render, so the error cache is
+      // per-render and transient failures self-heal on the next request.
       if (this.m_assets) return this.m_assets;
-      const release = await fetchrelease();
-      this.m_tag = release.data.tag_name;
-      this.m_assets = release.data.assets;
+      try {
+        const release = await fetchrelease();
+        this.m_tag = release.data.tag_name;
+        this.m_assets = release.data.assets;
+      } catch {
+        this.m_assets = [];
+      }
       return this.m_assets;
     }
 

--- a/editor/app/(www)/(downloads)/downloads/downloads.ts
+++ b/editor/app/(www)/(downloads)/downloads/downloads.ts
@@ -1,4 +1,5 @@
 import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest";
+import { unstable_cache } from "next/cache";
 import assert from "assert";
 
 export namespace downloads {
@@ -109,9 +110,78 @@ export namespace downloads {
     };
   }
 
+  export interface DownloadLinksForPage extends DownloadLinks {
+    default: {
+      platform: Platform;
+      maker: Maker;
+      arch: Arch;
+      url: string;
+    } | null;
+  }
+
+  function pickDefault(
+    os: Platform | null,
+    links: DownloadLinks
+  ): DownloadLinksForPage["default"] {
+    switch (os) {
+      case "mac":
+        return {
+          platform: "mac",
+          maker: "dmg",
+          arch: "arm64",
+          url: links.mac_dmg_arm64,
+        };
+      case "windows":
+        return {
+          platform: "windows",
+          maker: "squirrel.windows",
+          arch: "x64",
+          url: links.windows_exe_x64,
+        };
+      case "linux":
+        return {
+          platform: "linux",
+          maker: "deb",
+          arch: "x64",
+          url: links.linux_deb_x64,
+        };
+      default:
+        return null;
+    }
+  }
+
+  // Cached wrapper around getLinks() — hits GitHub's unauthenticated
+  // releases endpoint at most ~once per hour per region, keeping the
+  // page out of trouble with the 60 req/hr/IP rate limit.
+  // `unstable_cache` only memoizes successful resolutions; on throw,
+  // the next render re-attempts (so transient API blips self-heal).
+  const getCachedLinks = unstable_cache(
+    () => getLinks(),
+    ["downloads:getLinks"],
+    {
+      revalidate: 3600,
+    }
+  );
+
+  /**
+   * Page-bound helper: latest-release links + OS-aware default, cached.
+   * Falls back to the static v0.0.1 URLs if the GitHub API is unreachable.
+   */
+  export async function getLinksForPage(
+    os: Platform | null
+  ): Promise<DownloadLinksForPage> {
+    try {
+      const links = await getCachedLinks();
+      return { ...links, default: pickDefault(os, links) };
+    } catch {
+      return getLinks_v001(os);
+    }
+  }
+
   /**
    * @deprecated
-   * temporary static version of getLinks, until we find a reliable way to fetch release without rate limiting
+   * Static fallback used only when the GitHub API is unreachable.
+   * Prefer `getLinksForPage()`, which calls this internally on failure.
    */
   export function getLinks_v001(
     platform: Platform | null,

--- a/editor/app/(www)/(downloads)/downloads/downloads.ts
+++ b/editor/app/(www)/(downloads)/downloads/downloads.ts
@@ -7,9 +7,7 @@ export namespace downloads {
   type GithubReleaseAsset = GithubReleaseAssets[number];
 
   export interface DownloadLinks {
-    mac_dmg_x64: string;
     mac_dmg_arm64: string;
-    mac_dmg_universal: string;
     linux_deb_x64: string;
     linux_rpm_x64: string;
     linux_deb_arm64: string;
@@ -18,7 +16,7 @@ export namespace downloads {
   }
 
   export type Platform = "mac" | "windows" | "linux";
-  export type Arch = "x64" | "arm64" | "universal";
+  export type Arch = "x64" | "arm64";
   export type Maker = "dmg" | "squirrel.windows" | "deb" | "rpm";
 
   type Distro = {
@@ -27,7 +25,6 @@ export namespace downloads {
     ext: "dmg" | "exe" | "deb" | "rpm";
     arch: {
       arm64?: string | undefined;
-      universal?: string | undefined;
       x64?: string | undefined;
     };
   };
@@ -45,8 +42,6 @@ export namespace downloads {
         ext: "dmg",
         arch: {
           arm64: "arm64",
-          universal: "universal",
-          x64: "x64",
         },
       },
     ],
@@ -97,9 +92,7 @@ export namespace downloads {
   export async function getLinks(): Promise<DownloadLinks> {
     const f = new Fetcher();
 
-    const mac_dmg_x64 = await f.getAsset("mac", "dmg", "x64");
     const mac_dmg_arm64 = await f.getAsset("mac", "dmg", "arm64");
-    const mac_dmg_universal = await f.getAsset("mac", "dmg", "universal");
     const linux_deb_x64 = await f.getAsset("linux", "deb", "x64");
     const linux_rpm_x64 = await f.getAsset("linux", "rpm", "x64");
     const linux_deb_arm64 = await f.getAsset("linux", "deb", "arm64");
@@ -107,9 +100,7 @@ export namespace downloads {
     const windows_x64 = await f.getAsset("windows", "squirrel.windows", "x64");
 
     return {
-      mac_dmg_x64: mac_dmg_x64.browser_download_url,
       mac_dmg_arm64: mac_dmg_arm64.browser_download_url,
-      mac_dmg_universal: mac_dmg_universal.browser_download_url,
       linux_deb_x64: linux_deb_x64.browser_download_url,
       linux_rpm_x64: linux_rpm_x64.browser_download_url,
       linux_deb_arm64: linux_deb_arm64.browser_download_url,
@@ -134,12 +125,8 @@ export namespace downloads {
     } | null;
   } {
     const links: DownloadLinks = {
-      mac_dmg_x64:
-        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-x64.dmg",
       mac_dmg_arm64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-arm64.dmg",
-      mac_dmg_universal:
-        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-universal.dmg",
       linux_deb_x64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/grida_0.0.1_amd64.deb",
       linux_rpm_x64:
@@ -163,8 +150,8 @@ export namespace downloads {
         d = {
           platform: "mac",
           maker: "dmg",
-          arch: "universal",
-          url: links.mac_dmg_universal,
+          arch: "arm64",
+          url: links.mac_dmg_arm64,
         };
         break;
       }
@@ -189,12 +176,8 @@ export namespace downloads {
 
     return {
       default: d,
-      mac_dmg_x64:
-        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-x64.dmg",
       mac_dmg_arm64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-arm64.dmg",
-      mac_dmg_universal:
-        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-universal.dmg",
       linux_deb_x64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/grida_0.0.1_amd64.deb",
       linux_rpm_x64:

--- a/editor/app/(www)/(downloads)/downloads/downloads.ts
+++ b/editor/app/(www)/(downloads)/downloads/downloads.ts
@@ -173,7 +173,11 @@ export namespace downloads {
     try {
       const links = await getCachedLinks();
       return { ...links, default: pickDefault(os, links) };
-    } catch {
+    } catch (err) {
+      console.warn(
+        "[downloads] getLinks failed; falling back to static v0.0.1 links.",
+        err
+      );
       return getLinks_v001(os);
     }
   }
@@ -283,6 +287,11 @@ export namespace downloads {
     }
 
     async fetch() {
+      // Memoize: subsequent calls return the same release without re-hitting
+      // GitHub. `getLinks()` resolves 6 assets via separate `getAsset` calls;
+      // without this, a single cache miss in `getCachedLinks` would burn
+      // 6 unauthenticated requests against the 60/hr/IP limit.
+      if (this.m_assets) return this.m_assets;
       const release = await fetchrelease();
       this.m_tag = release.data.tag_name;
       this.m_assets = release.data.assets;

--- a/editor/app/(www)/(downloads)/downloads/page.tsx
+++ b/editor/app/(www)/(downloads)/downloads/page.tsx
@@ -96,24 +96,10 @@ export default async function DownloadsPage() {
 function DownloadButtons({ links }: { links: downloads.DownloadLinks }) {
   return (
     <div className="container max-w-3xl flex flex-wrap justify-center gap-3 mx-auto">
-      {/* macOS Universal */}
-      <Link href={links.mac_dmg_universal} download>
-        <Button size="lg" variant="outline">
-          <Apple className="size-4" /> Download for macOS (Universal)
-        </Button>
-      </Link>
-
       {/* macOS Apple Silicon */}
       <Link href={links.mac_dmg_arm64} download>
         <Button size="lg" variant="outline">
           <Apple className="size-4" /> Download for macOS (Apple Silicon)
-        </Button>
-      </Link>
-
-      {/* macOS Intel */}
-      <Link href={links.mac_dmg_x64} download>
-        <Button size="lg" variant="outline">
-          <Apple className="size-4" /> Download for macOS (Intel-based Macs)
         </Button>
       </Link>
 

--- a/editor/app/(www)/(downloads)/downloads/page.tsx
+++ b/editor/app/(www)/(downloads)/downloads/page.tsx
@@ -24,7 +24,7 @@ export default async function DownloadsPage() {
   const userAgent = headersList.get("user-agent");
 
   const os = downloads.getDesktopOS(userAgent || "");
-  const links = await downloads.getLinks_v001(os);
+  const links = await downloads.getLinksForPage(os);
 
   return (
     <main className="min-h-screen flex flex-col">


### PR DESCRIPTION
Two related cleanups now that macOS builds are arm64-only (#731).

## Summary

### 1. Downloads page

The `/downloads` page advertised macOS Universal and macOS Intel builds that we no longer produce. Removed those references end-to-end:

- [`downloads.ts`](https://github.com/gridaco/grida/blob/worktree-downloads-and-release-notes/editor/app/(www)/(downloads)/downloads/downloads.ts) — drop `mac_dmg_x64` / `mac_dmg_universal` from the `DownloadLinks` interface and from both `getLinks` and `getLinks_v001`. Drop `"universal"` from the `Arch` union. Switch the per-platform default for `"mac"` from `mac_dmg_universal` → `mac_dmg_arm64`.
- [`page.tsx`](https://github.com/gridaco/grida/blob/worktree-downloads-and-release-notes/editor/app/(www)/(downloads)/downloads/page.tsx) — remove the "macOS (Universal)" and "macOS (Intel-based Macs)" buttons. Keep "macOS (Apple Silicon)".

The legacy `v0.0.1` release still has the universal/x64 dmg artifacts so any direct download links out there keep working; the page just doesn't surface them anymore. New releases won't include those artifacts.

### 2. Release notes templating

GitHub Releases have no built-in body template, and forge's `publisher-github` doesn't expose `releaseNotes`. New tags land with empty bodies unless templatized externally — which means the neat Markdown table currently on [`v0.0.1`](https://github.com/gridaco/grida/releases/tag/v0.0.1) would have to be re-authored by hand each release.

- New file [`.github/release-notes/desktop.md`](https://github.com/gridaco/grida/blob/worktree-downloads-and-release-notes/.github/release-notes/desktop.md) — canonical body for desktop releases, with a `{{version}}` placeholder. Lives in `.github/` because it's release-process content, not desktop app source.
- New step `Update release notes from template` in [`.github/workflows/realease-desktop-app.yml`](https://github.com/gridaco/grida/blob/worktree-downloads-and-release-notes/.github/workflows/realease-desktop-app.yml). Runs once per release (gated to the macOS matrix row, which is the slowest job and so effectively the "end" of the release). Interpolates `{{version}}` from `desktop/package.json` and applies the body via `gh release edit`.

## Test plan

- [ ] CI workflow YAML parses (will surface immediately on push).
- [ ] Editor typecheck clean (downloads.ts changes are interface tightening; no other files import `mac_dmg_x64` or `mac_dmg_universal` per grep).
- [ ] On the next real release, body lands as templated (will need a real workflow run to verify end-to-end).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grida Desktop Technical Preview release notes covering nightly releases, platform packaging, supported builds, macOS auto-update cadence, and the “Restart to update” prompt.
  * Release notes for desktop builds are now published automatically when a desktop release is created.

* **Changes**
  * macOS downloads and download UI now target Apple Silicon (arm64) only; Intel and Universal options removed.
  * Downloads page now fetches updated release links with caching and a fallback to legacy download info.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->