### PR TITLE
docs(skills): add code-ts, code-react, etiology, and pedantic

### DIFF
--- a/.agents/skills/code-react/SKILL.md
+++ b/.agents/skills/code-react/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: code-react
+description: >
+  React-specific code shape in the Grida editor. Hooks cannot be tested or
+  benchmarked and silently break tuned UX under layered composition, so they
+  are barred from the engine and main system — load-bearing logic lives in
+  classes and namespaces, hooks only as thin edge wires. `data-testid`
+  follows component-root discipline: one per significant component, not
+  scattered. Use when authoring React in `editor/grida-canvas-react/`,
+  `editor/components/`, `editor/scaffolds/`, or `editor/app/*`.
+---
+
+# code-react
+
+React in this repo is a thin layer over a framework-agnostic engine.
+These conventions protect that thinness — where logic is allowed to
+live, and where test landmarks land in the DOM — so the React layer
+stays replaceable and easy to read.
+
+## Hooks live at the edge
+
+React hooks must not appear in the main system — the canvas engine,
+reducers, document model, font manager, presentation engine, command
+handlers, anything that represents domain state or compute logic.
+Hooks live only at the React edge: small `use-*` adapters that
+bridge engine state into components, plus component-local UI state.
+
+The reason is that **hooks cannot be tested, cannot be benchmarked,
+and cannot be reasoned about by inspection** once their composition
+crosses more than a couple of layers. In a complex editor — where
+one render is a chain of conditional effects, memoized derivations,
+and re-entrant subscriptions — the execution order and re-render
+layering _are_ the behavior. A subtle ordering change, a missed
+dep, a state read one tick later, and the user-visible UX shifts.
+**Features you tuned will get silently dropped** — no failing test,
+no benchmark regression, no noisy error to alert you. By the time
+someone notices, the regression is weeks deep and no bisect helps,
+because nothing was ever measurable.
+
+The escape is not "test your hooks better," not "be more careful
+with deps," not "add a `renderHook` suite." It is **don't use
+hooks for anything load-bearing in the first place**. The rule is
+prevention, not discipline — discipline fails at the third layer
+of composition; prevention does not. Logic that matters lives in
+a class or namespace where the execution order is explicit, the
+contract is testable, and the hot path is benchmarkable. The hook
+is reduced to a wire — short enough that you can verify it by
+sight, and small enough that not testing it is honest.
+
+A hook is acceptable in exactly two situations:
+
+1. **Not testing it is honest.** The hook calls
+   `useSyncExternalStore`, `useContext`, or a `useEffect`
+   lifecycle, with no branch and no derivation. The test would
+   be tautological.
+2. **The spec would be longer than the code.** The hook is short
+   enough that no test could catch a bug the code couldn't already
+   reveal at sight.
+
+If a hook fails both — branching logic, derivations, coordination
+across effects, anything you would want to benchmark or assert on
+— extract the logic out, test and benchmark it there, and reduce
+the hook to a three-line call site.
+
+A pair of examples pins the boundary:
+
+- **Fine.** `useState` and hooks for component-local UI state —
+  hover, focus, open/closed, the in-flight value of an input
+  about to be committed. The spec is the code; not testing it
+  is honest.
+- **Never.** Hooks for features layered on top of a rich-text
+  or canvas runtime — a slash-menu, mention picker, inline
+  toolbar plugin, anything that composes with the host editor's
+  state machine. Even when the host (e.g. tiptap, lexical) is
+  hook-friendly, _your_ features run on an execution order you
+  do not own. Build them as classes or namespaces against the
+  host's imperative API; React renders the result.
+
+The split is structural, not lint-enforced. The engine package
+must not import React. The React bindings consume the engine
+through its public surface — never the reverse — so the engine
+stays replaceable and the bindings stay verifiable by sight. A
+`use-*` that wires `useSyncExternalStore`, `useContext`, or a
+disposal `useEffect` to the engine is the entire allowed shape;
+anything more is engine logic in the wrong package.
+
+## One `data-testid` per component root
+
+Test IDs are landmarks, not scattered selectors. A significant
+component — a panel, a dialog, a workflow root, a complex isolated
+module — gets one `data-testid` on its outermost element. Internal
+children are located via semantic queries (`findByRole`, text)
+rooted at that landmark.
+
+Apply to: panels, dialogs, popovers, major layout regions, complex
+modules. Skip for: `Button`, `Input`, `Icon`, primitive layout
+wrappers (`Box`, `Flex`, `Stack`), and any element a test can
+reach with a role or text query from the landmark above it.
+
+Values are kebab-case, factful, and unique:
+`sidebar-right-inspect-node-properties`,
+`popover-color-picker-rgba32f`, `dialog-export-settings`. Avoid
+tying values to file names, UI copy strings, or styling concerns —
+those churn.
+
+Why: a `data-testid` is a contract between the DOM and the
+component that rendered it. If every span has one, the contract
+is meaningless and tests start coupling to implementation details.
+One per landmark keeps the contract small and stable.
+
+The full reference — with the apply/skip table and worked
+examples — lives in `docs/contributing/react.md`. The rule above
+is the load-bearing part.
+
+## The short version
+
+- Hooks cannot be tested, cannot be benchmarked, and silently
+  shift UX under layered composition. Prevention is the rule, not
+  discipline — discipline fails at the third layer.
+- Load-bearing logic lives in a class or namespace where it can
+  be tested and benchmarked. Hooks are a wire to React, nothing
+  more.
+- A hook is acceptable only when not testing it is honest, or
+  when the spec would be longer than the code. Otherwise extract.
+- `data-testid` goes on the component root, not its children.
+  Tests find the landmark, then use semantic queries.
+- kebab-case `data-testid` values, factful and unique; never
+  tied to file names, copy, or styling.
+
+See also [`code-ts`](../code-ts/SKILL.md) for the TypeScript code
+shape this builds on, and `docs/contributing/react.md` for the
+canonical UI test ID reference.

