### PR TITLE
chore(desktop): bump 0.0.2 + reword release notes

### DIFF
--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -1,6 +1,4 @@
-# Grida Desktop — Technical Preview
-
-This is a nightly release of Grida `{{version}}`.
+# Grida Desktop `{{version}}`
 
 - macOS (signed, notarized)
   - darwin arm64 — Apple Silicon


### PR DESCRIPTION
## Summary
- Bump `desktop/package.json` version `0.0.1` → `0.0.2`.
- Reword `.github/release-notes/desktop.md` to drop the "Technical Preview" header and "nightly release" line — carryover from the hand-authored v0.0.1 body, no longer accurate for ongoing releases. Placeholder `{{version}}` and supported-builds table preserved.

v0.0.1 release intentionally retains `Grida.Insiders-0.0.1-universal.dmg` from the April 2025 one-off manual build; no CI wiring for Insiders going forward.

## Test plan
- [x] Template still substitutes `{{version}}` via the workflow's `sed` step (`.github/workflows/realease-desktop-app.yml:116`).
- [ ] Trigger the desktop release workflow and confirm the rendered release body + tag (`v0.0.2`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes format to include version information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->