### PR TITLE
fix(svg, svg-editor): validate input at parse_svg / SvgDocument / createSvgEditor

### DIFF
--- a/packages/grida-svg-editor/__tests__/input-validation.test.ts
+++ b/packages/grida-svg-editor/__tests__/input-validation.test.ts
@@ -1,0 +1,71 @@
+// Boundary type-checks on the three svg-editor entry points that funnel
+// into `parse_svg`: the `SvgDocument` constructor, `SvgDocument.load`,
+// and `createSvgEditor({ svg })`. Each entry checks its own argument so
+// the thrown stack frame names the API the caller actually invoked —
+// not the internal parser. See gridaco/grida#746.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import { createSvgEditor } from "../src/core/editor";
+
+const VALID = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+describe("SvgDocument constructor input validation", () => {
+  it("throws a TypeError naming the API when svg is undefined", () => {
+    expect(() => new SvgDocument(undefined as unknown as string)).toThrow(
+      /new SvgDocument\(svg\) requires a string source, got undefined/
+    );
+  });
+
+  it("throws a TypeError when svg is null", () => {
+    expect(() => new SvgDocument(null as unknown as string)).toThrow(
+      /new SvgDocument\(svg\) requires a string source, got null/
+    );
+  });
+
+  it("accepts a string", () => {
+    expect(() => new SvgDocument(VALID)).not.toThrow();
+  });
+});
+
+describe("SvgDocument.load input validation", () => {
+  it("throws a TypeError naming the API when svg is undefined", () => {
+    const doc = new SvgDocument(VALID);
+    expect(() => doc.load(undefined as unknown as string)).toThrow(
+      /SvgDocument\.load\(svg\) requires a string source, got undefined/
+    );
+  });
+
+  it("throws a TypeError when svg is null", () => {
+    const doc = new SvgDocument(VALID);
+    expect(() => doc.load(null as unknown as string)).toThrow(
+      /SvgDocument\.load\(svg\) requires a string source, got null/
+    );
+  });
+});
+
+describe("createSvgEditor input validation", () => {
+  it("throws a TypeError when opts is undefined", () => {
+    expect(() =>
+      createSvgEditor(undefined as unknown as { svg: string })
+    ).toThrow(/createSvgEditor\(\{ svg \}\) requires \{ svg: string \}/);
+  });
+
+  it("throws a TypeError when opts.svg is undefined", () => {
+    expect(() =>
+      createSvgEditor({ svg: undefined as unknown as string })
+    ).toThrow(
+      /createSvgEditor\(\{ svg \}\) requires \{ svg: string \}, got svg=undefined/
+    );
+  });
+
+  it("throws a TypeError when opts.svg is null", () => {
+    expect(() => createSvgEditor({ svg: null as unknown as string })).toThrow(
+      /createSvgEditor\(\{ svg \}\) requires \{ svg: string \}, got svg=null/
+    );
+  });
+
+  it("accepts a valid options object", () => {
+    expect(() => createSvgEditor({ svg: VALID })).not.toThrow();
+  });
+});

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -104,6 +104,11 @@ export class SvgDocument implements DocumentEvents {
   private _geometry_version = 0;
 
   constructor(svg: string) {
+    if (typeof svg !== "string") {
+      throw new TypeError(
+        `new SvgDocument(svg) requires a string source, got ${svg === null ? "null" : typeof svg}`
+      );
+    }
     this.source = svg;
     const parsed = parse_svg(svg);
     this.original = parsed;
@@ -132,6 +137,11 @@ export class SvgDocument implements DocumentEvents {
 
   /** Replace document with new svg source (clears edits + history-owned state). */
   load(svg: string): void {
+    if (typeof svg !== "string") {
+      throw new TypeError(
+        `SvgDocument.load(svg) requires a string source, got ${svg === null ? "null" : typeof svg}`
+      );
+    }
     this.source = svg;
     const parsed = parse_svg(svg);
     this.original = parsed;

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -1853,6 +1853,17 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
  * attach later via `editor.attach(surface)`.
  */
 export function createSvgEditor(opts: CreateSvgEditorOptions): SvgEditor {
+  if (opts == null || typeof opts.svg !== "string") {
+    const got =
+      opts == null
+        ? String(opts)
+        : opts.svg === null
+          ? "null"
+          : typeof opts.svg;
+    throw new TypeError(
+      `createSvgEditor({ svg }) requires { svg: string }, got svg=${got}`
+    );
+  }
   return _create_svg_editor_internal(opts);
 }
 

--- a/packages/grida-svg/src/parser/__tests__/parser-input-validation.test.ts
+++ b/packages/grida-svg/src/parser/__tests__/parser-input-validation.test.ts
@@ -1,0 +1,36 @@
+// Boundary type-check on the `src` argument. The `parse_svg(src: string)`
+// signature is the entire contract — but callers from JS lose the
+// compile-time annotation, and `undefined` leaking through (hot-reload
+// races, stale state) used to crash at the internal `src.length` access
+// with a stack frame that read as a parser defect. The guard exists so
+// the error names the API and the actual type received.
+
+import { describe, expect, it } from "vitest";
+import { parse_svg } from "../parser.js";
+
+describe("parse_svg input validation", () => {
+  it("throws a TypeError naming the API when src is undefined", () => {
+    expect(() => parse_svg(undefined as unknown as string)).toThrow(TypeError);
+    expect(() => parse_svg(undefined as unknown as string)).toThrow(
+      /parse_svg requires a string source, got undefined/
+    );
+  });
+
+  it("throws a TypeError when src is null", () => {
+    expect(() => parse_svg(null as unknown as string)).toThrow(
+      /parse_svg requires a string source, got null/
+    );
+  });
+
+  it("throws a TypeError when src is a number", () => {
+    expect(() => parse_svg(42 as unknown as string)).toThrow(
+      /parse_svg requires a string source, got number/
+    );
+  });
+
+  it("still throws the existing 'no root element' for an empty string", () => {
+    // Empty string is a valid string — the guard must NOT catch it; the
+    // downstream "no root element" branch is the right error.
+    expect(() => parse_svg("")).toThrow(/no root element/);
+  });
+});

--- a/packages/grida-svg/src/parser/parser.ts
+++ b/packages/grida-svg/src/parser/parser.ts
@@ -133,6 +133,15 @@ export function reset_id_counter(): void {
 }
 
 export function parse_svg(src: string): ParseResult {
+  // Boundary type-check: callers from JS lose the `src: string` annotation,
+  // and a hot-reload race or stale state can leak `undefined` past it. Without
+  // this guard the parser crashes at `src.length` with a stack frame pointing
+  // at internal parser code, which reads as a parser defect.
+  if (typeof src !== "string") {
+    throw new TypeError(
+      `parse_svg requires a string source, got ${src === null ? "null" : typeof src}`
+    );
+  }
   reset_id_counter();
   const nodes = new Map<NodeId, AnyNode>();
   const prolog: AnyNode[] = [];


### PR DESCRIPTION
Closes #746.

## Summary

`parse_svg(undefined)` used to crash with `TypeError: Cannot read properties of undefined (reading 'length')`, and the stack frame pointed at parser line 19 — reading as a parser defect when the real cause is upstream of the call.

This change guards each public entry point so the thrown error names the API the caller actually invoked and the type it received:

| Entry point | Error message on `undefined` |
| --- | --- |
| `parse_svg(src)` | `parse_svg requires a string source, got undefined` |
| `new SvgDocument(svg)` | `new SvgDocument(svg) requires a string source, got undefined` |
| `SvgDocument.load(svg)` | `SvgDocument.load(svg) requires a string source, got undefined` |
| `createSvgEditor({ svg })` | `createSvgEditor({ svg }) requires { svg: string }, got svg=undefined` |

All four guards distinguish `null` from `undefined`. Empty-string input is **not** caught by the guard — it falls through to the existing `no root element` error, which is the correct diagnosis for that case.

## Why one guard per entry, not just at `parse_svg`

The whole point is that the stack frame names the API the caller invoked. A guard only at `parse_svg` would still throw from inside the parser. Each public entry has its own guard so the diagnostic redirects instantly to the right callsite.

## Test plan

- [x] `pnpm turbo test --filter='@grida/svg' --filter='@grida/svg-editor'` — 919 tests pass, including 13 new ones in `parser-input-validation.test.ts` (4) and `input-validation.test.ts` (9).
- [x] `pnpm turbo typecheck --filter='@grida/svg' --filter='@grida/svg-editor'` clean.
- [x] Empty-string case still throws the existing `no root element` error (pinned by a new test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to SVG editor and parser APIs to provide clear error messages when invalid data types are provided, preventing runtime crashes.

* **Tests**
  * Added comprehensive test coverage for input validation across SVG editor entry points and the parser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->