### PR TITLE
feat(agent-tools): introduce @grida/agent-tools package

### DIFF
--- a/docs/wg/feat-ai/tools-canvas.md
+++ b/docs/wg/feat-ai/tools-canvas.md
@@ -1,0 +1,229 @@
+---
+title: Canvas Tools (for AI)
+tags:
+  - internal
+  - wg
+  - ai
+  - editor
+  - canvas
+---
+
+# Canvas Tools (for AI)
+
+This document specifies the **canvas-specific** AI toolset — the tools
+that only make sense when an agent is editing a Grida design document.
+Operations on the scene graph (search, select, diff), specialized
+inserts (make_from_svg, make_from_markdown), canvas exec / lint /
+format, resource lookup.
+
+For tools that apply to **any** agent (filesystem, planning, tool
+discovery, future env basics), see
+[\`tools.md\`](./tools.md) — the fundamental toolset. Fundamentals
+assume a virtual filesystem (or real fs / shell when available) and
+nothing else; canvas tools assume an active editor instance.
+
+## Key principles (canvas-specific)
+
+- Versioning, sandboxing, and rolling back.
+- Scene-graph addressability: every tool that mutates state takes a
+  node id (or a search query that resolves to one). No "current
+  selection" implicit state — selection is its own tool surface.
+- Specialized inserts beat free-form generation: the agent should
+  reach for \`::make_from_svg\` / \`::make_from_markdown\` before
+  emitting raw geometry.
+
+## Tools
+
+---
+
+> **Search** Tools
+
+### `::man`
+
+This tool serves as the documentation and self-discovery interface for all other tools, inspired by the Unix `man` command. It displays structured, human-readable manual pages for any tool, including syntax, description, and examples, and acts as the primary entry point for understanding system capabilities.
+
+### `::tree`
+
+Similar to the [`tree`](<https://en.wikipedia.org/wiki/Tree_(command)>) command, this tool returns the tree structure of the node.
+
+It enables hierarchical understanding of design components for structured processing.
+
+Example:
+
+```
+└─ ⛶  Document (nodes=4, scenes=1, entry=scene)
+   └─ ⛶  Frame HeroSection  (type=container, id=frame)  [1280×720]  fill=#111111  opacity=0.9
+      ├─ ✎  Text Title  (type=text, id=text)  "Welcome to Grida"  font=Inter  size=32  weight=700
+      └─ ◼  Rect Button  (type=rectangle, id=button)  [160×48]  fill=#3B82F6  radius=8
+```
+
+### `::snapshot`
+
+This takes a snapshot of the current canvas state.
+
+### `::search`
+
+Searches the scene graph for nodes by **semantics**, **geometry**, and **structure**. Returns a stable, ordered list of node IDs (plus brief metadata) without dumping full nodes.
+
+- **Semantics**: type, role, name text, style tokens (fill/stroke/font), accessibility labels.
+- **Geometry**: point/region queries (contains, intersects, overlaps), relations (near, aligned_to, left_of, above), size/ratio ranges.
+- **Structure**: ancestry/descendancy (within, has_child, sibling_of), component/instance links.
+- **Ordering**: by z-index, document order, reading order, distance to point, or score.
+
+**Notes**
+
+- Read-only; pairs with `::select` and `::exec` for actions.
+- Supports boolean logic and filters (e.g., `type:Text AND near:(200,480,32)`), and pagination/cursors for large results.
+- Returns compact briefs `{id, type, name?, bbox?, z?}` to minimize token cost.
+
+This tool enables efficient retrieval of nodes based on complex criteria for precise design queries.
+
+### `::text_content`
+
+Similar to [DOM's textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent), this tool extracts the node as plain text.
+
+Unlike the DOM, the design is likely unordered; this tool accepts an optional argument for sorting, aligning with geometric layout so that the output follows the reading direction.
+
+This tool provides a clean textual representation of design elements to facilitate analysis and manipulation.
+
+### `::html`
+
+This exports a canvas subtree as HTML.
+
+It allows integration and reuse of design elements in web environments.
+
+### `::peek_pixels`
+
+This peeks at pixels at a specific point in the canvas or node.
+
+It provides precise visual inspection for pixel-level verification.
+
+### `::image`
+
+This exports a canvas subtree as an image.
+
+### `::diff`
+
+This diffs the nodes between the current canvas and the target canvas.
+
+It supports change detection and version comparison within designs.
+
+---
+
+> **Awareness** tools
+
+### `::select`
+
+This selects nodes at a specific point in the canvas.
+
+It facilitates targeted interaction and editing of design elements.
+
+---
+
+> **Run** tools
+
+### `::exec`
+
+This executes a command on the canvas scripting api sandbox.
+
+It enables dynamic manipulation of the canvas through scripted instructions.
+
+### `::lint`
+
+This generates a visual linting report for the current state of the canvas subtree.
+
+It helps identify and enforce design consistency and best practices.
+
+### `::format`
+
+Formats design elements for consistent presentation and output.
+
+---
+
+> **Specialized Insert** tools
+
+### `::make_from_grida`
+
+Insert a .grida compat partial or full packed subtree.
+
+This should support json and kdl format.
+
+```kdl
+clipboard {
+  container "page" {
+    container "header" {
+      text "Logo" {
+        font "Inter"
+        size 16
+        weight 700
+      }
+    }
+  }
+}
+```
+
+### `::make_from_svg`
+
+Insert a node from an SVG string.
+
+### `::make_from_image`
+
+Insert a node from an image URL/Data. (Non SVG)
+
+| image  | support                   |
+| ------ | ------------------------- |
+| `png`  | default                   |
+| `jpg`  | default                   |
+| `webp` | with webp feature enabled |
+| `gif`  | planned                   |
+| `svg`  | reject                    |
+
+### `::make_from_markdown`
+
+Insert a node from a markdown (or plain txt) string.
+
+### `::make_from_csv`
+
+Insert a table from a CSV string.
+
+### `::make_from_mermaid`
+
+Insert a diagram from a mermaid string.
+
+### `::make_from_html`
+
+Insert a node from an HTML string as wireframe (minimal styling).
+This exceptionally accepts interactive elements (e.g. inputs, buttons, etc.)
+
+### `::make_from_widget`
+
+Insert a subtree from a shortcode widget token (similar to flutter)
+This is useful for wireframing
+
+```xml
+<column width="1000" height="1000">
+  <button>
+    <text size="20" weight="bold">Click me</text>
+  </button>
+</column>
+```
+
+---
+
+> **Unsafe** tools
+
+### `::unsafe_js_eval`
+
+This calls eval() with the givven code string. needs explicit user approval.
+
+---
+
+> **Resource** tools
+
+### `::resource` / `::asset`
+
+Manages external resources and assets linked to the design for streamlined usage.
+
+- search fonts
+- search icons
+- search photos

--- a/docs/wg/feat-ai/tools-canvas.md
+++ b/docs/wg/feat-ai/tools-canvas.md
@@ -1,5 +1,8 @@
 ---
 title: Canvas Tools (for AI)
+description: Canvas-specific AI toolset for editing Grida design documents — scene-graph operations, specialized inserts, canvas exec/lint/format, and resource lookup.
+keywords: [ai, canvas, tools, editor, grida, scene-graph]
+format: md
 tags:
   - internal
   - wg
@@ -214,7 +217,7 @@ This is useful for wireframing
 
 ### `::unsafe_js_eval`
 
-This calls eval() with the givven code string. needs explicit user approval.
+This calls eval() with the given code string. Needs explicit user approval.
 
 ---
 

--- a/docs/wg/feat-ai/tools.md
+++ b/docs/wg/feat-ai/tools.md
@@ -9,204 +9,265 @@ tags:
 
 # Fundamental Tools (for AI)
 
-This document proposes the philosophical basis for the fundamental toolset, enabling machines to design like humans.
+This document specifies the **fundamental** AI toolset — tools that
+apply to any agent we ship, regardless of where it runs (chat, canvas,
+server, desktop) or what domain it works in.
 
-## Key Principles
+For canvas-specific tools (scene-graph search, specialized inserts,
+canvas exec / lint / format, resource lookup), see
+[`tools-canvas.md`](./tools-canvas.md).
 
-- Versioning, Sandboxing, and Rolling Back
+## Key principles
+
+- **Always available.** Fundamentals are the baseline every agent
+  surface ships with. A bare chat that has nothing else still has these.
+- **Zero or near-zero cost.** No sandbox, no provisioned environment,
+  no remote LLM-side spend. The host owns the implementation; the model
+  just calls the tool.
+- **Backend-agnostic by signature.** The same `read_file({ path })`
+  call works whether the underlying storage is in-memory (`MemoryBackend`),
+  OPFS in the browser (`OpfsBackend`), real disk in Node
+  (`NodeFsBackend`), or a future remote document store. What changes
+  across environments is the **backend** under the fs, not the tool
+  schema the model sees.
+- **Shell, when available, is additive — not a replacement.** A
+  desktop or sandbox agent that ships a `bash` tool still keeps the
+  structured fs tools. They aren't redundant: `edit_file`'s match-and-
+  replace contract is safer than `sed -i`; `grep_files`' structured
+  `{path, line, text}` output is cheaper than parsing `grep`'s pipe
+  format; the model can be granted `edit_file` without granting
+  arbitrary shell. This mirrors Claude Code's design, which exposes
+  `Read` / `Edit` / `Write` / `Glob` / `Grep` _alongside_ `Bash`.
+- **Mirror something proven.** Unix command surface where possible
+  (`grep`, `ls`), established IDE surface where unix doesn't apply
+  ("Find in Files"). The model already knows these shapes — naming with
+  them buys instant calibration. Constraint: agent tools can query but
+  can't pipe, so we mirror the **query** form, not the full shell
+  composition.
+
+## Categories
+
+| Category       | Tools                                                                  | Where it lives                          |
+| -------------- | ---------------------------------------------------------------------- | --------------------------------------- |
+| Filesystem     | `read_file` / `edit_file` / `write_file` / `list_files` / `grep_files` | `packages/grida-agent-tools/src/fs/`    |
+| Planning       | `todo_write`                                                           | `packages/grida-agent-tools/src/todos/` |
+| Tool discovery | `tool_search` _(proposed)_                                             | TBD                                     |
+| Shell          | `bash` _(future, env-specific)_                                        | host-supplied when sandbox/desktop      |
+
+## Mirror of Claude Code's tool surface
+
+The shapes track Claude Code closely, since the patterns are proven:
+
+| Claude Code  | Grida (fundamental)        | Notes                                                             |
+| ------------ | -------------------------- | ----------------------------------------------------------------- |
+| `Read`       | `read_file`                | Same shape.                                                       |
+| `Edit`       | `edit_file`                | Same shape, plus our version-checked staleness guard.             |
+| `Write`      | `write_file`               | Same shape, plus optional `version` for stale-check on overwrite. |
+| `Glob`       | (~`list_files`)            | We have a simpler enumerate; can promote to Glob-shape later.     |
+| `Grep`       | `grep_files`               | Same shape — literal/regex content search.                        |
+| `TodoWrite`  | `todo_write`               | Same shape, same semantics, snake-cased.                          |
+| `ToolSearch` | `tool_search` _(proposed)_ | Same shape, two-level (literal + semantic) proposed.              |
+| `Bash`       | — _(future)_               | Additive, not a replacement for the fs tools when we ship it.     |
 
 ## Tools
 
 ---
 
-> **Search** Tools
+> **Filesystem** tools (fundamental)
 
-### `::man`
+These tools cover the standard fs operations every code-aware agent
+needs. The signatures are storage-agnostic — `read_file("/canvas.svg")`
+makes the same sense whether the path resolves to an in-memory map, an
+OPFS file, a real `node:fs` file under a tmp dir, or a future remote
+document store. The implementation lives in
+[`packages/grida-agent-tools/src/fs/`](../../../packages/grida-agent-tools/src/fs/); the README there
+carries the full contract (mounts, bindings, backends, safety contract).
 
-This tool serves as the documentation and self-discovery interface for all other tools, inspired by the Unix `man` command. It displays structured, human-readable manual pages for any tool, including syntax, description, and examples, and acts as the primary entry point for understanding system capabilities.
+The fs is content-agnostic and multi-file. A path can be **bound** to
+live state (an editor, a doc model) or **pure** in-memory storage
+(notes, scratch). Both shapes share the API.
 
-### `::tree`
+These tools stay even when the agent gains shell access. Structured
+file ops coexist with `bash` rather than being replaced by it —
+`edit_file`'s match-and-replace contract is safer than `sed`, and the
+structured outputs are cheaper to consume than shell stdout.
 
-Similar to the [`tree`](<https://en.wikipedia.org/wiki/Tree_(command)>) command, this tool returns the tree structure of the node.
+### `::read_file`
 
-It enables hierarchical understanding of design components for structured processing.
+Read a file's content + a freshness token. Always call before any edit;
+re-read on `stale`. Same shape as Claude Code's `Read`.
 
-Example:
+### `::edit_file`
 
-```
-└─ ⛶  Document (nodes=4, scenes=1, entry=scene)
-   └─ ⛶  Frame HeroSection  (type=container, id=frame)  [1280×720]  fill=#111111  opacity=0.9
-      ├─ ✎  Text Title  (type=text, id=text)  "Welcome to Grida"  font=Inter  size=32  weight=700
-      └─ ◼  Rect Button  (type=rectangle, id=button)  [160×48]  fill=#3B82F6  radius=8
-```
+Match-and-replace edit. The default write path — cheap, safe, must
+locate the change.
 
-### `::snapshot`
+Matching: literal substring first, then a whitespace-normalized
+fallback. Ambiguous matches reject unless `replace_all: true`. The
+strategy is conservative on purpose — closer to Claude Code's `Edit`
+than to aider's diff fuzzing. Mirrors the find-and-replace shape every
+editor agent has settled on.
 
-This takes a snapshot of the current canvas state.
+### `::write_file`
 
-### `::search`
+Full-file upsert. `version` optional: include it (from the last read)
+for an explicit wholesale rewrite with staleness safety; omit it for a
+permissive write that bypasses the freshness check (use for fresh-start
+writes). Same shape as Claude Code's `Write`, plus the optional version
+for stale-check.
 
-Searches the scene graph for nodes by **semantics**, **geometry**, and **structure**. Returns a stable, ordered list of node IDs (plus brief metadata) without dumping full nodes.
+### `::list_files`
 
-- **Semantics**: type, role, name text, style tokens (fill/stroke/font), accessibility labels.
-- **Geometry**: point/region queries (contains, intersects, overlaps), relations (near, aligned_to, left_of, above), size/ratio ranges.
-- **Structure**: ancestry/descendancy (within, has_child, sibling_of), component/instance links.
-- **Ordering**: by z-index, document order, reading order, distance to point, or score.
+Enumerate every known file. Sorted absolute paths. Today this is a flat
+enumeration; if we need filename pattern matching later we'll promote
+to a Glob-shape (Claude Code's `Glob`).
 
-**Notes**
+### `::grep_files`
 
-- Read-only; pairs with `::select` and `::exec` for actions.
-- Supports boolean logic and filters (e.g., `type:Text AND near:(200,480,32)`), and pagination/cursors for large results.
-- Returns compact briefs `{id, type, name?, bbox?, z?}` to minimize token cost.
+Literal substring search across every known file. Returns one entry per
+matching line with a 1-indexed line number and the full line text.
+Mirrors `grep -n -F` (case-sensitive, fixed-string by default; pass
+`case_sensitive: false` for `-i`). Same shape as Claude Code's `Grep`.
+Does NOT count as a `read_file` — search is for finding things, not for
+claiming you've read them.
 
-This tool enables efficient retrieval of nodes based on complex criteria for precise design queries.
+Roadmap:
 
-### `::text_content`
-
-Similar to [DOM's textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent), this tool extracts the node as plain text.
-
-Unlike the DOM, the design is likely unordered; this tool accepts an optional argument for sorting, aligning with geometric layout so that the output follows the reading direction.
-
-This tool provides a clean textual representation of design elements to facilitate analysis and manipulation.
-
-### `::html`
-
-This exports a canvas subtree as HTML.
-
-It allows integration and reuse of design elements in web environments.
-
-### `::peek_pixels`
-
-This peeks at pixels at a specific point in the canvas or node.
-
-It provides precise visual inspection for pixel-level verification.
-
-### `::image`
-
-This exports a canvas subtree as an image.
-
-### `::diff`
-
-This diffs the nodes between the current canvas and the target canvas.
-
-It supports change detection and version comparison within designs.
+- **Level 1 (shipped):** literal substring search. Cheap, deterministic,
+  works offline.
+- **Level 2 (future):** semantic / RAG search. Higher cost, requires
+  embeddings infrastructure. Will ship as a separate tool name (e.g.
+  `semantic_search`) rather than overloading `grep_files`, so the model
+  picks the cost tier explicitly.
 
 ---
 
-> **Awareness** tools
+> **Planning** tools (fundamental)
 
-### `::select`
+### `::todo_write`
 
-This selects nodes at a specific point in the canvas.
+Plan and track work. Pass the complete list of todos every call — the
+prior list is replaced wholesale. Mirrors Claude Code's `TodoWrite`.
 
-It facilitates targeted interaction and editing of design elements.
-
----
-
-> **Run** tools
-
-### `::exec`
-
-This executes a command on the canvas scripting api sandbox.
-
-It enables dynamic manipulation of the canvas through scripted instructions.
-
-### `::lint`
-
-This generates a visual linting report for the current state of the canvas subtree.
-
-It helps identify and enforce design consistency and best practices.
-
-### `::format`
-
-Formats design elements for consistent presentation and output.
-
----
-
-> **Specialized Insert** tools
-
-### `::make_from_grida`
-
-Insert a .grida compat partial or full packed subtree.
-
-This should support json and kdl format.
-
-```kdl
-clipboard {
-  container "page" {
-    container "header" {
-      text "Logo" {
-        font "Inter"
-        size 16
-        weight 700
-      }
+```json
+{
+  "todos": [
+    {
+      "content": "Add a star", // imperative
+      "activeForm": "Adding a star", // present continuous
+      "status": "in_progress" // pending | in_progress | completed
     }
-  }
+  ]
 }
 ```
 
-### `::make_from_svg`
+- **Exactly one `in_progress` at a time.** Enforced socially by the
+  prompt; the visible list makes drift obvious.
+- **No batched updates.** The model should update as it works.
+- **Replace-all.** No per-item ops; the whole list is the input.
 
-Insert a node from an SVG string.
+Use it when the work is non-trivial (multiple edits, exploration,
+anything you'd break into steps). Skip it for one-shot edits.
 
-### `::make_from_image`
+Implementation:
+[`packages/grida-agent-tools/src/todos/`](../../../packages/grida-agent-tools/src/todos/).
 
-Insert a node from an image URL/Data. (Non SVG)
+---
 
-| image  | support                   |
-| ------ | ------------------------- |
-| `png`  | default                   |
-| `jpg`  | default                   |
-| `webp` | with webp feature enabled |
-| `gif`  | planned                   |
-| `svg`  | reject                    |
+> **Tool discovery** tools (fundamental) — _PROPOSED, not yet implemented_
 
-### `::make_from_markdown`
+### `::tool_search` _(proposed)_
 
-Insert a node from a markdown (or plain txt) string.
+As the toolkit grows — more fundamentals, per-env tools (canvas, future
+text-editor, future video timeline), custom MCP servers — the model
+can't reasonably hold every tool's full schema in its working context.
+We need a discovery mechanism that lets the model find tools by intent.
 
-### `::make_from_csv`
+Mirrors Claude Code's `ToolSearch`: deferred tool schemas live in a
+catalog; the model queries the catalog by name or by keyword, and the
+host returns the matching tools' full schemas inline. The model then
+calls those tools normally.
 
-Insert a table from a CSV string.
+**Two-level design:**
 
-### `::make_from_mermaid`
+| Level   | Search type          | Cost            | When                                                                           |
+| ------- | -------------------- | --------------- | ------------------------------------------------------------------------------ |
+| Level 1 | Text / token match   | Zero            | Default. Substring + ranked keyword match on tool name + description.          |
+| Level 2 | Semantic / embedding | Cheap, non-zero | Optional fallback when text match is empty. Embeddings over tool descriptions. |
 
-Insert a diagram from a mermaid string.
+The model picks the level via a hint (`mode: "literal" | "semantic"`),
+default `literal`. Level 2 is invoked only on miss, keeping the typical
+path zero-cost.
 
-### `::make_from_html`
+**Sketch of the surface:**
 
-Insert a node from an HTML string as wireframe (minimal styling).
-This exceptionally accepts interactive elements (e.g. inputs, buttons, etc.)
-
-### `::make_from_widget`
-
-Insert a subtree from a shortcode widget token (similar to flutter)
-This is useful for wireframing
-
-```xml
-<column width="1000" height="1000">
-  <button>
-    <text size="20" weight="bold">Click me</text>
-  </button>
-</column>
+```ts
+tool_search({
+  // Pick one shape:
+  query: "send slack message",         // free-text intent
+  // or
+  select: ["Read", "Edit", "Grep"],    // exact tool names
+  max_results?: 5,
+})
+→ {
+  tools: [
+    { name: "slack_post_message", description: "...", schema: {...} },
+    ...
+  ]
+}
 ```
 
+**Why we want this:**
+
+- Tool surface is going to grow fast: agent-fs (5) + agent-todos (1) +
+  canvas tools (15+) + future env tools + user-installed MCP servers.
+  Sending every schema with every request burns context for no reason.
+- Deferred schemas keep the system prompt small. Only tool _names_
+  ship in the always-present catalog; full schemas materialize on
+  demand.
+- Aligns with how Claude Code itself handles MCP discovery — the model
+  already knows this pattern.
+
+**Open questions** (decide before implementing):
+
+- Where does the tool catalog live? Static manifest per host (cheap,
+  rebuild on tool changes) vs. a runtime registry (live updates).
+- Who decides which tools are "always on" vs. "deferred"? Probably:
+  fundamentals always on, env tools always on for their env, MCP tools
+  deferred by default.
+- Level 2 embeddings — on-device (transformers.js) vs. a cheap remote
+  endpoint? Latency vs. infra cost tradeoff.
+
+Tracked status: **proposed**. No implementation yet; the four other
+fundamentals + canvas tools are enough that we haven't felt the pinch.
+When we add a second env (e.g. agent surface for the form builder) or
+the first MCP integration, this becomes the next thing to ship.
+
 ---
 
-> **Unsafe** tools
+## What lives where
 
-### `::unsafe_js_eval`
+- `packages/grida-agent-tools/src/fs/` — filesystem fundamentals
+  ([README](../../../packages/grida-agent-tools/src/fs/README.md))
+- `packages/grida-agent-tools/src/todos/` — planning fundamentals
+  ([README](../../../packages/grida-agent-tools/src/todos/README.md))
+- `packages/grida-agent-tools/src/tool-search/` — _not yet created; see proposal above_
+- `editor/grida-canvas-hosted/ai/tools/` — canvas tools (the existing
+  `canvas-use` collection); see
+  [`tools-canvas.md`](./tools-canvas.md) for the catalog.
 
-This calls eval() with the givven code string. needs explicit user approval.
+## Adding a new fundamental tool
 
----
+Bar: would every agent want this, regardless of env? If yes, it's
+fundamental. Examples that pass the bar: filesystem, planning, tool
+discovery, time/clock, env metadata. Examples that fail: anything
+canvas-specific, anything network-bound (those are MCP or per-env).
 
-> **Resource** tools
+Process:
 
-### `::resource` / `::asset`
-
-Manages external resources and assets linked to the design for streamlined usage.
-
-- search fonts
-- search icons
-- search photos
+1. Drop it in `packages/grida-agent-tools/src/<name>/` with its own README, class,
+   AI-SDK tool schema, and pure-logic tests.
+2. Add a row to the Categories table above.
+3. Add a `::<name>` section under the right category.
+4. If it's vfs-only (only needed because we lack shell), mark it so —
+   the host can then drop it when shell is available.

--- a/docs/wg/feat-ai/tools.md
+++ b/docs/wg/feat-ai/tools.md
@@ -1,5 +1,8 @@
 ---
 title: Fundamental Tools (for AI)
+description: Fundamental AI toolset — agent-host capabilities (filesystem, planning, tool discovery) that apply to any Grida agent regardless of surface or domain.
+keywords: [ai, tools, agent, filesystem, planning, grida]
+format: md
 tags:
   - internal
   - wg
@@ -80,7 +83,7 @@ needs. The signatures are storage-agnostic — `read_file("/canvas.svg")`
 makes the same sense whether the path resolves to an in-memory map, an
 OPFS file, a real `node:fs` file under a tmp dir, or a future remote
 document store. The implementation lives in
-[`packages/grida-agent-tools/src/fs/`](../../../packages/grida-agent-tools/src/fs/); the README there
+[`packages/grida-agent-tools/src/fs/`](https://github.com/gridaco/grida/tree/main/packages/grida-agent-tools/src/fs); the README there
 carries the full contract (mounts, bindings, backends, safety contract).
 
 The fs is content-agnostic and multi-file. A path can be **bound** to
@@ -170,7 +173,7 @@ Use it when the work is non-trivial (multiple edits, exploration,
 anything you'd break into steps). Skip it for one-shot edits.
 
 Implementation:
-[`packages/grida-agent-tools/src/todos/`](../../../packages/grida-agent-tools/src/todos/).
+[`packages/grida-agent-tools/src/todos/`](https://github.com/gridaco/grida/tree/main/packages/grida-agent-tools/src/todos).
 
 ---
 
@@ -248,9 +251,9 @@ the first MCP integration, this becomes the next thing to ship.
 ## What lives where
 
 - `packages/grida-agent-tools/src/fs/` — filesystem fundamentals
-  ([README](../../../packages/grida-agent-tools/src/fs/README.md))
+  ([README](https://github.com/gridaco/grida/blob/main/packages/grida-agent-tools/src/fs/README.md))
 - `packages/grida-agent-tools/src/todos/` — planning fundamentals
-  ([README](../../../packages/grida-agent-tools/src/todos/README.md))
+  ([README](https://github.com/gridaco/grida/blob/main/packages/grida-agent-tools/src/todos/README.md))
 - `packages/grida-agent-tools/src/tool-search/` — _not yet created; see proposal above_
 - `editor/grida-canvas-hosted/ai/tools/` — canvas tools (the existing
   `canvas-use` collection); see

--- a/packages/grida-agent-tools/CHANGELOG.md
+++ b/packages/grida-agent-tools/CHANGELOG.md
@@ -1,0 +1,66 @@
+# `@grida/agent-tools` changelog
+
+The package evolves on its own branch. Every breaking change to the public API surface (the symbols exported from any of the `exports` map entry points) must land in this changelog so consumers can track what to update.
+
+## Unreleased
+
+### Public API redesign — class + namespace pattern
+
+The package now exposes exactly two top-level symbols — `AgentFs` and `AgentTodos` — each a class with a same-named namespace. Everything that used to be a flat export from `@grida/agent-tools/fs` or `@grida/agent-tools/todos` is now grouped under one of those identifiers:
+
+| Before (flat export)                   | After (member of namespace)                    |
+| -------------------------------------- | ---------------------------------------------- |
+| `AgentFsBackend`                       | `AgentFs.Backend`                              |
+| `LiveBinding`                          | `AgentFs.LiveBinding`                          |
+| `FsEvent`                              | `AgentFs.Event`                                |
+| `FsListener`                           | `AgentFs.Listener`                             |
+| `AgentFsOptions`                       | `AgentFs.Options`                              |
+| `ReadResult`, `WriteResult`, …         | `AgentFs.ReadResult`, `AgentFs.WriteResult`, … |
+| `MemoryBackend`                        | `AgentFs.MemoryBackend`                        |
+| `tools` (or `fsTools`)                 | `AgentFs.tools`                                |
+| `TOOL_NAMES` (or `FS_TOOL_NAMES`)      | `AgentFs.TOOL_NAMES`                           |
+| `ToolName` (or `FsToolName`)           | `AgentFs.ToolName`                             |
+| `AgentFsTools`                         | `AgentFs.Tools`                                |
+| `resolveAgentFsToolCall`               | `AgentFs.resolveToolCall`                      |
+| `Todo`, `TodoStatus`                   | `AgentTodos.Todo`, `AgentTodos.Status`         |
+| `TodoWriteSuccess` (or `WriteSuccess`) | `AgentTodos.WriteSuccess`                      |
+| `tools` (or `todoTools`)               | `AgentTodos.tools`                             |
+| `TOOL_NAMES` (or `TODO_TOOL_NAMES`)    | `AgentTodos.TOOL_NAMES`                        |
+| `ToolName` (or `TodoToolName`)         | `AgentTodos.ToolName`                          |
+| `AgentTodosTools`                      | `AgentTodos.Tools`                             |
+| `resolveAgentTodosToolCall`            | `AgentTodos.resolveToolCall`                   |
+
+The root entry now re-exports only the two class+namespace symbols:
+
+```ts
+import { AgentFs, AgentTodos } from "@grida/agent-tools";
+```
+
+The previous `export * as fs / * as todos` namespace barrels are gone.
+
+Env-restricted backends still live behind their own subpaths — they have to, because they reach for env-specific globals (`navigator.storage`, `node:fs`):
+
+```ts
+import { OpfsBackend } from "@grida/agent-tools/fs/backends/opfs";
+import { NodeFsBackend } from "@grida/agent-tools/fs/backends/node";
+```
+
+Both implement `AgentFs.Backend`.
+
+### Removed — internal helpers no longer exported
+
+The match-and-replace helpers used by `AgentFs.edit()` were public but pure implementation detail. They have moved to `src/fs/internal/match.ts` and are no longer reachable from `@grida/agent-tools/fs`. Use `AgentFs.edit()` or the `edit_file` AI-SDK tool instead.
+
+- `findMatches`
+- `collapseWhitespace`
+- `applyReplacements`
+
+### Added
+
+- `src/__public-api__.test.ts` — guard test that pins the shape of every public symbol, including:
+  - That the root entry exposes exactly `AgentFs` and `AgentTodos` (adding a third is a deliberate design break).
+  - That internal helpers are NOT re-exported under the namespaces.
+
+## 0.0.0
+
+Initial private release. Co-located with `feature/svg-editor` for the SVG agent demo. Public surface is the one documented in [`README.md`](./README.md).

--- a/packages/grida-agent-tools/README.md
+++ b/packages/grida-agent-tools/README.md
@@ -1,0 +1,135 @@
+# `@grida/agent-tools`
+
+Storage-agnostic runtime primitives for Grida AI agents. Pure logic,
+no React, no LLM coupling. Tests run in Node — the filesystem backend
+suite uses a real `os.tmpdir()` workspace.
+
+## What's in the box
+
+Two top-level symbols, each a class with a same-named TypeScript namespace that groups its types, AI-SDK tool table, dispatcher, and (for `AgentFs`) default in-process backend:
+
+| Symbol                           | What it is                                                                |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| `AgentFs` (class + namespace)    | Virtual filesystem facade with versioned reads + match-and-replace edits. |
+| `AgentTodos` (class + namespace) | Replace-all plan / todo store the agent updates as it works.              |
+
+Env-restricted backends live behind their own subpaths so a bare `import "@grida/agent-tools"` never pulls `navigator.storage` or `node:fs`. Both implement `AgentFs.Backend`:
+
+| Subpath                               | What it exports                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| `@grida/agent-tools`                  | `AgentFs`, `AgentTodos` (re-exports of the subpath classes — preferred entry).   |
+| `@grida/agent-tools/fs`               | `AgentFs` (class + namespace) directly.                                          |
+| `@grida/agent-tools/fs/backends/opfs` | `OpfsBackend`. **Browser-only** — keeps `navigator.storage` out of Node bundles. |
+| `@grida/agent-tools/fs/backends/node` | `NodeFsBackend`. **Node-only** — keeps `node:fs` out of browser bundles.         |
+| `@grida/agent-tools/todos`            | `AgentTodos` (class + namespace) directly.                                       |
+
+Detailed contracts live in the per-module READMEs:
+
+- [`src/fs/README.md`](./src/fs/README.md) — fs primitives, bindings, backends, match-and-replace contract, AI-SDK tools (`read_file` / `edit_file` / `write_file` / `list_files` / `grep_files`).
+- [`src/todos/README.md`](./src/todos/README.md) — plan/todo store + `todo_write` tool.
+
+## Why this exists
+
+Every Grida AI agent — present (the `/svg` demo) and future (canvas
+agent, server-side workers, possible MCP servers, possible desktop
+agent) — needs the same set of low-level primitives:
+
+- A virtual filesystem with versioned reads and match-and-replace edits.
+- A plan/todo store the agent updates as it works.
+- AI-SDK tool schemas that expose both to the LLM.
+
+Co-locating them under one package keeps the contract auditable: there
+is **one** definition of what `edit_file` does, one definition of how
+ambiguity is rejected, one definition of how the staleness guard works.
+
+## Design tenets
+
+- **Class + namespace, never grab-bag exports.** The public surface
+  is grouped under `AgentFs` and `AgentTodos`. Adding a third top-level
+  symbol is a deliberate design break (and the public-API guard test
+  enforces it).
+- **Storage-agnostic signatures.** `read_file({ path })` has the same
+  shape against `AgentFs.MemoryBackend`, `OpfsBackend`, `NodeFsBackend`,
+  or a future remote backend. Backends change; the tool surface doesn't.
+- **No React.** Class-based, observable via `subscribe(cb)`. Hosts wire
+  `useSyncExternalStore` themselves.
+- **No LLM in tests.** Everything is unit-testable in Node, including
+  the real-filesystem backend.
+- **Mirror proven shapes.** `read_file`/`edit_file`/`write_file`/
+  `list_files`/`grep_files` mirror Claude Code's `Read`/`Edit`/`Write`/
+  `Glob`/`Grep`. `todo_write` mirrors `TodoWrite`. The model already
+  knows these shapes.
+- **YAGNI.** Two modules (`fs`, `todos`) is enough for today. Future
+  additions (tool discovery, etc.) slot in as new subdirs when shipped.
+
+## Dependencies
+
+| Kind           | Packages                         | Why                                                                  |
+| -------------- | -------------------------------- | -------------------------------------------------------------------- |
+| `dependencies` | _(none)_                         | Keep the runtime surface minimal.                                    |
+| `peerDeps`     | `ai >= 6`, `zod >= 4`            | The fs / todos `index.ts` modules use them. Hosts already have them. |
+| `devDeps`      | `vitest`, `typescript`, `tsdown` | Tests + build.                                                       |
+
+## Usage shape
+
+```ts
+import { AgentFs, AgentTodos } from "@grida/agent-tools";
+import { OpfsBackend } from "@grida/agent-tools/fs/backends/opfs";
+import {
+  Chat,
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from "ai";
+
+const fs = new AgentFs(
+  OpfsBackend.isSupported()
+    ? new OpfsBackend(["my-app", "v1"])
+    : new AgentFs.MemoryBackend()
+);
+fs.mount("/canvas.svg", myEditorBinding); // myEditorBinding: AgentFs.LiveBinding
+await fs.hydrate();
+
+const todos = new AgentTodos();
+
+const chat = new Chat({
+  transport: new DefaultChatTransport({ api: "/api/agent" }),
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  onToolCall: ({ toolCall }) => {
+    const output =
+      AgentFs.resolveToolCall(fs, toolCall) ??
+      AgentTodos.resolveToolCall(todos, toolCall);
+    if (output === undefined) return;
+    chat.addToolResult({
+      tool: toolCall.toolName,
+      toolCallId: toolCall.toolCallId,
+      output,
+    });
+  },
+});
+```
+
+Server-side agent definitions compose both tool tables:
+
+```ts
+import { AgentFs, AgentTodos } from "@grida/agent-tools";
+import { ToolLoopAgent } from "ai";
+
+const tools = { ...AgentFs.tools, ...AgentTodos.tools } as const;
+
+const agent = new ToolLoopAgent({ model, instructions, tools, ... });
+```
+
+## Testing
+
+```sh
+pnpm --filter @grida/agent-tools test
+```
+
+All tests run in Node. The Node backend tests create a fresh
+`os.tmpdir()` directory per test and clean up afterwards.
+
+## Status
+
+Private package, version `0.0.0`. The first consumer is `editor/` (the
+`/svg` demo). When a second consumer appears or we decide to publish,
+we'll flip `"private": false` and bump to `0.1.0`.

--- a/packages/grida-agent-tools/package.json
+++ b/packages/grida-agent-tools/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@grida/agent-tools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Storage-agnostic runtime primitives for Grida AI agents: virtual filesystem (with pluggable backends + live-state bindings), plan/todo store, and the AI-SDK tool schemas that expose them.",
+  "license": "MIT",
+  "author": "Grida",
+  "repository": "https://github.com/gridaco/grida",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./fs": {
+      "types": "./dist/fs/index.d.ts",
+      "import": "./dist/fs/index.mjs",
+      "require": "./dist/fs/index.js"
+    },
+    "./fs/backends/opfs": {
+      "types": "./dist/fs/backends/opfs.d.ts",
+      "import": "./dist/fs/backends/opfs.mjs",
+      "require": "./dist/fs/backends/opfs.js"
+    },
+    "./fs/backends/node": {
+      "types": "./dist/fs/backends/node.d.ts",
+      "import": "./dist/fs/backends/node.mjs",
+      "require": "./dist/fs/backends/node.js"
+    },
+    "./todos": {
+      "types": "./dist/todos/index.d.ts",
+      "import": "./dist/todos/index.mjs",
+      "require": "./dist/todos/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "prepack": "tsdown",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsdown": "^0.21.9",
+    "typescript": "^6",
+    "vitest": "^4"
+  },
+  "peerDependencies": {
+    "ai": "^6",
+    "zod": "^4"
+  }
+}

--- a/packages/grida-agent-tools/src/__public-api__.test.ts
+++ b/packages/grida-agent-tools/src/__public-api__.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Public-API guard test. Pins the shape and presence of every symbol
+ * `@grida/agent-tools` (and its subpaths) exports.
+ *
+ * This is intentionally separate from the behavioural tests in
+ * `fs/fs.test.ts`, `fs/backends/node.test.ts`, `todos/todos.test.ts`.
+ * Those exercise behaviour; this one exercises the **contract**. A
+ * rename, signature change, or accidental drop here = a breaking change
+ * for consumers — the test should fail until the README / CHANGELOG has
+ * been updated to advertise it.
+ *
+ * The package exposes exactly two top-level symbols (`AgentFs`,
+ * `AgentTodos`), each a class + same-named namespace. New public
+ * additions go inside one of those namespaces. New top-level exports
+ * are an explicit design decision — review carefully before adding.
+ */
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { AgentFs, AgentTodos } from "./index";
+import * as Root from "./index";
+import * as Fs from "./fs";
+import * as Todos from "./todos";
+import { OpfsBackend } from "./fs/backends/opfs";
+import { NodeFsBackend } from "./fs/backends/node";
+
+describe("@grida/agent-tools public API", () => {
+  describe("root entry", () => {
+    it("exposes exactly AgentFs and AgentTodos", () => {
+      // Two named exports — that's the entire root surface. Adding a
+      // third top-level symbol is a deliberate design break and should
+      // fail this assertion until both the README and the CHANGELOG are
+      // updated.
+      expectTypeOf<keyof typeof Root>().toEqualTypeOf<
+        "AgentFs" | "AgentTodos"
+      >();
+    });
+
+    it("re-exports the subpath classes verbatim", () => {
+      expectTypeOf(Root.AgentFs).toEqualTypeOf(Fs.AgentFs);
+      expectTypeOf(Root.AgentTodos).toEqualTypeOf(Todos.AgentTodos);
+    });
+  });
+
+  describe("AgentFs (class + namespace)", () => {
+    it("is constructible with a Backend", () => {
+      expectTypeOf(AgentFs).toBeConstructibleWith(new AgentFs.MemoryBackend());
+    });
+
+    it("exposes Backend, LiveBinding, Event, Listener", () => {
+      const backend: AgentFs.Backend = new AgentFs.MemoryBackend();
+      const binding: AgentFs.LiveBinding = {
+        serialize: () => "",
+        load: () => {},
+        getVersion: () => 0,
+      };
+      const ev: AgentFs.Event = { type: "write", path: "/x", version: 0 };
+      const listener: AgentFs.Listener = () => {};
+
+      // Runtime check anchors the type-only assertions above.
+      expect(backend).toBeInstanceOf(AgentFs.MemoryBackend);
+      expect(typeof binding.serialize).toBe("function");
+      expect(ev.type).toBe("write");
+      expect(typeof listener).toBe("function");
+    });
+
+    it("exposes result + arg types", () => {
+      // Pure-type guard: the file must compile against every public
+      // result/arg alias. A drop or rename trips the build.
+      type _R = AgentFs.ReadResult;
+      type _WA = AgentFs.WriteArgs;
+      type _W = AgentFs.WriteResult;
+      type _WS = AgentFs.WriteSuccess;
+      type _WF = AgentFs.WriteFailure;
+      type _EA = AgentFs.EditArgs;
+      type _E = AgentFs.EditResult;
+      type _ES = AgentFs.EditSuccess;
+      type _EF = AgentFs.EditFailure;
+      type _D = AgentFs.DeleteResult;
+      type _GA = AgentFs.GrepArgs;
+      type _GM = AgentFs.GrepMatch;
+      type _GR = AgentFs.GrepResult;
+      type _O = AgentFs.Options;
+
+      // Sample value lives on the result-success union — runtime
+      // anchor for the otherwise type-only block.
+      const ok: AgentFs.WriteSuccess = { ok: true, version: 1 };
+      expect(ok.ok).toBe(true);
+    });
+
+    it("exposes failure-reason vocabularies (zod + TS share a source)", () => {
+      // The const tuples that back the zod enums on `AgentFs.tools` are
+      // also the source of the `*FailureReason` TS unions. Catching a
+      // drop here = catching it before zod and TS get out of sync.
+      // Const tuples — readonly arrays of literal-typed strings.
+      expect(Array.isArray(AgentFs.WRITE_FAILURE_REASONS)).toBe(true);
+      expect(Array.isArray(AgentFs.EDIT_FAILURE_REASONS)).toBe(true);
+      expect(Array.isArray(AgentFs.DELETE_FAILURE_REASONS)).toBe(true);
+      expectTypeOf<AgentFs.WriteFailureReason>().toEqualTypeOf<
+        (typeof AgentFs.WRITE_FAILURE_REASONS)[number]
+      >();
+      expectTypeOf<AgentFs.EditFailureReason>().toEqualTypeOf<
+        (typeof AgentFs.EDIT_FAILURE_REASONS)[number]
+      >();
+      expectTypeOf<AgentFs.DeleteFailureReason>().toEqualTypeOf<
+        (typeof AgentFs.DELETE_FAILURE_REASONS)[number]
+      >();
+
+      // Spot-check membership so a typo in the const ARRAY (not the
+      // type alias) is caught at runtime.
+      expect(AgentFs.WRITE_FAILURE_REASONS).toContain("stale");
+      expect(AgentFs.EDIT_FAILURE_REASONS).toContain("ambiguous");
+      expect(AgentFs.DELETE_FAILURE_REASONS).toContain("mounted");
+    });
+
+    it("exposes the AI-SDK tool table + dispatcher", () => {
+      expectTypeOf(AgentFs.tools).toBeObject();
+      expectTypeOf(AgentFs.TOOL_NAMES).toBeObject();
+      expectTypeOf<AgentFs.ToolName>().toEqualTypeOf<
+        "read_file" | "edit_file" | "write_file" | "list_files" | "grep_files"
+      >();
+      expectTypeOf<AgentFs.Tools>().toEqualTypeOf<typeof AgentFs.tools>();
+      expectTypeOf(AgentFs.resolveToolCall).toBeFunction();
+    });
+
+    it("exposes MemoryBackend as the default in-process backend", () => {
+      expectTypeOf(AgentFs.MemoryBackend).toBeConstructibleWith();
+      const b: AgentFs.Backend = new AgentFs.MemoryBackend();
+      void b;
+    });
+
+    it("does NOT re-export internal match helpers under the namespace", () => {
+      // `findMatches` etc. live in `./internal/match` and are NOT
+      // public-facing. Catching a leak here = catching it before it
+      // turns into accidental contract.
+      expectTypeOf<keyof typeof AgentFs>().not.toEqualTypeOf<
+        | "findMatches"
+        | "collapseWhitespace"
+        | "applyReplacements"
+        | keyof typeof AgentFs
+      >();
+    });
+  });
+
+  describe("AgentFs subpath backends", () => {
+    it("OpfsBackend implements AgentFs.Backend", () => {
+      expectTypeOf(OpfsBackend).toBeConstructibleWith(["x"]);
+      const b: AgentFs.Backend = new OpfsBackend(["x"]);
+      void b;
+    });
+
+    it("NodeFsBackend implements AgentFs.Backend", () => {
+      expectTypeOf(NodeFsBackend).toBeConstructibleWith("/");
+      const b: AgentFs.Backend = new NodeFsBackend("/");
+      void b;
+    });
+  });
+
+  describe("AgentTodos (class + namespace)", () => {
+    it("is constructible with no args", () => {
+      expectTypeOf(AgentTodos).toBeConstructibleWith();
+    });
+
+    it("exposes Todo, Status, WriteSuccess", () => {
+      type _S = AgentTodos.Status;
+      type _T = AgentTodos.Todo;
+      type _W = AgentTodos.WriteSuccess;
+
+      // Runtime anchor — the types above must compose into a real value.
+      const sample: AgentTodos.Todo = {
+        content: "x",
+        activeForm: "x",
+        status: "pending",
+      };
+      expect(sample.status).toBe("pending");
+    });
+
+    it("exposes the AI-SDK tool table + dispatcher", () => {
+      expectTypeOf(AgentTodos.tools).toBeObject();
+      expectTypeOf(AgentTodos.TOOL_NAMES).toBeObject();
+      expectTypeOf<AgentTodos.ToolName>().toEqualTypeOf<"todo_write">();
+      expectTypeOf<AgentTodos.Tools>().toEqualTypeOf<typeof AgentTodos.tools>();
+      expectTypeOf(AgentTodos.resolveToolCall).toBeFunction();
+    });
+  });
+});

--- a/packages/grida-agent-tools/src/__public-api__.test.ts
+++ b/packages/grida-agent-tools/src/__public-api__.test.ts
@@ -132,12 +132,16 @@ describe("@grida/agent-tools public API", () => {
       // `findMatches` etc. live in `./internal/match` and are NOT
       // public-facing. Catching a leak here = catching it before it
       // turns into accidental contract.
-      expectTypeOf<keyof typeof AgentFs>().not.toEqualTypeOf<
-        | "findMatches"
-        | "collapseWhitespace"
-        | "applyReplacements"
-        | keyof typeof AgentFs
-      >();
+      //
+      // We assert that the *intersection* of public keys with the
+      // internal names is `never`, so any single leaked name trips
+      // the guard (a `not.toEqualTypeOf<A | B | C>` check would only
+      // fail if all three leaked simultaneously).
+      type LeakedInternalKeys = Extract<
+        keyof typeof AgentFs,
+        "findMatches" | "collapseWhitespace" | "applyReplacements"
+      >;
+      expectTypeOf<LeakedInternalKeys>().toEqualTypeOf<never>();
     });
   });
 

--- a/packages/grida-agent-tools/src/fs/README.md
+++ b/packages/grida-agent-tools/src/fs/README.md
@@ -1,0 +1,226 @@
+# `@/lib/agent-fs`
+
+A real-fs-shaped facade for AI agents to read, edit, write, and list
+files — either against live state (editors, doc models) or pure storage
+(notes, sketches, scratch). Content-agnostic, multi-file, pluggable
+persistence backend. No React, no LLM coupling, fully testable in Node.
+
+This is a **fundamental tool** in the sense
+[`docs/wg/feat-ai/tools.md`](../../../docs/wg/feat-ai/tools.md) uses the
+term: always available, applicable to any agent (chat, canvas,
+server-side), zero-cost, no sandbox required.
+
+The tool **signatures are storage-agnostic** — `read_file("/x.md")`
+makes the same sense whether the backing store is `MemoryBackend`,
+`OpfsBackend` (browser), `NodeFsBackend` (server / tests), or a future
+remote backend. What changes across environments is the backend, not
+the API the model sees. The fs tools also stay relevant when an agent
+gains shell access — `edit_file`'s match-and-replace contract is safer
+than `sed`, structured outputs are cheaper than shell stdout, and
+permissions can be scoped per-tool. This mirrors Claude Code, which
+ships `Read` / `Edit` / `Write` / `Glob` / `Grep` _alongside_ `Bash`.
+
+This module exists because the SVG agent's `AgentVFS` was a single-file,
+single-binding, SVG-shaped class. As soon as you imagine a second use site
+— a markdown notes agent, a multi-document canvas, a server-side worker
+— that shape stops working. `agent-fs` is what falls out when you remove
+those assumptions.
+
+## Mental model
+
+The fs is a flat map from `string` → file. Paths are absolute, start with
+`/`, and use `/` as separator regardless of host OS. Two file shapes
+share the API:
+
+- **Bound files.** `fs.mount(path, binding)` ties a path to an
+  `AgentFs.LiveBinding` — anything with `serialize()` / `load()` / `getVersion()`.
+  Reads and writes go through the binding; freshness comes from
+  `binding.getVersion()`. The backend persists serialized snapshots; on
+  `hydrate()` we feed them back via `binding.load(...)`.
+- **Pure files.** Anything not mounted. Stored as `{content, version}`
+  in memory; version starts at 0 and bumps per write. Persisted by the
+  same backend.
+
+The fs **never inspects bytes**. Formatting, parsing, schema validation
+are the binding's concern.
+
+## API
+
+```ts
+class AgentFs {
+  constructor(backend: AgentFs.Backend, opts?: AgentFs.Options);
+
+  // Mounting
+  mount(path: string, binding: AgentFs.LiveBinding): void;
+  unmount(path: string): void;
+
+  // Persistence lifecycle
+  hydrate(): Promise<void>;
+  dispose(): void;
+
+  // Watch
+  watch(listener: AgentFs.Listener): () => void;
+
+  // File ops
+  list(): string[];
+  exists(path: string): boolean;
+  read(path: string): AgentFs.ReadResult | null;
+  write(
+    path: string,
+    content: string,
+    expected_version: number | null
+  ): AgentFs.WriteResult;
+  edit(path: string, args: AgentFs.EditArgs): AgentFs.EditResult;
+  grep(args: AgentFs.GrepArgs): AgentFs.GrepResult;
+  delete(path: string): AgentFs.DeleteResult; // pure files only
+}
+```
+
+All types (`AgentFs.Backend`, `AgentFs.LiveBinding`, `AgentFs.ReadResult`, the result discriminated unions, etc.) live under the `AgentFs` namespace — see the source for the full list.
+
+## AI-SDK tools
+
+`AgentFs.tools` is the AI-SDK tool table (four zod-schema'd defs plus `grep_files`). Name constants live alongside as `AgentFs.TOOL_NAMES`:
+
+| Tool         | Operation                                                                                         | Claude Code parallel |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------- |
+| `read_file`  | `{ path }` → `{ content, version }`                                                               | `Read`               |
+| `edit_file`  | `{ path, old_string, new_string, replace_all?, version }` → match-and-replace                     | `Edit`               |
+| `write_file` | `{ path, content, version? }` → full upsert; version-checked or permissive                        | `Write`              |
+| `list_files` | `{}` → `{ files: string[] }` — flat enumeration                                                   | ~`Glob` (simpler)    |
+| `grep_files` | `{ pattern, path_prefix?, case_sensitive? }` → `{ matches, files_scanned }`, mirrors `grep -n -F` | `Grep`               |
+
+`AgentFs.resolveToolCall(fs, toolCall)` dispatches inbound calls. Hosts
+plug it into `Chat.onToolCall`:
+
+```ts
+const chat = new Chat({
+  transport: ...,
+  onToolCall: ({ toolCall }) => {
+    const output = AgentFs.resolveToolCall(fs, toolCall);
+    if (output === undefined) return; // not one of ours
+    chat.addToolResult({
+      tool: toolCall.toolName,
+      toolCallId: toolCall.toolCallId,
+      output,
+    });
+  },
+});
+```
+
+```ts
+namespace AgentFs {
+  interface LiveBinding {
+    serialize(): string;
+    load(content: string): void;
+    getVersion(): number;
+    subscribe?(cb: () => void): () => void; // optional, for auto-flush
+  }
+
+  interface Backend {
+    list(): Promise<string[]>;
+    read(path: string): Promise<string | null>;
+    write(path: string, content: string): Promise<void>;
+    delete(path: string): Promise<void>;
+  }
+}
+```
+
+## Safety contract
+
+Every mutating op enforces these invariants:
+
+| Precondition                                         | Failure       | Recovery                       |
+| ---------------------------------------------------- | ------------- | ------------------------------ |
+| `edit_file`: agent hasn't read this path yet         | `not_read`    | Read first                     |
+| `edit_file` / version-checked `write`: stale version | `stale`       | Re-read, integrate, retry      |
+| `edit_file`: `old_string` not in current content     | `not_found`   | Re-read, copy snippet verbatim |
+| `edit_file`: matched N > 1, no `replace_all`         | `ambiguous`   | Add context to disambiguate    |
+| `edit_file`: `old_string === new_string`             | `no_op`       | Pick a real change             |
+| `binding.load(content)` throws                       | `parse_error` | Model fixes the content        |
+| `write` with version on a missing path               | `not_found`   | Pass `version: null` to create |
+
+`write(path, content, null)` is **permissive** — bypasses `not_read` and
+`stale` entirely. Use only when the agent is genuinely starting fresh.
+The host's prompt should discourage casual use.
+
+## Match-and-replace (`edit_file`)
+
+Conservative on purpose — closer to Claude Code's `Edit` than to aider's
+diff fuzzing:
+
+1. **Literal substring match.** Wins almost always when the agent copies
+   the snippet from `read()`.
+2. **Whitespace-normalized fallback.** Runs of whitespace collapse to a
+   single space on both sides; indices map back to the original. Forgives
+   doubled spaces between attributes and minor newline drift; does **not**
+   enable attribute-order rewriting or semantic matching.
+3. **Ambiguity rejection.** N > 1 matches without `replace_all` → reject
+   with `reason: "ambiguous"` + the occurrence count.
+
+Implementation: `findMatches()` in `internal/match.ts` (not part of the public surface — call `AgentFs.edit()` instead).
+
+## Backends
+
+| Backend                                    | Where it runs | Use                                              |
+| ------------------------------------------ | ------------- | ------------------------------------------------ |
+| `AgentFs.MemoryBackend`                    | anywhere      | Tests, SSR, fallback when no persistence         |
+| `OpfsBackend` (subpath `/backends/opfs`)   | browser only  | The `/svg` demo and future canvas surfaces       |
+| `NodeFsBackend` (subpath `/backends/node`) | Node          | Unit tests against a real tmp dir; future server |
+
+All three implement `AgentFs.Backend`. `OpfsBackend` and `NodeFsBackend` live behind subpath imports so a bare `import "@grida/agent-tools/fs"` doesn't pull `window.navigator.storage` or `node:fs`.
+
+```ts
+import { OpfsBackend } from "@/lib/agent-fs/backends/opfs"; // browser
+import { NodeFsBackend } from "@/lib/agent-fs/backends/node"; // server / tests
+```
+
+Backends are pure I/O — no caching, no debouncing, no version tracking.
+The fs layer owns those.
+
+## Single-file demos
+
+The SVG demo's "the canvas is at `/canvas.svg`" constraint lives in **two
+thin places**: the binding's `serialize()` does SVG pretty-printing, and
+the system prompt tells the model the path. The fs and tools have no
+notion of a "primary file" — multi-file demos just mount more paths and
+the agent is told about them.
+
+## Testing
+
+Pure logic, runs in Node:
+
+- `fs.test.ts` covers the matcher, `MemoryBackend`, and the fs against
+  `MemoryBackend` — one file, grouped by `describe` block.
+- `backends/node.test.ts` covers `NodeFsBackend` against a real
+  `os.tmpdir()` workspace (created with `fs.mkdtemp`, cleaned up
+  `afterEach`).
+- `backends/opfs.ts` has no test — browser-only. Verify via the `/svg`
+  demo.
+
+Run from the editor root:
+
+```sh
+pnpm vitest run lib/agent-fs
+```
+
+## What this module deliberately is not
+
+- **A general-purpose VFS layer.** No symlinks, no permissions, no mtime,
+  no streaming. The agent surface is the only consumer.
+- **A locking primitive.** Single-tab, single-process. Backends don't
+  implement file locks; concurrent writers on the same path will race.
+- **An IR / format module.** Bytes are opaque to the fs. SVG pretty-
+  printing happens in the binding; markdown linting (if added) would
+  too.
+- **An LLM client.** Tools have no `execute()`; resolution is the host's
+  job via `AgentFs.resolveToolCall`.
+
+## FIXMEs before going beyond demo
+
+- Per-path schema versioning + migration story (today: bump
+  `OpfsBackend`'s root segment, orphan old data).
+- Surface backend failures to the user (today: `console.warn`).
+- Quarantine unparseable bytes (mirror canvas playground's
+  `Handle.quarantine`).
+- Atomic multi-file writes (today: each file flushes independently).

--- a/packages/grida-agent-tools/src/fs/README.md
+++ b/packages/grida-agent-tools/src/fs/README.md
@@ -1,4 +1,4 @@
-# `@/lib/agent-fs`
+# `@grida/agent-tools/fs`
 
 A real-fs-shaped facade for AI agents to read, edit, write, and list
 files — either against live state (editors, doc models) or pure storage
@@ -171,8 +171,8 @@ Implementation: `findMatches()` in `internal/match.ts` (not part of the public s
 All three implement `AgentFs.Backend`. `OpfsBackend` and `NodeFsBackend` live behind subpath imports so a bare `import "@grida/agent-tools/fs"` doesn't pull `window.navigator.storage` or `node:fs`.
 
 ```ts
-import { OpfsBackend } from "@/lib/agent-fs/backends/opfs"; // browser
-import { NodeFsBackend } from "@/lib/agent-fs/backends/node"; // server / tests
+import { OpfsBackend } from "@grida/agent-tools/fs/backends/opfs"; // browser
+import { NodeFsBackend } from "@grida/agent-tools/fs/backends/node"; // server / tests
 ```
 
 Backends are pure I/O — no caching, no debouncing, no version tracking.
@@ -198,10 +198,10 @@ Pure logic, runs in Node:
 - `backends/opfs.ts` has no test — browser-only. Verify via the `/svg`
   demo.
 
-Run from the editor root:
+Run from the repo root:
 
 ```sh
-pnpm vitest run lib/agent-fs
+pnpm --filter @grida/agent-tools test
 ```
 
 ## What this module deliberately is not

--- a/packages/grida-agent-tools/src/fs/backends/node.test.ts
+++ b/packages/grida-agent-tools/src/fs/backends/node.test.ts
@@ -26,6 +26,31 @@ describe("NodeFsBackend (real tmp fs)", () => {
     await expect(b.read("canvas.svg")).rejects.toThrow(/must start/);
   });
 
+  it("rejects path-traversal segments (no escape from baseDir)", async () => {
+    // Write a sentinel *outside* the sandbox so a successful escape would
+    // surface as a real read.
+    const sentinelDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "agent-fs-out-")
+    );
+    const sentinel = path.join(sentinelDir, "secret.txt");
+    await fs.writeFile(sentinel, "TOPSECRET", "utf8");
+    try {
+      const escape =
+        "/" + path.relative(tmp, sentinel).split(path.sep).join("/");
+      await expect(b.read(escape)).rejects.toThrow(/escapes baseDir/);
+      await expect(b.write(escape, "x")).rejects.toThrow(/escapes baseDir/);
+      await expect(b.delete(escape)).rejects.toThrow(/escapes baseDir/);
+      await expect(b.read("/../secret.txt")).rejects.toThrow(/escapes baseDir/);
+      await expect(b.read("/notes/../../secret.txt")).rejects.toThrow(
+        /escapes baseDir/
+      );
+      // Sentinel must still be intact.
+      expect(await fs.readFile(sentinel, "utf8")).toBe("TOPSECRET");
+    } finally {
+      await fs.rm(sentinelDir, { recursive: true, force: true });
+    }
+  });
+
   it("starts empty: list returns [] and read returns null", async () => {
     expect(await b.list()).toEqual([]);
     expect(await b.read("/canvas.svg")).toBeNull();

--- a/packages/grida-agent-tools/src/fs/backends/node.test.ts
+++ b/packages/grida-agent-tools/src/fs/backends/node.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NodeFsBackend } from "./node";
+
+/**
+ * Real-filesystem coverage for `NodeFsBackend`. Each test gets a fresh
+ * tmp dir under `os.tmpdir()` and cleans up afterwards. No mocking.
+ */
+describe("NodeFsBackend (real tmp fs)", () => {
+  let tmp: string;
+  let b: NodeFsBackend;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), "agent-fs-"));
+    b = new NodeFsBackend(tmp);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it("rejects non-absolute paths", async () => {
+    await expect(b.write("canvas.svg", "x")).rejects.toThrow(/must start/);
+    await expect(b.read("canvas.svg")).rejects.toThrow(/must start/);
+  });
+
+  it("starts empty: list returns [] and read returns null", async () => {
+    expect(await b.list()).toEqual([]);
+    expect(await b.read("/canvas.svg")).toBeNull();
+  });
+
+  it("write creates the file on disk; read returns it", async () => {
+    await b.write("/canvas.svg", "<svg/>");
+    expect(await b.read("/canvas.svg")).toBe("<svg/>");
+    // Independently verify with raw fs.
+    const onDisk = await fs.readFile(path.join(tmp, "canvas.svg"), "utf8");
+    expect(onDisk).toBe("<svg/>");
+  });
+
+  it("write creates intermediate directories", async () => {
+    await b.write("/notes/draft.md", "hello");
+    expect(await b.read("/notes/draft.md")).toBe("hello");
+    const stats = await fs.stat(path.join(tmp, "notes"));
+    expect(stats.isDirectory()).toBe(true);
+  });
+
+  it("list enumerates every file across nested directories", async () => {
+    await b.write("/canvas.svg", "A");
+    await b.write("/notes/idea.md", "B");
+    await b.write("/sketches/x/y/diagram.svg", "C");
+    expect(new Set(await b.list())).toEqual(
+      new Set(["/canvas.svg", "/notes/idea.md", "/sketches/x/y/diagram.svg"])
+    );
+  });
+
+  it("delete removes the file; read returns null after", async () => {
+    await b.write("/canvas.svg", "X");
+    await b.delete("/canvas.svg");
+    expect(await b.read("/canvas.svg")).toBeNull();
+  });
+
+  it("delete on a missing path is a no-op", async () => {
+    await expect(b.delete("/never-existed")).resolves.toBeUndefined();
+  });
+
+  it("survives reconstruction (persistence across instance lifetime)", async () => {
+    await b.write("/canvas.svg", "persistent");
+    const b2 = new NodeFsBackend(tmp);
+    expect(await b2.read("/canvas.svg")).toBe("persistent");
+  });
+});

--- a/packages/grida-agent-tools/src/fs/backends/node.ts
+++ b/packages/grida-agent-tools/src/fs/backends/node.ts
@@ -23,9 +23,25 @@ export class NodeFsBackend implements AgentFs.Backend {
     if (!p.startsWith("/")) {
       throw new Error(`agent-fs path must start with "/": ${p}`);
     }
-    // Normalize to disk path. `path.join` handles the rest; the leading
-    // slash is stripped because join treats it as part of the segment.
-    return path.join(this.baseDir, ...p.slice(1).split("/"));
+    // Reject traversal segments up front so a logical path like
+    // `/../etc/passwd` can't escape `baseDir`. Agent paths are POSIX —
+    // backslashes are not directory separators and must be rejected too.
+    const segments = p.slice(1).split("/");
+    if (segments.some((s) => s === ".." || s === "." || s.includes("\\"))) {
+      throw new Error(`agent-fs path escapes baseDir: ${p}`);
+    }
+    const base = path.resolve(this.baseDir);
+    const full = path.resolve(base, ...segments);
+    // Belt-and-suspenders: confirm the resolved path is inside baseDir.
+    const rel = path.relative(base, full);
+    if (
+      rel === ".." ||
+      rel.startsWith(".." + path.sep) ||
+      path.isAbsolute(rel)
+    ) {
+      throw new Error(`agent-fs path escapes baseDir: ${p}`);
+    }
+    return full;
   }
 
   async list(): Promise<string[]> {

--- a/packages/grida-agent-tools/src/fs/backends/node.ts
+++ b/packages/grida-agent-tools/src/fs/backends/node.ts
@@ -1,0 +1,92 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { AgentFs } from "../index";
+
+/**
+ * Node `fs.promises`-backed implementation. The fs's logical paths
+ * (`/canvas.svg`, `/notes/draft.md`) are rooted under `baseDir` on disk;
+ * subdirectories are created on demand.
+ *
+ * Use cases:
+ *  - Unit tests against a real filesystem (point at `os.tmpdir()`).
+ *  - Future server-side persistence (mount on a per-org / per-project
+ *    base directory; out of scope for the demo).
+ *
+ * Not safe for concurrent writers on the same path — there's no locking.
+ * The fs layer's auto-flush is debounced and serializes writes per path,
+ * which is enough for a single-tab single-process agent.
+ */
+export class NodeFsBackend implements AgentFs.Backend {
+  constructor(private readonly baseDir: string) {}
+
+  private resolve(p: string): string {
+    if (!p.startsWith("/")) {
+      throw new Error(`agent-fs path must start with "/": ${p}`);
+    }
+    // Normalize to disk path. `path.join` handles the rest; the leading
+    // slash is stripped because join treats it as part of the segment.
+    return path.join(this.baseDir, ...p.slice(1).split("/"));
+  }
+
+  async list(): Promise<string[]> {
+    const out: string[] = [];
+    await walk(this.baseDir, this.baseDir, out);
+    return out;
+  }
+
+  async read(p: string): Promise<string | null> {
+    try {
+      return await fs.readFile(this.resolve(p), "utf8");
+    } catch (err: unknown) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  async write(p: string, content: string): Promise<void> {
+    const full = this.resolve(p);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, "utf8");
+  }
+
+  async delete(p: string): Promise<void> {
+    try {
+      await fs.rm(this.resolve(p));
+    } catch (err: unknown) {
+      if (isNotFound(err)) return;
+      throw err;
+    }
+  }
+}
+
+async function walk(base: string, dir: string, out: string[]): Promise<void> {
+  let entries: { name: string; isDir: boolean }[];
+  try {
+    const raw = await fs.readdir(dir, { withFileTypes: true });
+    entries = raw.map((e) => ({ name: e.name, isDir: e.isDirectory() }));
+  } catch (err) {
+    if (isNotFound(err)) return;
+    throw err;
+  }
+  const dirs: string[] = [];
+  for (const ent of entries) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDir) {
+      dirs.push(full);
+    } else {
+      const rel = path.relative(base, full);
+      out.push("/" + rel.split(path.sep).join("/"));
+    }
+  }
+  // Descend into subdirectories in parallel — O(depth) round trips
+  // instead of O(entries) when the tree is wide.
+  await Promise.all(dirs.map((d) => walk(base, d, out)));
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}

--- a/packages/grida-agent-tools/src/fs/backends/opfs.ts
+++ b/packages/grida-agent-tools/src/fs/backends/opfs.ts
@@ -1,0 +1,136 @@
+import type { AgentFs } from "../index";
+
+/**
+ * Origin Private File System backend.
+ *
+ * `AgentFs` logical paths (`/canvas.svg`, `/notes/draft.md`) become OPFS
+ * directory + file handles under a fixed root (`baseSegments`). Bumping
+ * the trailing segment is the documented "clear all persisted data"
+ * lever; old data orphans until the browser garbage-collects.
+ *
+ * FIXME(agent-fs-opfs): demo-grade. Before promoting beyond /svg:
+ *   - Real migration story (read old → transform → write new → delete).
+ *   - Quarantine for unparseable bytes (mirror canvas playground).
+ *   - Surface failures to the user instead of console.warn.
+ */
+export class OpfsBackend implements AgentFs.Backend {
+  private root_promise: Promise<FileSystemDirectoryHandle> | null = null;
+
+  static isSupported(): boolean {
+    return (
+      typeof window !== "undefined" &&
+      "storage" in navigator &&
+      "getDirectory" in navigator.storage &&
+      window.isSecureContext
+    );
+  }
+
+  /**
+   * @param baseSegments  Path segments under the origin's OPFS root. The
+   * canonical demo uses `["grida-svg-demo", "v1"]`; bumping `v1` blows
+   * the cache.
+   */
+  constructor(private readonly baseSegments: readonly string[]) {}
+
+  private async getRoot(): Promise<FileSystemDirectoryHandle> {
+    if (!this.root_promise) {
+      this.root_promise = (async () => {
+        const root = await navigator.storage.getDirectory();
+        let cur = root;
+        for (const seg of this.baseSegments) {
+          cur = await cur.getDirectoryHandle(seg, { create: true });
+        }
+        return cur;
+      })().catch((err) => {
+        this.root_promise = null;
+        throw err;
+      });
+    }
+    return this.root_promise;
+  }
+
+  /**
+   * Resolve a logical path to a directory handle + file name pair,
+   * creating directories on demand when `create` is true.
+   */
+  private async resolveDir(
+    p: string,
+    create: boolean
+  ): Promise<{ dir: FileSystemDirectoryHandle; name: string }> {
+    if (!p.startsWith("/")) {
+      throw new Error(`agent-fs path must start with "/": ${p}`);
+    }
+    const segments = p.slice(1).split("/").filter(Boolean);
+    if (segments.length === 0) {
+      throw new Error(`agent-fs path must include a filename: ${p}`);
+    }
+    const name = segments[segments.length - 1];
+    let cur = await this.getRoot();
+    for (let i = 0; i < segments.length - 1; i++) {
+      cur = await cur.getDirectoryHandle(segments[i], { create });
+    }
+    return { dir: cur, name };
+  }
+
+  async list(): Promise<string[]> {
+    const out: string[] = [];
+    const root = await this.getRoot();
+    await walk(root, "", out);
+    return out;
+  }
+
+  async read(p: string): Promise<string | null> {
+    try {
+      const { dir, name } = await this.resolveDir(p, false);
+      const fh = await dir.getFileHandle(name);
+      const f = await fh.getFile();
+      return await f.text();
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  async write(p: string, content: string): Promise<void> {
+    const { dir, name } = await this.resolveDir(p, true);
+    const fh = await dir.getFileHandle(name, { create: true });
+    const writable = await fh.createWritable();
+    try {
+      await writable.write(content);
+    } finally {
+      await writable.close();
+    }
+  }
+
+  async delete(p: string): Promise<void> {
+    try {
+      const { dir, name } = await this.resolveDir(p, false);
+      await dir.removeEntry(name);
+    } catch (err) {
+      if (isNotFound(err)) return;
+      throw err;
+    }
+  }
+}
+
+async function walk(
+  dir: FileSystemDirectoryHandle,
+  prefix: string,
+  out: string[]
+): Promise<void> {
+  // `values()` is async-iterable in spec-compliant browsers.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const entries = (dir as unknown as { values(): AsyncIterable<any> }).values();
+  for await (const entry of entries) {
+    const path = `${prefix}/${entry.name}`;
+    if (entry.kind === "directory") {
+      await walk(entry as FileSystemDirectoryHandle, path, out);
+    } else {
+      out.push(path);
+    }
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "NotFoundError";
+}

--- a/packages/grida-agent-tools/src/fs/backends/opfs.ts
+++ b/packages/grida-agent-tools/src/fs/backends/opfs.ts
@@ -118,9 +118,11 @@ async function walk(
   prefix: string,
   out: string[]
 ): Promise<void> {
-  // `values()` is async-iterable in spec-compliant browsers.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const entries = (dir as unknown as { values(): AsyncIterable<any> }).values();
+  // `values()` is async-iterable in spec-compliant browsers — the typing
+  // for it isn't in the default lib yet.
+  const entries = (
+    dir as unknown as { values(): AsyncIterable<FileSystemHandle> }
+  ).values();
   for await (const entry of entries) {
     const path = `${prefix}/${entry.name}`;
     if (entry.kind === "directory") {

--- a/packages/grida-agent-tools/src/fs/fs.test.ts
+++ b/packages/grida-agent-tools/src/fs/fs.test.ts
@@ -1,0 +1,672 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentFs } from "./index";
+import { applyReplacements, findMatches } from "./internal/match";
+
+/**
+ * Tiny synthetic `LiveBinding` for tests — no editor, just a string +
+ * counter + manual subscribers. Lets us exercise the bound-file path
+ * without dragging `@grida/svg-editor` in.
+ */
+function makeBinding(initial = ""): AgentFs.LiveBinding & {
+  externalEdit(next: string): void;
+  emit(): void;
+  current(): string;
+} {
+  let content = initial;
+  let version = 0;
+  const subs = new Set<() => void>();
+  const emit = () => {
+    for (const cb of subs) cb();
+  };
+  return {
+    serialize: () => content,
+    load: (next: string) => {
+      if (next === "PARSE_FAIL") throw new Error("synthetic parse failure");
+      content = next;
+      version += 1;
+    },
+    getVersion: () => version,
+    subscribe: (cb) => {
+      subs.add(cb);
+      return () => subs.delete(cb);
+    },
+    // Test helpers.
+    externalEdit(next: string) {
+      content = next;
+      version += 1;
+      emit();
+    },
+    emit,
+    current() {
+      return content;
+    },
+  };
+}
+
+const tick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Match primitives
+// ---------------------------------------------------------------------------
+
+describe("findMatches", () => {
+  it("returns disjoint literal ranges in order", () => {
+    expect(findMatches("aaa-aaa", "aaa")).toEqual([
+      [0, 3],
+      [4, 7],
+    ]);
+  });
+
+  it("returns one range when needle matches once", () => {
+    const ranges = findMatches("hello world", "world");
+    expect(ranges).toEqual([[6, 11]]);
+  });
+
+  it("returns no ranges for an empty needle", () => {
+    expect(findMatches("anything", "")).toEqual([]);
+  });
+
+  it("returns no ranges when the needle is absent", () => {
+    expect(findMatches("hello", "xyz")).toEqual([]);
+  });
+
+  it("falls back to whitespace-normalized match when literal misses", () => {
+    const hay = `<rect x="10" y="10" fill="red"/>`;
+    // Doubled space — literal misses, normalized catches.
+    const ranges = findMatches(hay, `x="10"  y="10"`);
+    expect(ranges.length).toBe(1);
+    expect(hay.slice(ranges[0][0], ranges[0][1])).toBe(`x="10" y="10"`);
+  });
+
+  it("ignores leading / trailing whitespace in the needle when falling back", () => {
+    const hay = "alpha beta gamma";
+    const ranges = findMatches(hay, "  beta  ");
+    expect(ranges.length).toBe(1);
+    expect(hay.slice(ranges[0][0], ranges[0][1])).toBe("beta");
+  });
+});
+
+describe("applyReplacements", () => {
+  it("splices a single range", () => {
+    const out = applyReplacements("hello world", [[6, 11]], "there");
+    expect(out).toBe("hello there");
+  });
+
+  it("splices multiple ranges, preserving order", () => {
+    const out = applyReplacements(
+      "aXa-aXa-aXa",
+      [
+        [0, 3],
+        [4, 7],
+        [8, 11],
+      ],
+      "bYb"
+    );
+    expect(out).toBe("bYb-bYb-bYb");
+  });
+
+  it("is a no-op when ranges is empty", () => {
+    expect(applyReplacements("hello", [], "X")).toBe("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MemoryBackend
+// ---------------------------------------------------------------------------
+
+describe("MemoryBackend", () => {
+  it("starts empty", async () => {
+    const b = new AgentFs.MemoryBackend();
+    expect(await b.list()).toEqual([]);
+    expect(await b.read("/canvas.svg")).toBeNull();
+  });
+
+  it("round-trips write / read", async () => {
+    const b = new AgentFs.MemoryBackend();
+    await b.write("/canvas.svg", "<svg/>");
+    expect(await b.read("/canvas.svg")).toBe("<svg/>");
+  });
+
+  it("lists every persisted path", async () => {
+    const b = new AgentFs.MemoryBackend();
+    await b.write("/canvas.svg", "A");
+    await b.write("/notes/idea.md", "B");
+    expect(new Set(await b.list())).toEqual(
+      new Set(["/canvas.svg", "/notes/idea.md"])
+    );
+  });
+
+  it("delete removes the file; read returns null after", async () => {
+    const b = new AgentFs.MemoryBackend();
+    await b.write("/canvas.svg", "<svg/>");
+    await b.delete("/canvas.svg");
+    expect(await b.read("/canvas.svg")).toBeNull();
+  });
+
+  it("delete on a missing path is a no-op", async () => {
+    const b = new AgentFs.MemoryBackend();
+    await expect(b.delete("/never-existed")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentFs
+// ---------------------------------------------------------------------------
+
+describe("AgentFs — basics", () => {
+  it("starts empty and lists nothing", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    expect(fs.list()).toEqual([]);
+    expect(fs.exists("/canvas.svg")).toBe(false);
+    expect(fs.read("/canvas.svg")).toBeNull();
+  });
+
+  it("permissive write creates a pure file with version 1", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const r = fs.write("/notes/draft.md", {
+      content: "hello",
+      expected_version: null,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.version).toBe(1);
+    expect(fs.read("/notes/draft.md")).toEqual({
+      content: "hello",
+      version: 1,
+    });
+    expect(fs.list()).toEqual(["/notes/draft.md"]);
+  });
+
+  it("write with a version on a missing path returns not_found", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const r = fs.write("/notes/draft.md", {
+      content: "hello",
+      expected_version: 0,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("not_found");
+  });
+
+  it("write with stale version is rejected", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/x.md", { content: "v1", expected_version: null });
+    fs.write("/x.md", { content: "v2", expected_version: 1 });
+    const r = fs.write("/x.md", { content: "v3", expected_version: 1 }); // stale (current is 2)
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("stale");
+    expect(r.current_version).toBe(2);
+  });
+});
+
+describe("AgentFs — mounted (live binding)", () => {
+  it("reads through the binding and tracks its version", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding("<svg/>");
+    fs.mount("/canvas.svg", b);
+    expect(fs.read("/canvas.svg")).toEqual({
+      content: "<svg/>",
+      version: 0,
+    });
+  });
+
+  it("write goes through binding.load and the new version is reported", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding("<svg/>");
+    fs.mount("/canvas.svg", b);
+    const r = fs.write("/canvas.svg", {
+      content: "<svg><rect/></svg>",
+      expected_version: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.version).toBe(1);
+    expect(b.current()).toBe("<svg><rect/></svg>");
+  });
+
+  it("binding.load throw → parse_error, baseline unchanged", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding("<svg/>");
+    fs.mount("/canvas.svg", b);
+    const r = fs.write("/canvas.svg", {
+      content: "PARSE_FAIL",
+      expected_version: 0,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("parse_error");
+    // Next write at the same version still works.
+    const r2 = fs.write("/canvas.svg", {
+      content: "<svg/>",
+      expected_version: 0,
+    });
+    expect(r2.ok).toBe(true);
+  });
+
+  it("external (human) edit on the binding makes the next AI write stale", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding("<svg/>");
+    fs.mount("/canvas.svg", b);
+    const { version } = fs.read("/canvas.svg")!;
+    b.externalEdit("<svg/><!--human-->");
+    const r = fs.write("/canvas.svg", {
+      content: "<svg/>",
+      expected_version: version,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("stale");
+  });
+});
+
+describe("AgentFs.edit", () => {
+  it("requires a prior read on the path (not_read)", async () => {
+    // Seed the backend so hydrate brings in a file without any agent read.
+    // A direct `fs.write()` would count as a read, so we use hydrate here.
+    const backend = new AgentFs.MemoryBackend();
+    await backend.write("/notes.md", "alpha beta");
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+    const r = fs.edit("/notes.md", {
+      old_string: "alpha",
+      new_string: "ALPHA",
+      expected_version: 0,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("not_read");
+  });
+
+  it("applies a unique match and advances the version", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "alpha beta", expected_version: null });
+    const { version } = fs.read("/notes.md")!;
+    const r = fs.edit("/notes.md", {
+      old_string: "alpha",
+      new_string: "ALPHA",
+      expected_version: version,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.occurrences).toBe(1);
+    expect(fs.read("/notes.md")?.content).toBe("ALPHA beta");
+  });
+
+  it("refuses an ambiguous match without replace_all", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "x x x", expected_version: null });
+    const { version } = fs.read("/notes.md")!;
+    const r = fs.edit("/notes.md", {
+      old_string: "x",
+      new_string: "Y",
+      expected_version: version,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("ambiguous");
+    expect(r.occurrences).toBe(3);
+  });
+
+  it("applies all matches when replace_all is true", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "x x x", expected_version: null });
+    const { version } = fs.read("/notes.md")!;
+    const r = fs.edit("/notes.md", {
+      old_string: "x",
+      new_string: "Y",
+      replace_all: true,
+      expected_version: version,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.occurrences).toBe(3);
+    expect(fs.read("/notes.md")?.content).toBe("Y Y Y");
+  });
+
+  it("rejects no-op edits", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "alpha", expected_version: null });
+    const { version } = fs.read("/notes.md")!;
+    const r = fs.edit("/notes.md", {
+      old_string: "alpha",
+      new_string: "alpha",
+      expected_version: version,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("no_op");
+  });
+
+  it("returns not_found when snippet is absent", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "alpha", expected_version: null });
+    const { version } = fs.read("/notes.md")!;
+    const r = fs.edit("/notes.md", {
+      old_string: "gamma",
+      new_string: "GAMMA",
+      expected_version: version,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("not_found");
+  });
+
+  it("works on bound files", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding('<svg><rect fill="red"/></svg>');
+    fs.mount("/canvas.svg", b);
+    const { version } = fs.read("/canvas.svg")!;
+    const r = fs.edit("/canvas.svg", {
+      old_string: 'fill="red"',
+      new_string: 'fill="blue"',
+      expected_version: version,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(b.current()).toContain('fill="blue"');
+  });
+});
+
+describe("AgentFs.grep", () => {
+  function seed(): AgentFs {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes/a.md", {
+      content: "alpha\nBETA\ngamma alpha\n",
+      expected_version: null,
+    });
+    fs.write("/notes/b.md", {
+      content: "beta beta\ndelta\n",
+      expected_version: null,
+    });
+    fs.write("/canvas.svg", {
+      content: "<svg/>\n<rect/>\n",
+      expected_version: null,
+    });
+    return fs;
+  }
+
+  it("empty pattern returns no matches and scans nothing", () => {
+    const r = seed().grep({ pattern: "" });
+    expect(r.matches).toEqual([]);
+    expect(r.files_scanned).toBe(0);
+  });
+
+  it("returns one entry per matching line with 1-indexed line numbers", () => {
+    const r = seed().grep({ pattern: "alpha" });
+    expect(r.files_scanned).toBe(3);
+    expect(r.matches).toEqual([
+      { path: "/notes/a.md", line: 1, text: "alpha" },
+      { path: "/notes/a.md", line: 3, text: "gamma alpha" },
+    ]);
+  });
+
+  it("is case-sensitive by default (matches one entry per matching line)", () => {
+    const r = seed().grep({ pattern: "beta" });
+    // "/notes/a.md" has BETA (uppercase) → no match
+    // "/notes/b.md" line 1 "beta beta" → one entry (one line)
+    expect(r.matches).toEqual([
+      { path: "/notes/b.md", line: 1, text: "beta beta" },
+    ]);
+  });
+
+  it("case_sensitive: false catches both cases (mirrors grep -i)", () => {
+    const r = seed().grep({ pattern: "beta", case_sensitive: false });
+    // a.md line 2 "BETA" + b.md line 1 "beta beta" → 2 matching lines.
+    expect(r.matches).toEqual([
+      { path: "/notes/a.md", line: 2, text: "BETA" },
+      { path: "/notes/b.md", line: 1, text: "beta beta" },
+    ]);
+  });
+
+  it("path_prefix narrows the scope", () => {
+    const r = seed().grep({ pattern: "a", path_prefix: "/notes/" });
+    expect(r.files_scanned).toBe(2);
+    expect(r.matches.every((m) => m.path.startsWith("/notes/"))).toBe(true);
+  });
+
+  it("searches bound files via the binding (sees formatted output)", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const b = makeBinding('<svg>\n  <rect fill="red"/>\n</svg>');
+    fs.mount("/canvas.svg", b);
+    const r = fs.grep({ pattern: 'fill="red"' });
+    expect(r.matches.length).toBe(1);
+    expect(r.matches[0].path).toBe("/canvas.svg");
+    expect(r.matches[0].line).toBe(2);
+  });
+
+  it("does NOT count as a read — subsequent edit still requires read_file", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const backend = new AgentFs.MemoryBackend();
+    void backend; // unused
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    // simulate fresh session by hand: a write counts as a read, so use a fresh fs hydrated from backend.
+    // Easier: assert via a second fs that loaded without a read.
+    const b2Backend = new AgentFs.MemoryBackend();
+    return (async () => {
+      await b2Backend.write("/notes.md", "hello");
+      const fs2 = new AgentFs(b2Backend);
+      await fs2.hydrate();
+      const r = fs2.grep({ pattern: "hello" });
+      expect(r.matches.length).toBe(1);
+      // Now editing should still fail with not_read because grep didn't set last_read.
+      const e = fs2.edit("/notes.md", {
+        old_string: "hello",
+        new_string: "hi",
+        expected_version: 0,
+      });
+      expect(e.ok).toBe(false);
+      if (e.ok) return;
+      expect(e.reason).toBe("not_read");
+    })();
+  });
+});
+
+describe("AgentFs.delete", () => {
+  it("removes pure files", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "x", expected_version: null });
+    expect(fs.delete("/notes.md").ok).toBe(true);
+    expect(fs.exists("/notes.md")).toBe(false);
+  });
+
+  it("refuses mounted paths", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.mount("/canvas.svg", makeBinding());
+    const r = fs.delete("/canvas.svg");
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("mounted");
+  });
+
+  it("returns not_found for unknown paths", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const r = fs.delete("/missing");
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("not_found");
+  });
+});
+
+describe("AgentFs.hydrate", () => {
+  it("loads pure files from backend into the fs", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    await backend.write("/notes.md", "persisted!");
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+    expect(fs.read("/notes.md")?.content).toBe("persisted!");
+  });
+
+  it("feeds persisted bytes into mounted bindings via binding.load", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    await backend.write("/canvas.svg", "<svg/>");
+    const fs = new AgentFs(backend);
+    const b = makeBinding("");
+    fs.mount("/canvas.svg", b);
+    await fs.hydrate();
+    expect(b.current()).toBe("<svg/>");
+  });
+
+  it("is idempotent — concurrent calls share one promise", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    const spy = vi.spyOn(backend, "list");
+    const fs = new AgentFs(backend);
+    await Promise.all([fs.hydrate(), fs.hydrate(), fs.hydrate()]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AgentFs — auto-flush (debounced)", () => {
+  it("flushes pure-file writes to the backend after the debounce window", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    const fs = new AgentFs(backend, { flushDebounceMs: 10 });
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    expect(await backend.read("/notes.md")).toBeNull(); // not yet
+    await tick(30);
+    expect(await backend.read("/notes.md")).toBe("hello");
+    fs.dispose();
+  });
+
+  it("flushes external binding edits via subscribe", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    const fs = new AgentFs(backend, { flushDebounceMs: 10 });
+    const b = makeBinding("<svg/>");
+    fs.mount("/canvas.svg", b);
+    b.externalEdit("<svg><rect/></svg>");
+    await tick(30);
+    expect(await backend.read("/canvas.svg")).toBe("<svg><rect/></svg>");
+    fs.dispose();
+  });
+
+  it("dispose() cancels pending flushes", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    const fs = new AgentFs(backend, { flushDebounceMs: 50 });
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    fs.dispose();
+    await tick(80);
+    expect(await backend.read("/notes.md")).toBeNull();
+  });
+});
+
+describe("AgentFs.watch", () => {
+  it("emits write events for pure-file writes", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+      type: "write",
+      path: "/notes.md",
+      version: 1,
+    });
+  });
+
+  it("emits write events for bound writes (binding-routed)", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const binding = makeBinding("initial");
+    fs.mount("/doc.svg", binding);
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    fs.write("/doc.svg", { content: "updated", expected_version: null });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+      type: "write",
+      path: "/doc.svg",
+      version: 1,
+    });
+    expect(binding.current()).toBe("updated");
+  });
+
+  it("does not emit when a bound write throws parse_error", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.mount("/doc.svg", makeBinding("initial"));
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    const r = fs.write("/doc.svg", {
+      content: "PARSE_FAIL",
+      expected_version: null,
+    });
+    expect(r.ok).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits delete events", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    const r = fs.delete("/notes.md");
+    expect(r.ok).toBe(true);
+    expect(listener).toHaveBeenCalledWith({
+      type: "delete",
+      path: "/notes.md",
+    });
+  });
+
+  it("does not emit delete for missing or mounted paths", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.mount("/doc.svg", makeBinding(""));
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    expect(fs.delete("/missing.md").ok).toBe(false);
+    expect(fs.delete("/doc.svg").ok).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits on edit() commits", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/notes.md", { content: "hello world", expected_version: null });
+    const start = fs.read("/notes.md");
+    expect(start).not.toBeNull();
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    const r = fs.edit("/notes.md", {
+      old_string: "world",
+      new_string: "there",
+      expected_version: start!.version,
+    });
+    expect(r.ok).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toMatchObject({
+      type: "write",
+      path: "/notes.md",
+    });
+  });
+
+  it("unsubscribe stops further events", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const listener = vi.fn<AgentFs.Listener>();
+    const unsub = fs.watch(listener);
+    fs.write("/a.md", { content: "1", expected_version: null });
+    unsub();
+    fs.write("/b.md", { content: "2", expected_version: null });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() clears watchers", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const listener = vi.fn<AgentFs.Listener>();
+    fs.watch(listener);
+    fs.dispose();
+    // After dispose, writes are no-ops anyway, but watchers should also be cleared.
+    fs.write("/a.md", { content: "1", expected_version: null });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("a throwing listener doesn't break later listeners", () => {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    const bad = vi.fn<AgentFs.Listener>(() => {
+      throw new Error("boom");
+    });
+    const good = vi.fn<AgentFs.Listener>();
+    fs.watch(bad);
+    fs.watch(good);
+    // Suppress the console.warn from the catch in emit().
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fs.write("/notes.md", { content: "hello", expected_version: null });
+    warn.mockRestore();
+    expect(bad).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/grida-agent-tools/src/fs/index.ts
+++ b/packages/grida-agent-tools/src/fs/index.ts
@@ -126,8 +126,24 @@ export class AgentFs {
     if (this.disposed) return;
     this.unmount(path);
     this.bindings.set(path, binding);
-    // If a pure-file entry shadowed this path, drop it — the binding wins.
+    // If a pure-file entry shadowed this path (typically because
+    // `hydrate()` ran before `mount()` and parked persisted bytes in
+    // the file map), hand that snapshot to the binding before dropping
+    // it. Without this, attaching a binding after async init would
+    // silently discard the persisted document.
+    const existing = this.files.get(path);
     this.files.delete(path);
+    if (existing) {
+      try {
+        binding.load(existing.content);
+        this.last_flushed.set(path, existing.content);
+      } catch (err) {
+        console.warn(
+          `[agent-fs] binding.load(${path}) failed during mount:`,
+          err
+        );
+      }
+    }
     if (binding.subscribe) {
       const unsub = binding.subscribe(() => this.queueFlush(path));
       this.binding_unsubs.set(path, unsub);
@@ -550,6 +566,10 @@ export class AgentFs {
         if (!this.disposed) this.last_flushed.set(path, entry.content);
       } catch (err) {
         console.warn(`[agent-fs] backend.write(${path}) failed:`, err);
+        // Re-queue on transient failure so eventual persistence still
+        // holds; otherwise a single failed flush would silently drop
+        // the path until its content changes again.
+        if (!this.disposed) this.queueFlush(path);
       }
     }
   }

--- a/packages/grida-agent-tools/src/fs/index.ts
+++ b/packages/grida-agent-tools/src/fs/index.ts
@@ -1,0 +1,1099 @@
+/**
+ * `@grida/agent-tools/fs` — a real-fs-shaped facade for AI agents to read,
+ * edit, and write files against either live state (an editor, a doc model)
+ * or pure storage (notes, sketches, scratch).
+ *
+ * The public surface is grouped under a single `AgentFs` identifier:
+ * the class (the runtime fs) and a same-named namespace (its types,
+ * tool table, dispatcher, and default in-memory backend). Consumers
+ * import one symbol and reach everything via member access — no flat
+ * grab-bag of helpers.
+ *
+ *   import { AgentFs } from "@grida/agent-tools/fs";
+ *
+ *   const fs = new AgentFs(new AgentFs.MemoryBackend());
+ *   const binding: AgentFs.LiveBinding = ...;
+ *   fs.mount("/canvas.svg", binding);
+ *
+ *   const r: AgentFs.ReadResult | null = fs.read("/canvas.svg");
+ *   const w: AgentFs.WriteResult = fs.write("/canvas.svg", {
+ *     content: "...",
+ *     expected_version: null,
+ *   });
+ *
+ *   // AI-SDK tool table + dispatcher
+ *   const tools = AgentFs.tools;
+ *   const output = AgentFs.resolveToolCall(fs, toolCall);
+ *
+ * Env-restricted backends (`./backends/opfs`, `./backends/node`) live
+ * under their own subpaths so a bare `import "@grida/agent-tools/fs"`
+ * never pulls `navigator.storage` or `node:fs`. They implement
+ * `AgentFs.Backend`.
+ *
+ * See `./README.md` for the full contract.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { findMatches, applyReplacements } from "./internal/match";
+
+// ---------------------------------------------------------------------------
+// Module-private state shape (not part of the public namespace).
+// ---------------------------------------------------------------------------
+
+type FileEntry = {
+  content: string;
+  version: number;
+};
+
+const PATH_DESCRIPTION =
+  "Absolute path in the agent filesystem, starting with `/`. " +
+  "Examples: `/canvas.svg`, `/notes/draft.md`.";
+
+// ---------------------------------------------------------------------------
+// AgentFs — the class.
+//
+// Methods qualify all public-surface types via `AgentFs.X` (e.g.
+// `AgentFs.LiveBinding`) so the class body and the namespace below
+// stay obviously consistent. Declaration merging guarantees the
+// namespace's members are visible to the class.
+// ---------------------------------------------------------------------------
+
+/**
+ * `AgentFs` — a real-fs-shaped facade over a `LiveBinding` (e.g. an SVG
+ * editor) and an `AgentFs.Backend` (in-memory / OPFS / Node disk).
+ *
+ * Design goals:
+ *  - **Multi-file.** Paths are first-class. Single-file constraints belong
+ *    at the call site, not in the fs.
+ *  - **Content-agnostic.** The fs never inspects bytes. Formatting,
+ *    parsing, schema validation are the binding's concern.
+ *  - **No React.** Pure TypeScript; testable end-to-end in Node.
+ *  - **Mirrors real fs ops.** `read` / `write` / `edit` / `delete` /
+ *    `list` / `exists`, with a `mount` hook for paths backed by live
+ *    state.
+ *  - **Safety contract.** Read-before-write + version freshness checks
+ *    on every mutating op, so the agent can't silently overwrite human
+ *    edits or its own stale view.
+ *
+ * Two file shapes share the API:
+ *
+ *  - **Bound files.** `mount(path, binding)` ties a path to an
+ *    `AgentFs.LiveBinding`. `read` and `write` go through the binding;
+ *    `getVersion()` is the freshness token. The backend persists a
+ *    serialized snapshot; on `hydrate()` we load it via `binding.load()`.
+ *
+ *  - **Pure files.** Anything not mounted. Stored in memory as
+ *    `{content, version}` (version starts at 0, bumps per write). Useful
+ *    for notes / sketches / scratch — anything the agent wants to keep
+ *    across turns without it touching live editor state.
+ *
+ * **Mount before hydrate** wherever possible: that lets `hydrate()` load
+ * persisted bytes directly into the live binding instead of into the
+ * pure-file map (which would be wrong — the binding would be ignored).
+ */
+export class AgentFs {
+  private readonly flushDebounceMs: number;
+  private readonly bindings = new Map<string, AgentFs.LiveBinding>();
+  private readonly binding_unsubs = new Map<string, () => void>();
+  private readonly files = new Map<string, FileEntry>();
+  /** Paths the agent has called `read()` on this session. */
+  private readonly last_read = new Map<string, number>();
+  /** Last content sent to the backend per path. Avoids redundant writes. */
+  private readonly last_flushed = new Map<string, string>();
+  private readonly flush_queue = new Set<string>();
+  private flush_timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  private hydrate_promise: Promise<void> | null = null;
+  private readonly watchers = new Set<AgentFs.Listener>();
+
+  constructor(
+    private readonly backend: AgentFs.Backend,
+    opts: AgentFs.Options = {}
+  ) {
+    this.flushDebounceMs = opts.flushDebounceMs ?? 500;
+  }
+
+  // -------------------------------------------------------------------------
+  // Mounting
+  // -------------------------------------------------------------------------
+
+  /**
+   * Bind a path to live, externally-managed state. If the path is already
+   * mounted, the previous binding is replaced (its subscription torn down).
+   */
+  mount(path: string, binding: AgentFs.LiveBinding): void {
+    if (this.disposed) return;
+    this.unmount(path);
+    this.bindings.set(path, binding);
+    // If a pure-file entry shadowed this path, drop it — the binding wins.
+    this.files.delete(path);
+    if (binding.subscribe) {
+      const unsub = binding.subscribe(() => this.queueFlush(path));
+      this.binding_unsubs.set(path, unsub);
+    }
+  }
+
+  unmount(path: string): void {
+    const unsub = this.binding_unsubs.get(path);
+    if (unsub) {
+      unsub();
+      this.binding_unsubs.delete(path);
+    }
+    this.bindings.delete(path);
+    // Clear per-path bookkeeping so repeated mount/unmount cycles don't
+    // grow the maps unboundedly.
+    this.last_read.delete(path);
+    this.last_flushed.delete(path);
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Load every persisted path from the backend. Mounted paths get their
+   * content fed into `binding.load(...)`; everything else materializes as
+   * a pure file. Idempotent — concurrent / repeated calls return the same
+   * promise.
+   *
+   * On a `backend.list()` or per-path read failure: logs and continues,
+   * so a bad blob can't take down the agent. The fs is still usable; the
+   * affected path stays empty until the next write.
+   */
+  async hydrate(): Promise<void> {
+    if (this.hydrate_promise) return this.hydrate_promise;
+    this.hydrate_promise = this.runHydrate();
+    return this.hydrate_promise;
+  }
+
+  private async runHydrate(): Promise<void> {
+    let paths: string[];
+    try {
+      paths = await this.backend.list();
+    } catch (err) {
+      console.warn("[agent-fs] backend.list failed:", err);
+      return;
+    }
+    // Fan out reads; the apply-to-state step that follows must be
+    // sequential (binding.load + Map mutations aren't reentrant).
+    const reads = await Promise.allSettled(
+      paths.map((p) => this.backend.read(p))
+    );
+    for (let i = 0; i < paths.length; i++) {
+      if (this.disposed) return;
+      const p = paths[i];
+      const r = reads[i];
+      if (r.status === "rejected") {
+        console.warn(`[agent-fs] backend.read(${p}) failed:`, r.reason);
+        continue;
+      }
+      const content = r.value;
+      if (content == null) continue;
+      const binding = this.bindings.get(p);
+      if (binding) {
+        try {
+          binding.load(content);
+        } catch (err) {
+          console.warn(
+            `[agent-fs] binding.load(${p}) failed during hydrate:`,
+            err
+          );
+          continue;
+        }
+      } else {
+        this.files.set(p, { content, version: 0 });
+      }
+      this.last_flushed.set(p, content);
+    }
+  }
+
+  /**
+   * Tear down binding subscriptions and cancel any pending flush. The
+   * backend itself is *not* told to do anything — its lifetime is
+   * managed by the caller.
+   */
+  dispose(): void {
+    this.disposed = true;
+    for (const unsub of this.binding_unsubs.values()) unsub();
+    this.binding_unsubs.clear();
+    if (this.flush_timer) {
+      clearTimeout(this.flush_timer);
+      this.flush_timer = null;
+    }
+    this.flush_queue.clear();
+    this.watchers.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Watch
+  // -------------------------------------------------------------------------
+
+  /**
+   * Subscribe to mutation events on this fs. Fires synchronously after a
+   * write, edit, or delete commits — including writes routed through a
+   * `LiveBinding`. Returns an unsubscribe fn.
+   *
+   * Listeners receive *every* path's events; filter by `event.path` if
+   * you only care about a scope.
+   *
+   * **Echo discipline.** A listener that itself triggered the mutation
+   * (e.g. a doc-store calling `fs.write` and then receiving the resulting
+   * event) is responsible for detecting and skipping its own writes. The
+   * fs doesn't track origin — that would couple the watcher to the caller
+   * graph. Compare `event.version` or read-back content to dedup.
+   *
+   * **Synchronous, in-call.** Listeners run inside `write` / `edit` /
+   * `delete`; throwing from a listener will not corrupt fs state (the
+   * mutation is already committed) but will propagate. Wrap risky work
+   * in try/catch on your side.
+   */
+  watch(listener: AgentFs.Listener): () => void {
+    if (this.disposed) return () => {};
+    this.watchers.add(listener);
+    return () => {
+      this.watchers.delete(listener);
+    };
+  }
+
+  private emit(event: AgentFs.Event): void {
+    if (this.watchers.size === 0) return;
+    // Iterate a snapshot so a listener unsubscribing during dispatch
+    // doesn't skip later listeners.
+    for (const cb of Array.from(this.watchers)) {
+      try {
+        cb(event);
+      } catch (err) {
+        console.warn(`[agent-fs] watch listener threw on ${event.type}:`, err);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // File ops
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns every path the fs knows about: mounts plus pure files. The
+   * backend may know about more (paths persisted in a prior session that
+   * we never read this session) — call `hydrate()` first if you need those.
+   */
+  list(): string[] {
+    // Keys are disjoint by construction (`mount()` drops any shadowing
+    // pure-file entry; `write()` to a mounted path goes through the binding).
+    return [...this.bindings.keys(), ...this.files.keys()];
+  }
+
+  exists(path: string): boolean {
+    return this.bindings.has(path) || this.files.has(path);
+  }
+
+  /**
+   * Read the content + current version. Returns `null` for unknown paths
+   * (call `hydrate()` first if the file might only exist in the backend).
+   */
+  read(path: string): AgentFs.ReadResult | null {
+    const binding = this.bindings.get(path);
+    if (binding) {
+      const version = binding.getVersion();
+      this.last_read.set(path, version);
+      return { content: binding.serialize(), version };
+    }
+    const entry = this.files.get(path);
+    if (!entry) return null;
+    this.last_read.set(path, entry.version);
+    return { content: entry.content, version: entry.version };
+  }
+
+  /**
+   * Full-content upsert. See {@link AgentFs.WriteArgs} for the
+   * `expected_version` semantics (version-checked vs permissive).
+   */
+  write(path: string, args: AgentFs.WriteArgs): AgentFs.WriteResult {
+    const { content, expected_version } = args;
+    if (expected_version !== null) {
+      const entry = this.lookup(path);
+      if (entry === null) {
+        return {
+          ok: false,
+          reason: "not_found",
+          message: `No file at ${path}. Pass expected_version=null to create it.`,
+        };
+      }
+      if (entry.version !== expected_version) {
+        return {
+          ok: false,
+          reason: "stale",
+          message: `File at ${path} changed since you last read it. Re-read and retry.`,
+          current_version: entry.version,
+        };
+      }
+    }
+    return this.commit(path, content);
+  }
+
+  /**
+   * Match-and-replace edit. Requires the file to exist and the agent to
+   * have read it this session (`not_read` otherwise). Standard staleness
+   * check via `expected_version`.
+   *
+   * Matching: literal first, then whitespace-normalized — see
+   * `findMatches`. Ambiguous matches reject with `reason: "ambiguous"`
+   * unless `replace_all` is set.
+   */
+  edit(path: string, args: AgentFs.EditArgs): AgentFs.EditResult {
+    const { old_string, new_string, replace_all, expected_version } = args;
+
+    const entry = this.lookup(path);
+    if (entry === null) {
+      return {
+        ok: false,
+        reason: "not_found",
+        message: `No file at ${path}.`,
+      };
+    }
+    if (!this.last_read.has(path)) {
+      return {
+        ok: false,
+        reason: "not_read",
+        message: `Call read_file(${path}) before editing.`,
+      };
+    }
+    if (entry.version !== expected_version) {
+      return {
+        ok: false,
+        reason: "stale",
+        message: `File at ${path} changed since you last read it.`,
+        current_version: entry.version,
+      };
+    }
+    if (old_string.length === 0) {
+      return {
+        ok: false,
+        reason: "not_found",
+        message: "`old_string` must not be empty.",
+      };
+    }
+    if (old_string === new_string) {
+      return {
+        ok: false,
+        reason: "no_op",
+        message: "`old_string` and `new_string` are identical.",
+      };
+    }
+
+    const ranges = findMatches(entry.content, old_string);
+    if (ranges.length === 0) {
+      return {
+        ok: false,
+        reason: "not_found",
+        message: `\`old_string\` not found in ${path}. Re-read with read_file and copy the snippet verbatim.`,
+      };
+    }
+    if (ranges.length > 1 && !replace_all) {
+      return {
+        ok: false,
+        reason: "ambiguous",
+        message: `\`old_string\` matched ${ranges.length} locations in ${path}. Add context to disambiguate or pass replace_all=true.`,
+        occurrences: ranges.length,
+      };
+    }
+    const next = applyReplacements(entry.content, ranges, new_string);
+
+    const committed = this.commit(path, next);
+    if (!committed.ok) return committed;
+    return { ...committed, occurrences: ranges.length };
+  }
+
+  /**
+   * Literal substring search across every known file. Mirrors `grep -n -F`:
+   * line-oriented, fixed-string, returns one entry per matching line with
+   * a 1-indexed line number and the full line text.
+   *
+   * Bound files are searched via `binding.serialize()` (so the agent sees
+   * the same formatted bytes `read()` would return). Empty pattern → empty
+   * result. Scope can be narrowed with `path_prefix`.
+   *
+   * Side-effect-free: does NOT mark `last_read`, so a subsequent `edit_file`
+   * still has to read the file first. Search is for finding things, not
+   * for claiming you've read them.
+   */
+  grep(args: AgentFs.GrepArgs): AgentFs.GrepResult {
+    const matches: AgentFs.GrepMatch[] = [];
+    let scanned = 0;
+    const pattern = args.pattern;
+    if (pattern.length === 0) return { matches, files_scanned: 0 };
+
+    const ci = args.case_sensitive === false;
+    const needle = ci ? pattern.toLowerCase() : pattern;
+    const prefix = args.path_prefix ?? null;
+
+    for (const path of this.list()) {
+      if (prefix !== null && !path.startsWith(prefix)) continue;
+      const entry = this.lookup(path);
+      if (entry === null) continue;
+      scanned += 1;
+      const lines = entry.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const text = lines[i];
+        const haystack = ci ? text.toLowerCase() : text;
+        if (haystack.includes(needle)) {
+          matches.push({ path, line: i + 1, text });
+        }
+      }
+    }
+    return { matches, files_scanned: scanned };
+  }
+
+  /**
+   * Remove a pure file from the fs and the backend. Mounted paths can't
+   * be deleted through this API — unmount first if you really mean it.
+   */
+  delete(path: string): AgentFs.DeleteResult {
+    if (this.bindings.has(path)) {
+      return {
+        ok: false,
+        reason: "mounted",
+        message: `${path} is mounted to a live binding; unmount first.`,
+      };
+    }
+    if (!this.files.has(path)) {
+      return {
+        ok: false,
+        reason: "not_found",
+        message: `No file at ${path}.`,
+      };
+    }
+    this.files.delete(path);
+    this.last_read.delete(path);
+    this.last_flushed.delete(path);
+    void this.backend.delete(path).catch((err) => {
+      console.warn(`[agent-fs] backend.delete(${path}) failed:`, err);
+    });
+    this.emit({ type: "delete", path });
+    return { ok: true };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /** Resolve a path to its current { content, version }, or `null` if missing. */
+  private lookup(path: string): { content: string; version: number } | null {
+    const binding = this.bindings.get(path);
+    if (binding) {
+      return { content: binding.serialize(), version: binding.getVersion() };
+    }
+    const entry = this.files.get(path);
+    return entry ? { content: entry.content, version: entry.version } : null;
+  }
+
+  /**
+   * Apply `content` to the path. For bound paths, calls `binding.load()`;
+   * for pure paths, updates the in-memory entry and bumps the version.
+   * Then schedules a backend flush.
+   *
+   * On a binding `load()` throw, returns `parse_error` and does NOT
+   * advance any state — the next write at the same version still works.
+   */
+  private commit(path: string, content: string): AgentFs.WriteResult {
+    const binding = this.bindings.get(path);
+    if (binding) {
+      try {
+        binding.load(content);
+      } catch (err) {
+        return parseError(err);
+      }
+      const v = binding.getVersion();
+      this.last_read.set(path, v);
+      this.queueFlush(path);
+      this.emit({ type: "write", path, version: v });
+      return { ok: true, version: v };
+    }
+    const existing = this.files.get(path);
+    const next: FileEntry = {
+      content,
+      version: (existing?.version ?? 0) + 1,
+    };
+    this.files.set(path, next);
+    this.last_read.set(path, next.version);
+    this.queueFlush(path);
+    this.emit({ type: "write", path, version: next.version });
+    return { ok: true, version: next.version };
+  }
+
+  /**
+   * Mark a path dirty and (re)arm the flush timer. The timer fires once
+   * the writer goes idle (default 500 ms), serializing one
+   * `backend.write()` per dirty path.
+   */
+  private queueFlush(path: string): void {
+    if (this.disposed) return;
+    this.flush_queue.add(path);
+    if (this.flush_timer) clearTimeout(this.flush_timer);
+    this.flush_timer = setTimeout(() => {
+      this.flush_timer = null;
+      void this.runFlush();
+    }, this.flushDebounceMs);
+  }
+
+  private async runFlush(): Promise<void> {
+    const targets = [...this.flush_queue];
+    this.flush_queue.clear();
+    for (const path of targets) {
+      if (this.disposed) return;
+      const entry = this.lookup(path);
+      if (entry === null) continue;
+      if (this.last_flushed.get(path) === entry.content) continue;
+      try {
+        await this.backend.write(path, entry.content);
+        if (!this.disposed) this.last_flushed.set(path, entry.content);
+      } catch (err) {
+        console.warn(`[agent-fs] backend.write(${path}) failed:`, err);
+      }
+    }
+  }
+}
+
+function parseError(err: unknown): AgentFs.WriteFailure {
+  return {
+    ok: false,
+    reason: "parse_error",
+    message:
+      err instanceof Error
+        ? `Failed to parse content: ${err.message}`
+        : "Failed to parse content.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AgentFs — the namespace.
+//
+// Everything below is the public type + tool surface. Consumers access
+// these as `AgentFs.LiveBinding`, `AgentFs.tools`, `AgentFs.MemoryBackend`,
+// etc.
+// ---------------------------------------------------------------------------
+
+export namespace AgentFs {
+  // -------------------------------------------------------------------------
+  // Bindings & backend contracts
+  // -------------------------------------------------------------------------
+
+  /**
+   * A `LiveBinding` connects an `AgentFs` path to a live, externally-managed
+   * piece of state — e.g. a Grida SVG editor, a Monaco model, a Yjs doc.
+   *
+   * The fs is content-agnostic: it never inspects what `serialize()` returns
+   * or what `load()` accepts. That's the binding's contract.
+   *
+   * **Version is monotonic and host-owned.** `getVersion()` must change
+   * (typically increment) on every host-visible mutation — AI write, human
+   * gesture, undo, external sync. The fs uses it as a freshness token
+   * (`expected_version` matches → safe to write; mismatch → stale).
+   *
+   * **`subscribe` is optional** but recommended for live-bound paths. Without
+   * it, the fs only knows about its own writes — it can't auto-flush changes
+   * made by the human (e.g. dragging a shape) to the backend.
+   */
+  export interface LiveBinding {
+    /** Snapshot the current content as a string. Called by `read()`. */
+    serialize(): string;
+
+    /**
+     * Apply `content` to the live state. May throw if `content` is
+     * malformed; the fs surfaces those throws as `parse_error`.
+     */
+    load(content: string): void;
+
+    /**
+     * Monotonic freshness token. Must reflect every host-visible change
+     * (not just writes through the fs). The fs uses it to detect
+     * concurrent edits between the agent's read and write.
+     */
+    getVersion(): number;
+
+    /**
+     * Subscribe to version-changing events. Returns an unsubscribe fn.
+     * Optional — when absent, the fs only knows about its own writes.
+     */
+    subscribe?(cb: () => void): () => void;
+  }
+
+  /**
+   * Persistence backend contract for `AgentFs`.
+   *
+   * The backend is a flat key-value store keyed by **absolute file path**
+   * (e.g. `/canvas.svg`, `/notes/draft.md`). Paths begin with `/` and use
+   * `/` as separator regardless of host OS — backends translate to their
+   * native layout (subdirectories on disk, directory handles on OPFS, …).
+   *
+   * Backends are pure I/O — no caching, no debouncing, no version
+   * tracking. The fs layer owns those.
+   *
+   * Errors should be **thrown**, not swallowed. The fs handles them
+   * (typically by logging + falling back to in-memory state).
+   */
+  export interface Backend {
+    /** Enumerate every persisted path. Order undefined. */
+    list(): Promise<string[]>;
+
+    /** Read the bytes at `path`, or `null` if no such file. */
+    read(path: string): Promise<string | null>;
+
+    /**
+     * Write `content` to `path`, overwriting any prior content. Backends
+     * must create any required parent directories.
+     */
+    write(path: string, content: string): Promise<void>;
+
+    /** Remove the file at `path`. No-op when the file doesn't exist. */
+    delete(path: string): Promise<void>;
+  }
+
+  // -------------------------------------------------------------------------
+  // Mutation events
+  // -------------------------------------------------------------------------
+
+  /**
+   * Mutation notification surface. Emitted by `AgentFs` whenever a path's
+   * observable content changes — agent writes, edits, deletes, and writes
+   * routed through a `LiveBinding`.
+   *
+   * Shape is intentionally minimal and maps cleanly onto Node's `fs.watch`
+   * /ZenFS' `fs.watch` callback (`(eventType, filename) => ...`): when this
+   * ever moves to a real VFS layer, consumers can keep their listener
+   * signature and only swap the registration call.
+   *
+   * Not emitted for `mount` / `unmount` / `hydrate` — those are control-plane
+   * operations the host already coordinates. Listeners only see content
+   * mutations.
+   */
+  export type Event =
+    | { type: "write"; path: string; version: number }
+    | { type: "delete"; path: string };
+
+  export type Listener = (event: Event) => void;
+
+  // -------------------------------------------------------------------------
+  // Constructor options
+  // -------------------------------------------------------------------------
+
+  export type Options = {
+    /**
+     * Debounce window for backend flushes triggered by host-visible changes
+     * (binding emits, pure-file writes). Each change reschedules; the timer
+     * fires when the writer goes idle. Default 500 ms.
+     */
+    flushDebounceMs?: number;
+  };
+
+  // -------------------------------------------------------------------------
+  // Failure-reason vocabularies
+  //
+  // Single source of truth for each rejection-reason set. The TS union
+  // type and the zod enum in the AI-SDK tool schema below are both
+  // derived from these tuples, so they can't drift.
+  // -------------------------------------------------------------------------
+
+  export const WRITE_FAILURE_REASONS = [
+    "stale",
+    "parse_error",
+    "not_found",
+  ] as const;
+  export type WriteFailureReason = (typeof WRITE_FAILURE_REASONS)[number];
+
+  export const EDIT_FAILURE_REASONS = [
+    "not_read",
+    "stale",
+    "not_found",
+    "ambiguous",
+    "parse_error",
+    "no_op",
+  ] as const;
+  export type EditFailureReason = (typeof EDIT_FAILURE_REASONS)[number];
+
+  export const DELETE_FAILURE_REASONS = ["not_found", "mounted"] as const;
+  export type DeleteFailureReason = (typeof DELETE_FAILURE_REASONS)[number];
+
+  // -------------------------------------------------------------------------
+  // Result types (exported so callers can pattern-match without re-deriving)
+  // -------------------------------------------------------------------------
+
+  export type ReadResult = {
+    content: string;
+    version: number;
+  };
+
+  export type WriteArgs = {
+    content: string;
+    /**
+     * - Pass a number → must match the file's current version. Mismatch
+     *   → `stale`. Missing file → `not_found`.
+     * - Pass `null` → permissive write. Creates the file if missing,
+     *   overwrites otherwise; no freshness check.
+     */
+    expected_version: number | null;
+  };
+
+  export type WriteSuccess = { ok: true; version: number };
+  export type WriteFailure = {
+    ok: false;
+    reason: WriteFailureReason;
+    message: string;
+    current_version?: number;
+  };
+  export type WriteResult = WriteSuccess | WriteFailure;
+
+  export type EditArgs = {
+    old_string: string;
+    new_string: string;
+    replace_all?: boolean;
+    expected_version: number;
+  };
+
+  export type EditSuccess = {
+    ok: true;
+    version: number;
+    occurrences: number;
+  };
+  export type EditFailure = {
+    ok: false;
+    reason: EditFailureReason;
+    message: string;
+    current_version?: number;
+    /** Populated for `ambiguous` (how many matches). */
+    occurrences?: number;
+  };
+  export type EditResult = EditSuccess | EditFailure;
+
+  export type DeleteResult =
+    | { ok: true }
+    | { ok: false; reason: DeleteFailureReason; message: string };
+
+  export type GrepArgs = {
+    /** Literal substring to match. Empty pattern → empty result. */
+    pattern: string;
+    /** Limit to paths starting with this prefix (e.g. `/notes/`). */
+    path_prefix?: string;
+    /** Default true. Set false for case-insensitive match. */
+    case_sensitive?: boolean;
+  };
+
+  export type GrepMatch = {
+    path: string;
+    /** 1-indexed line number, mirroring `grep -n`. */
+    line: number;
+    /** The full line text. */
+    text: string;
+  };
+
+  export type GrepResult = {
+    matches: ReadonlyArray<GrepMatch>;
+    /** Number of files scanned (mounts + pure files matching the prefix). */
+    files_scanned: number;
+  };
+
+  // -------------------------------------------------------------------------
+  // AI-SDK tool table
+  //
+  // The canonical, path-aware tools. Hosts (e.g. the SVG demo) pass
+  // `AgentFs.tools` to a `ToolLoopAgent` directly and dispatch incoming
+  // calls via `chat.onToolCall` into an `AgentFs` instance using
+  // `AgentFs.resolveToolCall`.
+  //
+  // Tools have **no `execute()`** — they're client-resolved against a
+  // live `AgentFs`.
+  // -------------------------------------------------------------------------
+
+  export const TOOL_NAMES = {
+    read_file: "read_file",
+    edit_file: "edit_file",
+    write_file: "write_file",
+    list_files: "list_files",
+    grep_files: "grep_files",
+  } as const;
+
+  export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES];
+
+  export const tools = {
+    [TOOL_NAMES.read_file]: tool({
+      description:
+        "Read a file's content and version (a freshness token).\n\n" +
+        "Always call this before your first edit_file on a given path, and " +
+        "re-read whenever an edit / write returns reason='stale'.",
+      inputSchema: z.object({
+        path: z.string().describe(PATH_DESCRIPTION),
+      }),
+      outputSchema: z.union([
+        z.object({
+          content: z.string(),
+          version: z.number().int(),
+        }),
+        z.object({
+          ok: z.literal(false),
+          reason: z.literal("not_found"),
+          message: z.string(),
+        }),
+      ]),
+    }),
+
+    [TOOL_NAMES.edit_file]: tool({
+      description:
+        "Match-and-replace edit on a file. Find `old_string` and replace " +
+        "with `new_string`. The default write path — cheap, safe, must " +
+        "locate the change.\n\n" +
+        "Matching: literal substring first, then whitespace-normalized " +
+        "fallback (forgives doubled spaces / minor newline drift; not a " +
+        "semantic fuzzy match). Must be unique unless `replace_all` is " +
+        "true.\n\n" +
+        "Requires a prior read_file on this path. On reason='stale', the " +
+        "human edited in the meantime — read_file again and retry.",
+      inputSchema: z.object({
+        path: z.string().describe(PATH_DESCRIPTION),
+        old_string: z
+          .string()
+          .min(1)
+          .describe(
+            "Exact snippet from the read_file output. Include enough " +
+              "surrounding context to be unique."
+          ),
+        new_string: z
+          .string()
+          .describe(
+            "Replacement text. May be empty to delete the matched range."
+          ),
+        replace_all: z
+          .boolean()
+          .optional()
+          .describe(
+            "Default false. When false, ambiguous matches reject with " +
+              "reason='ambiguous' so you can disambiguate."
+          ),
+        version: z
+          .number()
+          .int()
+          .describe("Version from the most recent read_file."),
+      }),
+      outputSchema: z.discriminatedUnion("ok", [
+        z.object({
+          ok: z.literal(true),
+          version: z.number().int(),
+          occurrences: z.number().int(),
+        }),
+        z.object({
+          ok: z.literal(false),
+          reason: z.enum(EDIT_FAILURE_REASONS),
+          message: z.string(),
+          current_version: z.number().int().optional(),
+          occurrences: z.number().int().optional(),
+        }),
+      ]),
+    }),
+
+    [TOOL_NAMES.list_files]: tool({
+      description:
+        "Enumerate every known file in the agent filesystem. Returns " +
+        "sorted absolute paths (e.g. `/canvas.svg`, `/notes/draft.md`).",
+      inputSchema: z.object({}),
+      outputSchema: z.object({
+        files: z
+          .array(z.string())
+          .describe("Sorted absolute paths of every known file."),
+      }),
+    }),
+
+    [TOOL_NAMES.grep_files]: tool({
+      description:
+        "Literal substring search across every known file. Mirrors `grep -n -F`: " +
+        "returns one entry per matching line with a 1-indexed line number and " +
+        "the full line text.\n\n" +
+        "Use this to find references / occurrences before deciding what to " +
+        "edit. Does NOT count as a `read_file` — you still have to read a " +
+        "file before editing it.",
+      inputSchema: z.object({
+        pattern: z
+          .string()
+          .min(1)
+          .describe(
+            "Literal substring to match. Not a regex (v1). Case-sensitive by default."
+          ),
+        path_prefix: z
+          .string()
+          .optional()
+          .describe(
+            "Limit to paths starting with this prefix (e.g. `/notes/`). Omit to scan everything."
+          ),
+        case_sensitive: z
+          .boolean()
+          .optional()
+          .describe(
+            "Default true. Pass false for case-insensitive match (mirrors `grep -i`)."
+          ),
+      }),
+      outputSchema: z.object({
+        matches: z.array(
+          z.object({
+            path: z.string(),
+            line: z.number().int().describe("1-indexed line number."),
+            text: z.string().describe("Full line text."),
+          })
+        ),
+        files_scanned: z.number().int(),
+      }),
+    }),
+
+    [TOOL_NAMES.write_file]: tool({
+      description:
+        "Full-file upsert. Replace the entire content of `path` with " +
+        "`content`. For surgical changes, prefer edit_file — it's safer " +
+        "(must locate the change) and cheaper (smaller payload).\n\n" +
+        "`version` is optional:\n" +
+        "  • include it (from the most recent read_file) for an explicit " +
+        "wholesale rewrite — same staleness safety as edit_file.\n" +
+        "  • omit it for a permissive write (creates the file if missing; " +
+        "overwrites without a freshness check). Only use when you don't " +
+        "care what's currently there.",
+      inputSchema: z.object({
+        path: z.string().describe(PATH_DESCRIPTION),
+        content: z.string().describe("Complete new content for the file."),
+        version: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            "Optional. When provided, the write fails with reason='stale' " +
+              "unless the current version matches. Omit for permissive write."
+          ),
+      }),
+      outputSchema: z.discriminatedUnion("ok", [
+        z.object({
+          ok: z.literal(true),
+          version: z.number().int(),
+        }),
+        z.object({
+          ok: z.literal(false),
+          reason: z.enum(WRITE_FAILURE_REASONS),
+          message: z.string(),
+          current_version: z.number().int().optional(),
+        }),
+      ]),
+    }),
+  } as const;
+
+  export type Tools = typeof tools;
+
+  // -------------------------------------------------------------------------
+  // Tool-call dispatcher
+  //
+  // Hosts hand `AgentFs.resolveToolCall` to `Chat`'s `onToolCall`:
+  //
+  //   const chat = new Chat({
+  //     transport: ...,
+  //     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  //     onToolCall: ({ toolCall }) => {
+  //       const output = AgentFs.resolveToolCall(fs, toolCall);
+  //       if (output === undefined) return; // not one of ours
+  //       chat.addToolResult({
+  //         tool: toolCall.toolName,
+  //         toolCallId: toolCall.toolCallId,
+  //         output,
+  //       });
+  //     },
+  //   });
+  //
+  // Returns `undefined` when the tool name isn't one of our five, so the
+  // host can chain its own resolvers.
+  // -------------------------------------------------------------------------
+
+  type ReadFileInput = { path: string };
+  type EditFileInput = {
+    path: string;
+    old_string: string;
+    new_string: string;
+    replace_all?: boolean;
+    version: number;
+  };
+  type WriteFileInput = { path: string; content: string; version?: number };
+  type GrepFilesInput = {
+    pattern: string;
+    path_prefix?: string;
+    case_sensitive?: boolean;
+  };
+
+  export function resolveToolCall(
+    fs: AgentFs,
+    toolCall: { toolName: string; input: unknown; dynamic?: boolean }
+  ): unknown {
+    if (toolCall.dynamic) return undefined;
+    switch (toolCall.toolName) {
+      case TOOL_NAMES.read_file: {
+        const { path } = toolCall.input as ReadFileInput;
+        const r = fs.read(path);
+        if (r === null) {
+          return {
+            ok: false,
+            reason: "not_found",
+            message: `No file at ${path}.`,
+          };
+        }
+        return r;
+      }
+      case TOOL_NAMES.list_files: {
+        return { files: [...fs.list()].sort() };
+      }
+      case TOOL_NAMES.grep_files: {
+        const { pattern, path_prefix, case_sensitive } =
+          toolCall.input as GrepFilesInput;
+        return fs.grep({ pattern, path_prefix, case_sensitive });
+      }
+      case TOOL_NAMES.edit_file: {
+        const { path, old_string, new_string, replace_all, version } =
+          toolCall.input as EditFileInput;
+        return fs.edit(path, {
+          old_string,
+          new_string,
+          replace_all,
+          expected_version: version,
+        });
+      }
+      case TOOL_NAMES.write_file: {
+        const { path, content, version } = toolCall.input as WriteFileInput;
+        return fs.write(path, { content, expected_version: version ?? null });
+      }
+      default:
+        return undefined;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Default in-process backend.
+  //
+  // OPFS / Node backends live behind their own subpath imports so a bare
+  // `import "@grida/agent-tools/fs"` doesn't pull `navigator.storage` or
+  // `node:fs`.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Ephemeral in-process backend. Survives only for the lifetime of the
+   * `MemoryBackend` instance. Default for tests and SSR.
+   */
+  export class MemoryBackend implements Backend {
+    private files = new Map<string, string>();
+
+    async list(): Promise<string[]> {
+      return [...this.files.keys()];
+    }
+
+    async read(path: string): Promise<string | null> {
+      return this.files.has(path) ? (this.files.get(path) as string) : null;
+    }
+
+    async write(path: string, content: string): Promise<void> {
+      this.files.set(path, content);
+    }
+
+    async delete(path: string): Promise<void> {
+      this.files.delete(path);
+    }
+  }
+}

--- a/packages/grida-agent-tools/src/fs/internal/match.ts
+++ b/packages/grida-agent-tools/src/fs/internal/match.ts
@@ -1,0 +1,109 @@
+/**
+ * Internal match-and-replace primitives used by `AgentFs.edit()`.
+ *
+ * Not part of the public package surface — consumers should call
+ * `AgentFs.edit()` (or the `edit_file` AI-SDK tool) rather than depend
+ * on these directly. They live under `internal/` so the `exports` map
+ * doesn't surface them and a future refactor can change their shape
+ * without a contract bump.
+ */
+
+/**
+ * Find every occurrence of `needle` in `hay`. Used by `AgentFs.edit()`
+ * to locate the snippet the model passed as `old_string` and splice in
+ * `new_string`. Content-agnostic.
+ *
+ * Strategy (first hit wins):
+ *
+ *  1. **Literal substring match.** Wins almost always — the agent copies
+ *     `old_string` from `read()` output, which is byte-stable.
+ *  2. **Whitespace-normalized fallback.** Runs of whitespace on both sides
+ *     collapse to a single space (`/\s+/g → " "`); the resulting indices
+ *     are mapped back to the original document. Forgives doubled spaces
+ *     between attributes and minor newline drift; **does not** enable
+ *     attribute-order rewriting or semantic matching.
+ *
+ * That conservatism is deliberate: stricter than aider, looser than
+ * Claude Code's `Edit` (which is literal-only). A single semantically-
+ * fuzzy match in SVG can silently change a selector or `xlink:href` and
+ * break the document.
+ *
+ * Returns half-open ranges `[start, end)` against `hay`. Empty for empty
+ * `needle`.
+ */
+export function findMatches(
+  hay: string,
+  needle: string
+): Array<[number, number]> {
+  if (needle.length === 0) return [];
+
+  const literal: Array<[number, number]> = [];
+  let i = hay.indexOf(needle);
+  while (i !== -1) {
+    literal.push([i, i + needle.length]);
+    i = hay.indexOf(needle, i + needle.length);
+  }
+  if (literal.length > 0) return literal;
+
+  const compactNeedle = needle.replace(/\s+/g, " ").trim();
+  if (compactNeedle.length === 0) return [];
+
+  const { compact: compactHay, map } = collapseWhitespace(hay);
+
+  const ranges: Array<[number, number]> = [];
+  let j = compactHay.indexOf(compactNeedle);
+  while (j !== -1) {
+    const start = map[j];
+    const lastChar = j + compactNeedle.length - 1;
+    const end = map[lastChar] + 1;
+    ranges.push([start, end]);
+    j = compactHay.indexOf(compactNeedle, j + compactNeedle.length);
+  }
+  return ranges;
+}
+
+/**
+ * Collapse runs of whitespace in `s` to a single ASCII space, while
+ * recording the original-string index of each surviving character. The
+ * returned `map[i]` is the index in `s` corresponding to `compact[i]`.
+ */
+export function collapseWhitespace(s: string): {
+  compact: string;
+  map: number[];
+} {
+  let compact = "";
+  const map: number[] = [];
+  let prevSpace = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      if (prevSpace) continue;
+      compact += " ";
+      map.push(i);
+      prevSpace = true;
+    } else {
+      compact += ch;
+      map.push(i);
+      prevSpace = false;
+    }
+  }
+  return { compact, map };
+}
+
+/**
+ * Apply replacements at the given ranges. Splices right-to-left so
+ * earlier indices stay valid. Ranges must be disjoint and in ascending
+ * order (which is what `findMatches` returns).
+ */
+export function applyReplacements(
+  source: string,
+  ranges: ReadonlyArray<readonly [number, number]>,
+  replacement: string
+): string {
+  let next = source;
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const [start, end] = ranges[i];
+    next = next.slice(0, start) + replacement + next.slice(end);
+  }
+  return next;
+}

--- a/packages/grida-agent-tools/src/index.ts
+++ b/packages/grida-agent-tools/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * `@grida/agent-tools` — storage-agnostic runtime primitives for Grida AI agents.
+ *
+ * Two top-level symbols, each a class with a same-named namespace that
+ * groups its types, tool table, dispatcher, and (for `AgentFs`) default
+ * backend:
+ *
+ *   import { AgentFs, AgentTodos } from "@grida/agent-tools";
+ *
+ *   const fs = new AgentFs(new AgentFs.MemoryBackend());
+ *   const todos = new AgentTodos();
+ *
+ *   // tool tables / dispatchers
+ *   const tools = { ...AgentFs.tools, ...AgentTodos.tools };
+ *   const output =
+ *     AgentFs.resolveToolCall(fs, toolCall) ??
+ *     AgentTodos.resolveToolCall(todos, toolCall);
+ *
+ * Env-restricted backends live behind their own subpaths so the main
+ * entry never pulls `navigator.storage` or `node:fs`:
+ *
+ *   import { OpfsBackend } from "@grida/agent-tools/fs/backends/opfs";
+ *   import { NodeFsBackend } from "@grida/agent-tools/fs/backends/node";
+ *
+ * Both implement `AgentFs.Backend`.
+ */
+
+export { AgentFs } from "./fs";
+export { AgentTodos } from "./todos";

--- a/packages/grida-agent-tools/src/todos/README.md
+++ b/packages/grida-agent-tools/src/todos/README.md
@@ -1,0 +1,112 @@
+# `@/lib/agent-todos`
+
+A tiny live store + AI-SDK tool for the agent's plan. Mirrors Claude
+Code's `TodoWrite`.
+
+This is a **fundamental tool** in the sense `docs/wg/feat-ai/tools.md`
+uses the term: always available, applicable to any agent (chat,
+canvas, server-side), zero-cost, no sandbox required.
+
+## Why it exists
+
+When an agent's work is non-trivial — multiple files, multiple steps,
+exploration — both the agent and the user benefit from a shared,
+visible plan. The plan should be:
+
+- **Live** — updates as the agent works, not just at the start.
+- **Replace-all** — the agent passes the whole list each call; no
+  per-item ops, no merge logic, no stale-item drift.
+- **Tiny** — three statuses, no metadata, no due-dates.
+
+If you want long-lived TODOs (across sessions, across users), write a
+markdown file with `@/lib/agent-fs` instead. That's the right tool for
+that job.
+
+## API
+
+```ts
+class AgentTodos {
+  snapshot(): ReadonlyArray<AgentTodos.Todo>;
+  write(todos: ReadonlyArray<AgentTodos.Todo>): AgentTodos.WriteSuccess;
+  clear(): void;
+  subscribe(cb: () => void): () => void;
+}
+
+namespace AgentTodos {
+  type Status = "pending" | "in_progress" | "completed";
+
+  type Todo = {
+    content: string; // imperative: "Run tests"
+    activeForm: string; // present continuous: "Running tests"
+    status: Status;
+  };
+
+  type WriteSuccess = { ok: true; count: number; todos: ReadonlyArray<Todo> };
+}
+```
+
+## Contract
+
+- **Exactly one `in_progress` at a time.** Enforced socially by the
+  system prompt, not the tool — the visible list makes drift obvious
+  and the model self-corrects.
+- **No batched updates.** The model should update the list as it
+  works, not once at the end. That's the whole point of having it
+  live.
+- **Status transitions are pending → in_progress → completed.** No
+  "blocked", "cancelled", "skipped" — keep the surface small. If a
+  task is no longer relevant, remove it.
+- **Replace-all on every call.** `write(todos)` is the only mutator;
+  prior state is discarded entirely. There is no `add_todo` or
+  `update_todo`.
+
+## AI-SDK tool
+
+`AgentTodos.tools` is the AI-SDK tool table (with `AgentTodos.TOOL_NAMES.todo_write`) — a single tool whose input is the full list:
+
+```ts
+todo_write({
+  todos: [
+    {
+      content: "Audit /svg agent",
+      activeForm: "Auditing /svg agent",
+      status: "in_progress",
+    },
+    {
+      content: "Add focus styles",
+      activeForm: "Adding focus styles",
+      status: "pending",
+    },
+  ],
+});
+```
+
+Resolve via `resolveAgentTodosToolCall(store, toolCall)` in
+`chat.onToolCall`.
+
+## Mirror of Claude Code's `TodoWrite`
+
+| Claude Code  | This module  | Note                                  |
+| ------------ | ------------ | ------------------------------------- |
+| `TodoWrite`  | `todo_write` | snake-cased to match `read_file` etc. |
+| `content`    | `content`    | same                                  |
+| `activeForm` | `activeForm` | same                                  |
+| `status`     | `status`     | same three values                     |
+
+If you've used Claude Code, you already know how this works.
+
+## Testing
+
+Pure logic, no React, no LLM:
+
+```sh
+pnpm vitest run lib/agent-todos
+```
+
+## What this module deliberately is not
+
+- **Persistent.** Sessions are short-lived; the plan is a function of
+  the current turn. Use `agent-fs` for durable lists.
+- **A workflow engine.** No dependencies, no priorities, no due dates.
+- **A renderer.** The host owns the UI — subscribe to the store and
+  render with `useSyncExternalStore`.

--- a/packages/grida-agent-tools/src/todos/README.md
+++ b/packages/grida-agent-tools/src/todos/README.md
@@ -1,4 +1,4 @@
-# `@/lib/agent-todos`
+# `@grida/agent-tools/todos`
 
 A tiny live store + AI-SDK tool for the agent's plan. Mirrors Claude
 Code's `TodoWrite`.
@@ -19,7 +19,7 @@ visible plan. The plan should be:
 - **Tiny** — three statuses, no metadata, no due-dates.
 
 If you want long-lived TODOs (across sessions, across users), write a
-markdown file with `@/lib/agent-fs` instead. That's the right tool for
+markdown file with `@grida/agent-tools/fs` instead. That's the right tool for
 that job.
 
 ## API
@@ -81,7 +81,7 @@ todo_write({
 });
 ```
 
-Resolve via `resolveAgentTodosToolCall(store, toolCall)` in
+Resolve via `AgentTodos.resolveToolCall(store, toolCall)` in
 `chat.onToolCall`.
 
 ## Mirror of Claude Code's `TodoWrite`
@@ -100,7 +100,7 @@ If you've used Claude Code, you already know how this works.
 Pure logic, no React, no LLM:
 
 ```sh
-pnpm vitest run lib/agent-todos
+pnpm --filter @grida/agent-tools test
 ```
 
 ## What this module deliberately is not

--- a/packages/grida-agent-tools/src/todos/index.ts
+++ b/packages/grida-agent-tools/src/todos/index.ts
@@ -1,0 +1,224 @@
+/**
+ * `@grida/agent-tools/todos` — fundamental planning tool. Mirrors Claude
+ * Code's `TodoWrite`: an in-memory, replace-all todo list the agent updates
+ * as it works, rendered in the chat panel.
+ *
+ * State lives in memory, scoped to the session. We don't persist — the
+ * plan is a function of the current turn, not a long-lived doc. (If you
+ * want long-lived TODOs, write a markdown file with `agent-fs`; that's
+ * the right tool for that job.)
+ *
+ * No React. Subscribe via `subscribe(cb)` and read `snapshot()` —
+ * `useSyncExternalStore` is the host's call.
+ *
+ * Public surface is grouped under the `AgentTodos` class + a same-named
+ * namespace:
+ *
+ *   import { AgentTodos } from "@grida/agent-tools/todos";
+ *
+ *   const todos = new AgentTodos();
+ *   const list: ReadonlyArray<AgentTodos.Todo> = todos.snapshot();
+ *
+ *   const tools = AgentTodos.tools;
+ *   const output = AgentTodos.resolveToolCall(todos, toolCall);
+ *
+ * See `./README.md` for the full contract.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// AgentTodos — the class.
+// ---------------------------------------------------------------------------
+
+/**
+ * `AgentTodos` — a tiny live store for the agent's plan.
+ *
+ * Mirrors Claude Code's `TodoWrite`:
+ *   - Replace-all: every call carries the full list.
+ *   - Status transitions: `pending` → `in_progress` → `completed`.
+ *   - Exactly one `in_progress` at a time (enforced socially by the prompt,
+ *     not the tool — the host shows a visible list so the model self-
+ *     corrects).
+ */
+export class AgentTodos {
+  private todos: AgentTodos.Todo[] = [];
+  private readonly subs = new Set<() => void>();
+
+  /** Current list. Cheap; safe to call in a render. */
+  snapshot(): ReadonlyArray<AgentTodos.Todo> {
+    return this.todos;
+  }
+
+  /**
+   * Replace the entire list. Returns the count + the new snapshot for
+   * the agent's tool result.
+   */
+  write(todos: ReadonlyArray<AgentTodos.Todo>): AgentTodos.WriteSuccess {
+    // Defensive copy: callers don't get to mutate our internal array.
+    const next = todos.map(normalize);
+    // Skip notify on identity-equal replays — the agent re-sends the
+    // full list every TodoWrite call and identical replays would
+    // otherwise rerender every subscriber for no UI change.
+    if (!shallowEqual(this.todos, next)) {
+      this.todos = next;
+      this.notify();
+    }
+    return { ok: true, count: this.todos.length, todos: this.todos };
+  }
+
+  /** Clear the list (e.g. start of a new turn). */
+  clear(): void {
+    if (this.todos.length === 0) return;
+    this.todos = [];
+    this.notify();
+  }
+
+  /** Subscribe to changes. Returns an unsubscribe fn. */
+  subscribe(cb: () => void): () => void {
+    this.subs.add(cb);
+    return () => this.subs.delete(cb);
+  }
+
+  private notify(): void {
+    for (const cb of this.subs) cb();
+  }
+}
+
+function normalize(t: AgentTodos.Todo): AgentTodos.Todo {
+  return {
+    content: t.content,
+    activeForm: t.activeForm,
+    status: t.status,
+  };
+}
+
+function shallowEqual(
+  a: ReadonlyArray<AgentTodos.Todo>,
+  b: ReadonlyArray<AgentTodos.Todo>
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.content !== y.content ||
+      x.activeForm !== y.activeForm ||
+      x.status !== y.status
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// AgentTodos — the namespace.
+// ---------------------------------------------------------------------------
+
+export namespace AgentTodos {
+  // -------------------------------------------------------------------------
+  // Data types
+  // -------------------------------------------------------------------------
+
+  export type Status = "pending" | "in_progress" | "completed";
+
+  export type Todo = {
+    /**
+     * Imperative form of the task. Examples: "Run tests",
+     * "Add focus styles", "Audit /svg agent".
+     */
+    content: string;
+    /**
+     * Present-continuous form, shown while this task is the current one
+     * the agent is working on. Examples: "Running tests", "Adding focus
+     * styles". Distinct from `content` because shells of words read
+     * differently when paused vs. live.
+     */
+    activeForm: string;
+    status: Status;
+  };
+
+  export type WriteSuccess = {
+    ok: true;
+    count: number;
+    todos: ReadonlyArray<Todo>;
+  };
+
+  // -------------------------------------------------------------------------
+  // AI-SDK tool table
+  //
+  // One tool, one shape: pass the full list of todos every time. The host
+  // renders the list in the chat panel; the agent updates it as it works.
+  // -------------------------------------------------------------------------
+
+  export const TOOL_NAMES = {
+    todo_write: "todo_write",
+  } as const;
+
+  export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES];
+
+  const STATUS = z.enum(["pending", "in_progress", "completed"]);
+
+  const TODO = z.object({
+    content: z
+      .string()
+      .min(1)
+      .describe(
+        'Imperative form of the task. Example: "Run tests", "Add focus styles".'
+      ),
+    activeForm: z
+      .string()
+      .min(1)
+      .describe(
+        "Present-continuous form, shown while this task is in_progress. " +
+          'Example: "Running tests", "Adding focus styles".'
+      ),
+    status: STATUS,
+  });
+
+  export const tools = {
+    [TOOL_NAMES.todo_write]: tool({
+      description:
+        "Plan and track your work. Pass the complete list of todos every " +
+        "call — the prior list is replaced wholesale.\n\n" +
+        "Rules:\n" +
+        "  • Exactly one task should be `in_progress` at any time.\n" +
+        "  • Mark a task `completed` immediately after finishing it; don't " +
+        "batch updates.\n" +
+        "  • Status transitions: `pending` → `in_progress` → `completed`.\n\n" +
+        "Use this any time the work is non-trivial (multiple files, multiple " +
+        "steps, exploratory). Skip it for one-shot edits.",
+      inputSchema: z.object({
+        todos: z.array(TODO).describe("The complete new list of todos."),
+      }),
+      outputSchema: z.object({
+        ok: z.literal(true),
+        count: z.number().int(),
+      }),
+    }),
+  } as const;
+
+  export type Tools = typeof tools;
+
+  // -------------------------------------------------------------------------
+  // Tool-call dispatcher
+  //
+  // Symmetric to `AgentFs.resolveToolCall` — hosts can chain both in
+  // `Chat.onToolCall`.
+  // -------------------------------------------------------------------------
+
+  type TodoWriteInput = { todos: ReadonlyArray<Todo> };
+
+  export function resolveToolCall(
+    store: AgentTodos,
+    toolCall: { toolName: string; input: unknown; dynamic?: boolean }
+  ): unknown {
+    if (toolCall.dynamic) return undefined;
+    if (toolCall.toolName !== TOOL_NAMES.todo_write) return undefined;
+    const { todos } = toolCall.input as TodoWriteInput;
+    const r = store.write(todos);
+    return { ok: r.ok, count: r.count };
+  }
+}

--- a/packages/grida-agent-tools/src/todos/todos.test.ts
+++ b/packages/grida-agent-tools/src/todos/todos.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentTodos } from "./index";
+
+const t = (
+  content: string,
+  status: AgentTodos.Todo["status"] = "pending",
+  activeForm?: string
+): AgentTodos.Todo => ({
+  content,
+  activeForm: activeForm ?? content.replace(/^\w+/, (m) => `${m}ing`),
+  status,
+});
+
+describe("AgentTodos", () => {
+  it("starts empty", () => {
+    const store = new AgentTodos();
+    expect(store.snapshot()).toEqual([]);
+  });
+
+  it("write replaces the entire list", () => {
+    const store = new AgentTodos();
+    const r1 = store.write([t("A"), t("B", "in_progress")]);
+    expect(r1.ok).toBe(true);
+    expect(r1.count).toBe(2);
+    expect(store.snapshot().map((x) => x.content)).toEqual(["A", "B"]);
+
+    const r2 = store.write([t("C", "completed")]);
+    expect(r2.count).toBe(1);
+    expect(store.snapshot().map((x) => x.content)).toEqual(["C"]);
+  });
+
+  it("clear empties the list", () => {
+    const store = new AgentTodos();
+    store.write([t("A")]);
+    store.clear();
+    expect(store.snapshot()).toEqual([]);
+  });
+
+  it("clear is a no-op when already empty (no spurious notify)", () => {
+    const store = new AgentTodos();
+    const cb = vi.fn<() => void>();
+    store.subscribe(cb);
+    store.clear();
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("subscribe fires on every write and clear", () => {
+    const store = new AgentTodos();
+    const cb = vi.fn<() => void>();
+    const unsub = store.subscribe(cb);
+    store.write([t("A")]);
+    store.write([t("A"), t("B")]);
+    store.clear();
+    expect(cb).toHaveBeenCalledTimes(3);
+    unsub();
+    store.write([t("Z")]);
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it("write with an identical list is a no-op (no notify, no snapshot churn)", () => {
+    const store = new AgentTodos();
+    const cb = vi.fn<() => void>();
+    store.write([t("A"), t("B", "in_progress")]);
+    const before = store.snapshot();
+    store.subscribe(cb);
+    store.write([t("A"), t("B", "in_progress")]);
+    expect(cb).not.toHaveBeenCalled();
+    expect(store.snapshot()).toBe(before);
+    // A genuine change still fires.
+    store.write([t("A", "completed"), t("B", "in_progress")]);
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("snapshot returns the same array reference until the next write", () => {
+    const store = new AgentTodos();
+    store.write([t("A")]);
+    const a = store.snapshot();
+    const b = store.snapshot();
+    expect(a).toBe(b);
+    store.write([t("B")]);
+    expect(store.snapshot()).not.toBe(a);
+  });
+
+  it("write defensively copies — caller's mutation doesn't leak in", () => {
+    const store = new AgentTodos();
+    const list: AgentTodos.Todo[] = [t("A")];
+    store.write(list);
+    list[0].content = "MUTATED";
+    expect(store.snapshot()[0].content).toBe("A");
+  });
+});

--- a/packages/grida-agent-tools/tsconfig.json
+++ b/packages/grida-agent-tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/packages/grida-agent-tools/tsdown.config.ts
+++ b/packages/grida-agent-tools/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "src/fs/index.ts",
+    "src/fs/backends/opfs.ts",
+    "src/fs/backends/node.ts",
+    "src/todos/index.ts",
+  ],
+  format: ["cjs", "esm"],
+  platform: "neutral",
+  dts: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,25 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/grida-agent-tools:
+    dependencies:
+      ai:
+        specifier: ^6
+        version: 6.0.116(zod@4.3.6)
+      zod:
+        specifier: ^4
+        version: 4.3.6
+    devDependencies:
+      tsdown:
+        specifier: ^0.21.9
+        version: 0.21.9(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+
   packages/grida-canvas-bitmap:
     dependencies:
       '@grida/cmath':


### PR DESCRIPTION
## Summary

Introduce `@grida/agent-tools` — storage-agnostic runtime primitives for Grida AI agents. Virtual filesystem with pluggable backends + live-state bindings, plan/todo store, AI-SDK tool schemas.

Two top-level symbols, each a class with a same-named TypeScript namespace:

```ts
import { AgentFs, AgentTodos } from "@grida/agent-tools";

const fs = new AgentFs(new AgentFs.MemoryBackend());
const binding: AgentFs.LiveBinding = ...;
fs.mount("/canvas.svg", binding);

const tools = { ...AgentFs.tools, ...AgentTodos.tools };
const output =
  AgentFs.resolveToolCall(fs, toolCall) ??
  AgentTodos.resolveToolCall(todos, toolCall);
```

Env-restricted backends stay behind subpath imports (both implement `AgentFs.Backend`):

- `@grida/agent-tools/fs/backends/opfs` — browser-only
- `@grida/agent-tools/fs/backends/node` — node-only

The public surface is pinned by `packages/grida-agent-tools/src/__public-api__.test.ts`. Adding a third top-level symbol is a deliberate design break — the contract guard tests will trip until `CHANGELOG.md` is updated.

## Context

Extracted from `feature/svg-editor` as the cross-cutting "fundamental tooling" layer. The branch contains only the package + its working-group docs under `docs/wg/feat-ai/`. SVG-editor-specific consumers (the `_ai/` UI, the chat route, the doc-store glue) live on `feature/svg-editor` and depend on this package as a workspace package.

## Test plan

- [x] `pnpm --filter @grida/agent-tools test` (84 tests pass — incl. 14 public-API contract guards)
- [x] `pnpm --filter @grida/agent-tools typecheck`
- [x] `pnpm --filter @grida/agent-tools build`
- [x] `pnpm exec oxlint packages/grida-agent-tools` (0 warnings, 0 errors)
- [x] `pnpm turbo typecheck --filter=editor --filter=@grida/agent-tools` (cross-package, green)
- [x] Standalone build off main + new package (no consumers) — clean install + tests + build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced private `@grida/agent-tools` package offering storage-agnostic filesystem and todo stores for AI agents; adds in-memory, OPFS (browser) and Node filesystem backends plus read/write/edit/list/grep tools.
* **Documentation**
  * New comprehensive docs: canvas-specific AI toolset and fundamental agent/toolset guidance with usage examples.
* **Tests**
  * Added extensive test suites validating filesystem/todo behaviors and public API surface.
* **Chores**
  * Public API/packaging cleanup and build/test configuration added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->