### PR TITLE
docs(desktop): direct download links + drop misleading auto-update section

### DIFF
--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -4,14 +4,14 @@
 
 ## Downloads
 
-| Platform | Arch  | Format | Signed | Download                                                                                                                              |
-| -------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-arm64-{{version}}.dmg)        |
-| `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)           |
-| `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)          |
-| `linux`  | x64   | deb    |        | see Assets below                                                                                                                      |
-| `linux`  | arm64 | deb    |        | see Assets below                                                                                                                      |
-| `linux`  | x64   | rpm    |        | see Assets below                                                                                                                      |
-| `linux`  | arm64 | rpm    |        | see Assets below                                                                                                                      |
+| Platform | Arch  | Format | Signed | Download                                                                                                                        |
+| -------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-arm64-{{version}}.dmg) |
+| `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)    |
+| `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)   |
+| `linux`  | x64   | deb    |        | see Assets below                                                                                                                |
+| `linux`  | arm64 | deb    |        | see Assets below                                                                                                                |
+| `linux`  | x64   | rpm    |        | see Assets below                                                                                                                |
+| `linux`  | arm64 | rpm    |        | see Assets below                                                                                                                |
 
 > macOS arm64 only — Rosetta 2 cannot run arm64 binaries on Intel.

--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -1,26 +1,17 @@
 # Grida Desktop `{{version}}`
 
-- macOS (signed, notarized)
-  - darwin arm64 — Apple Silicon
-  - dmg · zip
-- linux
-  - deb · rpm
-  - arm64 · x64
-- windows (not signed)
-  - x64
+[Downloads](https://grida.co/downloads) · [Join Slack](https://grida.co/join-slack) to learn more.
 
-[Join Slack](https://grida.co/join-slack) to learn more.
+## Downloads
 
-## Supported builds
+| Platform | Arch  | Format | Signed | Download                                                                                                                              |
+| -------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-arm64-{{version}}.dmg)        |
+| `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)           |
+| `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)          |
+| `linux`  | x64   | deb    |        | see Assets below                                                                                                                      |
+| `linux`  | arm64 | deb    |        | see Assets below                                                                                                                      |
+| `linux`  | x64   | rpm    |        | see Assets below                                                                                                                      |
+| `linux`  | arm64 | rpm    |        | see Assets below                                                                                                                      |
 
-| Name    | Platform | x64 | arm64 | makers           | signed | notes                                                             |
-| ------- | -------- | --- | ----- | ---------------- | ------ | ----------------------------------------------------------------- |
-| `Grida` | `darwin` |     | ✓     | `zip`, `dmg`     | ✓      | Apple Silicon only. Rosetta 2 cannot run arm64 binaries on Intel. |
-| `Grida` | `win32`  | ✓   |       | `exe (squirrel)` |        | x64 only / not signed                                             |
-| `Grida` | `linux`  | ✓   | ✓     | `deb`, `rpm`     |        |                                                                   |
-
-## Auto-update
-
-macOS installs receive updates automatically via [`update.electronjs.org`](https://github.com/electron/update.electronjs.org). The running app polls every 6 hours; when a newer release is available, a "Restart to update" prompt appears.
-
-Releases marked **pre-release** on this page are _not_ served to existing installs — they're for manual download / testing only.
+> macOS arm64 only — Rosetta 2 cannot run arm64 binaries on Intel.


### PR DESCRIPTION
## Summary

Polishes `.github/release-notes/desktop.md` (the template that renders into every desktop release's notes via the workflow's `gh release edit` step).

- **Drop the "Auto-update" section.** Wrong audience (release-page visitors aren't the people who need autoupdate guidance), wrong content (claimed a 6-hour poll cadence, but `update-electron-app` actually defaults to 10 minutes), and it nudged readers into thinking they had to *do* something to get updates.
- **Add direct download links for macOS / Windows** so users can click straight from the notes instead of scrolling to the Assets list. Link text is friendly ("Download for Mac (Apple Silicon)"), not the raw filename.
- **Linux rows defer to the Assets list.** Too many distro/arch combinations to label cleanly, and Linux users are used to scrolling for the right package.
- **Add a `grida.co/downloads` link** next to the existing Slack link.
- **Drop the redundant platform/arch bullet list** at the top of the file — the Downloads table covers the same ground.

## Brittleness note

Templating filenames into URLs means a maker default change could 404 the links silently. The macOS dmg/zip and Windows Squirrel exe filenames are stable. The RPM `-1` release number was the most fragile piece, and is no longer in the template since Linux rows now defer to the Assets list.

## Test plan

- [ ] Visual check the rendered notes on the next desktop release (workflow runs `sed` on `{{version}}` and feeds the result to `gh release edit`).
- [ ] Verify each templated link 200s against an actual release (e.g. v0.0.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned the Downloads section with a per-platform table showing platform, architecture, format, signing, and direct download links that include the release version.
  * Shortened and clarified macOS arm64/Rosetta warning to a single concise note.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->