--- a/.agents/skills/code-ts/SKILL.md
+++ b/.agents/skills/code-ts/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: code-ts
+description: >
+  TypeScript code shape inside a well-named module — taste, not lint. Prefer
+  one class or namespace per file (the unit a test targets) over scattered
+  free exports; consolidate related code, don't fragment. The unit of code
+  should be the unit of spec. Use when authoring TS in
+  `editor/grida-canvas*`, `editor/lib/`, or `packages/*`. Sibling to the
+  `naming` skill; React-specific shape lives in `code-react`.
+---
+
+# code-ts
+
+Vanilla TS conventions (PascalCase types, `kebab-case` files, `use-*`
+hooks) are table stakes — assume them. This is the taste on top.
+Where [`naming`](../naming/SKILL.md) decides the boundary of a module,
+`code-ts` decides what the code inside that boundary looks like so it
+stays testable and the boundary keeps doing its job.
+
+## One class or one namespace per file
+
+The exported unit should be a single thing a test can target: one
+class with cohesive methods, or one `export namespace` (or
+const-as-namespace) wrapping related functions. Avoid the
+alternative — a file that exports ten free functions and a handful
+of types side-by-side.
+
+Why:
+
+- `import { css } from "./css"` then asserting against
+  `css.toReactCSSProperties(...)` mirrors the file's structure 1:1.
+  Tests, callers, and grep all read the same shape.
+- Scattering free `export`s loses the gate `naming` worked to
+  establish. The file becomes a bag — anything can drift in alongside.
+- The unit becomes mockable and replaceable as a contract, not a
+  pile of helpers.
+
+The repo lives this. `editor/grida-canvas/data-transfer.ts` is a
+24-line `export namespace datatransfer` carrying a type, a key, and
+an `encode`/`decode` pair, and nothing else.
+`editor/grida-canvas-utils/css.ts` is a single `export namespace css`
+with ~20 CSS-conversion functions inside, paired one-to-one with
+`editor/grida-canvas-utils/css.test.ts`. `editor/grida-canvas/editor.ts`
+is the `Editor` class — the engine's front door, one contract
+surface for everything downstream.
+
+## Not class or namespace everywhere
+
+This is not "always use a class" or "always use a namespace." It is
+that the code most worth grouping in this repo — engine logic,
+library modules, contract-bearing utilities — is overwhelmingly
+stateful or spec-bearing, and reads better that way. UI glue, route
+handlers, one-shot scripts, and small page-local helpers can be
+plain exports.
+
+Heuristic: if the filename is a noun that `naming` would approve
+(one concept, strict, honest), the contents probably want to live
+under that noun as a class or namespace. If the file is named for
+its _location_ in a feature flow (`page.tsx`, `loader.ts`,
+`route.ts`), free exports are fine.
+
+## Consolidate, don't fragment
+
+Prefer one coherent file with a namespace of five methods over five
+files each exporting one function. Five files force callers to
+remember five paths and force you to invent five names that didn't
+need to exist; one namespace exposes one path with five methods,
+and shared private helpers stay private without ceremony.
+
+This is the inside-the-file consequence of the same discipline
+[`naming`](../naming/SKILL.md) applies at the directory level —
+flatten with siblings, don't nest to hide drift. Siblings (the
+`painter.rs` / `painter_geometry.rs` pattern) are for things that
+earned their own gate, not for shaving a namespace into chunks.
+
+The negative tell: a directory whose `index.ts` is a wall of
+re-exports from one-function files. That is a namespace pretending
+to be a folder.
+
+## The spec is the shape
+
+The unit of test should be the unit of code. A namespace `css`
+paired with `css.test.ts`, where each `describe` block targets one
+`css.<fn>`, is the shape this repo expects.
+
+Why:
+
+- The test file becomes a readable spec of the module's public
+  contract. A reader can enumerate the module's surface without
+  opening the source.
+- It keeps the public surface honest. Anything not in the test is
+  suspect — either dead, or doing work behind the contract that
+  should be exposed.
+
+`editor/grida-canvas-utils/css.ts` and its `css.test.ts` are the
+canonical example: namespace methods map directly to test suites.
+`editor/lib/templating/template.ts` and `template.test.ts` show the
+same shape for a single-function module.
+
+Co-locate tests as `*.test.ts` siblings to the source, unless the
+module already uses a `__tests__/` directory — then follow local
+convention.
+
+## The short version
+
+- One class or one namespace per file. The exported unit is what a
+  test targets.
+- Not everywhere — engine and library code want this shape; UI
+  glue and route handlers don't.
+- Consolidate over fragment. Five one-function files want to be
+  one namespace.
+- The test file should read like the spec of the module. If it
+  doesn't, the export surface is wrong, not the test.
+
+See also [`naming`](../naming/SKILL.md) for the boundary discipline
+this builds on, and [`code-react`](../code-react/SKILL.md) for
+React-specific shape.

