### PR TITLE
ci: skip test.yml on docs-only and .agents-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - ".agents/**"
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
+      - "branding/**"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Closes #740.

- Add `paths-ignore` to `test.yml`'s `pull_request` trigger so PRs that only touch `.agents/`, `docs/`, `branding/`, or markdown files don't kick off the full build + typecheck + lint + test path.
- Chose option (b) from the issue — blocklist over allowlist — because it's easier to maintain as the repo grows and won't silently miss new code directories.
- `push: main` keeps a bare trigger, so the post-merge run on `main` still always executes.

## Scope notes

- **`test-crates.yml`** is already scoped via `paths:` (allowlist on `crates/**`, `Cargo.{lock,toml}`, `rust-toolchain.toml`, `third_party/**`, `.github/workflows/**`). The issue title mentions it, but the current file already does not run on docs-only PRs — no change needed there.
- **Required status checks**: verified via `gh api repos/gridaco/grida/rulesets/11745213` that the main-branch ruleset only enforces `deletion`, `non_fast_forward`, and a `pull_request` rule with `required_approving_review_count: 0`. No `required_status_checks` rule, so the companion always-pass-job workaround from the issue's "gotcha" section is not needed.

## Test plan

- [x] CI on this PR: `test packages` should run (this PR touches a workflow under `.github/workflows/`, not docs).
- [x] Open a follow-up docs-only PR (or recheck #739 once merged) to confirm `test packages` is skipped.
- [x] Confirm `fmt` and `typos` still run on docs PRs (they keep their bare `pull_request:` trigger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test workflow to skip unnecessary runs when only documentation, metadata, and branding files are modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->