### PR TITLE
fix(svg-editor): content_version so AI binding survives UI emissions

### DIFF
--- a/editor/app/(canvas)/svg/_ai/binding-svg.ts
+++ b/editor/app/(canvas)/svg/_ai/binding-svg.ts
@@ -10,10 +10,13 @@ import { formatSvg } from "./format-svg";
  *   `read_file` — stable, line-oriented, perfect for `edit_file`'s
  *   match-and-replace.
  * - `load()` accepts any valid SVG; the editor handles re-formatting.
- * - `getVersion()` reflects every host-visible change (AI write, human
- *   gesture, undo).
+ * - `getVersion()` returns `content_version` so UI-state emissions
+ *   (selection, scope, mode, tool) don't strand AI writes as stale —
+ *   a click between the agent's read and write must not invalidate
+ *   the write.
  * - `subscribe()` wires the editor's emit channel to the fs for
- *   auto-flush to the backend.
+ *   auto-flush to the backend. The fs dedups by content, so it's fine
+ *   that this fires on every emission.
  *
  * Lives at the call site because pretty-printing is SVG-specific. The
  * generic `@grida/agent-tools/fs` knows nothing about element-per-line
@@ -23,7 +26,7 @@ export function svgEditorBinding(editor: SvgEditor): AgentFs.LiveBinding {
   return {
     serialize: () => formatSvg(editor.serialize()),
     load: (content) => editor.load(content),
-    getVersion: () => editor.state.version,
+    getVersion: () => editor.state.content_version,
     subscribe: (cb) => editor.subscribe(cb),
   };
 }

--- a/packages/grida-svg-editor/__tests__/content-version.test.ts
+++ b/packages/grida-svg-editor/__tests__/content-version.test.ts
@@ -1,0 +1,113 @@
+// Verifies `editor.state.content_version` bumps on document mutations
+// only — not on UI-state emissions like selection, scope, mode, or tool.
+// Sibling to `version`, `structure_version`, `geometry_version`, and
+// `load_version`.
+
+import { describe, expect, it } from "vitest";
+import { createSvgEditor } from "../src";
+
+const SVG_A = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect id="a" x="0" y="0" width="10" height="10" fill="red"/><text id="t" x="20" y="20">hello</text></svg>`;
+const SVG_B = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><circle id="c" cx="50" cy="50" r="10" fill="blue"/></svg>`;
+
+function idByTag(editor: ReturnType<typeof createSvgEditor>, tag: string) {
+  return [...editor.tree().nodes.values()].find((n) => n.tag === tag)!.id;
+}
+
+describe("editor.state.content_version", () => {
+  it("starts at 0 on a fresh editor (constructor input is the factory state)", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    expect(editor.state.content_version).toBe(0);
+  });
+
+  it("does NOT bump on selection change", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    const rect_id = idByTag(editor, "rect");
+    const c0 = editor.state.content_version;
+    const v0 = editor.state.version;
+    editor.commands.select(rect_id);
+    expect(editor.state.version).toBeGreaterThan(v0);
+    expect(editor.state.content_version).toBe(c0);
+  });
+
+  it("does NOT bump on deselect", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    editor.commands.select(idByTag(editor, "rect"));
+    const c0 = editor.state.content_version;
+    editor.commands.select([]);
+    expect(editor.state.content_version).toBe(c0);
+  });
+
+  it("does NOT bump on tool change", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    const c0 = editor.state.content_version;
+    editor.set_tool({ type: "insert", tag: "rect" });
+    expect(editor.state.content_version).toBe(c0);
+    editor.set_tool({ type: "cursor" });
+    expect(editor.state.content_version).toBe(c0);
+  });
+
+  it("does NOT bump on scope enter/exit", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    const rect_id = idByTag(editor, "rect");
+    const c0 = editor.state.content_version;
+    editor.commands.enter_scope(rect_id);
+    expect(editor.state.content_version).toBe(c0);
+    editor.commands.exit_scope();
+    expect(editor.state.content_version).toBe(c0);
+  });
+
+  it("bumps on attribute write", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    editor.commands.select(idByTag(editor, "rect"));
+    const c0 = editor.state.content_version;
+    editor.commands.set_property("fill", "green");
+    expect(editor.state.content_version).toBeGreaterThan(c0);
+  });
+
+  it("bumps on text edit", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    editor.commands.select(idByTag(editor, "text"));
+    const c0 = editor.state.content_version;
+    editor.commands.set_text("changed");
+    expect(editor.state.content_version).toBeGreaterThan(c0);
+  });
+
+  it("bumps on remove / undo / redo", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    editor.commands.select(idByTag(editor, "rect"));
+    const c0 = editor.state.content_version;
+    editor.commands.remove();
+    const c1 = editor.state.content_version;
+    expect(c1).toBeGreaterThan(c0);
+    editor.commands.undo();
+    const c2 = editor.state.content_version;
+    expect(c2).toBeGreaterThan(c1);
+    editor.commands.redo();
+    expect(editor.state.content_version).toBeGreaterThan(c2);
+  });
+
+  it("bumps on editor.load(svg)", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    const c0 = editor.state.content_version;
+    editor.load(SVG_B);
+    expect(editor.state.content_version).toBeGreaterThan(c0);
+  });
+
+  it("is selector-stable: subscribe_with_selector(s => s.content_version, ...) fires only on mutations", () => {
+    const editor = createSvgEditor({ svg: SVG_A });
+    const seen: number[] = [];
+    editor.subscribe_with_selector(
+      (s) => s.content_version,
+      (next) => seen.push(next)
+    );
+    // UI-state emissions — must not fire the selector.
+    editor.commands.select(idByTag(editor, "rect"));
+    editor.commands.select([]);
+    editor.set_tool({ type: "insert", tag: "rect" });
+    expect(seen).toEqual([]);
+    // Mutation — fires once.
+    editor.commands.select(idByTag(editor, "rect"));
+    editor.commands.set_property("fill", "green");
+    expect(seen.length).toBe(1);
+  });
+});

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -377,6 +377,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       can_undo: history.stack.canUndo,
       can_redo: history.stack.canRedo,
       version,