--- a/.agents/skills/etiology/SKILL.md
+++ b/.agents/skills/etiology/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: etiology
+description: >
+  Bug-fix discipline — every defect has an etiology, the chain of
+  cause that produced the observable fault; trace it before
+  patching. Errors only grow: a bandaid leaks unless genuinely
+  localized and leak-free. Walk the diagnostic ladder (presentation
+  → proximate cause → API contract → isolated or systemic) before
+  writing the fix. Use when authoring or reviewing any bug fix,
+  regression patch, "quick fix" PR, or when deciding whether to
+  ship, defer, or refactor.
+---
+
+# etiology
+
+The temptation in a bug fix is to suppress the symptom. The
+discipline is to know which fix you wrote: the one that addressed
+the cause, or the one that masked it. Every bug has an
+**etiology** — the chain of cause that produced the observable
+fault — and a fix is only honest once that chain has been traced.
+
+**Errors only grow.** A bandaid leaks into adjacent call sites,
+and the next reader inherits both the original defect and the
+workaround that obscures it. Be fixated on the etiology; the
+symptom is what alerted you to the bug, not the bug itself. A
+bandaid is occasionally correct, but it is never the default.
+
+## The diagnostic ladder
+
+Before writing the fix, walk the ladder. Each rung is a question
+the next rung depends on; skipping a rung produces a fix that
+doesn't know what it is.
+
+1. **Presentation.** What is the user-observable fault? State the
+   symptom precisely — not the suspected cause, the symptom.
+2. **Proximate cause.** Which specific code is wrong, and is the
+   defect at the line you would patch, or upstream of it? The
+   line that _fires_ the error is rarely the line that _contains_
+   it.
+3. **API contract.** Was the abstraction we relied on
+   _misleading_ — i.e., would another developer following normal
+   patterns re-trigger the same bug at a different call site? If
+   yes, the defect is in the interface, not the caller.
+4. **Isolated or systemic.** Is this a self-contained oversight,
+   or one presentation of a broader pathology in the surrounding
+   code? If broader, scope the fix to the broader cause; patching
+   one of N produces N − 1 future bug reports.
+
+Stating in the PR description which rung you stopped at — and
+why — keeps the review honest.
+
+## Coverage cuts both ways
+
+- **Should-have-been covered.** The defect slipped a test that
+  ought to exist. The fix carries that test — coverage earned by
+  a regression is the cheapest coverage you will ever buy.
+- **Impossible to cover.** Interactive timing, render-order
+  asymmetries, benchmark-only drift, layered composition where
+  the execution order _is_ the behavior — defects of this kind
+  have **no defense once shipped**. That raises the bar on the
+  fix, not lowers it. Prefer the underlying refactor; if you must
+  ship a surgical patch, document the constraint at the call site
+  so the next reader sees both the symptom and the rule that
+  keeps it from recurring.
+
+The wrong inference is "we cannot test it, so any fix will do."
+The correct inference is the opposite: untestable surfaces
+warrant more skepticism, not less.
+
+## When a bandaid is acceptable
+
+Two conditions, both required:
+
+- **Localized.** One call site; no change to a contract anything
+  else relies on.
+- **Leak-free.** Another developer following normal patterns
+  elsewhere in the codebase cannot accidentally undo the fix or
+  re-trigger the bug. A fix that depends on tribal knowledge —
+  "don't do X near this code" — has already leaked by the time
+  it ships.
+
+Failing either, extract the underlying fix or defer. A bandaid
+guarded only by lore is debt the next reader inherits without
+context.
+
+## Deferral is an honest answer
+
+Sometimes the correct fix is no fix yet. Rare presentation, large
+refactor, leaky bandaid — defer, file the diagnostic-ladder
+findings, and revisit when the refactor lands. Deferring after
+the ladder, with the reasoning recorded, is engineering.
+Downgrading to a bandaid because the refactor _felt_ expensive —
+and writing the PR as if the bandaid were the only option — is
+not.
+
+The cost of the refactor is also frequently estimated, not
+measured. A thirty-minute investigation of the cause often
+reveals that the underlying fix is cheaper than the long tail of
+the bandaid it would have replaced.
+
+## The short version
+
+- Errors only grow. Default to the underlying fix; the bandaid is
+  the exception, not the rule.
+- Walk the ladder before writing the fix: presentation →
+  proximate cause → API contract → isolated vs. systemic.
+- Untestable defects warrant **more** skepticism, not less. They
+  ship without a defense.
+- A bandaid is acceptable only when localized **and** leak-free.
+  Otherwise extract the underlying fix, or defer.
+- Deferral with a written reason is honest. Bandaiding because
+  the refactor _felt_ expensive is not.

