### PR TITLE
chore(desktop): bump version to 0.0.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],


### PR DESCRIPTION
## Summary
- Follow-up to [#733](https://github.com/gridaco/grida/pull/733), which was titled "bump 0.0.2 + reword release notes" but only touched the release notes — `desktop/package.json` was never actually bumped from `0.0.1`.
- Bumps `desktop/package.json` version `0.0.1` → `0.0.2`.

## Test plan
- [ ] Trigger the desktop release workflow and confirm the rendered release body + tag (`v0.0.2`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->