### PR TITLE
docs(skills): add oss-standards, ee, ee-billing

### DIFF
--- a/.agents/skills/ee-billing/SKILL.md
+++ b/.agents/skills/ee-billing/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ee-billing
+description: >
+  Surface workflow for billing in Grida — Stripe (subscriptions) +
+  Metronome (AI credit ledger). The stable contracts: `grida_billing.*`
+  is not REST-exposed (views/RPCs only), `fn_billing_apply_*` are the
+  single mutation points, webhook receivers are `GRIDA-SEC-001`, BYOK
+  is the `GRIDA-SEC-003` carve-out. Use when touching
+  `editor/lib/billing/`, `editor/scripts/billing/`, the
+  `grida_billing` schema, the webhook receivers, or the entitlement
+  gate. Companion to `ee`.
+---
+
+# ee-billing
+
+This is the surface skill for billing — the workflow once the
+[`ee`](../ee/SKILL.md) anchor has placed billing on the EE side and
+the contributor setup is done. Setup itself is documented; cite it,
+don't restate it:
+
+- [docs/contributing/billing](https://grida.co/docs/contributing/billing) —
+  local Stripe + Metronome sandbox, cloudflared tunnel, env vars,
+  troubleshooting.
+- [docs/wg/platform/billing/](https://grida.co/docs/wg/platform/billing/) —
+  design notes: AI credits master plan, Metronome integration,
+  known issues.
+- [docs/platform/billing](https://grida.co/docs/platform/billing) —
+  user-facing copy.
+
+## Stable surface (the contract)
+
+These shapes are _locked_. A change that breaks any of them must be
+intentional and called out in the PR description.
+
+- **`grida_billing.*` schema** — not REST-exposed. Public reads go
+  through `v_billing_*` views; writes only through `fn_billing_*`
+  RPCs. Don't add a new direct-access surface; add a view or an
+  RPC. Schema discipline lives in
+  [`database`](../database/SKILL.md) / `supabase/AGENTS.md`.
+- **`public.fn_billing_apply_stripe_event`** — the _only_ place
+  Stripe-driven subscription state mutates. Mutating from a new
+  direction (UI form, ad-hoc RPC, hand-written migration) corrupts
+  the projector model.
+- **`public.fn_billing_apply_metronome_event`** — same role for
+  Metronome credit / alert / `payment_gate` events.
+- **Webhook receivers** — `/webhooks/stripe` and
+  `/webhooks/metronome` are the only billing ingress; both are
+  signature-verified per `GRIDA-SEC-001`.
+- **`editor/lib/billing/metronome.ts`** — the service module
+  surface: `provisionOrg`, `addStripeChargedCommit`, `setAutoReload`,
+  `getEntitlement`, `ingestUsageEvent`. New billing actions go
+  _through_ this module, not adjacent to it.
+
+## Substrates
+
+Two external clouds; both use per-contributor sandbox accounts.
+**Credentials are never shared.** Live keys are refused at boot.
+
+- **Stripe** — subscriptions + payment processing. Provision via
+  `pnpm tsx editor/scripts/billing/cli.ts setup:stripe`. Idempotent;
+  re-run after every `supabase db reset` (writes price IDs into the
+  catalog).
+- **Metronome** — AI credit ledger. Provision via
+  `pnpm tsx editor/scripts/billing/cli.ts setup:metronome`. Same
+  idempotency / re-run rule.
+
+`editor/scripts/billing/cli.ts` is the single entry point for every
+billing script; run without arguments for the full subcommand list.
+See `editor/scripts/billing/README.md`.
+
+## The seam: how OSS reads entitlement
+
+OSS code that needs to gate on a paid plan, AI credit balance, or
+org entitlement does not import billing internals. The seam is
+`getEntitlement` (from `editor/lib/billing/metronome.ts`) and its
+typed wrappers. New gates go through this function so fail-closed
+and BYOK behavior stay centralized.
+
+## BYOK carve-out — `GRIDA-SEC-003`
+
+If `BYOK_OPENROUTER_API_KEY` or `BYOK_AI_GATEWAY_API_KEY` is set in
+`editor/.env.local`, the AI-SDK text path routes through the
+contributor's provider and bypasses billing.
+
+- **Auth is never bypassed.** A resolvable org is still required.
+- **Text/chat only.** Image and audio still go through Replicate
+  and still bill, even under BYOK.
+- **Never set `BYOK_*` on a hosted or preview deploy.** It disables
+  billing _and_ the org-id sanity gate for every org. See
+  `SECURITY.md` (`GRIDA-SEC-003`).
+
+## Working on billing
+
+1. Read [docs/contributing/billing](https://grida.co/docs/contributing/billing)
+   for setup before the first change. Don't skip cloudflared if you
+   need Metronome — webhook delivery requires public HTTPS.
+2. Tag every billing file with `GRIDA-EE: billing` per the
+   [`ee`](../ee/SKILL.md) skill.
+3. Webhook receivers also carry `GRIDA-SEC-001` — the
+   [`security`](../security/SKILL.md) review runs first.
+4. Don't mutate `grida_billing.*` outside `fn_billing_apply_*` or the
+   migration that creates it.
+5. Run the E2E suite before opening the PR (refuses to start unless
+   every channel is demonstrably test-mode):
+   `pnpm --filter editor vitest run lib/billing/__tests__/e2e`.
+6. For schema changes, the [`database`](../database/SKILL.md) skill
+   governs — `grida_billing` is a regular `grida_*` schema under
+   that discipline.
+
+## Known issues
+
+[docs/wg/platform/billing/known-issues](https://grida.co/docs/wg/platform/billing/known-issues)
+is the living register (`KI-BILL-NNN`). Add to it when you mitigate
+or accept an issue; don't quietly bake the mitigation into a PR
+without registering it.
+
+See also: [`ee`](../ee/SKILL.md) (the EE anchor),
+[`security`](../security/SKILL.md) (`GRIDA-SEC-001`,
+`GRIDA-SEC-003`), [`database`](../database/SKILL.md) (schema
+discipline for `grida_billing`).

--- a/.agents/skills/ee/SKILL.md
+++ b/.agents/skills/ee/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ee
+description: >
+  Working pattern for enterprise-edition features in Grida — the
+  commercial/hosted concerns (entitlement, BYOD, billing) on top of
+  the OSS core. Anchor for the `GRIDA-EE: <surface>` grep marker,
+  `(ee)` route group, `*-hosted` package suffix, and namespaced
+  `grida_*` schema. Use when adding or touching an EE-only feature,
+  or deciding whether a feature is EE territory. Surface skills
+  (`ee-billing`) are siblings.
+---
+
+# ee
+
+Grida is open source. Some features only exist because Grida is also
+a hosted commercial product — org-level entitlement, custom domains,
+billing. Those features are **EE (enterprise edition)**: they ship in
+the same monorepo as the OSS core, but a self-hoster running the
+codebase without paid infrastructure should be able to identify and
+strip them.
+
+This skill is the anchor for that boundary. No `GRIDA-EE` marker
+exists in the repo today; this skill establishes the convention.
+
+## What counts as EE
+
+The test: _would this feature still make sense in a single-user,
+no-billing self-hosted instance?_ If no, it is EE.
+
+Three surfaces today:
+
+- **Org / entitlement** — the commercial layer on top of multi-tenant
+  routing. Paid plans, member seats, the entitlement check that gates
+  paid features. _The tenant routing substrate itself (`(tenant)`
+  route group, RLS, hostname resolution) is OSS infrastructure — only
+  the commercial layer on top of it is EE._
+- **Custom domains (BYOD)** — user-owned apex + subdomain mapping on
+  Vercel. See [multi-tenant-custom-domain-vercel](https://grida.co/docs/wg/platform/multi-tenant-custom-domain-vercel).
+- **Billing** — subscriptions, AI credit, the entitlement gate
+  primitive. See the `ee-billing` skill (planned) for the workflow.
+
+## The `GRIDA-EE` marker
+
+Like `GRIDA-SEC`, the boundary is grep-able. Tag every file that
+exists _only_ for EE, with the surface as the sub-label:
+
+```ts
+// GRIDA-EE: entitlement — paid-plan gate
+// GRIDA-EE: byod — apex domain verification
+// GRIDA-EE: billing — see ee-billing
+```
+
+Sub-labels are surface names (`entitlement` / `byod` / `billing`),
+not ids — there is no central registry like `SECURITY.md`. The grep
+is the index:
+
+```sh
+grep -rn 'GRIDA-EE' editor crates packages
+```
+
+Tag the file header when the entire file is EE; tag inline when only
+a branch is EE.
+
+**Known limitation.** The marker captures files that exist _only_ for
+EE. Shared utilities that EE imports but OSS also uses are not
+tagged — strip-time discovery has to come from an import audit, not
+grep. Don't tag OSS modules with EE callers; tag inline at the EE
+branch instead.
+
+## Physical placement
+
+Co-locate by surface so the grep doesn't have to do all the work.
+
+- **Next.js routes** — group under `(ee)` only when a cluster of
+  EE-only routes shares chrome/auth distinct from OSS readers
+  (per [`naming`](../naming/SKILL.md), route groups encode the
+  reader on the other side of the screen). For a single EE route
+  inside an OSS reader's surface, tag inline rather than fragmenting
+  the existing group. Tenant _content rendering_ stays in `(tenant)`
+  — that is the OSS routing substrate, not EE.
+- **Packages and crates** — use the existing `*-hosted` suffix when
+  the whole package is EE-only. `grida_hosted` already lives in the
+  DB schemas as the parallel namespace, and `*-hosted` is in
+  `naming`'s established suffix list. Don't mint a parallel `*-ee`
+  suffix. Mixed packages stay unsuffixed and tag the EE branches
+  inside.
+- **Database** — namespaced schema. Existing examples:
+  `grida_billing`, `grida_hosted`. Don't bleed EE columns into
+  OSS-relevant tables. Schema-design rules live in the
+  [`database`](../database/SKILL.md) skill / `supabase/AGENTS.md`;
+  consult those.
+
+When in doubt, default to the EE-named location. The cost of moving
+later is the cost of every import.
+
+## Working on EE features
+
+1. Tag every file you create or touch with `GRIDA-EE: <surface>`.
+2. Place new code in an EE-named location. If there's no existing EE
+   location for the surface yet, create it — don't dilute an OSS one.
+3. **Direction of dependency: EE → OSS, not OSS → EE.** Stripping the
+   `(ee)` group and `*-hosted` packages must not break OSS modules.
+   Where OSS needs to query an EE concept (entitlement, paid plan,
+   member seats), define the interface in OSS and let EE provide the
+   implementation — not a direct import of an EE module from an OSS
+   one.
+4. Fail-closed at the EE boundary is
+   [`security`](../security/SKILL.md) discipline — see `GRIDA-SEC-003`
+   (BYOK fail-closed) for the worked example.
+
+## When EE crosses security
+
+EE surfaces that also carry a `GRIDA-SEC-<id>` tag — the Stripe and
+Metronome webhook receivers (`GRIDA-SEC-001`), the BYOK carve-out
+(`GRIDA-SEC-003`), any path that gates entitlement on a signed
+payload — run the [`security`](../security/SKILL.md) review first;
+this pattern is the second pass. Tag the file with both markers.
+
+> Precedence is stated here only; if the rule becomes load-bearing,
+> mirror it into `security/SKILL.md` so a reader entering from that
+> side doesn't miss it.
+
+See also: `ee-billing` (billing workflow — planned),
+[`security`](../security/SKILL.md) (boundary contracts, fail-closed
+discipline), [`naming`](../naming/SKILL.md) (the suffix list this
+inherits), [`oss-standards`](../oss-standards/SKILL.md)
+(public-by-default discipline), [`database`](../database/SKILL.md)
+(schema namespacing).

--- a/.agents/skills/oss-standards/SKILL.md
+++ b/.agents/skills/oss-standards/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: oss-standards
+description: >
+  Pre-PR discipline for a public-by-default repo. What a reviewer
+  enforces beyond CI: secrets and internal data in diffs or
+  screenshots, docs that name their reader, and the cleaning pass
+  where incomplete or confusing artifacts get dropped. Use before
+  opening any PR against `gridaco/grida` or when finalizing work for
+  review.
+---
+
+# oss-standards
+
+Grida is open source. CI checks catch the mechanical failures —
+format, lint, typecheck, tests, typos, generated-file freshness. This
+skill is the _extra_ bar a reviewer enforces because the repo is
+public, the threat model is public, and the audience for every
+artifact in a PR includes a stranger who arrived via Google.
+
+The defaults that flip:
+
+- **Public-by-default.** Names, comments, fixtures, screenshots,
+  commit messages — assume a stranger reads them first. There is no
+  internal channel; everything is the channel.
+- **Push = publish.** A secret in a branch push is a published secret,
+  even if you delete the commit five minutes later. "I'll redact
+  before merge" is not a plan; rotation is.
+- **Incomplete is worse than absent.** "I'll finish it next PR" lands
+  on `main`, gets indexed, and becomes the example the next
+  contributor copies. Use `draft: true`, defer the PR, or just don't
+  ship — but don't ship half.
+
+## Code
+
+Beyond what CI catches and what `CLAUDE.md` / `naming` / `code-ts` /
+`code-react` already enforce:
+
+- **No personal TODOs.** `// TODO(me): …`, "fix later", "@username
+  knows" — private notes published. Either resolve, or rewrite as a
+  neutral TODO with a tracking issue link.
+- **No machine-specific paths.** See the [`links`](../links/SKILL.md)
+  pre-commit gate — absolute paths, `~/scratch/...`, `/tmp/...`, and
+  untracked references resolve to nothing for anyone else.
+- **One concern per PR.** A reviewer in public cannot accept half a
+  PR; bundled unrelated changes are unreviewable. Split or rebase.
+- **New public surface is a semver commitment.** YAGNI applies
+  everywhere, but in OSS the cost of adding an exported name today is
+  the deprecation path you owe tomorrow. Wait for the second caller.
+
+For bug fixes specifically, the [`etiology`](../etiology/SKILL.md)
+skill is mandatory — bandaids in `main` become tribal knowledge that
+external contributors have no access to.
+
+## Security
+
+The full boundary discipline lives in the
+[`security`](../security/SKILL.md) skill — `GRIDA-SEC-<id>` tags, the
+mandatory review before commit. Two extra OSS gates on top, both
+because _push = publish_:
+
+- **Secrets in diffs, fixtures, or tests.** Any credential, signing
+  key, Stripe/Metronome id, webhook signature, or production-shaped
+  URL committed has been published the moment the branch is pushed.
+  Use `.env.local` (gitignored) and fixture placeholders.
+- **Internal URLs and screenshots.** Webhook URLs, dev-tunnel URLs,
+  staging hosts, dashboard links, and screenshots that show real org
+  slugs, account ids, or tenant data leak the same way. A doc PR with
+  a real org slug visible in the screenshot chrome is a published org
+  slug.
+
+If a `GRIDA-SEC-<id>` tag appears anywhere in your diff, the
+`security` skill's review runs first; this skill's cleaning pass is
+downstream of that.
+
+## Docs and prose
+
+Anything user-facing — README, `docs/**`, blog post, in-product copy,
+the PR description itself — has an audience that doesn't share your
+context.
+
+**Name the reader before writing.** One sentence: "an external
+contributor first opening the repo," "a designer evaluating Grida vs
+Figma," "an agent grounding before a refactor." If you can't name the
+reader, the page doesn't know what it is — and that surfaces as prose
+that hedges, repeats, or assumes.
+
+- **No "we know that…" prose.** "We" is the maintainers; the reader is
+  someone else. Explain the fact or link to where it lives.
+- **No private references.** Slack threads, internal tickets, "as we
+  discussed" — invisible to the reader.
+- **Link form follows the rendering surface.** See the
+  [`links`](../links/SKILL.md) skill — local-only or untracked targets
+  are correctness bugs in OSS, not style.
+- **Ship-or-draft is the doc taxonomy gate.** `draft: true` is the
+  honest answer when a page isn't useful enough yet; shipping a
+  half-page because "something is better than nothing" is not. See
+  [`docs/AGENTS.md`](../../../docs/AGENTS.md).
+
+## The cleaning pass
+
+Final pass before opening the PR. For every file touched, ask
+literally:
+
+> If a stranger reads this file with no context, does it help them, or
+> does it leave a question they cannot answer?
+
+Apply the answer:
+
+- **Helps → keep.**
+- **Recoverable question → fix it** (rename, expand the doc, add the
+  one comment that explains the non-obvious constraint).
+- **Unrecoverable question → drop** the file, the code block, the doc
+  section, the fixture, the screenshot.
+
+The bias is to drop. A confusing artifact in `main` outlives the PR
+and is the first thing the next contributor finds when they grep.
+
+Common removals on this pass:
+
+- Scratch files committed by mistake (`tmp.ts`, `notes.md`, unnamed
+  fixtures, snapshots from a one-off debug run).
+- Half-written doc pages with no audience or no conclusion — `draft:
+true` or delete.
+- TODO blocks that reference internal context.
+- Examples or fixtures that don't run or aren't referenced.
+- Inline comments that paraphrase code instead of stating the
+  non-obvious _why_ (per the repo-wide rule in `CLAUDE.md`).
+
+## The PR description and commit message
+
+These are public artifacts permanently linked from the diff.
+
+- **Commit message** makes `git log` a useful index. `"fix"` is not a
+  commit message; neither is `"updates"`.
+- **PR description** lets a future contributor reconstruct _why_ the
+  change exists without reading the diff line by line. Bug fix → name
+  the diagnostic-ladder rung (`etiology`). Feature → name the audience
+  and the concrete use case that pulled it in.
+
+## The short version
+
+- Public-by-default. Push = publish. Nothing is internal.
+- CI catches the mechanical. This skill catches the rest.
+- Secrets, internal URLs, machine paths, screenshots with real data —
+  published on push; rotation is the only remedy.
+- Docs name the reader, or they don't know what they are.
+- Final pass: every artifact justifies itself to a stranger, or it
+  drops. Bias is to drop.
+- The PR description and commit message are the permanent index.
+  Write them as such.
+
+See also: [`security`](../security/SKILL.md),
+[`links`](../links/SKILL.md), [`etiology`](../etiology/SKILL.md),
+[`naming`](../naming/SKILL.md), [`code-ts`](../code-ts/SKILL.md),
+[`code-react`](../code-react/SKILL.md),
+[`pedantic`](../pedantic/SKILL.md) (when you want a hard critique
+before opening the PR).


### PR DESCRIPTION
## Summary

Three new agent skills under `.agents/skills/`:

- **`oss-standards`** — pre-PR discipline for the public repo. What a reviewer enforces beyond CI: secrets and internal data in diffs/screenshots, audience-named docs, the drop-incomplete cleaning pass.
- **`ee`** — working pattern for enterprise-edition features (entitlement, BYOD, billing) layered on the OSS core. Establishes the `GRIDA-EE: <surface>` grep marker and the `(ee)` route group / `*-hosted` package suffix / namespaced `grida_*` schema convention.
- **`ee-billing`** — surface workflow for the billing path (Stripe + Metronome). Captures the `grida_billing.*` stable contracts, the `fn_billing_apply_*` projector mutation points, webhook receivers as `GRIDA-SEC-001`, BYOK as `GRIDA-SEC-003`.

The skills cross-reference each other and defer to existing skills (`security`, `links`, `naming`, `code-ts`, `code-react`, `database`, `etiology`) rather than restating their content.

## Notes for reviewers

- `ee` was code-reviewed via three parallel agents (overlap audit, pedantic pass, concision/structural fit). The convergent findings were applied. Most notably:
  - **`*-hosted` chosen over `*-ee` for the suffix** because `grida_hosted` schema already exists and `naming` lists `*-hosted` in its established suffix family — avoiding a parallel convention.
  - **Tenancy split** into the OSS routing substrate (`(tenant)` group, RLS, hostname resolution) vs. the commercial layer on top (paid plans, entitlement, member seats). Only the latter is EE.
  - **`(ee)` route group softened** to "only when a cluster of EE-only routes has chrome/auth distinct from OSS readers" — reconciles with `naming`'s reader-as-group rule.
- `ee-billing` is the first surface-specific skill under the `ee` anchor; future siblings would follow the same pattern.
- **No `GRIDA-EE` markers exist in code yet** — the convention is being introduced. The `ee` skill body acknowledges this.
- The "security wins when both markers apply" precedence rule is stated in `ee` only; flagged in the body as needing a mirror in `security/SKILL.md` if it becomes load-bearing.
- Frontmatter descriptions were trimmed to keep the always-loaded skill index lean (~340 → ~160 words across all three).

## Test plan

- [ ] Skill frontmatter loads cleanly (YAML valid, descriptions concise)
- [ ] All inter-skill links resolve (`../security/SKILL.md`, `../naming/SKILL.md`, `../database/SKILL.md`, etc.)
- [ ] Docs links use hosted URL form per the `links` skill (source → docs page)
- [ ] All cited paths exist (`editor/lib/billing/metronome.ts`, `editor/scripts/billing/cli.ts`, `supabase/schemas/grida_billing.sql`, `docs/contributing/billing.md`, `docs/wg/platform/billing/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive skill documentation for billing workflows, enterprise-edition boundaries, and open-source standards to support development team guidelines and processes.

**Note:** These are internal documentation updates with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->