+      content_version: doc_version,
       structure_version: doc.structure_version,
       geometry_version: doc.geometry_version,
       load_version,

--- a/packages/grida-svg-editor/src/types.ts
+++ b/packages/grida-svg-editor/src/types.ts
@@ -262,8 +262,24 @@ export type EditorState = {
    * any change — selection, history, mutation. NOT a good cache key for
    * tree-shape views because it fires on attribute writes too (e.g. x/y
    * during a drag).
+   *
+   * NOT a content fingerprint either: this bumps on UI-state emissions
+   * (selection, scope, mode, tool) that leave the serialized SVG
+   * unchanged. For "did the document content change?" use
+   * {@link content_version}.
    */
   readonly version: number;
+  /**
+   * Bumps on every document mutation — insert, remove, reorder, attribute
+   * write, style write, undo, redo, load. Stable across pure UI-state
+   * emissions (selection, scope, mode, tool).
+   *
+   * The honest fingerprint for serialized content: if `content_version`
+   * is unchanged, `editor.serialize()` returns the same bytes. Use this
+   * — not `version` — as the freshness token when persisting, diffing,
+   * or hashing the document.
+   */
+  readonly content_version: number;
   /**
    * Bumps only when the document's tree shape or display-label-affecting
    * data changes — node added/removed/reordered, text content, or the


### PR DESCRIPTION
## Summary

- Adds `content_version` to `EditorState` (exposes the existing internal `doc_version` counter), which bumps only on document mutations — insert, remove, reorder, attribute/style write, undo, redo, load.
- Migrates `svgEditorBinding.getVersion()` from `editor.state.version` to `editor.state.content_version` so AI writes don't get stranded as stale by intervening UI-state emissions (selection, scope, mode, tool).
- Adds a 10-case test suite covering UI-state stability, mutation/load bumps, and selector stability via `subscribe_with_selector`.

## Why

`editor.state.version` bumps on every editor emission, including selection changes. The AI fs binding used `version` as its freshness token, so a click between the agent's `read_file` and `edit_file` would invalidate the agent's `expected_version` and refuse the write — even though the document content was unchanged.

`content_version` is the honest fingerprint for serialized content: if it's unchanged, `editor.serialize()` returns the same bytes. It sits alongside the existing peer fields (`version`, `structure_version`, `geometry_version`, `load_version`).

## Notes for reviewer

- `content_version` exposes the existing internal `doc_version` literally — no transform. The internal/public name asymmetry is a pre-existing convention worth reconciling in a separate pass (16 cache sites still reference `doc_version`).
- Verified `AgentFs.runFlush` dedups by content (string equality on `last_flushed`), so the decoupling — `getVersion` stable across selection while `subscribe` still fires — is safe.
- Out of scope: [editor/app/(canvas)/svg/_storage/doc-store.ts](https://github.com/gridaco/grida/blob/feature/svg-editor/editor/app/%28canvas%29/svg/_storage/doc-store.ts) also uses `editor.state.version` as its persistence freshness token; would short-circuit earlier on `content_version` but still correct today (falls back to string equality).

## Test plan

- [x] `pnpm vitest run __tests__/content-version.test.ts` — 10/10 pass
- [ ] CI: typecheck, lint, package tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `content_version` field to the editor state, providing a dedicated content freshness tracker that changes only on document mutations while ignoring UI-state changes. This improves detection of actual content modifications.

* **Tests**
  * Added test suite validating `content_version` behavior across document mutations, undo/redo operations, and UI interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->