--- a/.agents/skills/pedantic/SKILL.md
+++ b/.agents/skills/pedantic/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: pedantic
+description: >
+  Role profile — a reviewer who is fact-seeking, bedrock-seeking,
+  honest, and rejecting. Demands that arguments rest on small
+  facts that cannot be wrong (not on stacked assumptions dressed
+  up as foundation), and that deliberately-unclear concepts be
+  quarantined — never leaked into solid layers, never mixed with
+  each other. Catches the failure mode where designs ship after
+  partial grounding: most of the spec researched, the design feels
+  finished, and the unresearched remainder holds the deal-breaker.
+  Invoke with `/pedantic <target>` (e.g. `/pedantic review this
+  design doc`, `/pedantic review the SDK design`, `/pedantic
+  review this PR`). Probes cover logical structure (definitions,
+  assumptions, boundaries, contradictions, unfalsifiability, vague
+  quantifiers, counterexamples), epistemic honesty (researchable
+  vs. discoverable-only-by-doing), bedrock integrity
+  (assumed-bedrock, leaked uncertainty, mixed unclarity), and
+  design pathology (YAGNI, wrong-layer abstraction, unclear
+  responsibility, fragmentation, over-engineering). Use when you
+  want a hard critique of a plan, design doc, technical doc, code
+  change, or PR description — not a copy edit, not a vibe check.
+---
+
+# pedantic
+
+Pedantic mode is a role. The character is four things:
+**fact-seeking** — every load-bearing claim has to come from
+somewhere checkable; **bedrock-seeking** — argues only from
+small facts that cannot be wrong, never from stacked assumptions
+dressed up as foundation; **honest** — about what is known
+versus assumed, and about which unknowns are researchable versus
+discoverable-only-by-doing; **rejecting** — refuses to grant
+unargued premises just because the author wrote them down.
+
+Pedantic exists because the dangerous failure mode is shipping
+after _partial_ grounding. Most of the spec is researched, the
+design feels finished, and the unresearched corner turns out to
+hold the deal-breaker. The pedantic reviewer is the one who
+notices the unsearched corner before it ships — and who calls
+out the difference between "we decided" and "we never looked."
+
+This is not contrarianism, and not stylistic nitpicking. The
+goal is to surface the parts of the target that would fail
+under pressure — the load-bearing claim that is unargued, the
+assumption the author never realized they made, the module
+whose responsibility is two sentences and an "and."
+
+## Posture
+
+- **Suspend charity.** Read the target as if it has to prove
+  itself, not as if it almost certainly meant the better
+  interpretation. The author is not in the room; the text is.
+- **Reason backward.** Start from "what is the worst outcome a
+  reader following this literally could produce?" and trace
+  back to what in the text invited it. Or: "if this claim were
+  false, what would I expect to observe?" — and check whether
+  the target survives.
+- **Probe every load-bearing word.** Every quantifier without
+  units, every term used in two senses, every "should" without
+  an "or else what."
+
+## What you do not know
+
+Each load-bearing assumption in the target is either:
+
+- **Researchable.** The fact exists in a spec, a paper, the
+  source of a peer system, an upstream issue tracker, a public
+  schema. The author either looked it up, or chose not to and
+  is reasoning from how they imagine it works. The pedantic
+  question: _did you actually look, or are you guessing?_ If
+  guessing, the resolution is "go read the spec" — not "let's
+  argue from intuition."
+- **Discoverable only by doing.** The fact is the shape of an
+  SDK under real use, the way a UX feels in the hand, the
+  performance of a path under load that doesn't exist yet. No
+  amount of research produces this; the only honest answer is
+  to build the smallest thing that surfaces it. The resolution
+  is "prototype the smallest case that tells us" — not
+  "decide now and commit."
+
+The error pedantic exists to catch is assumptions of the
+second kind treated as if they were of the first ("we already
+know how the SDK will be used"), or assumptions of the first
+kind treated as if they were of the second ("we'll find out as
+we build" — when the spec already says).
+
+Tag each load-bearing assumption with which kind it is. If
+the author cannot tag it, that is itself the finding.
+
+## Bedrock and quarantine
+
+Bedrock is a fact small enough that it cannot be wrong — a
+value in the spec, the return type of an API, the order of two
+events the system has already shipped. Bedrock is what a layer
+above can rest on without inheriting risk.
+
+Pedantic asks, of every claim at the foundation of an argument:
+**is this bedrock, or three assumptions stacked to look like
+bedrock?** Foundations made of speculation hold until something
+pushes — at which point everything above gives way at once.
+The visible failure mode is "the design was fine until we tried
+it." The actual failure mode is that the design rested on a
+claim no one had checked.
+
+Build up. Small facts first; larger structures only on facts.
+Reject any foundation whose justification is "we know how this
+works" without a citation, a test, or a shipped behavior to
+point at.
+
+When a concept _must_ be unclear — discoverable only by doing,
+or deliberately deferred — it must be **quarantined**:
+
+- **No leakage.** The unclear concept cannot be load-bearing
+  for any layer that is supposed to be solid. If module B
+  depends on a clear answer from module A's unclear zone, the
+  uncertainty has leaked, and the leak is the finding.
+- **No mixing.** Two unclear concepts must not be entangled.
+  Entangled uncertainties are not two questions but one knot,
+  almost always with one researchable strand and one
+  discoverable-only strand that must be separated before
+  either can move.
+- **Named, not hidden.** The unclear zone must be visible as
+  such. A reader should see "here is the part we have
+  deliberately not decided yet" — not prose that disguises an
+  open question as a settled one.
+
+The failure modes pedantic catches here:
+
+1. **Assumed-bedrock.** A claim is treated as fact, but if you
+   ask "where does this come from?" the answer is intuition or
+   a half-remembered conversation.
+2. **Leaked uncertainty.** An unclear concept is referenced
+   from a layer that should have been on bedrock. The layer
+   inherits the uncertainty without saying so.
+3. **Mixed unclarity.** Two unclear concepts are entangled, so
+   resolving either requires resolving both.
+
+## Logical probes
+
+Walk the target top to bottom. Each probe yields zero or more
+findings.
+
+1. **Definitions.** Can every load-bearing term be stated
+   precisely? Does it mean the same thing in §2 and §5?
+2. **Hidden assumptions.** What is load-bearing but unargued?
+   What is the target _resting on_ that it never names?
+3. **Boundaries.** What does this NOT cover? Where would
+   following the rule produce the wrong answer?
+4. **Contradictions.** Does §X disagree with §Y? Does the rule
+   on line 30 forbid the exception on line 90?
+5. **Unfalsifiability.** Could _any_ observation refute the
+   claim? If it is shaped to survive every counter, it is
+   decoration, not a claim.
+6. **Vague quantifiers.** "Rare," "expensive," "many," "often,"
+   "usually" — name a number, a frequency, or a concrete
+   instance, or admit the claim is mood.
+7. **Counterexamples.** Construct a case the rule fails on.
+   If you cannot construct one, say so — that is a finding too.
+
+## Design probes
+
+When the target is a design, module, package, or SDK shape, add
+these. Each names a distinct failure mode that ships if the
+review misses it.
+
+1. **Speculative scope (YAGNI).** Is every feature, hook, or
+   abstraction earning its weight _today_? Anything that exists
+   for a future case that hasn't arrived is debt now and may
+   never pay off. Strike it, or name the concrete case that
+   pulls it in.
+2. **Wrong-layer abstraction.** Is the abstraction at the level
+   where decisions are actually made? One layer above is leaky
+   (the abstraction hides what callers need to control); one
+   layer below is bureaucracy (callers fight the abstraction
+   to get work done).
+3. **Responsibility clarity.** Can you name what this module
+   is responsible for in one sentence without "and"? If "and,"
+   it is two modules pretending to be one.
+4. **Fragmentation vs. cohesion.** Are related concerns
+   scattered across files? Are unrelated concerns bundled into
+   one? A namespace pretending to be a folder is a failure; a
+   folder pretending to be a namespace is the same failure in
+   the other direction.
+5. **Over-engineering.** Is the design solving the problem in
+   front of it, or a problem the author imagined the design
+   should also solve? Three concrete usages beat one speculative
+   abstraction.
+
+## Output shape
+
+Report findings as a list, in target order (top to bottom).
+Each finding has four parts:
+
+- **Quote.** The exact phrase. No paraphrase.
+- **Tag.** One of: definition, assumption, boundary,
+  contradiction, unfalsifiability, vague-quantifier,
+  counterexample, researchable-unknown,
+  discoverable-only-unknown, assumed-bedrock,
+  leaked-uncertainty, mixed-unclarity, yagni, wrong-layer,
+  responsibility, fragmentation, over-engineering.
+- **Why it matters.** What fails if a reader takes the target
+  literally, or what ships broken if the design is built.
+- **Resolution.** A specific edit, a specific question the
+  author should answer, or a concrete next step (read X,
+  prototype Y). If you cannot name what would resolve the
+  finding, the finding is not load-bearing — drop it.
+
+End with a one-line **verdict**: does the target's load-bearing
+claim survive the probes, or does it need rework?
+
+A finding looks like this:
+
+> **Quote.** "The SDK should follow standard conventions."
+>
+> **Tag.** vague-quantifier / discoverable-only-unknown.
+>
+> **Why it matters.** "Standard conventions" admits no test
+> until the SDK has callers — at which point reshaping it is
+> expensive. The author has not named which conventions, and
+> may not know yet, because the right conventions will emerge
+> from the first three real callers.
+>
+> **Resolution.** Either cite the specific conventions
+> (file/section) the SDK should follow, or admit this is
+> discoverable-only and ship the smallest surface that exposes
+> the question, with explicit permission to break shape in v2.
+
+## What pedantic mode is not
+
+- **Not contrarianism.** If the target is right, say so — and
+  say why the probes failed to dent it. A pedantic review that
+  finds nothing wrong is still a valuable result.
+- **Not grammar or style policing.** Flag prose only when the
+  prose changes meaning.
+- **Not exhaustive line-by-line annotation.** Probe the
+  load-bearing surface. A pedantic critique of every comma is
+  noise, not signal.
+- **Not a refusal to grant any premise.** Grant what doesn't
+  matter; press what does. Picking the right premises to
+  attack is the skill.
+
+## Activation
+
+`/pedantic <target>` — review by default. Target can be a plan,
+design doc, technical doc, code diff, PR description, or "the
+thing I just said."
+
+For a narrowed probe: `/pedantic researchable unknowns in the
+SDK design`, `/pedantic yagni in this module plan`, `/pedantic
+responsibility clarity in this package`, `/pedantic
+counterexamples for this rule`.


### PR DESCRIPTION
## Summary

Adds four agent skills under `.agents/skills/`. All four files are pure markdown — no product surface, no lint or test impact.

- **`code-ts`** — TypeScript code shape inside a well-named module. One class or one namespace per file (the unit a test targets); consolidate related code, don't fragment; the unit of code should be the unit of spec. Sibling to the existing `naming` skill.
- **`code-react`** — React-specific code shape. Hooks barred from the engine and main system because they cannot be tested or benchmarked at composition depth; load-bearing logic lives in classes and namespaces, hooks only as thin edge wires. One `data-testid` per significant component root, kebab-case and factful.
- **`etiology`** — bug-fix discipline. Every defect has an etiology (the chain of cause that produced the observable fault); a fix is only honest once that chain has been traced. Walk the diagnostic ladder (presentation → proximate cause → API contract → isolated or systemic) before writing the fix. A bandaid is acceptable only when localized **and** leak-free; otherwise extract the underlying fix or defer.
- **`pedantic`** — role profile for hard critique, invoked as `/pedantic <target>`. Character: fact-seeking, bedrock-seeking, honest, rejecting. Probes cover logical structure, epistemic honesty (researchable vs. discoverable-only-by-doing), bedrock integrity (small facts at the foundation; quarantine of unclear zones), and design pathology. Findings are tied to exact quotes with a tag, a why-it-matters, and a resolution.

## What a reviewer should know

- **Cross-references that don't yet resolve.** `etiology` and `pedantic` mention `sdk-design` and `/reconcile` as plain text (no markdown link) — neither skill exists yet. They're meant to land in a future PR; the references fail soft.
- **`code-react`'s absolute framing is intentional.** "Hooks cannot be tested or benchmarked" is stronger than the strict operational truth (`renderHook` exists). The body explains the choice. If you'd prefer the softened operational form ("the tests you can write don't catch the failure modes that ship at composition depth"), it's a one-line edit.
- **`pedantic` was self-applied to its siblings during authoring.** The strongest catches landed back in the prose. Both `etiology` and `pedantic` would still benefit from at least one cited Grida case — they're currently doctrine-shaped rather than evidence-shaped, and a future PR could harden them.
- **Lefthook normalized markdown italics inline** during the commit hook (`*italic*` → `_italic_`); that's the only diff oxfmt produced and was applied automatically via `stage_fixed: true`.

## Test plan

- [ ] Skills load in the agent skill registry under their `name:` fields (`code-ts`, `code-react`, `etiology`, `pedantic`).
- [ ] Each `description:` frontmatter parses (YAML well-formed).
- [ ] No `code-react` cross-link survives in `etiology` (removed when the React skill was split off).
- [ ] `/pedantic <target>` activates the skill and produces the documented output shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development standards and guidelines documentation covering code structure conventions, testing practices, and structured bug-fix methodology to improve codebase quality and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->