### PR TITLE
feat(hud): classes/ architecture — padding, transform-box, vector-path

### DIFF
--- a/editor/app/(dev)/ui/components/hud/_fixtures.ts
+++ b/editor/app/(dev)/ui/components/hud/_fixtures.ts
@@ -1,4 +1,118 @@
 import type { SelectionShape, VectorOverlay } from "@grida/hud";
+import type vn from "@grida/vn";
+
+// ───────────────────────────────────────────────────────────────────────────
+// vn.VectorNetwork → HUD VectorOverlay adapter.
+//
+// `vn.VectorNetwork` (and `PathModel.snapshot()`, structurally identical)
+// carries segments with RELATIVE tangent vectors (`ta`, `tb`). HUD's
+// `VectorOverlay` wants ABSOLUTE control points (`a_control`, `b_control`)
+// — already projected into doc-space. The conversion is documented on
+// `VectorOverlay`'s JSDoc:
+//   a_control = vertices[a] + ta
+//   b_control = vertices[b] + tb
+//
+// This is the only place in the demo that does that conversion; once
+// HUD's vector chrome adopts vn-style tangent fields directly, this
+// helper goes away.
+//
+// Mutable vector demos hold state as a live `vn.VectorNetwork` and call
+// this directly — no parse/serialize round-trip per tick. For bootstrap,
+// the same call composes trivially:
+//
+//   networkToVectorOverlay(PathModel.fromSvgPathD(D).snapshot(), opts)
+//
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Structural shape both `vn.VectorNetwork` and `PathModel.snapshot()` satisfy. */
+type NetworkLike = {
+  vertices: ReadonlyArray<readonly [number, number]>;
+  segments: ReadonlyArray<{
+    a: number;
+    b: number;
+    ta: readonly [number, number];
+    tb: readonly [number, number];
+  }>;
+};
+
+export function networkToVectorOverlay(
+  net: NetworkLike,
+  opts: {
+    origin?: readonly [number, number];
+    neighbours?: ReadonlyArray<number>;
+    regions?: ReadonlyArray<{ segments: ReadonlyArray<number> }>;
+  } = {}
+): VectorOverlay {
+  return {
+    vertices: net.vertices,
+    segments: net.segments.map((s) => ({
+      a: s.a,
+      b: s.b,
+      a_control: [
+        net.vertices[s.a][0] + s.ta[0],
+        net.vertices[s.a][1] + s.ta[1],
+      ] as const,
+      b_control: [
+        net.vertices[s.b][0] + s.tb[0],
+        net.vertices[s.b][1] + s.tb[1],
+      ] as const,
+    })),
+    origin: opts.origin ?? [0, 0],
+    neighbours: opts.neighbours,
+    regions: opts.regions,
+  };
+}
+
+/**
+ * Deep-clone (and widen) a `vn.VectorNetwork`-shaped value into a mutable
+ * `vn.VectorNetwork`. Accepts the structural `NetworkLike` shape so it
+ * can also lift `PathModel.snapshot()` (which exposes readonly tuples)
+ * into the mutable form `vn.VectorNetworkEditor` requires.
+ *
+ * `vn.VectorNetworkEditor` stores references to the input arrays and
+ * mutates them in place — the mutable vector demos clone before passing
+ * through the editor so React's setState contract holds.
+ */
+export function cloneNetwork(net: NetworkLike): vn.VectorNetwork {
+  return {
+    vertices: net.vertices.map((v) => [v[0], v[1]] as [number, number]),
+    segments: net.segments.map((s) => ({
+      a: s.a,
+      b: s.b,
+      ta: [s.ta[0], s.ta[1]] as [number, number],
+      tb: [s.tb[0], s.tb[1]] as [number, number],
+    })),
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Canonical `d` strings the vector demos parse to bootstrap their
+// `vn.VectorNetwork` state. Exported so the section can do the parse
+// itself (it needs the live network, not just the static overlay shape).
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Open polyline — 4 vertices on a horizontal row, no tangents. */
+export const VECTOR_FIXTURE_OPEN_D = "M 80 100 L 200 100 L 320 100 L 440 100";
+
+/** Closed cubic-Bezier circle, centered (300, 300), radius 100.
+ *  k = (4/3)·(√2 − 1)·r ≈ 55.23 per side. */
+export const VECTOR_FIXTURE_CLOSED_D = (() => {
+  const k = (4 / 3) * (Math.SQRT2 - 1) * 100;
+  return [
+    "M 300 200",
+    `C ${300 + k} 200, 400 ${300 - k}, 400 300`,
+    `C 400 ${300 + k}, ${300 + k} 400, 300 400`,
+    `C ${300 - k} 400, 200 ${300 + k}, 200 300`,
+    `C 200 ${300 - k}, ${300 - k} 200, 300 200`,
+    "Z",
+  ].join(" ");
+})();
+
+/** Annulus: outer square 0..200 + inner hole 70..130, both straight-edged. */
+export const VECTOR_REGION_ANNULUS_D = [
+  "M 0 0 L 200 0 L 200 200 L 0 200 Z",
+  "M 70 70 L 130 70 L 130 130 L 70 130 Z",
+].join(" ");
 
 // ───────────────────────────────────────────────────────────────────────────
 // Toy scene model — the smallest thing that lets a hud demo prove itself.
@@ -142,104 +256,134 @@ export function selectionIntentFixture(): Fixture {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Vector scene — one open path and one closed path with cubic segments.
+// Line scene — three line specimens (diagonal, horizontal, vertical) so the
+// line-specific selection chrome and its axis-aligned MIN_HIT_SIZE inflation
+// are both visible in one stage.
+//
+// `kind: "line"` resolves to `{ kind: "line", p1, p2 }` via fixtureToShape;
+// the surface paints an outline along the segment and two endpoint knobs at
+// p1/p2. For axis-aligned lines the chrome inflates the body's AABB to
+// MIN_HIT_SIZE on the squeezed axis so a 1-px-tall line is still grabbable.
 // ───────────────────────────────────────────────────────────────────────────
 
-// Two specimens stacked vertically:
-//   - top band: open polyline (straight edges) — 4 vertices on a square
-//     grid, no tangents. Demonstrates vertex knobs without the noise of
-//     tangent diamonds.
-//   - bottom band: closed circle approximation — 4 vertices on the
-//     cardinal points of a 100-px-radius circle, with cubic tangents of
-//     the canonical length k = 4/3 × (√2 − 1) × r ≈ 55. Symmetric so the
-//     tangent diamonds land in predictable, comparable positions.
-export function vectorFixture(): Fixture {
-  // Open path — 4 vertices in a horizontal row at y=100, x stepping by 120
-  // (so [80, 200, 320, 440]). Even spacing makes the segment-strip hit
-  // regions easy to compare.
-  const openVertices: Array<[number, number]> = [
-    [80, 100],
-    [200, 100],
-    [320, 100],
-    [440, 100],
-  ];
-  const openSegments = [
-    { a: 0, b: 1 },
-    { a: 1, b: 2 },
-    { a: 2, b: 3 },
-  ].map((s) => ({
-    ...s,
-    a_control: openVertices[s.a],
-    b_control: openVertices[s.b],
-  }));
-
-  // Closed path — circle approximation centered at (300, 300), radius 100.
-  // Cardinal vertices + canonical Bézier tangent length for a circle.
-  const cx = 300;
-  const cy = 300;
-  const r = 100;
-  const k = (4 / 3) * (Math.SQRT2 - 1) * r; // ≈ 55.23
-  const closedVertices: Array<[number, number]> = [
-    [cx, cy - r], // 0: top
-    [cx + r, cy], // 1: right
-    [cx, cy + r], // 2: bottom
-    [cx - r, cy], // 3: left
-  ];
-  const closedSegments = [
-    {
-      a: 0,
-      b: 1,
-      a_control: [cx + k, cy - r] as [number, number],
-      b_control: [cx + r, cy - k] as [number, number],
-    },
-    {
-      a: 1,
-      b: 2,
-      a_control: [cx + r, cy + k] as [number, number],
-      b_control: [cx + k, cy + r] as [number, number],
-    },
-    {
-      a: 2,
-      b: 3,
-      a_control: [cx - k, cy + r] as [number, number],
-      b_control: [cx - r, cy + k] as [number, number],
-    },
-    {
-      a: 3,
-      b: 0,
-      a_control: [cx - r, cy - k] as [number, number],
-      b_control: [cx - k, cy - r] as [number, number],
-    },
-  ];
-
+export function lineFixture(): Fixture {
   return {
     nodes: [
       {
-        id: "path-open",
-        kind: "vector",
+        id: "diagonal",
+        kind: "line",
+        p1: [120, 100],
+        p2: [480, 320],
         stroke: STROKE,
-        vector: {
-          vertices: openVertices,
-          segments: openSegments,
-          origin: [0, 0],
-        },
       },
       {
-        id: "path-closed",
-        kind: "vector",
+        id: "horizontal",
+        kind: "line",
+        p1: [120, 380],
+        p2: [480, 380],
         stroke: STROKE,
-        vector: {
-          vertices: closedVertices,
-          segments: closedSegments,
-          // Every vertex in a closed path has two adjacent segments, so all
-          // get tangent diamonds when in content-edit.
-          neighbours: [0, 1, 2, 3],
-          origin: [0, 0],
-        },
+      },
+      {
+        id: "vertical",
+        kind: "line",
+        p1: [60, 100],
+        p2: [60, 380],
+        stroke: STROKE,
       },
     ],
-    initialSelection: ["path-closed"],
+    initialSelection: ["diagonal"],
   };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Vector scenes — the canonical `d` strings live above
+// (`VECTOR_FIXTURE_OPEN_D`, `VECTOR_FIXTURE_CLOSED_D`,
+// `VECTOR_REGION_ANNULUS_D`). The interactive vector demos in
+// `_showcase.tsx` bootstrap their `vn.VectorNetwork` state from those
+// constants directly — geometry is host state, not a fixture.
+//
+// No static `vectorFixture()` / `vectorRegionFixture()` wrappers ship
+// from here; if a future read-only caller needs them, it composes
+// `networkToVectorOverlay(PathModel.fromSvgPathD(D).snapshot())` inline.
+// ───────────────────────────────────────────────────────────────────────────
+
+// ───────────────────────────────────────────────────────────────────────────
+// Padding overlay scene — a flex-parent container plus a derived "content"
+// rect that visualises what the padding actually does. The content rect's
+// geometry = container inset by the current padding on each side, so the
+// padding-overlay section can re-derive the fixture per intent and the
+// reader sees the content shrink/grow as they drag the handles.
+// ───────────────────────────────────────────────────────────────────────────
+
+export const PADDING_OVERLAY_CONTAINER_RECT = {
+  x: 100,
+  y: 80,
+  width: 400,
+  height: 300,
+};
+
+export function paddingOverlayFixture(padding: {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}): Fixture {
+  const c = PADDING_OVERLAY_CONTAINER_RECT;
+  // Clamp content to non-negative dimensions — if the user piles padding
+  // past the container the content collapses to a sliver but the demo
+  // doesn't crash.
+  const contentRect = {
+    x: c.x + padding.left,
+    y: c.y + padding.top,
+    width: Math.max(0, c.width - padding.left - padding.right),
+    height: Math.max(0, c.height - padding.top - padding.bottom),
+  };
+  return {
+    nodes: [
+      // Content first → container is the LAST node, so hit-pick (which
+      // walks the array in reverse) picks the container first. The user
+      // can still see the content layer but can't accidentally select it.
+      {
+        id: "content",
+        kind: "rect",
+        rect: contentRect,
+        fill: "#dbeafe", // blue-100
+        stroke: "#60a5fa", // blue-400
+        label: "content",
+      },
+      {
+        id: "container",
+        kind: "rect",
+        rect: c,
+        fill: FILL,
+        stroke: STROKE,
+        label: "flex parent",
+      },
+    ],
+    initialSelection: ["container"],
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Transform-box fixture — single rect that hosts BOTH demo sections
+// (image-fit transform binding + free-transform binding). The fixture
+// is shape-only; binding state (id, transform, size, origin) is
+// constructed per-section in the showcase.
+// ───────────────────────────────────────────────────────────────────────────
+
+export const TRANSFORM_BOX_FIXTURE_RECT = {
+  x: 120,
+  y: 80,
+  width: 320,
+  height: 200,
+};
+
+export function transformBoxFixture(): Fixture {
+  // Empty fixture — the image overlay rendered in `_showcase.tsx` is
+  // the entire visual. No fixture rect (would compete with the image
+  // for the frame role) and no `initialSelection` (would draw a
+  // selection box around an invisible target).
+  return { nodes: [], initialSelection: [] };
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -1,17 +1,27 @@
 "use client";
 
 // ───────────────────────────────────────────────────────────────────────────
-// Minimal hud host adapter.
+// Dev showcase host — NOT a reference adapter.
 //
-// `HUDStage` is the thinnest possible consumer of `@grida/hud`:
+// `HUDStage` is the thinnest possible consumer of `@grida/hud` for the
+// `/packages/@grida/hud` spec page. It exists to render the section
+// fixtures, not to be copied verbatim into a production host. The intent
+// dispatcher, preview/commit state, and ref-mirrored selection live here
+// in hooks because this is a dev page; a production host should lift
+// that logic into a class against `Surface`'s imperative API so it can
+// be tested and benchmarked (see `code-react` skill: hooks barred from
+// load-bearing canvas logic).
+//
+// What the showcase does demonstrate honestly:
 //   - an SVG underlay paints the toy scene (fixture)
 //   - a canvas overlay drives the hud surface
 //   - container pointer / wheel / keyboard events forward to `surface.dispatch`
-//   - selection mirror + camera live in local state
+//   - selection mirror + camera live in host state
 //
 // The surface owns gesture, hover, cursor, hit-test. The host owns
-// document content, selection, camera. This separation is the contract
-// `@grida/hud` was built around — see README §"Layer responsibilities".
+// document content, selection, camera. That separation is the real
+// contract `@grida/hud` was built around — see the package README
+// §"Layer responsibilities".
 // ───────────────────────────────────────────────────────────────────────────
 
 import * as React from "react";
@@ -137,6 +147,41 @@ export interface HUDStageProps {
    * the section's reducer per `/sdk-design`.
    */
   onParametricHandle?: (intent: Intent) => void;
+  /**
+   * Enable hud's Layer B padding overlay — diagonal-stripe inset side
+   * rects + mid-edge drag handles on a flex-parent container. The
+   * host owns the padding values; the hud emits `padding_handle`
+   * intents on drag (preview-stream + commit). Forward via
+   * {@link onPaddingHandle}; on apply, push back the updated input.
+   *
+   * Pass `null` (or omit) to disable. Schema-level feature flag —
+   * absence is the off-state.
+   */
+  paddingOverlay?: import("@grida/hud").PaddingOverlayInput | null;
+  /**
+   * Receive `padding_handle` intents emitted by the hud. The HUDStage
+   * does not interpret — the section's reducer applies the value to
+   * its `padding` state (and to the opposite side when `mirror` is
+   * true), and pushes back the updated `paddingOverlay` input.
+   */
+  onPaddingHandle?: (intent: Intent) => void;
+  /**
+   * Transform-box (Layer B) — push the bound transform + size + origin
+   * + optional container rotation. Hud paints the quad outline,
+   * intercepts handles (corner = rotate, side = scale, body =
+   * translate), and emits `transform_box` intents on drag. Forward via
+   * {@link onTransformBox}; on apply, push back the updated input.
+   *
+   * Pass `null` (or omit) to disable. Schema-level feature flag —
+   * absence is the off-state.
+   */
+  transformBox?: import("@grida/hud").TransformBoxInput | null;
+  /**
+   * Receive `transform_box` intents from the hud. The HUDStage does not
+   * interpret — the section's reducer commits `intent.transform` to its
+   * bound state and pushes back the updated input.
+   */
+  onTransformBox?: (intent: Intent) => void;
   /** Block all mutating intents. */
   readonly?: boolean;
   /**
@@ -151,7 +196,15 @@ export interface HUDStageProps {
   /** Decoration layered on top of the hud surface chrome. */
   extra?: HUDExtraBuilder;
   /** Vector content-edit overlay — pass `null` to exit content-edit. */
-  vectorEdit?: { id: string; selection?: { vertices: number[] } } | null;
+  vectorEdit?: {
+    id: string;
+    selection?: {
+      vertices: number[];
+      segments?: number[];
+      tangents?: Array<[number, 0 | 1]>;
+      regions?: number[];
+    };
+  } | null;
   /** Surface vector insertion / selection / bend mode toggles. */
   vectorInsertionMode?: "midpoint" | "projected";
   vectorSelectionMode?: "marquee" | "lasso";
@@ -225,12 +278,17 @@ function hitPick(fixture: Fixture, point: [number, number]): NodeId | null {
 function FixtureSvg({
   fixture,
   offsets,
+  endpointPreviews,
   width,
   height,
   transform,
 }: {
   fixture: Fixture;
   offsets: Record<string, [number, number]>;
+  endpointPreviews: Record<
+    string,
+    { p1?: [number, number]; p2?: [number, number] }
+  >;
   width: number;
   height: number;
   transform: cmath.Transform;
@@ -246,7 +304,10 @@ function FixtureSvg({
     >
       <g transform={t}>
         {fixture.nodes.map((n) => (
-          <FixtureShape key={n.id} node={applyOffsetToNode(n, offsets)} />
+          <FixtureShape
+            key={n.id}
+            node={applyOffsetToNode(n, offsets, endpointPreviews)}
+          />
         ))}
       </g>
     </svg>
@@ -476,30 +537,50 @@ function eventButton(e: PointerEvent): "primary" | "secondary" | "middle" {
 
 function applyOffsetToNode(
   n: FixtureNode,
-  offs: Record<string, [number, number]>
+  offs: Record<string, [number, number]>,
+  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>
 ): FixtureNode {
   const off = offs[n.id];
-  if (!off) return n;
-  const [dx, dy] = off;
-  if (n.rect)
-    return { ...n, rect: { ...n.rect, x: n.rect.x + dx, y: n.rect.y + dy } };
-  if (n.p1 && n.p2)
-    return {
-      ...n,
-      p1: [n.p1[0] + dx, n.p1[1] + dy],
-      p2: [n.p2[0] + dx, n.p2[1] + dy],
+  const ep = endpoints?.[n.id];
+  if (!off && !ep) return n;
+  let next: FixtureNode = n;
+  if (off) {
+    const [dx, dy] = off;
+    if (next.rect)
+      next = {
+        ...next,
+        rect: { ...next.rect, x: next.rect.x + dx, y: next.rect.y + dy },
+      };
+    if (next.p1 && next.p2)
+      next = {
+        ...next,
+        p1: [next.p1[0] + dx, next.p1[1] + dy],
+        p2: [next.p2[0] + dx, next.p2[1] + dy],
+      };
+  }
+  if (ep && next.p1 && next.p2) {
+    next = {
+      ...next,
+      p1: ep.p1 ?? next.p1,
+      p2: ep.p2 ?? next.p2,
     };
-  return n;
+  }
+  return next;
 }
 
 function commitOffsets(
   fixture: Fixture,
-  offs: Record<string, [number, number]>
+  offs: Record<string, [number, number]>,
+  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>
 ): Fixture {
-  if (Object.keys(offs).length === 0) return fixture;
+  if (
+    Object.keys(offs).length === 0 &&
+    (!endpoints || Object.keys(endpoints).length === 0)
+  )
+    return fixture;
   return {
     ...fixture,
-    nodes: fixture.nodes.map((n) => applyOffsetToNode(n, offs)),
+    nodes: fixture.nodes.map((n) => applyOffsetToNode(n, offs, endpoints)),
   };
 }
 
@@ -520,6 +601,10 @@ export function HUDStage(props: HUDStageProps) {
     onCornerRadius,
     parametricHandles = null,
     onParametricHandle,
+    paddingOverlay = null,
+    onPaddingHandle,
+    transformBox = null,
+    onTransformBox,
     readonly = false,
     interactionLocked = false,
     extra,
@@ -569,6 +654,16 @@ export function HUDStage(props: HUDStageProps) {
   const previewOffsetsRef = React.useRef(previewOffsets);
   previewOffsetsRef.current = previewOffsets;
 
+  // Line-endpoint preview overrides, applied on top of liveFixture in shapeOf
+  // and the SVG underlay. Unlike translate offsets (deltas), endpoint moves
+  // are absolute positions — `set_endpoint` carries `pos`, not `dx/dy` —
+  // so they live in their own map keyed by node id, partial per endpoint.
+  const [endpointPreviews, setEndpointPreviews] = React.useState<
+    Record<string, { p1?: [number, number]; p2?: [number, number] }>
+  >({});
+  const endpointPreviewsRef = React.useRef(endpointPreviews);
+  endpointPreviewsRef.current = endpointPreviews;
+
   // Camera. `initialTransform` is read once at mount — runtime changes
   // would fight the user's wheel-zoom, so we don't track it as a dep.
   const [transform, setTransform] = React.useState<cmath.Transform>(
@@ -585,6 +680,10 @@ export function HUDStage(props: HUDStageProps) {
   const onCornerRadiusRef = React.useRef(onCornerRadius);
   const onParametricHandleRef = React.useRef(onParametricHandle);
   onParametricHandleRef.current = onParametricHandle;
+  const onPaddingHandleRef = React.useRef(onPaddingHandle);
+  onPaddingHandleRef.current = onPaddingHandle;
+  const onTransformBoxRef = React.useRef(onTransformBox);
+  onTransformBoxRef.current = onTransformBox;
   const interactionLockedRef = React.useRef(interactionLocked);
   interactionLockedRef.current = interactionLocked;
   const lastIntentRef = React.useRef<Intent | null>(null);
@@ -632,7 +731,8 @@ export function HUDStage(props: HUDStageProps) {
       (intent.kind === "select" ||
         intent.kind === "deselect_all" ||
         intent.kind === "marquee_select" ||
-        intent.kind === "translate")
+        intent.kind === "translate" ||
+        intent.kind === "set_endpoint")
     ) {
       return;
     }
@@ -683,6 +783,34 @@ export function HUDStage(props: HUDStageProps) {
           return next;
         });
       }
+    } else if (intent.kind === "set_endpoint") {
+      // Line endpoint drag — `pos` is absolute doc-space. Preview keeps it
+      // in `endpointPreviews` (consumed by hitPick / shapeOf / SVG); commit
+      // bakes it into liveFixture and clears the override. Mirrors the
+      // translate handler's preview/commit pairing for offsets.
+      const { id, endpoint, pos } = intent;
+      if (intent.phase === "preview") {
+        setEndpointPreviews((prev) => {
+          const cur = prev[id] ?? {};
+          const existing = cur[endpoint];
+          if (existing && existing[0] === pos[0] && existing[1] === pos[1])
+            return prev;
+          return {
+            ...prev,
+            [id]: { ...cur, [endpoint]: [pos[0], pos[1]] as [number, number] },
+          };
+        });
+      } else if (intent.phase === "commit") {
+        setLiveFixture((prev) =>
+          commitOffsets(prev, {}, { [id]: { [endpoint]: [pos[0], pos[1]] } })
+        );
+        setEndpointPreviews((prev) => {
+          if (!prev[id]) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+      }
     } else if (
       intent.kind === "corner_radius" ||
       intent.kind === "corner_radius_explicit" ||
@@ -701,6 +829,18 @@ export function HUDStage(props: HUDStageProps) {
       // mutates its host-owned scalar values and pushes back updated
       // `parametricHandles` inputs on the next render.
       onParametricHandleRef.current?.(intent);
+    } else if (intent.kind === "padding_handle") {
+      // Layer B padding model — section owns the per-side values and
+      // the active-side mirror. Forwards `padding_handle` (preview /
+      // commit) and the `mirror` flag; HUDStage stays unopinionated.
+      onPaddingHandleRef.current?.(intent);
+    } else if (intent.kind === "transform_box") {
+      // Layer B transform-box model — section owns the bound
+      // transform. Forwards `transform_box` (preview / commit); the
+      // section's reducer commits `intent.transform` to whatever
+      // field it bound to (image-paint transform, node-local
+      // transform, …). HUDStage stays unopinionated.
+      onTransformBoxRef.current?.(intent);
     } else if (intent.kind === "marquee_select" && intent.phase === "commit") {
       // In vector content-edit, marquee targets vertices, not nodes — let
       // the host's section-level intent observer (subscribed to
@@ -736,7 +876,11 @@ export function HUDStage(props: HUDStageProps) {
     // Apply preview offsets so both hit-test and shape resolution follow
     // the in-flight drag.
     const ghosted = (): Fixture =>
-      commitOffsets(fixtureRef.current, previewOffsetsRef.current);
+      commitOffsets(
+        fixtureRef.current,
+        previewOffsetsRef.current,
+        endpointPreviewsRef.current
+      );
     const s = new Surface(canvasRef.current, {
       pick: (p) => hitPick(ghosted(), p),
       shapeOf: (id) => {
@@ -846,7 +990,14 @@ export function HUDStage(props: HUDStageProps) {
     if (selectionGroups) surface.setSelection(selectionGroups);
     else surface.setSelection(selectionRef.current);
     surface.draw(computeExtra());
-  }, [surface, liveFixture, previewOffsets, selectionGroups, computeExtra]);
+  }, [
+    surface,
+    liveFixture,
+    previewOffsets,
+    endpointPreviews,
+    selectionGroups,
+    computeExtra,
+  ]);
 
   React.useEffect(() => {
     if (!surface) return;
@@ -899,6 +1050,26 @@ export function HUDStage(props: HUDStageProps) {
     surface.draw(computeExtra());
   }, [surface, parametricHandles, computeExtra]);
 
+  // Padding overlay (Layer B) — host pushes the container rect + per-side
+  // values + optional `active_side` mirror; hud paints and emits
+  // `padding_handle` intents on drag. Loop closes when the host applies
+  // the value and pushes a new `paddingOverlay` input back.
+  React.useEffect(() => {
+    if (!surface) return;
+    surface.setPaddingOverlay(paddingOverlay);
+    surface.draw(computeExtra());
+  }, [surface, paddingOverlay, computeExtra]);
+
+  // Transform-box (Layer B) — host pushes the bound transform + size +
+  // origin + optional rotation. Hud paints the quad outline + handles
+  // and emits `transform_box` intents on drag. Loop closes when the
+  // host commits `intent.transform` and pushes back a new input.
+  React.useEffect(() => {
+    if (!surface) return;
+    surface.setTransformBox(transformBox);
+    surface.draw(computeExtra());
+  }, [surface, transformBox, computeExtra]);
+
   // Host-`extra`-only change → nudge a redraw. `extra` is read through
   // `extraRef.current` at draw time (so per-frame draws always see the
   // latest closure), but hud has no internal reason to redraw when only
@@ -918,8 +1089,9 @@ export function HUDStage(props: HUDStageProps) {
       surface.setVectorSelection({
         node_id: vectorEdit.id,
         vertices: vectorEdit.selection?.vertices ?? [],
-        segments: [],
-        tangents: [],
+        segments: vectorEdit.selection?.segments ?? [],
+        tangents: vectorEdit.selection?.tangents ?? [],
+        regions: vectorEdit.selection?.regions ?? [],
       });
     } else {
       surface.setVectorSelection(null);
@@ -1166,6 +1338,7 @@ export function HUDStage(props: HUDStageProps) {
       <FixtureSvg
         fixture={liveFixture}
         offsets={previewOffsets}
+        endpointPreviews={endpointPreviews}
         width={size.width}
         height={size.height}
         transform={transform}

--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -723,18 +723,16 @@ export function HUDStage(props: HUDStageProps) {
   handleIntentRef.current = (intent) => {
     lastIntentRef.current = intent;
     // When the host has locked interaction to corner-radius only, drop
-    // every intent kind that would mutate selection or position. The hud
-    // still emits these (it doesn't know about the lock) — the host
-    // refuses them. `corner_radius*` intents fall through untouched.
+    // every intent kind that isn't a corner-radius mutation. The hud
+    // still emits everything (it doesn't know about the lock); the host
+    // is the gate. Allowlist on purpose — a future intent kind defaults
+    // to "blocked while locked," which is the safer default for a
+    // "corner-radius only" stage.
     if (
       interactionLockedRef.current &&
-      (intent.kind === "select" ||
-        intent.kind === "deselect_all" ||
-        intent.kind === "marquee_select" ||
-        intent.kind === "translate" ||
-        intent.kind === "set_endpoint" ||
-        intent.kind === "padding_handle" ||
-        intent.kind === "transform_box")
+      intent.kind !== "corner_radius" &&
+      intent.kind !== "corner_radius_explicit" &&
+      intent.kind !== "corner_radius_uniform"
     ) {
       return;
     }

--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -732,7 +732,9 @@ export function HUDStage(props: HUDStageProps) {
         intent.kind === "deselect_all" ||
         intent.kind === "marquee_select" ||
         intent.kind === "translate" ||
-        intent.kind === "set_endpoint")
+        intent.kind === "set_endpoint" ||
+        intent.kind === "padding_handle" ||
+        intent.kind === "transform_box")
     ) {
       return;
     }

--- a/editor/app/(dev)/ui/components/hud/_showcase.tsx
+++ b/editor/app/(dev)/ui/components/hud/_showcase.tsx
@@ -14,6 +14,8 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 import * as React from "react";
+import vn from "@grida/vn";
+import { PathModel } from "@grida/svg-editor";
 import type {
   HUDDraw,
   HUDPaint,
@@ -22,7 +24,13 @@ import type {
   SelectionGroup,
   SurfaceVisibilityPolicy,
 } from "@grida/hud";
-import { DEFAULT_RULER_DRAG_THRESHOLD, measurementToHUDDraw } from "@grida/hud";
+import {
+  DEFAULT_RULER_DRAG_THRESHOLD,
+  measurementToHUDDraw,
+  type PaddingOverlayInput,
+  type TransformBoxInput,
+  type AffineTransform,
+} from "@grida/hud";
 import { ParametricStar } from "./_star";
 import { SvgEditorCanvas, SvgEditorProvider } from "@grida/svg-editor/react";
 import { cursors as hud_cursors } from "@grida/hud/cursors";
@@ -44,13 +52,21 @@ import {
   CORNER_RADIUS_COMBO_RIGHT_RECT,
   emptyFixture,
   groupFixture,
+  lineFixture,
   measurementDemoFixture,
   pixelGridFixture,
   rotatedRectFixture,
   singleRectFixture,
   snapDemoFixture,
   unionShape,
-  vectorFixture,
+  VECTOR_FIXTURE_OPEN_D,
+  VECTOR_FIXTURE_CLOSED_D,
+  networkToVectorOverlay,
+  cloneNetwork,
+  paddingOverlayFixture,
+  PADDING_OVERLAY_CONTAINER_RECT,
+  transformBoxFixture,
+  TRANSFORM_BOX_FIXTURE_RECT,
   type Fixture,
 } from "./_fixtures";
 
@@ -449,7 +465,7 @@ export function PrimitivesSection() {
 
   return (
     <Section anchor="primitives">
-      <SectionHeader eyebrow="§0 Primitives" title="The atoms HUD ships">
+      <SectionHeader eyebrow="Primitives" title="The atoms HUD ships">
         Every chrome surface in this package — selection outlines, knobs,
         rulers, snap guides, measurement overlays — composes from six draw
         primitives. The stage walks them top to bottom: lines, rects, polylines,
@@ -602,10 +618,7 @@ export function PrimitivesSection() {
 export function ArchitectureSection() {
   return (
     <Section anchor="architecture">
-      <SectionHeader
-        eyebrow="§1 Architecture"
-        title="Three layers, one direction"
-      >
+      <SectionHeader eyebrow="Architecture" title="Three layers, one direction">
         Hud is a state machine plus a canvas renderer plus a thin wired surface.
         Dependencies flow{" "}
         <code className="rounded bg-zinc-100 px-1 text-[12px]">
@@ -651,7 +664,7 @@ export function SelectionScenariosSection() {
   return (
     <Section anchor="selection-scenarios">
       <SectionHeader
-        eyebrow="§2 Selection intent"
+        eyebrow="Selection intent"
         title="Pointer-down → Scenario, deterministically"
       >
         Every pointer-down classifies into one of a finite set of named
@@ -800,7 +813,7 @@ export function GroupSelectionSection() {
   return (
     <Section anchor="group-selection">
       <SectionHeader
-        eyebrow="§3 Group selection"
+        eyebrow="Group selection"
         title="One envelope, many members"
       >
         Hosts pass a pre-computed{" "}
@@ -882,7 +895,7 @@ export function LayoutSection() {
   return (
     <Section anchor="layout">
       <SectionHeader
-        eyebrow="§4 Selection chrome layout"
+        eyebrow="Selection chrome layout"
         title="9-slice — priority ladder, axis-independent negotiation"
       >
         Selection chrome is a 9-slice over the selection rect: body + 4 corners
@@ -991,7 +1004,7 @@ export function TransformedSection() {
   return (
     <Section anchor="transformed">
       <SectionHeader
-        eyebrow="§5 Transformed selections"
+        eyebrow="Transformed selections"
         title="Knobs follow the artwork, not its AABB"
       >
         When{" "}
@@ -1053,31 +1066,137 @@ export function TransformedSection() {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Line selection — endpoint chrome on a `kind: "line"` shape.
+//
+// When `shapeOf(id)` returns `{ kind: "line", p1, p2 }`, the surface skips
+// the 9-slice ladder entirely and emits a line-specific chrome: an outline
+// along the segment plus two endpoint knobs at p1/p2 carrying
+// `endpoint_handle` actions. The body translate zone uses the segment's
+// AABB inflated to `MIN_HIT_SIZE` on each axis so axis-aligned lines
+// (1-px-tall AABB) are still grabbable in the body.
+//
+// The demo runs three specimens — diagonal, horizontal, vertical — to
+// exercise both the diagonal case (real AABB) and the axis-aligned cases
+// (inflated AABB).
+// ───────────────────────────────────────────────────────────────────────────
+
+export function LineSection() {
+  const fixture = React.useMemo(() => lineFixture(), []);
+  const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
+  return (
+    <Section anchor="line">
+      <SectionHeader
+        eyebrow="Line selection"
+        title="Endpoint knobs, not a 9-slice"
+      >
+        When{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">shapeOf</code>{" "}
+        returns{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">
+          {"{ kind: 'line', p1, p2 }"}
+        </code>
+        , the surface skips the 9-slice ladder and paints a line-specific chrome
+        — an outline along the segment plus two endpoint knobs that emit{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">
+          set_endpoint
+        </code>{" "}
+        intents. The body translate zone uses the segment&apos;s AABB inflated
+        to{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">
+          MIN_HIT_SIZE
+        </code>{" "}
+        on each axis so axis-aligned lines (a 1-px-tall AABB) stay grabbable.
+        Click any line to select it, drag an endpoint to move it, or drag the
+        body to translate.
+      </SectionHeader>
+      <SplitStage
+        stage={<HUDStage fixture={fixture} onState={setState} />}
+        inspector={<InspectorPanel state={state} title="Line" />}
+      />
+      <div className="mt-6">
+        <SpecTable
+          rows={[
+            {
+              name: "SelectionShape.line",
+              rule: (
+                <>
+                  <code>{"{ kind: 'line', p1, p2 }"}</code> — two doc-space
+                  endpoints. No rect, no transform; the surface treats the
+                  segment itself as the artwork.
+                </>
+              ),
+            },
+            {
+              name: "Endpoint knobs (p1, p2)",
+              rule: (
+                <>
+                  One paired overlay per endpoint, drawn as an{" "}
+                  <code>HUDScreenRect</code> at the doc-space point. Action
+                  kind: <code>endpoint_handle</code> → scenario{" "}
+                  <code>HandleEndpoint</code> → intent <code>set_endpoint</code>{" "}
+                  (preview / commit).
+                </>
+              ),
+            },
+            {
+              name: "Body AABB inflation",
+              rule: (
+                <>
+                  Body translate zone uses the segment&apos;s AABB inflated to{" "}
+                  <code>MIN_HIT_SIZE</code> on each axis. Without inflation, a
+                  horizontal or vertical line has a degenerate (zero-thickness)
+                  AABB and the body would be ungrabbable. Diagonal lines reach
+                  the threshold naturally and skip the inflation.
+                </>
+              ),
+            },
+            {
+              name: "Outline render",
+              rule: (
+                <>
+                  One <code>HUDLine</code> primitive along p1→p2 — the same
+                  primitive every other chrome uses for its outlines. No 9-slice
+                  corners or edges; the segment IS the outline.
+                </>
+              ),
+            },
+            {
+              name: "No rotation halo",
+              rule: "Endpoint drag IS the rotation affordance — moving an endpoint pivots the line around the other endpoint. No separate rotation knob.",
+            },
+            {
+              name: "set_endpoint contract",
+              rule: (
+                <>
+                  Absolute <code>pos</code>, not a delta. Hosts that bind the
+                  line to a node update the corresponding endpoint coordinate on{" "}
+                  <code>commit</code>; <code>preview</code> ghosts it without
+                  committing to history.
+                </>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </Section>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // Vector chrome
 // ───────────────────────────────────────────────────────────────────────────
 
-// Ray-cast point-in-polygon, doc-space. Lasso polygons come in as
-// `[number, number][]` oldest-first; the surface treats them as closed
-// (last → first implicit), so the standard even-odd test applies.
-function pointInPolygon(
-  p: [number, number],
-  poly: readonly (readonly [number, number])[]
-): boolean {
-  if (poly.length < 3) return false;
-  let inside = false;
-  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
-    const [xi, yi] = poly[i];
-    const [xj, yj] = poly[j];
-    const intersect =
-      yi > p[1] !== yj > p[1] &&
-      p[0] < ((xj - xi) * (p[1] - yi)) / (yj - yi) + xi;
-    if (intersect) inside = !inside;
-  }
-  return inside;
-}
+// Stable per-loop segment indices for the merged demo. The closed circle
+// in the fixture is a single 4-segment closed loop (segments 0..3); we
+// hand it to the surface as a single region so region chrome composes
+// on the same shape that demos vertex / tangent / segment chrome.
+// Region geometry is host-derived (`vn.snapshot()` doesn't expose loops)
+// and the loop's topology is stable across vertex translations.
+const CLOSED_PATH_REGIONS: ReadonlyArray<{ segments: number[] }> = [
+  { segments: [0, 1, 2, 3] },
+];
 
 export function VectorChromeSection() {
-  const fixture = React.useMemo(() => vectorFixture(), []);
   const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
   const [insertionMode, setInsertionMode] = React.useState<
     "midpoint" | "projected"
@@ -1086,39 +1205,102 @@ export function VectorChromeSection() {
     "marquee"
   );
   const [bendMode, setBendMode] = React.useState<"auto" | "always">("auto");
-  // Minimal vertex sub-selection state. The marquee/lasso intents from the
-  // surface come through `state.lastIntent` and we run our own vertex hit-
-  // test below to update this set — same shape svg-editor's path-edit
-  // session keeps.
+  // Region feature-flag toggle — proves the schema-level absence rule
+  // (no `regions` field → no region chrome rendered).
+  const [regionsEnabled, setRegionsEnabled] = React.useState(true);
+
+  // Live path geometry — held as `vn.VectorNetwork` for two reasons:
+  //   - It's vn's mutation primitives (`translateVertex`, `updateTangent`,
+  //     `splitSegment`, `bendSegment`) that turn HUD intents into geometry
+  //     changes, so holding the network avoids parse/serialize per tick.
+  //   - `@grida/svg-editor`'s `PathModel` is used ONCE at mount to parse
+  //     the canonical `d` string into a network; after that, svg-editor
+  //     stays out of the hot path. (Producer position recorded in spec
+  //     table below: `vn`-as-mutation + `PathModel`-as-serialization is
+  //     the intended composition seam.)
+  const [openNetwork, setOpenNetwork] = React.useState<vn.VectorNetwork>(() =>
+    cloneNetwork(PathModel.fromSvgPathD(VECTOR_FIXTURE_OPEN_D).snapshot())
+  );
+  const [closedNetwork, setClosedNetwork] = React.useState<vn.VectorNetwork>(
+    () =>
+      cloneNetwork(PathModel.fromSvgPathD(VECTOR_FIXTURE_CLOSED_D).snapshot())
+  );
+
+  // Sub-selection state — vertices, segments, tangents. Marquee / lasso
+  // and direct vertex/segment/tangent clicks update these; mutation
+  // intents read them (translate_vector_selection unions the selected
+  // sub-state with `additional_vertex_indices` before applying).
   const [selectedVertices, setSelectedVertices] = React.useState<number[]>([]);
+  const [selectedSegments, setSelectedSegments] = React.useState<number[]>([]);
+  const [selectedTangents, setSelectedTangents] = React.useState<
+    Array<[number, 0 | 1]>
+  >([]);
+  const [selectedRegions, setSelectedRegions] = React.useState<number[]>([]);
+
+  // Gesture-start snapshot. HUD emits intent deltas as "from gesture
+  // start to now," not incremental — so we freeze the network at
+  // preview-phase-1 and re-apply the full delta from that snapshot each
+  // tick. Cleared on commit (or on a new gesture taking over).
+  const gestureSnapshotRef = React.useRef<vn.VectorNetwork | null>(null);
+
   const vectorEdit = React.useMemo(
     () => ({
       id: "path-closed" as string,
-      selection: { vertices: selectedVertices },
+      selection: {
+        vertices: selectedVertices,
+        segments: selectedSegments,
+        tangents: selectedTangents,
+        regions: selectedRegions,
+      },
     }),
-    [selectedVertices]
+    [selectedVertices, selectedSegments, selectedTangents, selectedRegions]
   );
 
-  // Doc-space vertices of the path under edit. The hit-test predicates
-  // run against these. Closed path's origin defaults to (0,0) so the
-  // vertices already are doc-space; the +origin is here for safety.
-  const pathVertices = React.useMemo<[number, number][]>(() => {
-    const n = fixture.nodes.find((x) => x.id === "path-closed");
-    if (!n?.vector) return [];
-    const [ox, oy] = n.vector.origin ?? [0, 0];
-    return n.vector.vertices.map(
-      (v) => [v[0] + ox, v[1] + oy] as [number, number]
-    );
-  }, [fixture]);
+  // Derive the static fixture once from initial geometry, just to give
+  // HUDStage the node identities + selection bbox shape. The interactive
+  // overlay below replaces the vector overlay per render.
+  const fixture = React.useMemo<Fixture>(
+    () => ({
+      nodes: [
+        {
+          id: "path-open",
+          kind: "vector",
+          stroke: "#94A3B8",
+          vector: networkToVectorOverlay(openNetwork),
+        },
+        {
+          id: "path-closed",
+          kind: "vector",
+          stroke: "#94A3B8",
+          vector: networkToVectorOverlay(closedNetwork, {
+            neighbours: closedNetwork.vertices.map((_, i) => i),
+            regions: regionsEnabled
+              ? CLOSED_PATH_REGIONS.map((r) => ({ segments: r.segments }))
+              : undefined,
+          }),
+        },
+      ],
+      initialSelection: ["path-closed"],
+    }),
+    [openNetwork, closedNetwork, regionsEnabled]
+  );
 
-  // React to vector-select intents — runs once per real intent emission
-  // by deduping on the intent reference. Surface re-emits a fresh object
-  // every time, so reference identity is a clean edge trigger.
+  // Doc-space vertices of the closed path (for marquee/lasso hit-test).
+  const pathVertices = React.useMemo<[number, number][]>(
+    () => closedNetwork.vertices.map((v) => [v[0], v[1]] as [number, number]),
+    [closedNetwork]
+  );
+
+  // React to intents — selection + mutation. One effect, one ref-dedupe
+  // pattern. Mutation branches route by `intent.node_id` to the right
+  // network setter.
   const lastSeenIntentRef = React.useRef<Intent | null>(null);
   React.useEffect(() => {
     const intent = state?.lastIntent;
     if (!intent || intent === lastSeenIntentRef.current) return;
     lastSeenIntentRef.current = intent;
+
+    // ── Selection intents (read) ───────────────────────────────────────
     if (intent.kind === "marquee_select" && intent.phase === "commit") {
       const r = intent.rect;
       const hits: number[] = [];
@@ -1134,15 +1316,20 @@ export function VectorChromeSection() {
       setSelectedVertices((curr) =>
         intent.additive ? Array.from(new Set([...curr, ...hits])) : hits
       );
-    } else if (intent.kind === "lasso_select" && intent.phase === "commit") {
+      return;
+    }
+    if (intent.kind === "lasso_select" && intent.phase === "commit") {
       const hits: number[] = [];
       pathVertices.forEach((v, i) => {
-        if (pointInPolygon(v, intent.polygon)) hits.push(i);
+        if (cmath.polygon.pointInPolygon(v, intent.polygon as cmath.Vector2[]))
+          hits.push(i);
       });
       setSelectedVertices((curr) =>
         intent.additive ? Array.from(new Set([...curr, ...hits])) : hits
       );
-    } else if (intent.kind === "select_vertex") {
+      return;
+    }
+    if (intent.kind === "select_vertex") {
       setSelectedVertices((curr) => {
         if (intent.mode === "replace") return [intent.index];
         const s = new Set(curr);
@@ -1151,27 +1338,205 @@ export function VectorChromeSection() {
         else s.add(intent.index);
         return Array.from(s);
       });
-    } else if (intent.kind === "clear_vector_selection") {
-      setSelectedVertices([]);
+      return;
     }
-  }, [state?.lastIntent, pathVertices]);
+    if (intent.kind === "select_segment") {
+      setSelectedSegments((curr) => {
+        if (intent.mode === "replace") return [intent.segment];
+        const s = new Set(curr);
+        if (intent.mode === "add") s.add(intent.segment);
+        else if (s.has(intent.segment)) s.delete(intent.segment);
+        else s.add(intent.segment);
+        return Array.from(s);
+      });
+      return;
+    }
+    if (intent.kind === "select_region") {
+      // Mirrors the main editor's `selectLoop` policy: region selection
+      // also implies the loop's segments, so the segment chrome
+      // highlights alongside the region's stripe paint.
+      setSelectedRegions((curr) => {
+        if (intent.mode === "replace") return [intent.region];
+        const s = new Set(curr);
+        if (intent.mode === "add") s.add(intent.region);
+        else if (s.has(intent.region)) s.delete(intent.region);
+        else s.add(intent.region);
+        return Array.from(s);
+      });
+      const segs = CLOSED_PATH_REGIONS[intent.region]?.segments ?? [];
+      setSelectedSegments((curr) => {
+        if (intent.mode === "replace") return [...segs];
+        const s = new Set(curr);
+        if (intent.mode === "add") for (const x of segs) s.add(x);
+        else if (segs.every((x) => s.has(x))) for (const x of segs) s.delete(x);
+        else for (const x of segs) s.add(x);
+        return Array.from(s);
+      });
+      return;
+    }
+    if (intent.kind === "select_tangent") {
+      // HUD's intent.tangent is readonly `[number, 0|1]`; we hold a
+      // mutable copy in state because HUD's vectorEdit selection field
+      // is typed mutable.
+      const t0 = intent.tangent[0];
+      const t1 = intent.tangent[1];
+      const next: [number, 0 | 1] = [t0, t1];
+      setSelectedTangents((curr) => {
+        const same = (t: [number, 0 | 1]) => t[0] === t0 && t[1] === t1;
+        if (intent.mode === "replace") return [next];
+        if (intent.mode === "add" && !curr.some(same)) return [...curr, next];
+        if (intent.mode === "toggle") {
+          return curr.some(same)
+            ? curr.filter((t) => !same(t))
+            : [...curr, next];
+        }
+        return curr;
+      });
+      return;
+    }
+    if (intent.kind === "clear_vector_selection") {
+      setSelectedVertices([]);
+      setSelectedSegments([]);
+      setSelectedTangents([]);
+      setSelectedRegions([]);
+      return;
+    }
+
+    // ── Mutation intents — route by node_id ──────────────────────────────
+    const isMut =
+      intent.kind === "translate_vertices" ||
+      intent.kind === "translate_vector_selection" ||
+      intent.kind === "set_tangent" ||
+      intent.kind === "bend_segment" ||
+      intent.kind === "split_segment";
+    if (!isMut) return;
+
+    const targetId = intent.node_id;
+    if (targetId !== "path-closed" && targetId !== "path-open") return;
+    const liveNetwork =
+      targetId === "path-closed" ? closedNetwork : openNetwork;
+    const setNetwork =
+      targetId === "path-closed" ? setClosedNetwork : setOpenNetwork;
+
+    // ── Snapshot / phase plumbing ───────────────────────────────────────
+    // `split_segment` is atomic (no phase); everything else uses the
+    // freeze-at-preview-1, apply-from-frozen, clear-on-commit pattern.
+    if (intent.kind !== "split_segment") {
+      if (intent.phase === "preview" && !gestureSnapshotRef.current) {
+        gestureSnapshotRef.current = cloneNetwork(liveNetwork);
+      }
+    }
+    const base =
+      intent.kind === "split_segment"
+        ? liveNetwork
+        : (gestureSnapshotRef.current ?? liveNetwork);
+    const next = cloneNetwork(base);
+    const editor = new vn.VectorNetworkEditor(next);
+
+    if (intent.kind === "translate_vertices") {
+      for (const i of intent.indices) {
+        editor.translateVertex(i, [intent.dx, intent.dy]);
+      }
+    } else if (intent.kind === "translate_vector_selection") {
+      // Union: explicit additional indices + currently selected vertices
+      // + endpoints of selected segments. This mirrors the contract on
+      // the intent: HUD seeds `additional_vertex_indices`; the host
+      // unions with its own authoritative sub-selection.
+      const idxs = new Set<number>(intent.additional_vertex_indices);
+      for (const v of selectedVertices) idxs.add(v);
+      for (const segIdx of selectedSegments) {
+        const seg = base.segments[segIdx];
+        if (seg) {
+          idxs.add(seg.a);
+          idxs.add(seg.b);
+        }
+      }
+      for (const i of idxs) {
+        editor.translateVertex(i, [intent.dx, intent.dy]);
+      }
+    } else if (intent.kind === "set_tangent") {
+      const [vIdx, side] = intent.tangent;
+      // side === 0 means "ta of the segment whose a === vIdx";
+      // side === 1 means "tb of the segment whose b === vIdx".
+      const segIdx = base.segments.findIndex((s) =>
+        side === 0 ? s.a === vIdx : s.b === vIdx
+      );
+      if (segIdx >= 0) {
+        const v = base.vertices[vIdx];
+        const relative: [number, number] = [
+          intent.pos[0] - v[0],
+          intent.pos[1] - v[1],
+        ];
+        editor.updateTangent(
+          segIdx,
+          side === 0 ? "ta" : "tb",
+          relative,
+          intent.mirror
+        );
+      }
+    } else if (intent.kind === "bend_segment") {
+      const frozen = base.segments[intent.segment];
+      if (frozen) {
+        editor.bendSegment(intent.segment, intent.ca, intent.cb, {
+          a: [base.vertices[frozen.a][0], base.vertices[frozen.a][1]],
+          b: [base.vertices[frozen.b][0], base.vertices[frozen.b][1]],
+          ta: [frozen.ta[0], frozen.ta[1]],
+          tb: [frozen.tb[0], frozen.tb[1]],
+        });
+      }
+    } else if (intent.kind === "split_segment") {
+      editor.splitSegment({ segment: intent.segment, t: intent.t });
+    }
+
+    setNetwork(editor.value);
+
+    if (intent.kind !== "split_segment" && intent.phase === "commit") {
+      gestureSnapshotRef.current = null;
+    }
+  }, [
+    state?.lastIntent,
+    pathVertices,
+    closedNetwork,
+    openNetwork,
+    selectedVertices,
+    selectedSegments,
+  ]);
+  const resetGeometry = React.useCallback(() => {
+    setOpenNetwork(
+      cloneNetwork(PathModel.fromSvgPathD(VECTOR_FIXTURE_OPEN_D).snapshot())
+    );
+    setClosedNetwork(
+      cloneNetwork(PathModel.fromSvgPathD(VECTOR_FIXTURE_CLOSED_D).snapshot())
+    );
+    setSelectedVertices([]);
+    setSelectedSegments([]);
+    setSelectedTangents([]);
+    setSelectedRegions([]);
+    gestureSnapshotRef.current = null;
+  }, []);
+
   return (
     <Section anchor="vector">
       <SectionHeader
-        eyebrow="§6 Vector chrome"
-        title="Vertices, tangents, segments — all in the package"
+        eyebrow="Vector chrome"
+        title="Vertices, tangents, segments, regions — all in the package"
       >
         Pass{" "}
         <code className="rounded bg-zinc-100 px-1 text-[12px]">
           setVectorSelection({"{ node_id, vertices }"})
         </code>{" "}
         and the surface draws vertex circles, tangent diamonds, segment outlines
-        (with idle/hover/selected state), and a ghost insertion knob at the
-        cursor. Three modes — insertion (midpoint / projected), selection
-        (marquee / lasso), bend (auto / always) — match the editor's active
-        tool. Marquee or lasso the closed path's vertices and watch the chrome's
-        selected-vertex fill update — the host runs the hit-test, the hud
-        renders the result.
+        (with idle/hover/selected state), region body chrome for closed loops,
+        and a ghost insertion knob at the cursor. The path is fully editable —
+        drag a vertex, drag a tangent diamond, alt-drag a segment to bend, click
+        the ghost to insert, click inside a closed loop to select the region.
+        The host applies every mutation intent through{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">@grida/vn</code>{" "}
+        and re-emits geometry to HUD; the seam between the two SDKs is host
+        territory by design. The{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">regions</code>{" "}
+        field on the overlay is the schema-level feature flag — toggle it off
+        and region chrome disappears entirely, without any HUD-side branching.
       </SectionHeader>
       <SplitStage
         toolbar={
@@ -1194,6 +1559,19 @@ export function VectorChromeSection() {
               options={["auto", "always"]}
               onChange={(v) => setBendMode(v as "auto" | "always")}
             />
+            <ToggleChip
+              label="Regions"
+              checked={regionsEnabled}
+              onCheckedChange={setRegionsEnabled}
+            />
+            <button
+              type="button"
+              onClick={resetGeometry}
+              className="ml-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-[11px] text-zinc-700 hover:bg-zinc-50"
+              title="Reset both paths to their initial geometry"
+            >
+              Reset
+            </button>
           </>
         }
         stage={
@@ -1205,13 +1583,23 @@ export function VectorChromeSection() {
             vectorBendMode={bendMode}
             onState={setState}
           >
-            <div className="pointer-events-none absolute left-3 top-3 z-10 rounded-md border border-zinc-200 bg-white/95 px-2 py-1 font-mono text-[11px] text-zinc-700 shadow backdrop-blur">
-              vertices selected:{" "}
-              <span className="text-zinc-900">
-                {selectedVertices.length === 0
-                  ? "—"
-                  : `[${selectedVertices.sort((a, b) => a - b).join(", ")}]`}
-              </span>
+            <div className="pointer-events-none absolute left-3 top-3 z-10 space-y-0.5 rounded-md border border-zinc-200 bg-white/95 px-2 py-1 font-mono text-[11px] text-zinc-700 shadow backdrop-blur">
+              <div>
+                vertices:{" "}
+                <span className="text-zinc-900">
+                  {selectedVertices.length === 0
+                    ? "—"
+                    : `[${selectedVertices.sort((a, b) => a - b).join(", ")}]`}
+                </span>
+              </div>
+              <div>
+                regions:{" "}
+                <span className="text-zinc-900">
+                  {selectedRegions.length === 0
+                    ? "—"
+                    : `[${selectedRegions.sort((a, b) => a - b).join(", ")}]`}
+                </span>
+              </div>
             </div>
           </HUDStage>
         }
@@ -1249,16 +1637,558 @@ export function VectorChromeSection() {
               rule: "Empty-space drag inside content-edit fires marquee_select or lasso_select (per vectorSelectionMode) with phase preview→commit. The host runs the predicate (rect contains vertex / point-in-polygon) and pushes the result back via setVectorSelection.",
             },
             {
+              name: "Vertex drag",
+              rule: "translate_vertices preview/commit — drag any vertex (selection or not) and the selected sub-set translates with it. The host freezes the network at preview-1 and applies the gesture-from-start delta against the frozen state each tick, so deltas never accumulate.",
+            },
+            {
+              name: "Tangent drag",
+              rule: "set_tangent preview/commit — the host maps HUD's (vertex, side) tangent reference to vn's (segmentIndex, ta|tb), subtracts the vertex position to convert HUD's absolute target to vn's relative tangent vector, then applies through vn's mirror policy (auto/none/angle/all).",
+            },
+            {
               name: "Segment drag (no Meta)",
-              rule: "translate_vector_selection preview/commit — the whole sub-selection moves with the cursor.",
+              rule: "translate_vector_selection preview/commit — the whole sub-selection moves with the cursor. The host unions HUD's additional_vertex_indices with the selected vertices + endpoints of selected segments before applying translateVertex.",
             },
             {
               name: "Segment drag with Meta",
-              rule: "bend_segment preview/commit — the pivot is the drag-start projection on the curve (not 0.5).",
+              rule: "bend_segment preview/commit — the pivot is the drag-start projection on the curve (not 0.5). The host passes the segment's frozen endpoints + tangents to vn.bendSegment so each preview tick re-solves the cubic from the same starting state.",
             },
             {
               name: "Ghost split-and-drag",
-              rule: "Pointer-down on ghost → split_segment fires immediately, then translate_vertices on the newly-inserted vertex. Press-no-drag commits insert with zero delta.",
+              rule: "Pointer-down on ghost → split_segment fires immediately (atomic, no phase), then translate_vertices preview/commit on the newly-inserted vertex. Press-no-drag commits insert with zero delta.",
+            },
+            {
+              name: "Region — feature flag (schema-level)",
+              rule: "Absence of `VectorOverlay.regions` = no region chrome rendered. No separate `enableRegions` boolean — the data is the flag. Backends that can't enumerate loops simply omit the field. Toggle the toolbar switch to prove it: region chrome disappears entirely without any HUD-side branching.",
+            },
+            {
+              name: "Region — geometry",
+              rule: "Each region carries `segments: number[]` — segment indices forming a closed loop. The HUD reconstructs the cubic path at chrome build time from `vertices` + the referenced segments. Regions carry no own geometry.",
+            },
+            {
+              name: "Region — hit-test & priority",
+              rule: "Screen-space AABB + `customHitTest` running `cmath.polygon.pointInPolygon` against the rasterised loop polygon. Priority REGION_PRIORITY (9) strictly above SEGMENT_STRIP_PRIORITY (8) — any vertex / tangent / ghost / segment-strip control within the loop wins. Wins over empty-space miss → clicking the interior selects the region instead of starting a marquee.",
+            },
+            {
+              name: "Region — paint",
+              rule: "Idle: no render (hit registered, body visually transparent). Hover: doc_polyline fill with `style.vectorRegionHoverPaint` (default HUDPaintStripes 45° / 8px / 1.5px, accent, 50%). Selected: `style.vectorRegionSelectedPaint` (default same stripes at 70%). Hover wins over selected.",
+            },
+            {
+              name: "Region — select intent",
+              rule: "select_region { node_id, region, mode } — eager at pointer-down. Shift → toggle, no-shift → replace. The host mirrors the loop's segments into the segment sub-selection (the main editor's `selectLoop` policy) so segment chrome highlights along with the region's stripe paint.",
+            },
+            {
+              name: "Region — drag",
+              rule: "Drag from a region body promotes to `translate_vector_selection` (no new translate intent kind). The HUD seeds `additional_vertex_indices` with the loop's endpoint vertices so the gesture works even before the host echoes the region select.",
+            },
+            {
+              name: "Mutation seam (producer position)",
+              rule: (
+                <>
+                  <code>@grida/vn</code> provides the vector-network mutation
+                  primitives; <code>@grida/svg-editor</code>&apos;s{" "}
+                  <code>PathModel</code> provides canonical{" "}
+                  <code>d ↔ vector-network</code> conversion. Hosts that want to
+                  mutate a path&apos;s geometry compose the two at the host
+                  layer. The seam is intentional; widening{" "}
+                  <code>PathModel</code>&apos;s public surface to carry
+                  mutation, or shipping a host-shaped reducer that names a
+                  specific intent vocabulary, is out of scope. This demo is the
+                  proof.
+                </>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </Section>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Padding overlay (Layer B)
+// ───────────────────────────────────────────────────────────────────────────
+
+export function PaddingOverlaySection() {
+  const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
+
+  // Host-owned padding values. The HUD reads them via `setPaddingOverlay`
+  // each render; intents flow back via `onPaddingHandle`. Active-side
+  // mirror is HUD-owned (derived from gesture state) — no host shadow.
+  const [padding, setPadding] = React.useState({
+    top: 24,
+    right: 16,
+    bottom: 32,
+    left: 16,
+  });
+  // Feature-flag toggle in the inspector — pop `paddingOverlay` to `null`
+  // and chrome disappears entirely (schema-level absence is the off state).
+  const [overlayEnabled, setOverlayEnabled] = React.useState(true);
+
+  // Rebuild the fixture each render so the inner "content" rect tracks
+  // the live padding values — the reader sees the content shrink/grow as
+  // the handles drag, which is what makes the affordance intuitive.
+  const fixture = React.useMemo(
+    () => paddingOverlayFixture(padding),
+    [padding]
+  );
+
+  const containerRect = PADDING_OVERLAY_CONTAINER_RECT;
+
+  const paddingOverlay = React.useMemo<PaddingOverlayInput | null>(() => {
+    if (!overlayEnabled) return null;
+    return {
+      node_id: "container",
+      rect: containerRect,
+      padding,
+    };
+  }, [overlayEnabled, containerRect, padding]);
+
+  // Forward `padding_handle` intents to the local reducer.
+  const handlePadding = React.useCallback((intent: Intent) => {
+    if (intent.kind !== "padding_handle") return;
+    setPadding((prev) => {
+      const next = { ...prev };
+      next[intent.side] = Math.round(intent.value);
+      if (intent.mirror) {
+        const opp =
+          intent.side === "top"
+            ? "bottom"
+            : intent.side === "bottom"
+              ? "top"
+              : intent.side === "left"
+                ? "right"
+                : "left";
+        next[opp] = Math.round(intent.value);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <Section anchor="padding-overlay">
+      <SectionHeader
+        eyebrow="Padding overlay"
+        title="Flex-parent padding chrome — a Layer B model"
+      >
+        Four hover-sensitive inset side rects with diagonal-stripe affordance
+        and a mid-edge drag handle each. Drag a handle and the inner blue{" "}
+        <em>content</em> rect resizes live — the host re-derives its layout from
+        the per-side padding values streamed back via{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">
+          padding_handle
+        </code>{" "}
+        intents. Toggle the switch above the canvas to prove the schema-level
+        feature flag — the chrome disappears entirely without any host-side
+        branching. Alt-drag mirrors the value to the opposite side; HUD reads
+        the modifier directly (no host-pushed shadow).
+      </SectionHeader>
+      <SplitStage
+        toolbar={
+          <div className="flex items-center gap-2 px-1 text-[12px]">
+            <Switch
+              id="padding-flag"
+              checked={overlayEnabled}
+              onCheckedChange={setOverlayEnabled}
+            />
+            <label
+              htmlFor="padding-flag"
+              className="cursor-pointer font-mono text-zinc-700"
+            >
+              setPaddingOverlay input pushed
+            </label>
+          </div>
+        }
+        stage={
+          <HUDStage
+            fixture={fixture}
+            paddingOverlay={paddingOverlay}
+            onPaddingHandle={handlePadding}
+            onState={setState}
+          >
+            <div className="pointer-events-none absolute left-3 top-3 z-10 rounded-md border border-zinc-200 bg-white/95 px-2 py-1 font-mono text-[11px] text-zinc-700 shadow backdrop-blur">
+              padding: t={padding.top} r={padding.right} b={padding.bottom} l=
+              {padding.left}
+            </div>
+          </HUDStage>
+        }
+        inspector={<InspectorPanel state={state} title="Padding overlay" />}
+      />
+      <div className="mt-6">
+        <SpecTable
+          rows={[
+            {
+              name: "Feature flag (schema-level)",
+              rule: "Absence of `surface.setPaddingOverlay(...)` input = no chrome rendered. No separate `enablePadding` boolean — the data is the flag. Hosts that don't track padding don't push input.",
+            },
+            {
+              name: "Geometry",
+              rule: "Per-side inset rect in doc-space. `top` = full width × top padding; `right` = right padding × full height; bottom/left symmetric. Absent / zero sides skipped — no overlay element, no hit region.",
+            },
+            {
+              name: "Hit-test",
+              rule: "Region: doc-space rect projected to a screen-space AABB on every frame, so the hit body scales with zoom. Handle: 16px screen-px square at the mid-edge, padded to MIN_HIT_SIZE.",
+            },
+            {
+              name: "Hit-priority",
+              rule: "PADDING_HANDLE_PRIORITY (12) wins over corner-radius (15), resize (≥30), translate body (40). PADDING_REGION_PRIORITY (35) wins over body, loses to resize — clicking inside the padding fires hover; clicking a corner still resizes.",
+            },
+            {
+              name: "Paint — idle",
+              rule: "No fill (render omitted). Hit still registered — the body becomes interactive on hover.",
+            },
+            {
+              name: "Paint — hover",
+              rule: "doc_polyline fill with `style.paddingHoverPaint` — default HUDPaintStripes 45° / 8px / 1.5px, accent color, 50% opacity. Alt-held: BOTH the hovered side AND its opposite paint. HUD reads `alt` directly.",
+            },
+            {
+              name: "Paint — selected (during drag)",
+              rule: "Stroked OUTLINE of the side rect (no stripe fill). `color = style.paddingSelectedStroke`, `strokeWidth = selectionOutlineWidth`. HUD-owned — derived from `state.gesture` when a `padding_handle` drag is in flight. The outline communicates the live padding value cleanly; stripes would read as hover preview. Mirrors to opposite side when `alt` is held.",
+            },
+            {
+              name: "Paint — hover on handle",
+              rule: "The hover stripe also lights up when the cursor is on the side's drag handle (not just the region body) — the handle is part of the side's affordance, so losing the stripe when the cursor crosses onto the knob would be jarring.",
+            },
+            {
+              name: "Value math (2× handle displacement)",
+              rule: "Handle sits at the CENTER of the padding strip (`y = padding.top / 2` for top). For the handle to track the cursor 1:1, padding changes at 2× the cursor displacement from the rect edge: `value = 2 × (cursor_y - rect.y)` for top, symmetric for others. Click-no-drag preserves the initial value.",
+            },
+            {
+              name: "Intent — drag",
+              rule: "`padding_handle { node_id, side, value, mirror, phase }`. Preview-stream on every move + one commit on release. `mirror` is read LIVE per frame — toggling alt mid-drag flips the flag on subsequent previews. Layer B dedicated kind; internally reducible to parametric-handle drag math.",
+            },
+          ]}
+        />
+      </div>
+    </Section>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Transform-box (Layer B) — TWO sections that share the same chrome but
+// commit to DIFFERENT host-side targets. The duality IS the demo seam's
+// dogfooding pass: per sdk-design, a public contract is shaped by ≥2
+// internal consumers. Until the main-editor image-paint editor lands,
+// the demo plays the role of consumer #2.
+// ───────────────────────────────────────────────────────────────────────────
+
+const IDENTITY_AFFINE: AffineTransform = [
+  [1, 0, 0],
+  [0, 1, 0],
+];
+
+/** Demo image — public asset, abstract placeholder. */
+const TRANSFORM_BOX_DEMO_IMAGE = "/images/abstract-placeholder.jpg";
+
+/** Decompose an affine transform into rotation°/scale/translation for
+ *  inspector display. Mirrors the math primitive's `decompose` without
+ *  pulling cmath transitively into the demo. */
+function decomposeAffineForDisplay(m: AffineTransform): {
+  rotation: number;
+  scale: [number, number];
+  translation: [number, number];
+} {
+  const a = m[0][0];
+  const b = m[1][0];
+  const c = m[0][1];
+  const d = m[1][1];
+  const sx = Math.hypot(a, b);
+  const sy = Math.hypot(c, d);
+  const rotation = (Math.atan2(b, a) * 180) / Math.PI;
+  return { rotation, scale: [sx, sy], translation: [m[0][2], m[1][2]] };
+}
+
+function TransformBoxLiveOverlay({
+  transform,
+  op,
+}: {
+  transform: AffineTransform;
+  op: string;
+}) {
+  const d = decomposeAffineForDisplay(transform);
+  return (
+    <div className="pointer-events-none absolute left-3 top-3 z-10 space-y-0.5 rounded-md border border-zinc-200 bg-white/95 px-2 py-1 font-mono text-[11px] text-zinc-700 shadow backdrop-blur">
+      <div>op: {op}</div>
+      <div>
+        a={transform[0][0].toFixed(3)} b={transform[1][0].toFixed(3)} c=
+        {transform[0][1].toFixed(3)} d={transform[1][1].toFixed(3)}
+      </div>
+      <div>
+        tx={transform[0][2].toFixed(3)} ty={transform[1][2].toFixed(3)}
+      </div>
+      <div>
+        rot={d.rotation.toFixed(1)}° scale=[{d.scale[0].toFixed(2)},
+        {d.scale[1].toFixed(2)}]
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Two-layer image overlay aligned to the transform-box's frame.
+ *
+ *   Layer 1 (ghost): full image at opacity 0.5, NOT clipped — extends
+ *                    past the parent rect so the user can see where the
+ *                    transform is going.
+ *   Layer 2 (clear): same image, clipped by `overflow: hidden` on the
+ *                    parent-rect wrapper — the "real" image as it would
+ *                    render inside the frame.
+ *
+ * Both layers apply the same affine `input.transform` to the image via
+ * CSS `matrix()`, with translation components denormalized by the
+ * frame's screen-px size (mirrors how the math primitive denormalizes
+ * to pixel-space). The frame wrapper itself rotates by `input.rotation`.
+ */
+function TransformBoxImageOverlay({
+  input,
+  state,
+  clipped,
+}: {
+  input: TransformBoxInput | null;
+  state: HUDPlaygroundState | null;
+  /** When false (free-transform case), the clear layer's wrapper does
+   *  NOT clip — the whole image renders. The ghost layer is also
+   *  suppressed (no frame → no overflow to ghost into). */
+  clipped: boolean;
+}) {
+  if (!input || !state) return null;
+  // Camera transform: doc → screen. Off-diagonals always 0 (no camera
+  // rotation in this demo); read scale + translate from the diagonal.
+  const camSx = state.transform[0][0];
+  const camSy = state.transform[1][1];
+  const camTx = state.transform[0][2];
+  const camTy = state.transform[1][2];
+
+  const originScreenX = input.origin[0] * camSx + camTx;
+  const originScreenY = input.origin[1] * camSy + camTy;
+  const frameW = input.size[0] * camSx;
+  const frameH = input.size[1] * camSy;
+
+  // CSS matrix(a, b, c, d, e, f) corresponds to:
+  //   [a c e]
+  //   [b d f]
+  // Our AffineTransform shape is [[m00, m01, m02], [m10, m11, m12]],
+  // and `m02 / m12` are normalized [0..1] against the box size — so
+  // denormalize by (frameW, frameH) for the screen-px CSS matrix.
+  const m = input.transform;
+  const cssMatrix = `matrix(${m[0][0]}, ${m[1][0]}, ${m[0][1]}, ${m[1][1]}, ${m[0][2] * frameW}, ${m[1][2] * frameH})`;
+
+  const imgStyle: React.CSSProperties = {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: frameW,
+    height: frameH,
+    transform: cssMatrix,
+    transformOrigin: "0 0",
+    objectFit: "fill",
+    userSelect: "none",
+    pointerEvents: "none",
+  };
+
+  const frameWrapper: React.CSSProperties = {
+    position: "absolute",
+    left: originScreenX,
+    top: originScreenY,
+    width: frameW,
+    height: frameH,
+    transform: `rotate(${input.rotation ?? 0}deg)`,
+    transformOrigin: "0 0",
+    pointerEvents: "none",
+  };
+
+  return (
+    <>
+      {clipped ? (
+        <>
+          {/* Ghost — extends past the frame, opacity 0.5. */}
+          <div style={{ ...frameWrapper, opacity: 0.5 }}>
+            {/* eslint-disable-next-line @next/next/no-img-element -- dev showcase: image is being live-transformed; next/image fights interactive transforms */}
+            <img
+              src={TRANSFORM_BOX_DEMO_IMAGE}
+              alt=""
+              style={imgStyle}
+              draggable={false}
+            />
+          </div>
+          {/* Clear — clipped to the frame. Frame outline as a subtle
+              border so the user sees the clipping boundary. */}
+          <div
+            style={{
+              ...frameWrapper,
+              overflow: "hidden",
+              boxShadow: "inset 0 0 0 1px rgba(0, 0, 0, 0.1)",
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- dev showcase: image is being live-transformed; next/image fights interactive transforms */}
+            <img
+              src={TRANSFORM_BOX_DEMO_IMAGE}
+              alt=""
+              style={imgStyle}
+              draggable={false}
+            />
+          </div>
+        </>
+      ) : (
+        // Free-transform: no clipping frame — the image is the object
+        // being transformed, not a paint inside a parent. One layer
+        // only, full opacity.
+        <div style={frameWrapper}>
+          {/* eslint-disable-next-line @next/next/no-img-element -- dev showcase: image is being live-transformed; next/image fights interactive transforms */}
+          <img
+            src={TRANSFORM_BOX_DEMO_IMAGE}
+            alt=""
+            style={imgStyle}
+            draggable={false}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Consumer #1: image-fit transform binding. Simulates the future
+ * main-editor image-paint editor — the host binds the transform-box's
+ * `transform` to a `cg.ImagePaint.transform` value.
+ */
+export function TransformBoxImageFitSection() {
+  const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
+  const [transform, setTransform] =
+    React.useState<AffineTransform>(IDENTITY_AFFINE);
+  const [containerRotation, setContainerRotation] = React.useState<0 | 30 | 90>(
+    0
+  );
+  const [enabled, setEnabled] = React.useState(true);
+  const [lastOp, setLastOp] = React.useState<string>("(idle)");
+
+  const fixture = React.useMemo(() => transformBoxFixture(), []);
+  const r = TRANSFORM_BOX_FIXTURE_RECT;
+
+  const transformBox = React.useMemo<TransformBoxInput | null>(() => {
+    if (!enabled) return null;
+    return {
+      id: "image-fit-fixture",
+      transform,
+      size: [r.width, r.height],
+      origin: [r.x, r.y],
+      rotation: containerRotation,
+    };
+  }, [enabled, transform, containerRotation, r.height, r.width, r.x, r.y]);
+
+  const handleTransformBox = React.useCallback((intent: Intent) => {
+    if (intent.kind !== "transform_box") return;
+    setTransform(intent.transform);
+    setLastOp(
+      intent.op.type === "translate"
+        ? "translate"
+        : intent.op.type === "scale_side"
+          ? `scale_side(${intent.op.side})`
+          : `rotate(${intent.op.corner})`
+    );
+  }, []);
+
+  return (
+    <Section anchor="transform-box">
+      <SectionHeader
+        eyebrow="Transform box"
+        title="Affine transform box — a Layer B model"
+      >
+        Quad outline + 4 corner rotate handles + 4 side scale handles + body
+        translate. The image is bound to the chrome&apos;s affine transform; the
+        parent rect clips the &quot;real&quot; rendering and a 50% ghost shows
+        the same image extending past the frame so you can see where the
+        transform is going. Drag a corner to rotate, a side to scale on that
+        axis, the body to translate. Toggle the container-rotation chip to
+        exercise the de-rotation path. The HUD intent (`transform_box`) is
+        target-agnostic — the same chrome would work against any 2×3 affine
+        target.
+      </SectionHeader>
+      <SplitStage
+        toolbar={
+          <div className="flex flex-wrap items-center gap-3 px-1 text-[12px]">
+            <div className="flex items-center gap-2">
+              <Switch
+                id="tb-flag"
+                checked={enabled}
+                onCheckedChange={setEnabled}
+              />
+              <label
+                htmlFor="tb-flag"
+                className="cursor-pointer font-mono text-zinc-700"
+              >
+                setTransformBox input pushed
+              </label>
+            </div>
+            <ModeChip
+              label="Container rotation"
+              value={String(containerRotation)}
+              options={["0", "30", "90"]}
+              onChange={(v) => setContainerRotation(Number(v) as 0 | 30 | 90)}
+            />
+            <button
+              type="button"
+              className="rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs shadow-sm hover:bg-zinc-50"
+              onClick={() => setTransform(IDENTITY_AFFINE)}
+            >
+              reset transform
+            </button>
+          </div>
+        }
+        stage={
+          <HUDStage
+            fixture={fixture}
+            transformBox={transformBox}
+            onTransformBox={handleTransformBox}
+            onState={setState}
+          >
+            <TransformBoxImageOverlay
+              input={transformBox}
+              state={state}
+              clipped
+            />
+            <TransformBoxLiveOverlay transform={transform} op={lastOp} />
+          </HUDStage>
+        }
+        inspector={<InspectorPanel state={state} title="Transform box" />}
+      />
+      <div className="mt-6">
+        <SpecTable
+          rows={[
+            {
+              name: "Feature flag (schema-level)",
+              rule: "Absence of `surface.setTransformBox(...)` input = no chrome rendered. No `enableTransformBox` boolean — the data IS the flag. Same pattern as `setPaddingOverlay` / `setCornerRadius`.",
+            },
+            {
+              name: "Target-agnostic (Layer B doctrine)",
+              rule: "The model is NOT image-specific. The intent's `id` lets the host route the resolved `transform` to whatever it bound to — `cg.ImagePaint.transform`, a node's local transform, a future free-transform tool. The input is marked `@unstable` until the main-editor image-paint editor migrates onto it — the contract is locked in only after ≥2 internal consumers shape it.",
+            },
+            {
+              name: "Geometry",
+              rule: "Box-relative affine — translation components ([0][2], [1][2]) normalized [0..1] against `size`. Pipeline: box_local → transform → +rotation around origin → +origin → doc-space.",
+            },
+            {
+              name: "Hit-priority (corner > side > body)",
+              rule: "TRANSFORM_BOX_CORNER_PRIORITY=13 wins over corner-radius (15). TRANSFORM_BOX_SIDE_PRIORITY=14. TRANSFORM_BOX_BODY_PRIORITY=38 beats marquee/translate-body, loses to every resize.",
+            },
+            {
+              name: "Hit asymmetry (D3 — Layer B doctrine)",
+              rule: "Visible stroke: 1px (selectionOutlineWidth). Hit strip: 12px thick (Fitts'-reach). Corner hit AABB: 16×16 (≥ MIN_HIT_SIZE). Hit strictly contains the rendered bbox — the pinning test for the asymmetric-outputs discipline.",
+            },
+            {
+              name: "Cursors — rotation-aware",
+              rule: "Side hit → resize cursor tilted by the box's effective screen-space rotation (`container.rotation + decompose(transform).rotation`). Corner hit → rotate-arc cursor with the same baseAngle. Mirrors `resize_handle.baseAngle` / `rotate_handle.baseAngle` on selection chrome — the cursor stays aligned to the visual axis at any rotation.",
+            },
+            {
+              name: "Intent",
+              rule: "`transform_box { id, op: { type, side?/corner? }, transform, phase }`. HUD has already reduced — host commits `transform` directly. `op` carries TYPE and TARGET only (no pointer delta — D1: subscribe to outcomes, not events).",
+            },
+            {
+              name: "Container rotation",
+              rule: "When `input.rotation !== 0`, the gesture's doc-space cursor delta is de-rotated by `-rotation` before being fed to the Layer A reducer. The intent's `transform` stays in box-relative space — the host re-applies its container rotation on the next push.",
+            },
+            {
+              name: "Math primitive (Layer A)",
+              rule: "`reduceTransformBox(base, action, {size})` — pure, exported from `@grida/hud`. The same reducer is the engine behind this chrome and behind any host's own non-UI transform manipulation.",
             },
           ]}
         />
@@ -1291,10 +2221,7 @@ export function SizeMeterSection() {
   );
   return (
     <Section anchor="size-meter">
-      <SectionHeader
-        eyebrow="§7 Size meter"
-        title="W × H, on the lowest OBB edge"
-      >
+      <SectionHeader eyebrow="Size meter" title="W × H, on the lowest OBB edge">
         Host-fed pill that reads the selection's local width × height. For
         axis-aligned rects it sits below the bottom edge; for rotated /
         transformed selections it picks the visually-lowest edge of the OBB and
@@ -1347,7 +2274,7 @@ export function SnapSection() {
   );
   return (
     <Section anchor="snap">
-      <SectionHeader eyebrow="§8 Snap" title="Edge / center alignment guides">
+      <SectionHeader eyebrow="Snap" title="Edge / center alignment guides">
         Full-viewport rules drawn at every doc-space offset where a dragged
         shape's edge or center lines up with a neighbour's. The svg-editor emits
         these live during translate, resize, and insert gestures; the static
@@ -1434,7 +2361,7 @@ export function MeasurementSection() {
   return (
     <Section anchor="measurement">
       <SectionHeader
-        eyebrow="§9 Measurement"
+        eyebrow="Measurement"
         title="Distance between two rectangles"
       >
         The 4-side distance overlay: a guide line per non-zero side from the
@@ -1577,7 +2504,7 @@ export function VisibilitySection() {
   return (
     <Section anchor="visibility">
       <SectionHeader
-        eyebrow="§10 Visibility groups"
+        eyebrow="Visibility groups"
         title="Suppress chrome families per-gesture, without re-wiring draws"
       >
         Hosts assign string group names to chrome slots via{" "}
@@ -1674,7 +2601,7 @@ export function PixelGridSection() {
   return (
     <Section anchor="pixel-grid">
       <SectionHeader
-        eyebrow="§11 Pixel grid"
+        eyebrow="Pixel grid"
         title="Back-most chrome — visible past the zoom threshold"
       >
         Pixel grid is a named built-in chrome behind selection chrome. The host
@@ -1844,10 +2771,7 @@ export function CursorsSection() {
   const [rotationAware, setRotationAware] = React.useState(true);
   return (
     <Section anchor="cursors">
-      <SectionHeader
-        eyebrow="§12 Cursors"
-        title="Rotation-aware, tree-shake-safe"
-      >
+      <SectionHeader eyebrow="Cursors" title="Rotation-aware, tree-shake-safe">
         The surface owns cursor state via{" "}
         <code className="rounded bg-zinc-100 px-1 text-[12px]">
           surface.cursor()
@@ -1987,7 +2911,7 @@ export function ClickTrackerSection() {
   return (
     <Section anchor="click-tracker">
       <SectionHeader
-        eyebrow="§13 Click tracker"
+        eyebrow="Click tracker"
         title="Canvas-tuned 250ms / 4-px double-click window"
       >
         The surface ships its own click counter, tuned for canvas workflows
@@ -2045,44 +2969,33 @@ export function ClickTrackerSection() {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Migration sections — one per editor feature the main editor wires today
-// that the surface chrome doesn't build yet. Each section is a live host-
-// built prototype using existing primitives; the "not yet built" section
-// at the end lists what still needs new primitives or DOM escape hatches.
-//
-// These will land as named built-in chrome once the gesture + intent shape
-// has been dogfooded enough to lock the API.
+// StandardSection — thin wrapper around Section + SectionHeader + SplitStage
+// + SpecTable. Used by sections that don't need the full bespoke layout the
+// large interactive demos build by hand.
 // ───────────────────────────────────────────────────────────────────────────
 
-function MigrationSection({
+function StandardSection({
   anchor,
-  num,
+  eyebrow,
   title,
   prose,
   toolbar,
   stage,
   inspector,
   rows,
-  // Default category. Sections move off "Migration" once the affordance is
-  // shipped — "Stable" for items whose canonical home is resolved and the
-  // contract is no longer moving (e.g. §16 aspect-ratio guide: geometry
-  // available as `cmath.ui.diagonalForDirection`, render is a host-side
-  // composition over `HUDLine`).
-  kind = "Migration",
 }: {
   anchor: string;
-  num: string;
+  eyebrow: string;
   title: string;
   prose: React.ReactNode;
   toolbar?: React.ReactNode;
   stage: React.ReactNode;
   inspector: React.ReactNode;
   rows?: SpecRow[];
-  kind?: "Migration" | "Stable";
 }) {
   return (
     <Section anchor={anchor}>
-      <SectionHeader eyebrow={`${num} ${kind}`.trim()} title={title}>
+      <SectionHeader eyebrow={eyebrow} title={title}>
         {prose}
       </SectionHeader>
       <SplitStage toolbar={toolbar} stage={stage} inspector={inspector} />
@@ -2140,85 +3053,46 @@ function clampRadius(v: number): number {
 export function CornerRadiusSection() {
   return (
     <Section anchor="corner-radius">
-      <SectionHeader
-        eyebrow="Stable"
-        title="Parametric handles — corner radius + parametric star"
-      >
-        Hud&apos;s universal &quot;scalar-on-a-1D-manifold&quot; primitive in
-        two guises. <strong>Demo A</strong> wires{" "}
+      <SectionHeader eyebrow="Corner radius" title="Per-corner radius handles">
         <code className="rounded bg-zinc-100 px-1 text-[12px]">
           surface.setCornerRadius
         </code>{" "}
-        — the corner-radius affordance on two rects in one canvas (axis-aligned
-        + rotated). Each knob sits at its corner&apos;s ARC CENTER, offset by{" "}
+        — corner-radius chrome on two rects in one canvas (axis-aligned +
+        rotated). Each knob sits at its corner&apos;s ARC CENTER, offset by{" "}
         <code>r</code> in BOTH x and y from the corner toward the interior;
         position <em>is</em> the radius value, and the rotated rect&apos;s knobs
         ride the rotated diagonals via the input&apos;s{" "}
         <code className="rounded bg-zinc-100 px-1 text-[12px]">transform</code>.
-        Internally this API is an adapter over the universal primitive (a local{" "}
-        <code className="rounded bg-zinc-100 px-1 text-[12px]">
-          cornerRadiusHandles
-        </code>{" "}
-        composer +{" "}
-        <code className="rounded bg-zinc-100 px-1 text-[12px]">
-          surface.setParametricHandles
-        </code>
-        ); the 43-test corner-radius behavior pin proves the equivalence.{" "}
-        <strong>Demo B</strong> uses the universal primitive directly: a
-        parametric star, rendered on a custom <code>&lt;canvas&gt;</code>{" "}
-        underlay (no SVG fixture), with three handles — tip-radius (N segment
-        handles, one per outer tip), inner/outer ratio (segment from center to a
-        tip), and point-count (a stepped arc around the center, snapping to
-        integers 3..12). Hud doesn&apos;t know the shape is a star — the host
-        paints it, hud paints the knobs, intents flow.
+        Internally this API is a thin adapter over the universal parametric
+        handle primitive (see the next section); the 43-test corner-radius
+        behavior pin proves the equivalence.
       </SectionHeader>
 
       <CornerRadiusComboDemo />
-      <div className="h-4" />
-      <ParametricStarDemo />
 
       <div className="mt-6">
         <SpecTable
           rows={[
             {
-              name: "Primitive",
-              rule: (
-                <>
-                  The universal affordance:{" "}
-                  <code>
-                    surface.setParametricHandles(input | input[] | null)
-                  </code>{" "}
-                  — one or more handles, each a scalar <code>value</code>{" "}
-                  constrained to a 1D <code>curve</code>. Two curve kinds today:{" "}
-                  <code>segment</code> (corner-radius, ratio) and{" "}
-                  <code>arc</code> (count). Use-case composers (like the
-                  corner-radius one) live next to their callers and build the
-                  input from shape-specific schemas; the producer never knows
-                  what shape the host is editing.
-                </>
-              ),
-            },
-            {
               name: "Corner-radius wrapper",
               rule: (
                 <>
-                  <code>surface.setCornerRadius</code> remains as a thin adapter
-                  — its public types and the three <code>corner_radius*</code>{" "}
-                  intent kinds are unchanged from pre-migration. Internally,
-                  every input is composed by a local{" "}
-                  <code>cornerRadiusHandles</code> helper next to the primitive
-                  and routed through the universal parametric handle. The
-                  43-test corner-radius behavior pin (
+                  <code>surface.setCornerRadius</code> is a thin adapter — its
+                  public types and the three <code>corner_radius*</code> intent
+                  kinds are unchanged from pre-migration. Internally, every
+                  input is composed by a local <code>cornerRadiusHandles</code>{" "}
+                  helper next to the primitive and routed through the universal
+                  parametric handle. The 43-test corner-radius behavior pin (
                   <code>__tests__/corner-radius.test.ts</code>) is the
                   equivalence proof.
                 </>
               ),
             },
             {
-              name: "Arc-center position (corner-radius rect)",
+              name: "Arc-center position",
               rule: (
                 <>
-                  Each corner-radius knob sits at the rounded corner&apos;s{" "}
+                  Each knob sits at the rounded corner&apos;s{" "}
                   <em>arc center</em> — offset by radius <code>r</code> in BOTH
                   x and y from its corner, toward the rect interior. Translates
                   to a segment curve from corner → (corner + (max, max) · sign)
@@ -2236,8 +3110,8 @@ export function CornerRadiusSection() {
                   When ALL members are within ε of each other in doc-space, the
                   producer registers ONE hit region for the group; direction
                   resolution picks among the listed candidates only.
-                  Corner-radius declares its 4-corner group; star handles
-                  don&apos;t need to. Class-agnostic.
+                  Corner-radius declares its 4-corner group so a single knob
+                  drives all four when they&apos;re equal.
                 </>
               ),
             },
@@ -2247,24 +3121,80 @@ export function CornerRadiusSection() {
                 <>
                   Producer-side floor: at rest, the knob is floored to{" "}
                   <code>inset</code> in the track&apos;s own units. During a
-                  gesture the floor is lifted. Corner-radius&apos;s "16 px per
-                  axis" UX convention is the caller&apos;s concern — the
-                  corner-radius primitive computes{" "}
-                  <code>inset = 16 · √2 / zoom</code> per frame (the diagonal
-                  track at 45° turns a per-axis pixel into <code>√2</code> along
-                  the track) before populating the field.
+                  gesture the floor is lifted. The "16 px per axis" UX
+                  convention computes <code>inset = 16 · √2 / zoom</code> per
+                  frame (the diagonal track at 45° turns a per-axis pixel into{" "}
+                  <code>√2</code> along the track) before populating the field.
                 </>
               ),
             },
             {
-              name: "Stepped domains",
+              name: "Intents",
               rule: (
                 <>
-                  <code>domain.step</code> snaps the EMITTED value during
-                  projection. The star demo&apos;s point-count handle uses{" "}
-                  <code>{`{ min: 3, max: 12, step: 1 }`}</code> on an arc curve
-                  — the knob can hover continuously around the arc, but the
-                  intent payload always carries an integer.
+                  Three named kinds: <code>corner_radius</code> (all-or-named,
+                  default drag), <code>corner_radius_explicit</code>{" "}
+                  (alt-modifier, always named anchor),{" "}
+                  <code>corner_radius_uniform</code> (line geometry, always
+                  all). Preserved for backward compat — see{" "}
+                  <code>CHECKPOINT-setCornerRadius.md</code>.
+                </>
+              ),
+            },
+          ]}
+        />
+      </div>
+    </Section>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Parametric handles — the agnostic primitive underlying corner-radius.
+// The star demo proves the same primitive composes for an arbitrary shape
+// HUD knows nothing about.
+// ───────────────────────────────────────────────────────────────────────────
+
+export function ParametricHandlesSection() {
+  return (
+    <Section anchor="parametric-handles">
+      <SectionHeader
+        eyebrow="Parametric handles"
+        title="The agnostic primitive — scalar on a 1D manifold"
+      >
+        HUD&apos;s universal &quot;scalar-on-a-1D-manifold&quot; primitive,{" "}
+        <code className="rounded bg-zinc-100 px-1 text-[12px]">
+          surface.setParametricHandles
+        </code>
+        . One or more handles, each a scalar <code>value</code> constrained to a
+        1D <code>curve</code>. The corner-radius affordance above is a thin
+        wrapper over this; the demo below uses the primitive <em>directly</em>{" "}
+        on a shape HUD knows nothing about — a parametric star, rendered on a
+        custom <code>&lt;canvas&gt;</code> underlay (no SVG fixture), with three
+        handles: tip-radius (one segment handle per outer tip), inner / outer
+        ratio (segment from center to a tip), and point-count (a stepped arc
+        around the center, snapping to integers). The host paints the star, HUD
+        paints the knobs, intents flow.
+      </SectionHeader>
+
+      <ParametricStarDemo />
+
+      <div className="mt-6">
+        <SpecTable
+          rows={[
+            {
+              name: "Primitive",
+              rule: (
+                <>
+                  <code>
+                    surface.setParametricHandles(input | input[] | null)
+                  </code>{" "}
+                  — one or more handles, each a scalar <code>value</code>{" "}
+                  constrained to a 1D <code>curve</code>. Two curve kinds today:{" "}
+                  <code>segment</code> (corner-radius, ratio) and{" "}
+                  <code>arc</code> (count). Use-case composers (like the
+                  corner-radius one) live next to their callers and build the
+                  input from shape-specific schemas; the producer never knows
+                  what shape the host is editing.
                 </>
               ),
             },
@@ -2282,16 +3212,26 @@ export function CornerRadiusSection() {
               ),
             },
             {
-              name: "Intents",
+              name: "Stepped domains",
+              rule: (
+                <>
+                  <code>domain.step</code> snaps the EMITTED value during
+                  projection. The star demo&apos;s point-count handle uses{" "}
+                  <code>{`{ min: 3, max: 12, step: 1 }`}</code> on an arc curve
+                  — the knob can hover continuously around the arc, but the
+                  intent payload always carries an integer.
+                </>
+              ),
+            },
+            {
+              name: "Intent",
               rule: (
                 <>
                   Universal API: <code>parametric_handle</code> with{" "}
                   <code>{`{ node_id, handle_id, value, modifiers: { alt, shift }, phase }`}</code>
                   . Modifier policy lives in the host — the producer reports
                   flags, the host&apos;s reducer decides "all vs one,"
-                  "broadcast vs explicit," etc. The corner-radius wrapper
-                  preserves its three named kinds for backward compat (decided
-                  at Phase 3 — see <code>CHECKPOINT-setCornerRadius.md</code>).
+                  "broadcast vs explicit," etc.
                 </>
               ),
             },
@@ -2906,10 +3846,9 @@ export function AspectRatioSection() {
     [direction]
   );
   return (
-    <MigrationSection
+    <StandardSection
       anchor="aspect-ratio"
-      num=""
-      kind="Stable"
+      eyebrow="Aspect ratio"
       title="Aspect-ratio guide"
       prose={
         <>
@@ -3125,7 +4064,7 @@ export function RulerGuidesSection() {
   return (
     <Section anchor="ruler-guides">
       <SectionHeader
-        eyebrow="§14 Ruler & guides"
+        eyebrow="Ruler & guides"
         title="Built-in ruler chrome + host-owned guide state"
       >
         Ruler is named built-in chrome — same shape as pixel-grid, opposite slot
@@ -3607,7 +4546,7 @@ export function PerformanceSection() {
   return (
     <Section anchor="performance">
       <SectionHeader
-        eyebrow="§17 Performance"
+        eyebrow="Performance"
         title="N × N grid — chrome cost is selection-sized, not scene-sized"
       >
         Mounts the same{" "}
@@ -3699,7 +4638,7 @@ export function NotYetBuiltSection() {
   return (
     <Section anchor="not-yet-built">
       <SectionHeader
-        eyebrow="§18 Not yet built"
+        eyebrow="Not yet built"
         title="Open work — what hud needs next"
       >
         Items the main editor wires today but the demo cannot prototype with

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/hud/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/hud/page.tsx
@@ -8,8 +8,12 @@ import {
   CursorsSection,
   GroupSelectionSection,
   LayoutSection,
+  LineSection,
   MeasurementSection,
   NotYetBuiltSection,
+  PaddingOverlaySection,
+  TransformBoxImageFitSection,
+  ParametricHandlesSection,
   PerformanceSection,
   PixelGridSection,
   PrimitivesSection,
@@ -47,25 +51,29 @@ const WG_SELECTION =
 // + _live-section.tsx.
 const SECTIONS: { id: string; label: string }[] = [
   { id: "live", label: "Live editor" },
-  { id: "primitives", label: "§0 Primitives" },
-  { id: "architecture", label: "§1 Architecture" },
-  { id: "selection-scenarios", label: "§2 Selection intent" },
-  { id: "group-selection", label: "§3 Group selection" },
-  { id: "layout", label: "§4 Layout / 9-slice" },
-  { id: "transformed", label: "§5 Transformed" },
-  { id: "vector", label: "§6 Vector chrome" },
-  { id: "size-meter", label: "§7 Size meter" },
-  { id: "snap", label: "§8 Snap" },
-  { id: "measurement", label: "§9 Measurement" },
-  { id: "visibility", label: "§10 Visibility groups" },
-  { id: "pixel-grid", label: "§11 Pixel grid" },
-  { id: "cursors", label: "§12 Cursors" },
-  { id: "click-tracker", label: "§13 Click tracker" },
-  { id: "ruler-guides", label: "§14 Ruler & guides" },
+  { id: "primitives", label: "Primitives" },
+  { id: "architecture", label: "Architecture" },
+  { id: "selection-scenarios", label: "Selection intent" },
+  { id: "group-selection", label: "Group selection" },
+  { id: "transformed", label: "Transformed" },
+  { id: "line", label: "Line selection" },
+  { id: "layout", label: "Layout / 9-slice" },
+  { id: "size-meter", label: "Size meter" },
   { id: "corner-radius", label: "Corner radius" },
+  { id: "padding-overlay", label: "Padding overlay" },
+  { id: "transform-box", label: "Transform box" },
   { id: "aspect-ratio", label: "Aspect ratio" },
-  { id: "performance", label: "§17 Performance" },
-  { id: "not-yet-built", label: "§18 Not yet built" },
+  { id: "parametric-handles", label: "Parametric handles" },
+  { id: "vector", label: "Vector chrome" },
+  { id: "snap", label: "Snap" },
+  { id: "measurement", label: "Measurement" },
+  { id: "ruler-guides", label: "Ruler & guides" },
+  { id: "pixel-grid", label: "Pixel grid" },
+  { id: "cursors", label: "Cursors" },
+  { id: "click-tracker", label: "Click tracker" },
+  { id: "visibility", label: "Visibility groups" },
+  { id: "performance", label: "Performance" },
+  { id: "not-yet-built", label: "Not yet built" },
 ];
 
 function SidebarToc({
@@ -135,8 +143,8 @@ export default function HudSpecPage() {
                   </p>
                 </div>
 
-                {/* Quick links + install */}
-                <div className="flex flex-wrap items-center gap-3">
+                {/* Quick links */}
+                <div className="flex flex-wrap items-center gap-2">
                   <Link
                     href={README_URL}
                     target="_blank"
@@ -185,9 +193,12 @@ export default function HudSpecPage() {
                       source
                     </Button>
                   </Link>
-                  <div className="ml-auto w-full max-w-xs">
-                    <CopyToClipboardInput value="pnpm add @grida/hud" />
-                  </div>
+                </div>
+
+                {/* Install — its own row so it doesn't compete with the
+                    button cluster on narrow viewports */}
+                <div className="w-full max-w-sm">
+                  <CopyToClipboardInput value="pnpm add @grida/hud" />
                 </div>
 
                 {/* Table of contents — inline on small screens; floats on xl+ */}
@@ -217,19 +228,23 @@ export default function HudSpecPage() {
           <ArchitectureSection />
           <SelectionScenariosSection />
           <GroupSelectionSection />
-          <LayoutSection />
           <TransformedSection />
-          <VectorChromeSection />
+          <LineSection />
+          <LayoutSection />
           <SizeMeterSection />
+          <CornerRadiusSection />
+          <PaddingOverlaySection />
+          <TransformBoxImageFitSection />
+          <AspectRatioSection />
+          <ParametricHandlesSection />
+          <VectorChromeSection />
           <SnapSection />
           <MeasurementSection />
-          <VisibilitySection />
+          <RulerGuidesSection />
           <PixelGridSection />
           <CursorsSection />
           <ClickTrackerSection />
-          <RulerGuidesSection />
-          <CornerRadiusSection />
-          <AspectRatioSection />
+          <VisibilitySection />
           <PerformanceSection />
           <NotYetBuiltSection />
         </div>

--- a/packages/grida-canvas-hud/README.md
+++ b/packages/grida-canvas-hud/README.md
@@ -10,6 +10,104 @@ The HUD is the non-content visual chrome drawn on top of the viewport: selection
 
 In industry terms: Blender calls this "Overlays", Unity calls it "Gizmos", game engines call it "HUD". We use HUD.
 
+## What this package is — two tiers
+
+The package ships **two tiers** of API with different audiences. They are not a hierarchy — they are two products shipped from one package.
+
+### Tier 1 — Named classes (the inhouse vocabulary)
+
+A **named class** is a composed, opinionated interaction model that represents one coherent editable concept. Each class encapsulates:
+
+- A model — the math it edits, the gesture grammar that mutates it, the intent contract it commits to
+- HUD-owned hover, cursor, hit priority, modifier interpretation
+- A bounded feature surface — _capability_ toggles only (does this instance have padding? does it support corner radius?), not visual variants (colors, thicknesses — those are style tokens)
+
+Named classes are the vocabulary the Grida editor uses by default. The host writes a compact binding class around `@grida/hud` that calls one setter per active named class per logical "thing" being edited. HUD does not try to _be_ the binding class — that's the god-class trap.
+
+The hard rule that prevents god classes: **a named class is defined by its model, not its chrome.** Padding (4 side numerics), corner-radius (4 corner radii), resize-box (rect mutation), size-meter (display-only) all share "a rect" as their target — they are four classes, not features of one. If two candidates share a model and only differ visually, they are one class with a style/feature axis.
+
+### Tier 2 — Primitives (the open building blocks)
+
+Two kinds of code live in `primitives/`, with different audiences:
+
+- **Genuinely-Tier-2 atoms** — un-opinionated, externally-consumable building blocks. The draw vocabulary (`HUDRect`, `HUDPaint`, `HUDPolyline`, `HUDScreenRect`, `HUDMarker`, paint primitives), the hit-priority infrastructure, the cursor renderer protocol. External consumers building editors that don't fit any named class compose against these.
+
+- **Class-bound math factored out of a class** — `reduceTransformBox`, corner-radius geometry, parametric-handle math. These live in `primitives/` for code organization (one file per math domain, pure-function tests without mounting the chrome), but their closure of valid actions IS the chrome's gesture grammar. An external consumer cannot use `reduceTransformBox` without re-implementing the transform-box chrome around it. They are not Tier 2 in the audience sense — they are class-bound implementation details that happen to live alongside Tier 2 atoms.
+
+When auditing whether a new module belongs in `primitives/` vs. `classes/<name>/`, the question is _consumability_: would an external consumer building an unrelated editor use this directly? If yes, Tier 2. If no but the code is pure and reusable by tests, `primitives/` is still its home — but flag it in the module header as class-bound, and don't claim Tier 2 in docs.
+
+### Composition contract
+
+The central guarantee that makes the inhouse pattern work — multiple setters from a compact host binding class targeting the same logical thing via a shared `id` — and the part this package treats as _tested_ (not emergent):
+
+1. Multiple setters may target the same logical thing via a shared `id`. The `id` is an opaque string the host chooses — it is the _composition-time matching key_, not a typed contract. Classes that target different concepts use different field names by convention (`node_id` for scene-node-bound classes; bare `id` for affine-bound classes like transform-box, which can edit non-node things like image fills), but two classes co-target the same logical thing iff the host hands them the same string.
+2. `HUDSemanticGroup` + the host's visibility policy gate which classes are active.
+3. The SDK owns the priority ladder. It is internal, deterministic, and stable across releases.
+4. Any combination of active classes × visibility config × id-sharing pattern produces:
+   - A deterministic hover state (highest-priority hit wins, ties broken by declaration order)
+   - A deterministic cursor (resolved from hover)
+   - Independent intents per class (each class commits to its own field; no shared intent payloads, no implicit coordination)
+   - No phantom hits, no flickering hover, no stuck cursor
+5. A **co-target test matrix** under [`__tests__/composition/`](./__tests__/composition/) enforces (4). The matrix exists today with the first cell (`padding × transform-box`, 5 assertions); each subsequent class migration adds one row + one column. The full matrix is planned out in [`__tests__/composition/README.md`](./__tests__/composition/README.md); today's coverage is one pair, growing per-migration.
+
+#### Priority overrides — deferred
+
+Per-instance priority bias is currently **unspecified**. `HUDSemanticGroup` + the host's visibility policy is the only host-facing knob for "what shows when." If a real consumer needs to override priority under a specific circumstance, file an issue with the concrete use case; the API choice (closed enum, numeric bias, group-driven) follows the consumer. Until then: no API. This is consistent with the promotion-bar's "two consumers shape the contract" rule.
+
+### Named-class conventions
+
+- **Schema-level feature flags.** Absence of the host's `setX(...)` input is the off-state. No `SurfaceOptions.features.X` booleans to drift.
+- **HUD-owned hover and modifier reading.** Hosts push state; HUD owns the live affordance.
+- **Host-owned commit.** Intents stream `phase: "preview"` and a final `phase: "commit"`.
+- **Anti-goals header per class.** Each named class's surface module enumerates what it deliberately is NOT, in plain English.
+
+### What justifies a new named class
+
+The promotion bar — first match wins, top down. Apply this to every candidate that wants to land as a class (new model, or split-out of an existing module):
+
+1. **Model audit.** Does the candidate share a model (math + gestures + intent payload shape) with an existing class? If yes, **fold** — it is a feature toggle, a style axis, or a binding-target on the existing class, not a new one.
+2. **Closed gesture grammar.** Can every interaction be enumerated as a finite (target × gesture × modifier) → intent table, with no open-ended customization slot? If no, it is **host code over primitives**, not a named class.
+3. **Two consumers (or one + adversarial demo).** Is the model exercised by ≥2 distinct internal consumers, or by 1 real consumer plus a demo whose binding target differs enough to falsify accidental coupling? If no, **wait** — the contract is not yet shaped; keep it private inside the consumer.
+4. **Feature flags are capability flags.** Every flag must name a _capability_ (has padding? supports corner radius?), never a _visual variant_ (color, thickness, dash pattern — those are style tokens). Shape-of-model toggles count as capability (`single radius` vs `4 per-corner radii` is a model-shape difference, so it's a capability — but the class then commits to handling both shapes coherently in one gesture grammar; if it can't, see rule #1).
+5. **Stable identity.** One noun. `VectorPath`, not `Path-with-vertices-and-segments-and-regions`. If naming requires a phrase, the model is not yet crisp.
+
+A candidate failing any rule routes to: fold (1), host code (2), wait (3), style token (4), or naming work (5).
+
+### Promotion contract
+
+Every promoted class ships with:
+
+- Public input type declared `@unstable` until rule #3 is satisfied for real.
+- Anti-goals header in the class's `surface.ts`.
+- Tests under [`__tests__/classes/<name>/`](./__tests__/) covering: feature-flag null-state, hit asymmetry (visible chrome strictly contained in hit region — Fitts'-reach), every gesture in the grammar, every intent variant, hover + cursor mapping, decision-module wiring, equality + snapshot of public types.
+- One row in the [co-target test matrix](./__tests__/composition/) per (this-class, other-class) pair that may share an `id`.
+- Demo section in `editor/app/(dev)/ui/components/hud/_showcase.tsx` — fixture, host adapter, intent log, every feature toggled, verified off-state.
+- One row in the **Named classes** table below.
+
+### Named classes
+
+The table below lists every promoted named class. The package ships them; the host's binding class consumes them.
+
+| Class           | Model                                                                                            | Source                                               | Demo                                               |
+| --------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | -------------------------------------------------- |
+| `padding`       | 4 side numerics (top/right/bottom/left) committed by side-handle drag, optional alt-mirror       | [`classes/padding/`](./classes/padding/)             | `editor/app/(dev)/ui/components/hud/_showcase.tsx` |
+| `transform-box` | 2×3 affine on a unit box, mutated by 4 corners (rotate) / 4 sides (scale) / body (translate)     | [`classes/transform-box/`](./classes/transform-box/) | `editor/app/(dev)/ui/components/hud/_showcase.tsx` |
+| `vector-path`   | Path (vertices + segments + tangents + optional regions) under 10 intent variants over one model | [`classes/vector-path/`](./classes/vector-path/)     | `editor/app/(dev)/ui/components/hud/_showcase.tsx` |
+
+**Co-target coverage gap.** The promotion contract above requires one matrix row per `(this-class, other-class)` pair. Today's matrix covers `padding × transform-box` only; `vector-path`'s rows are pending (`vector-path × padding` and `vector-path × transform-box` are both `N/A` per the matrix plan since vector-path cannot share an `id` with rect-bound classes, but the N/A cells should still be marked in the matrix — see `__tests__/composition/README.md`). Tracked as a follow-up; does not block further migrations.
+
+#### Pending migrations
+
+Modules below predate the doctrine and are **candidates** for promotion under the rules above. Each migration is one PR.
+
+| Existing module                                                                                                                | Target                                                                             | Audit status                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `primitives/corner-radius.ts` (chrome path) + `setCornerRadius`                                                                | `classes/corner-radius/`                                                           | pending — chrome currently inline in `surface/surface.ts:778–927`; needs extraction before relocation |
+| `primitives/parametric-handle.ts` (chrome path) + `setParametricHandles`                                                       | `classes/parametric-handle/`                                                       | pending — same situation as corner-radius (inline in surface.ts)                                      |
+| Selection chrome inside `surface/chrome.ts` (resize handles, rotate handles, selection outline, hover overlay, marquee, lasso) | split per audit into `classes/{resize-box, selection-outline, marquee, lasso, …}/` | deferred — largest single migration; lands last after smaller migrations settle the contract          |
+
+See [`classes/README.md`](./classes/README.md) for the folder convention each migration adopts and the per-module promotion-bar dry-run.
+
 ## Why a canvas-based surface
 
 The DOM approach — positioned `<div>` handles, `data-grida-id` for hit-test, native dblclick — works until it doesn't. Concrete failures we hit before this package existed:
@@ -500,6 +598,59 @@ The `resize` gesture operates in the local frame: `applyResize` takes a `Selecti
 
 **v1 caveats.** Pure rotation is exact at every level (render, hit, gesture). Skew and non-uniform scale render correctly but use a uniform-scale fallback for handle sizing — anisotropic per-axis sizing is a follow-up.
 
+## Vector regions
+
+A **region** is a closed loop of segments — a "face" of the vector network — that the user can click on to select. The interior fills with a diagonal-stripe pattern on hover; on commit, the same paint at higher opacity reads as the selected affordance. Drag from the interior translates the loop's segments and endpoint vertices.
+
+Region picking is part of the core interaction model for path content-edit on closed sub-paths (without it, the user can't get from "hovering the artwork" to "editing this loop" without aiming at a thin segment outline). But the data — closed-loop enumeration — varies by backend: some hosts derive faces via planar-graph traversal (e.g. `vn.VectorNetworkEditor.getLoops()`); others can't.
+
+**The feature flag is the schema.** Hosts that can enumerate loops populate `VectorOverlay.regions`; hosts that can't omit the field. Absence is the off-state. No separate boolean to keep in sync with the data, no runtime `if (regionsEnabled)` branches — the shape of what the host hands the HUD IS the flag.
+
+```ts
+type VectorOverlay = {
+  vertices: ReadonlyArray<readonly [number, number]>;
+  segments?: ReadonlyArray<{ a; b; a_control; b_control }>;
+  neighbours?: ReadonlyArray<number>;
+  /** Schema-level feature flag — omit if not supported. */
+  regions?: ReadonlyArray<{ segments: ReadonlyArray<number> }>;
+  origin?: readonly [number, number];
+};
+```
+
+Each region names the segment indices forming one closed loop, in traversal order. The HUD reconstructs the cubic path at chrome build time from `vertices + segments[region.segments[i]]` — regions carry no own geometry, so "region equals closed loop of segments" stays a structural truth.
+
+### Selection mirror
+
+Hosts push the host-authoritative region selection through `setVectorSelection({ ..., regions: [N] })`. The field is optional for backward compat — `undefined` is treated as `[]`. The chrome reads it each frame to apply the `selected` paint.
+
+### Hit-test
+
+Region hit-test is **polygon-in-screen-space**: the chrome builder rasterises the cubic loop to N samples per segment and registers a screen-space AABB paired with a `customHitTest` closure that runs `cmath.polygon.pointInPolygon`. Same AABB-plus-refinement model the segment-strip uses — no new geometry primitive in `HitRegions`, no separate doc-space path-hit infrastructure.
+
+### Priority
+
+`REGION_PRIORITY = 9` — strictly above `SEGMENT_STRIP_PRIORITY (8)`, so any vertex / tangent / ghost / segment-strip control within the loop wins on overlap; strictly below the implicit "no overlay → empty-space miss" so an interior click selects the region instead of falling through to the marquee.
+
+### Paint states
+
+| State    | Render                                                                                                                                       |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| idle     | No fill — render omitted entirely. The hit region is registered, but the body is visually transparent.                                       |
+| hover    | `doc_polyline` with `fillPaint = style.vectorRegionHoverPaint` (default: `HUDPaintStripes` at 45° / 8px / 1.5px, accent color, 50% opacity). |
+| selected | Same shape, `fillPaint = style.vectorRegionSelectedPaint` (default: same stripes at 70% opacity).                                            |
+
+Hover wins over selected — matches the precedence on every other vector overlay (vertex / tangent / segment / ghost knobs).
+
+### Intent
+
+```ts
+| { kind: "select_region"; node_id: NodeId; region: number; mode: SelectMode }
+```
+
+Eager at pointer-down (parity with `select_segment` on the "not yet in axis-set" branch). Shift toggles, no-shift replaces — the host's commit policy decides whether to also propagate the loop's segments into the sub-selection mirror.
+
+Drag from the region body promotes to the existing `translate_vector_selection` intent (no new translate kind). The HUD seeds `additional_vertex_indices` with the loop's endpoint vertices so the gesture works even before the host echoes the region select back into the sub-selection mirror.
+
 ## Primitives — what `HUDCanvas` can draw
 
 | Primitive       | Coordinate space                                       | Used by                                       |
@@ -523,7 +674,7 @@ packages/grida-canvas-hud/
 ├── README.md
 ├── index.ts                   # Surface, HUDCanvas, public types
 ├── react.tsx                  # useHUDSurface hook
-├── primitives/                # UI — dumb render shapes
+├── primitives/                # Tier 2 — un-opinionated draw + math atoms
 │   ├── canvas.ts              # HUDCanvas
 │   ├── types.ts               # HUDDraw, HUDLine, HUDRect, HUDPolyline, HUDRule, HUDScreenRect
 │   ├── pixel-grid.ts          # inlined pure draw routine (sibling: @grida/pixel-grid)
@@ -532,26 +683,36 @@ packages/grida-canvas-hud/
 │   ├── measurement-guide.ts   # HUDDraw builder
 │   ├── marquee.ts             # legacy HUDDraw builder (surface emits its own marquee)
 │   └── lasso.ts               # HUDDraw builder
-├── event/                     # the math core
+├── event/                     # the math core (shared dispatch, cross-class)
 │   ├── event.ts               # SurfaceEvent, Modifiers, PointerButton
 │   ├── gesture.ts             # SurfaceGesture + transitions
 │   ├── hit-regions.ts         # screen-space AABB region registry
 │   ├── handles.ts             # 8 resize + 4 rotate geometry & hit-test
 │   ├── click-tracker.ts       # dblclick / multi-click detection
 │   ├── cursor.ts              # CursorIcon, ResizeDirection, RotationCorner
-│   ├── intent.ts              # Intent types + builders
+│   ├── intent.ts              # Intent types + builders (unions across all classes)
 │   ├── transform.ts           # screen ↔ doc helpers
 │   └── state.ts               # SurfaceState — pure dispatch entry
-├── surface/                   # the wired class
-│   ├── surface.ts             # Surface class
-│   ├── chrome.ts              # builds HUDDraw from SurfaceState + shapeOf
+├── classes/                   # Tier 1 — promoted named classes (see classes/README.md)
+│   ├── README.md              # folder convention + per-class file layout + promotion-bar dry-run
+│   ├── padding/               # migrated from surface/padding-overlay.ts
+│   ├── transform-box/         # migrated from surface/transform-box.ts
+│   └── vector-path/           # migrated from surface/vector-chrome.ts
+├── surface/                   # orchestration only
+│   ├── surface.ts             # Surface class — still hosts inline chrome for corner-radius + parametric-handle (pending extraction)
+│   ├── chrome.ts              # builds HUDDraw from SurfaceState + shapeOf (pre-migration host of selection chrome — split deferred)
 │   └── style.ts               # HUDStyle defaults + merge
-└── cursors/                   # opt-in subpath: @grida/hud/cursors
-    ├── index.ts               # cursors.defaultRenderer(), templates, encoder
-    ├── renderer.ts            # CursorIcon → CSS cursor: with rotation-aware SVGs
-    ├── templates.ts           # parameterized SVG cursor templates
-    └── encode.ts              # SVG → data: URL
+├── cursors/                   # opt-in subpath: @grida/hud/cursors
+│   ├── index.ts               # cursors.defaultRenderer(), templates, encoder
+│   ├── renderer.ts            # CursorIcon → CSS cursor: with rotation-aware SVGs
+│   ├── templates.ts           # parameterized SVG cursor templates
+│   └── encode.ts              # SVG → data: URL
+└── __tests__/
+    ├── composition/           # NEW — co-target matrix (see __tests__/composition/README.md)
+    └── …                      # per-class tests relocate under __tests__/classes/<name>/ as migrations land
 ```
+
+The shared dispatcher (`event/state.ts` and friends) stays unified across all classes — hover, hit-test, cursor resolution are _across_ classes. Per-class folders contribute their intent variant + priority constants, which `event/intent.ts` unions over.
 
 ## Naming conventions
 
@@ -661,47 +822,50 @@ locks the behaviour. Three layers, all required.
 
 Non-exhaustive index — open the test files for the full surface.
 
-| Behaviour                                                                                     | Pinned in                              |
-| --------------------------------------------------------------------------------------------- | -------------------------------------- |
-| Single-click on unselected node → immediate select                                            | `decision.test.ts`                     |
-| Single-click on already-selected node → defer (drag is a live candidate)                      | `decision.test.ts`, `state.test.ts`    |
-| Shift-click on selected node → defer (toggle-remove vs drag is ambiguous)                     | `decision.test.ts`                     |
-| Click in body region with selection → always defer (drag claim)                               | `decision.test.ts`                     |
-| Dblclick on content → emits `enter_content_edit`                                              | `decision.test.ts`, `state.test.ts`    |
-| Dblclick on empty space / other node / body WHILE in content-edit → emits `exit_content_edit` | `decision.test.ts`, `state.test.ts`    |
-| Dblclick on vertex / tangent / segment-strip WHILE in content-edit → handler runs (no exit)   | `decision.test.ts`                     |
-| Marquee starts from empty-space pointer-down                                                  | `state.test.ts`                        |
-| Drag past threshold cancels a deferred select (drag-vs-click discriminator)                   | `state.test.ts`                        |
-| Tangent knob renders as a 45°-rotated square ("diamond"), smaller than vertex                 | `vector-chrome-extended.test.ts`       |
-| Vertex knob renders as a circle, selected fills with chrome color                             | `vector-chrome-extended.test.ts`       |
-| Selected tangent line is thicker than idle                                                    | `vector-chrome-extended.test.ts`       |
-| Segment outline: idle gray → hover @ 50% accent → selected solid accent                       | `vector-chrome-segment-render.test.ts` |
-| Segment strip emits N inner samples per cubic, t ∈ (0, 1)                                     | `vector-chrome-extended.test.ts`       |
-| Priority ladder: tangent (4) < vertex (5) < segment (8)                                       | `vector-chrome-extended.test.ts`       |
-| Rotation-aware cursor CSS via `cursors.defaultRenderer`                                       | `cursors.test.ts`                      |
-| Click-tracker: single vs double within window + position threshold                            | `click-tracker.test.ts`                |
+| Behaviour                                                                                     | Pinned in                                      |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Single-click on unselected node → immediate select                                            | `decision.test.ts`                             |
+| Single-click on already-selected node → defer (drag is a live candidate)                      | `decision.test.ts`, `state.test.ts`            |
+| Shift-click on selected node → defer (toggle-remove vs drag is ambiguous)                     | `decision.test.ts`                             |
+| Click in body region with selection → always defer (drag claim)                               | `decision.test.ts`                             |
+| Dblclick on content → emits `enter_content_edit`                                              | `decision.test.ts`, `state.test.ts`            |
+| Dblclick on empty space / other node / body WHILE in content-edit → emits `exit_content_edit` | `decision.test.ts`, `state.test.ts`            |
+| Dblclick on vertex / tangent / segment-strip WHILE in content-edit → handler runs (no exit)   | `decision.test.ts`                             |
+| Marquee starts from empty-space pointer-down                                                  | `state.test.ts`                                |
+| Drag past threshold cancels a deferred select (drag-vs-click discriminator)                   | `state.test.ts`                                |
+| Tangent knob renders as a 45°-rotated square ("diamond"), smaller than vertex                 | `classes/vector-path/surface-extended.test.ts` |
+| Vertex knob renders as a circle, selected fills with chrome color                             | `classes/vector-path/surface-extended.test.ts` |
+| Selected tangent line is thicker than idle                                                    | `classes/vector-path/surface-extended.test.ts` |
+| Segment outline: idle gray → hover @ 50% accent → selected solid accent                       | `classes/vector-path/segment-render.test.ts`   |
+| Segment strip emits N inner samples per cubic, t ∈ (0, 1)                                     | `classes/vector-path/surface-extended.test.ts` |
+| Priority ladder: tangent (4) < vertex (5) < segment (8)                                       | `classes/vector-path/surface-extended.test.ts` |
+| Rotation-aware cursor CSS via `cursors.defaultRenderer`                                       | `cursors.test.ts`                              |
+| Click-tracker: single vs double within window + position threshold                            | `click-tracker.test.ts`                        |
 
 ### Test file index
 
-| File                                   | Domain pinned by tests                                                                                                                                                                                                                         |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `transform.test.ts`                    | screen ↔ doc across translate, scale, DPR                                                                                                                                                                                                      |
-| `hit-regions.test.ts`                  | topmost wins, reverse iteration, clear/empty, AABB containment                                                                                                                                                                                 |
-| `handles.test.ts`                      | 8 resize + 4 rotate positions; screen-space hit-test; visibility threshold                                                                                                                                                                     |
-| `click-tracker.test.ts`                | single vs double within window; position threshold; multi-button isolation                                                                                                                                                                     |
-| `gesture.test.ts`                      | legal transitions (idle↔translate/resize/marquee/cancel; deferred selection)                                                                                                                                                                   |
-| `state.test.ts`                        | dispatch sequences: click selects, drag-empty marquees, drag-handle resizes, drag-node translates, exit-edit                                                                                                                                   |
-| `intent.test.ts`                       | intent stream + `phase` correctness across a full drag (preview·N → commit)                                                                                                                                                                    |
-| `decision.test.ts`                     | one test per named scenario in the selection-intent classifier, including ExitEdit gating                                                                                                                                                      |
-| `chrome.test.ts`                       | given state + bounds, assert resulting `HUDDraw` shape — primitive counts and coords                                                                                                                                                           |
-| `chrome-transformed.test.ts`           | `SelectionShape.transformed` end-to-end                                                                                                                                                                                                        |
-| `chrome-priority.test.ts`              | overlay priority ladder over scenarios                                                                                                                                                                                                         |
-| `cursors.test.ts`                      | `cursors.defaultRenderer` produces rotation-aware CSS values; tree-shake invariant                                                                                                                                                             |
-| `vector-chrome.test.ts`                | vector chrome baseline: vertex emission, neighbouring filter, hit-region pad                                                                                                                                                                   |
-| `vector-chrome-extended.test.ts`       | vector chrome UX: tangent diamond shape + size, selection highlight, priority ladder                                                                                                                                                           |
-| `vector-chrome-segment-render.test.ts` | segment outline state machine: idle / hover / selected styling                                                                                                                                                                                 |
-| `vector-gesture.test.ts`               | vector-specific gesture state machine: tangent drag, segment-strip click→split, drag→bend                                                                                                                                                      |
-| `ruler.test.ts`                        | inlined ruler draw routine: layout helpers (step / subtick / range-merge), drawRuler call sequence, HUDCanvas wiring (setRuler/setRulerTransform, substrate-vs-frame paint-order: ruler top-most over chrome and extras, pixel-grid back-most) |
+| File                                           | Domain pinned by tests                                                                                                                                                                                                                         |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transform.test.ts`                            | screen ↔ doc across translate, scale, DPR                                                                                                                                                                                                      |
+| `hit-regions.test.ts`                          | topmost wins, reverse iteration, clear/empty, AABB containment                                                                                                                                                                                 |
+| `handles.test.ts`                              | 8 resize + 4 rotate positions; screen-space hit-test; visibility threshold                                                                                                                                                                     |
+| `click-tracker.test.ts`                        | single vs double within window; position threshold; multi-button isolation                                                                                                                                                                     |
+| `gesture.test.ts`                              | legal transitions (idle↔translate/resize/marquee/cancel; deferred selection)                                                                                                                                                                   |
+| `state.test.ts`                                | dispatch sequences: click selects, drag-empty marquees, drag-handle resizes, drag-node translates, exit-edit                                                                                                                                   |
+| `intent.test.ts`                               | intent stream + `phase` correctness across a full drag (preview·N → commit)                                                                                                                                                                    |
+| `decision.test.ts`                             | one test per named scenario in the selection-intent classifier, including ExitEdit gating                                                                                                                                                      |
+| `chrome.test.ts`                               | given state + bounds, assert resulting `HUDDraw` shape — primitive counts and coords                                                                                                                                                           |
+| `chrome-transformed.test.ts`                   | `SelectionShape.transformed` end-to-end                                                                                                                                                                                                        |
+| `chrome-priority.test.ts`                      | overlay priority ladder over scenarios                                                                                                                                                                                                         |
+| `cursors.test.ts`                              | `cursors.defaultRenderer` produces rotation-aware CSS values; tree-shake invariant                                                                                                                                                             |
+| `classes/vector-path/surface.test.ts`          | vector chrome baseline: vertex emission, neighbouring filter, hit-region pad                                                                                                                                                                   |
+| `classes/vector-path/surface-extended.test.ts` | vector chrome UX: tangent diamond shape + size, selection highlight, priority ladder                                                                                                                                                           |
+| `classes/vector-path/segment-render.test.ts`   | segment outline state machine: idle / hover / selected styling                                                                                                                                                                                 |
+| `classes/vector-path/region.test.ts`           | vector regions: closed-loop fill (idle / hover / selected), polygon hit-test, REGION_PRIORITY ladder                                                                                                                                           |
+| `classes/vector-path/gesture.test.ts`          | vector-specific gesture state machine: tangent drag, segment-strip click→split, drag→bend                                                                                                                                                      |
+| `classes/padding/surface.test.ts`              | padding overlay: per-side rect geometry, mirror handles, hover stripe / drag outline, priority ladder                                                                                                                                          |
+| `classes/transform-box/surface.test.ts`        | transform-box chrome: quad corners, side strips, body translate, cursor rotation, container-rotation de-rotation                                                                                                                               |
+| `ruler.test.ts`                                | inlined ruler draw routine: layout helpers (step / subtick / range-merge), drawRuler call sequence, HUDCanvas wiring (setRuler/setRulerTransform, substrate-vs-frame paint-order: ruler top-most over chrome and extras, pixel-grid back-most) |
 
 Render output (visual canvas correctness — paint order, anti-aliasing, the
 actual pixel result) is verified in the browser, not unit-tested. Every UX

--- a/packages/grida-canvas-hud/README.md
+++ b/packages/grida-canvas-hud/README.md
@@ -822,25 +822,25 @@ locks the behaviour. Three layers, all required.
 
 Non-exhaustive index — open the test files for the full surface.
 
-| Behaviour                                                                                     | Pinned in                                      |
-| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| Single-click on unselected node → immediate select                                            | `decision.test.ts`                             |
-| Single-click on already-selected node → defer (drag is a live candidate)                      | `decision.test.ts`, `state.test.ts`            |
-| Shift-click on selected node → defer (toggle-remove vs drag is ambiguous)                     | `decision.test.ts`                             |
-| Click in body region with selection → always defer (drag claim)                               | `decision.test.ts`                             |
-| Dblclick on content → emits `enter_content_edit`                                              | `decision.test.ts`, `state.test.ts`            |
-| Dblclick on empty space / other node / body WHILE in content-edit → emits `exit_content_edit` | `decision.test.ts`, `state.test.ts`            |
-| Dblclick on vertex / tangent / segment-strip WHILE in content-edit → handler runs (no exit)   | `decision.test.ts`                             |
-| Marquee starts from empty-space pointer-down                                                  | `state.test.ts`                                |
-| Drag past threshold cancels a deferred select (drag-vs-click discriminator)                   | `state.test.ts`                                |
-| Tangent knob renders as a 45°-rotated square ("diamond"), smaller than vertex                 | `classes/vector-path/surface-extended.test.ts` |
-| Vertex knob renders as a circle, selected fills with chrome color                             | `classes/vector-path/surface-extended.test.ts` |
-| Selected tangent line is thicker than idle                                                    | `classes/vector-path/surface-extended.test.ts` |
-| Segment outline: idle gray → hover @ 50% accent → selected solid accent                       | `classes/vector-path/segment-render.test.ts`   |
-| Segment strip emits N inner samples per cubic, t ∈ (0, 1)                                     | `classes/vector-path/surface-extended.test.ts` |
-| Priority ladder: tangent (4) < vertex (5) < segment (8)                                       | `classes/vector-path/surface-extended.test.ts` |
-| Rotation-aware cursor CSS via `cursors.defaultRenderer`                                       | `cursors.test.ts`                              |
-| Click-tracker: single vs double within window + position threshold                            | `click-tracker.test.ts`                        |
+| Behaviour                                                                                   | Pinned in                                      |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Single-click on unselected node → immediate select                                          | `decision.test.ts`                             |
+| Single-click on already-selected node → defer (drag is a live candidate)                    | `decision.test.ts`, `state.test.ts`            |
+| Shift-click on selected node → defer (toggle-remove vs drag is ambiguous)                   | `decision.test.ts`                             |
+| Click in body region with selection → always defer (drag claim)                             | `decision.test.ts`                             |
+| Dblclick on content → emits `enter_content_edit`                                            | `decision.test.ts`, `state.test.ts`            |
+| Dblclick on empty space / other node WHILE in content-edit → emits `exit_content_edit`      | `decision.test.ts`, `state.test.ts`            |
+| Dblclick on vertex / tangent / segment-strip WHILE in content-edit → handler runs (no exit) | `decision.test.ts`                             |
+| Marquee starts from empty-space pointer-down                                                | `state.test.ts`                                |
+| Drag past threshold cancels a deferred select (drag-vs-click discriminator)                 | `state.test.ts`                                |
+| Tangent knob renders as a 45°-rotated square ("diamond"), smaller than vertex               | `classes/vector-path/surface-extended.test.ts` |
+| Vertex knob renders as a circle, selected fills with chrome color                           | `classes/vector-path/surface-extended.test.ts` |
+| Selected tangent line is thicker than idle                                                  | `classes/vector-path/surface-extended.test.ts` |
+| Segment outline: idle gray → hover @ 50% accent → selected solid accent                     | `classes/vector-path/segment-render.test.ts`   |
+| Segment strip emits N inner samples per cubic, t ∈ (0, 1)                                   | `classes/vector-path/surface-extended.test.ts` |
+| Priority ladder: tangent (4) < vertex (5) < segment (8)                                     | `classes/vector-path/surface-extended.test.ts` |
+| Rotation-aware cursor CSS via `cursors.defaultRenderer`                                     | `cursors.test.ts`                              |
+| Click-tracker: single vs double within window + position threshold                          | `click-tracker.test.ts`                        |
 
 ### Test file index
 

--- a/packages/grida-canvas-hud/__tests__/classes/padding/surface.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/padding/surface.test.ts
@@ -1,0 +1,721 @@
+// Tests for the padding-overlay Layer B model.
+//
+// Pins:
+//   - Schema-level feature flag: absence of `setPaddingOverlay` input
+//     = no chrome; absent / zero sides skipped.
+//   - Per-side geometry: inset rect from container + padding values.
+//   - Hit-priority: handle (12) wins over region (35); region wins
+//     over translate body (40); region loses to resize (30/31).
+//   - Paint states: idle (no render), hover (paddingHoverPaint),
+//     mirror-hover (alt → both sides), selected (paddingSelectedPaint),
+//     mirror-selected (alt + active_side → both sides).
+//   - Handle visibility: suppressed for active_side; present otherwise.
+//   - Intent dispatch: drag emits `padding_handle` preview stream;
+//     commit on release; mirror reflects current alt; value clamps.
+//   - Classifier: `padding_handle` → HandlePaddingDrag (noop in
+//     dispatch — eager intercept in state); `padding_region` → Noop.
+//   - Hover derivation: region hover; alt populates mirror_side;
+//     handle preempts region.
+//   - Semantic group propagation.
+//   - Snapshot/equality: hoversEqual variants; identity preserved.
+
+import { describe, it, expect } from "vitest";
+import cmath from "@grida/cmath";
+import {
+  buildPaddingOverlay,
+  paddingSideRect,
+  projectPaddingValue,
+  PADDING_HANDLE_PRIORITY,
+  PADDING_REGION_PRIORITY,
+  type PaddingOverlayInput,
+  type PaddingHover,
+} from "../../../classes/padding";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import {
+  classifyScenario,
+  decidePointerDown,
+  decideIdleCursor,
+  Scenario,
+} from "../../../event/decision";
+import { NO_MODS } from "../../../event/event";
+import { SurfaceState } from "../../../event/state";
+import { HUDHitPriority } from "../../../event/selection-controls";
+import type { OverlayElement } from "../../../event/overlay";
+import type { Intent } from "../../../event/intent";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────────
+
+/** 400×300 container at origin with all four sides padded. */
+function fourSideOverlay(): PaddingOverlayInput {
+  return {
+    node_id: "container",
+    rect: { x: 0, y: 0, width: 400, height: 300 },
+    padding: { top: 24, right: 16, bottom: 32, left: 16 },
+  };
+}
+
+/** Same container, only `top` padding non-zero. */
+function topOnlyOverlay(): PaddingOverlayInput {
+  return {
+    node_id: "container",
+    rect: { x: 0, y: 0, width: 400, height: 300 },
+    padding: { top: 24 },
+  };
+}
+
+const IDENTITY: cmath.Transform = [
+  [1, 0, 0],
+  [0, 1, 0],
+];
+
+function build(
+  overlay: PaddingOverlayInput,
+  opts: {
+    hover?: PaddingHover | null;
+    alt?: boolean;
+    transform?: cmath.Transform;
+    active_side?: cmath.RectangleSide;
+  } = {}
+): OverlayElement[] {
+  return buildPaddingOverlay({
+    overlay,
+    style: DEFAULT_STYLE,
+    hover: opts.hover ?? null,
+    alt_held: opts.alt ?? false,
+    transform: opts.transform ?? IDENTITY,
+    active_side: opts.active_side,
+  });
+}
+
+function regions(els: readonly OverlayElement[]): readonly OverlayElement[] {
+  return els.filter((e) => e.action.kind === "padding_region");
+}
+
+function handles(els: readonly OverlayElement[]): readonly OverlayElement[] {
+  return els.filter((e) => e.action.kind === "padding_handle");
+}
+
+function sideOf(el: OverlayElement): cmath.RectangleSide | undefined {
+  if (
+    el.action.kind === "padding_region" ||
+    el.action.kind === "padding_handle"
+  ) {
+    return el.action.side;
+  }
+  return undefined;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Feature flag — schema-level opt-in
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — feature flag (schema-level)", () => {
+  it("emits 4 regions + 4 handles for all-sided padding", () => {
+    const els = build(fourSideOverlay());
+    expect(regions(els).length).toBe(4);
+    expect(handles(els).length).toBe(4);
+  });
+
+  it("skips sides whose value is 0 or undefined", () => {
+    const els = build(topOnlyOverlay());
+    expect(regions(els).length).toBe(1);
+    expect(handles(els).length).toBe(1);
+    expect(sideOf(regions(els)[0])).toBe("top");
+  });
+
+  it("emits nothing when all four sides are 0", () => {
+    const els = build({
+      node_id: "n",
+      rect: { x: 0, y: 0, width: 10, height: 10 },
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+    });
+    expect(els.length).toBe(0);
+  });
+
+  it("emits nothing when padding object is empty", () => {
+    const els = build({
+      node_id: "n",
+      rect: { x: 0, y: 0, width: 10, height: 10 },
+      padding: {},
+    });
+    expect(els.length).toBe(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. Geometry — inset rects from container + padding
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — geometry", () => {
+  it("top side inset rect = full width × top padding", () => {
+    const r = paddingSideRect(
+      { x: 0, y: 0, width: 400, height: 300 },
+      { top: 24, right: 16, bottom: 32, left: 16 },
+      "top"
+    );
+    expect(r).toEqual({ x: 0, y: 0, width: 400, height: 24 });
+  });
+
+  it("right side inset rect = right padding × full height, anchored to right edge", () => {
+    const r = paddingSideRect(
+      { x: 10, y: 20, width: 400, height: 300 },
+      { right: 16 },
+      "right"
+    );
+    expect(r).toEqual({ x: 394, y: 20, width: 16, height: 300 });
+  });
+
+  it("bottom side inset rect = full width × bottom padding, anchored to bottom edge", () => {
+    const r = paddingSideRect(
+      { x: 0, y: 0, width: 400, height: 300 },
+      { bottom: 32 },
+      "bottom"
+    );
+    expect(r).toEqual({ x: 0, y: 268, width: 400, height: 32 });
+  });
+
+  it("left side inset rect = left padding × full height, anchored to left edge", () => {
+    const r = paddingSideRect(
+      { x: 0, y: 0, width: 400, height: 300 },
+      { left: 16 },
+      "left"
+    );
+    expect(r).toEqual({ x: 0, y: 0, width: 16, height: 300 });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. Hit-priority
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — hit priority", () => {
+  it("handle priority is strictly above region priority (lower wins)", () => {
+    expect(PADDING_HANDLE_PRIORITY).toBeLessThan(PADDING_REGION_PRIORITY);
+  });
+
+  it("region wins over translate body (PADDING_REGION_PRIORITY < TRANSLATE_BODY)", () => {
+    expect(PADDING_REGION_PRIORITY).toBeLessThan(HUDHitPriority.TRANSLATE_BODY);
+  });
+
+  it("region loses to resize controls (PADDING_REGION_PRIORITY > RESIZE_HANDLE_CORNER)", () => {
+    expect(PADDING_REGION_PRIORITY).toBeGreaterThan(
+      HUDHitPriority.RESIZE_HANDLE_CORNER
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. Paint states — idle / hover / mirror-hover / selected / mirror-selected
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — paint states", () => {
+  function regionFor(
+    els: readonly OverlayElement[],
+    side: cmath.RectangleSide
+  ): OverlayElement {
+    const r = regions(els).find((e) => sideOf(e) === side);
+    if (!r) throw new Error(`no region for side ${side}`);
+    return r;
+  }
+
+  it("idle = no render (fillPaint not present, render omitted)", () => {
+    const els = build(fourSideOverlay());
+    for (const r of regions(els)) {
+      expect(r.render).toBeUndefined();
+    }
+  });
+
+  it("hover on side N → only that side has fillPaint (hover paint)", () => {
+    const els = build(fourSideOverlay(), {
+      hover: { kind: "padding_region", node_id: "container", side: "top" },
+    });
+    const top = regionFor(els, "top");
+    const bottom = regionFor(els, "bottom");
+    if (top.render?.kind !== "doc_polyline") throw new Error("top no render");
+    expect(top.render.fillPaint).toEqual(DEFAULT_STYLE.paddingHoverPaint);
+    expect(bottom.render).toBeUndefined();
+  });
+
+  it("hover on the side's drag HANDLE also paints the side's stripe (handle is part of the side's affordance)", () => {
+    const els = build(fourSideOverlay(), {
+      hover: { kind: "padding_handle", node_id: "container", side: "top" },
+    });
+    const top = regionFor(els, "top");
+    if (top.render?.kind !== "doc_polyline") throw new Error("top no render");
+    expect(top.render.fillPaint).toEqual(DEFAULT_STYLE.paddingHoverPaint);
+  });
+
+  it("alt-hover on side N → BOTH N and its opposite get hover paint", () => {
+    const els = build(fourSideOverlay(), {
+      hover: { kind: "padding_region", node_id: "container", side: "top" },
+      alt: true,
+    });
+    const top = regionFor(els, "top");
+    const bottom = regionFor(els, "bottom");
+    if (top.render?.kind !== "doc_polyline") throw new Error("top no render");
+    if (bottom.render?.kind !== "doc_polyline")
+      throw new Error("bottom no render");
+    expect(top.render.fillPaint).toEqual(DEFAULT_STYLE.paddingHoverPaint);
+    expect(bottom.render.fillPaint).toEqual(DEFAULT_STYLE.paddingHoverPaint);
+    // Sides perpendicular to top/bottom stay unpainted.
+    expect(regionFor(els, "left").render).toBeUndefined();
+    expect(regionFor(els, "right").render).toBeUndefined();
+  });
+
+  it("active_side → that side renders a STROKED OUTLINE (no stripe fill); stronger than hover", () => {
+    const els = build(fourSideOverlay(), { active_side: "left" });
+    const left = regionFor(els, "left");
+    if (left.render?.kind !== "doc_polyline") throw new Error("left no render");
+    expect(left.render.stroke).toBe(true);
+    expect(left.render.fill).toBe(false);
+    expect(left.render.color).toBe(DEFAULT_STYLE.paddingSelectedStroke);
+    expect(left.render.fillPaint).toBeUndefined();
+  });
+
+  it("active_side + alt → BOTH active and its opposite render the STROKED outline", () => {
+    const els = build(fourSideOverlay(), { active_side: "left", alt: true });
+    const left = regionFor(els, "left");
+    const right = regionFor(els, "right");
+    if (
+      left.render?.kind !== "doc_polyline" ||
+      right.render?.kind !== "doc_polyline"
+    )
+      throw new Error("missing render");
+    expect(left.render.stroke).toBe(true);
+    expect(left.render.fill).toBe(false);
+    expect(left.render.color).toBe(DEFAULT_STYLE.paddingSelectedStroke);
+    expect(right.render.stroke).toBe(true);
+    expect(right.render.fill).toBe(false);
+    expect(right.render.color).toBe(DEFAULT_STYLE.paddingSelectedStroke);
+  });
+
+  it("active_side beats hover on the same side — outline wins, no stripe fill", () => {
+    const els = build(fourSideOverlay(), {
+      active_side: "top",
+      hover: { kind: "padding_region", node_id: "container", side: "top" },
+    });
+    const top = regionFor(els, "top");
+    if (top.render?.kind !== "doc_polyline") throw new Error("top no render");
+    expect(top.render.stroke).toBe(true);
+    expect(top.render.fill).toBe(false);
+    expect(top.render.fillPaint).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Handle visibility — suppressed for active_side
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — handle visibility", () => {
+  it("ALL handles disappear while a drag is in flight (any active_side suppresses every knob)", () => {
+    const els = build(fourSideOverlay(), { active_side: "top" });
+    expect(handles(els).length).toBe(0);
+  });
+
+  it("no active_side → all 4 handles present", () => {
+    const els = build(fourSideOverlay());
+    expect(handles(els).length).toBe(4);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Intent dispatch — drag stream + commit
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — intent dispatch", () => {
+  function setupSurface() {
+    const intents: Intent[] = [];
+    const state = new SurfaceState();
+    state.setTransform(IDENTITY);
+    const deps = {
+      pick: () => null,
+      shapeOf: () => null,
+      emitIntent: (i: Intent) => {
+        intents.push(i);
+      },
+    };
+    // Register a padding-handle hit region at screen [200, 50] (top edge mid).
+    const overlay = fourSideOverlay();
+    const els = build(overlay);
+    const top_handle = handles(els).find((h) => sideOf(h) === "top")!;
+    // Forge a fake registry entry — the gesture-open path reads
+    // `ui_action` from the hit-test, so we register the action directly.
+    const regions = state.hitRegions();
+    regions.push({
+      rect: { x: 195, y: 45, width: 20, height: 20 },
+      action: top_handle.action,
+      priority: PADDING_HANDLE_PRIORITY,
+      label: "padding_handle:top",
+    });
+    return { intents, state, deps };
+  }
+
+  it("pointer_down on handle opens gesture; pointer_move emits preview with 2× math", () => {
+    const { intents, state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 100, mods: NO_MODS },
+      deps
+    );
+    expect(intents.length).toBe(1);
+    expect(intents[0].kind).toBe("padding_handle");
+    const i = intents[0] as Extract<Intent, { kind: "padding_handle" }>;
+    expect(i.side).toBe("top");
+    expect(i.phase).toBe("preview");
+    // top: value = 2 × (cursor_y - rect.y) = 2 × (100 - 0) = 200.
+    // Handle sits at center of padding strip; padding changes at 2× cursor
+    // displacement so the visual knob tracks the cursor 1:1.
+    expect(i.value).toBe(200);
+    expect(i.mirror).toBe(false);
+  });
+
+  it("pointer_up after drag emits commit", () => {
+    const { intents, state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 80, mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_up", x: 200, y: 80, button: "primary", mods: NO_MODS },
+      deps
+    );
+    const commit = intents.find(
+      (i) => i.kind === "padding_handle" && i.phase === "commit"
+    );
+    expect(commit).toBeDefined();
+  });
+
+  it("mirror reflects current alt state, live per frame", () => {
+    const { intents, state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      {
+        kind: "pointer_move",
+        x: 200,
+        y: 80,
+        mods: { ...NO_MODS, alt: true },
+      },
+      deps
+    );
+    const i = intents[0] as Extract<Intent, { kind: "padding_handle" }>;
+    expect(i.mirror).toBe(true);
+  });
+
+  it("value clamps to 0 when cursor goes above the top edge", () => {
+    const { intents, state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: -100, mods: NO_MODS },
+      deps
+    );
+    const i = intents[0] as Extract<Intent, { kind: "padding_handle" }>;
+    expect(i.value).toBe(0);
+  });
+
+  it("click-no-drag (pointer_down then pointer_up at same point) does NOT emit commit", () => {
+    const { intents, state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_up", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    expect(
+      intents.find((i) => i.kind === "padding_handle" && i.phase === "commit")
+    ).toBeUndefined();
+  });
+
+  it("during drag, gesture is `padding_handle` carrying the dragged side", () => {
+    // Pin the HUD-internal source of `active_side` for the chrome
+    // builder: the surface reads its own gesture state and passes the
+    // dragged side into `buildPaddingOverlay` — no host shadow.
+    const { state, deps } = setupSurface();
+    state.dispatch(
+      { kind: "pointer_down", x: 200, y: 50, button: "primary", mods: NO_MODS },
+      deps
+    );
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 100, mods: NO_MODS },
+      deps
+    );
+    expect(state.gesture).toMatchObject({
+      kind: "padding_handle",
+      side: "top",
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. Decision classifier — padding_handle / padding_region routing
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — decision classifier", () => {
+  it("`padding_handle` action → HandlePaddingDrag scenario", () => {
+    const scenario = classifyScenario({
+      ui_action: {
+        kind: "padding_handle",
+        node_id: "n",
+        side: "top",
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        initial_value: 10,
+      },
+      hovered_id: null,
+      selection_ids: [],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+    });
+    expect(scenario).toBe(Scenario.HandlePaddingDrag);
+  });
+
+  it("`padding_region` action falls through to Tier-2 — body is event-transparent", () => {
+    // No hovered_id, no selection, no shift → empty-space marquee. The
+    // padding_region ui_action does NOT short-circuit classification —
+    // only the handle is interactive; the body's stripe / outline never
+    // blocks click events on whatever lives behind it.
+    const scenario = classifyScenario({
+      ui_action: { kind: "padding_region", node_id: "n", side: "top" },
+      hovered_id: null,
+      selection_ids: [],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+    });
+    expect(scenario).toBe(Scenario.EmptyMarquee);
+  });
+
+  it("`padding_region` over a selected container → ContentNarrowOrDrag (drag = translate the container)", () => {
+    const scenario = classifyScenario({
+      ui_action: { kind: "padding_region", node_id: "container", side: "top" },
+      hovered_id: "container",
+      selection_ids: ["container"],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+    });
+    expect(scenario).toBe(Scenario.ContentNarrowOrDrag);
+  });
+
+  it("`padding_region` drag dispatches a `pend` whose pending.ids_at_down is the selection (drag → translate)", () => {
+    const decision = decidePointerDown({
+      ui_action: { kind: "padding_region", node_id: "container", side: "top" },
+      hovered_id: "container",
+      selection_ids: ["container"],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+    });
+    expect(decision).toMatchObject({
+      kind: "pend",
+      pending: { ids_at_down: ["container"] },
+    });
+  });
+
+  it("readonly: padding_handle → Noop", () => {
+    const scenario = classifyScenario({
+      ui_action: {
+        kind: "padding_handle",
+        node_id: "n",
+        side: "top",
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        initial_value: 10,
+      },
+      hovered_id: null,
+      selection_ids: [],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: true,
+    });
+    expect(scenario).toBe(Scenario.Noop);
+  });
+
+  it("decideIdleCursor for `padding_handle` → axis-appropriate resize cursor", () => {
+    const top_cursor = decideIdleCursor({
+      ui_action: {
+        kind: "padding_handle",
+        node_id: "n",
+        side: "top",
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        initial_value: 10,
+      },
+      hovered_id: null,
+      selection_ids: [],
+    });
+    expect(top_cursor).toEqual({ kind: "resize", direction: "n" });
+
+    const left_cursor = decideIdleCursor({
+      ui_action: {
+        kind: "padding_handle",
+        node_id: "n",
+        side: "left",
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        initial_value: 10,
+      },
+      hovered_id: null,
+      selection_ids: [],
+    });
+    expect(left_cursor).toEqual({ kind: "resize", direction: "w" });
+  });
+
+  it("dispatch HandlePaddingDrag → noop (eager intercept already handled it)", () => {
+    const decision = decidePointerDown({
+      ui_action: {
+        kind: "padding_handle",
+        node_id: "n",
+        side: "top",
+        rect: { x: 0, y: 0, width: 100, height: 100 },
+        initial_value: 10,
+      },
+      hovered_id: null,
+      selection_ids: [],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+    });
+    expect(decision.kind).toBe("noop");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 8. Hover derivation — SurfaceState integration
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — hover derivation", () => {
+  function setupHoverable() {
+    const state = new SurfaceState();
+    state.setTransform(IDENTITY);
+    state.hitRegions().push({
+      rect: { x: 0, y: 0, width: 400, height: 24 },
+      action: { kind: "padding_region", node_id: "container", side: "top" },
+      priority: PADDING_REGION_PRIORITY,
+      label: "padding_region:top",
+    });
+    return state;
+  }
+
+  it("pointer over region body → PaddingHover with kind 'padding_region'", () => {
+    const state = setupHoverable();
+    state.dispatch(
+      { kind: "pointer_move", x: 100, y: 10, mods: NO_MODS },
+      { pick: () => null, shapeOf: () => null, emitIntent: () => undefined }
+    );
+    const h = state.getPaddingHover();
+    expect(h).toEqual({
+      kind: "padding_region",
+      node_id: "container",
+      side: "top",
+      mirror_side: undefined,
+    });
+  });
+
+  it("alt-held over region → mirror_side populated with opposite", () => {
+    const state = setupHoverable();
+    state.dispatch(
+      {
+        kind: "pointer_move",
+        x: 100,
+        y: 10,
+        mods: { ...NO_MODS, alt: true },
+      },
+      { pick: () => null, shapeOf: () => null, emitIntent: () => undefined }
+    );
+    expect(state.getPaddingHover()).toEqual({
+      kind: "padding_region",
+      node_id: "container",
+      side: "top",
+      mirror_side: "bottom",
+    });
+  });
+
+  it("pointer moves OFF region → hover clears to null", () => {
+    const state = setupHoverable();
+    const deps = {
+      pick: () => null,
+      shapeOf: () => null,
+      emitIntent: () => undefined,
+    };
+    state.dispatch(
+      { kind: "pointer_move", x: 100, y: 10, mods: NO_MODS },
+      deps
+    );
+    expect(state.getPaddingHover()).not.toBeNull();
+    state.dispatch(
+      { kind: "pointer_move", x: 100, y: 100, mods: NO_MODS },
+      deps
+    );
+    expect(state.getPaddingHover()).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 9. Semantic group propagation
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — semantic group", () => {
+  it("every emitted overlay carries the input's `group` field", () => {
+    const overlay: PaddingOverlayInput = {
+      ...fourSideOverlay(),
+      group: "paddingOverlay",
+    };
+    const els = build(overlay);
+    for (const e of els) {
+      expect(e.group).toBe("paddingOverlay");
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 10. Value projection — pure math
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("padding — projectPaddingValue (2× the handle displacement)", () => {
+  const rect = { x: 0, y: 0, width: 100, height: 100 };
+
+  it("top: value = 2 × (cursor_y - rect.y), clamped to [0, height]", () => {
+    expect(projectPaddingValue(rect, "top", [50, 30])).toBe(60);
+    expect(projectPaddingValue(rect, "top", [50, -10])).toBe(0);
+    expect(projectPaddingValue(rect, "top", [50, 200])).toBe(100);
+  });
+
+  it("right: value = 2 × ((rect.x + rect.width) - cursor_x), clamped", () => {
+    expect(projectPaddingValue(rect, "right", [70, 50])).toBe(60);
+    expect(projectPaddingValue(rect, "right", [200, 50])).toBe(0);
+    expect(projectPaddingValue(rect, "right", [-10, 50])).toBe(100);
+  });
+
+  it("bottom: value = 2 × ((rect.y + rect.height) - cursor_y), clamped", () => {
+    expect(projectPaddingValue(rect, "bottom", [50, 70])).toBe(60);
+    expect(projectPaddingValue(rect, "bottom", [50, 200])).toBe(0);
+    expect(projectPaddingValue(rect, "bottom", [50, -10])).toBe(100);
+  });
+
+  it("left: value = 2 × (cursor_x - rect.x), clamped", () => {
+    expect(projectPaddingValue(rect, "left", [30, 50])).toBe(60);
+    expect(projectPaddingValue(rect, "left", [-10, 50])).toBe(0);
+    expect(projectPaddingValue(rect, "left", [200, 50])).toBe(100);
+  });
+
+  it("click-no-drag preserves initial value: cursor at handle center (initial/2) → value = initial", () => {
+    // Top handle for initial value 40 is at y = 20 (center of 0..40 strip).
+    expect(projectPaddingValue(rect, "top", [50, 20])).toBe(40);
+    // Right handle for initial value 30 sits at x = 100 - 15 = 85.
+    expect(projectPaddingValue(rect, "right", [85, 50])).toBe(30);
+  });
+});

--- a/packages/grida-canvas-hud/__tests__/classes/transform-box/surface.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/transform-box/surface.test.ts
@@ -1,0 +1,633 @@
+// Tests for the transform-box Layer B model.
+//
+// Pins (D1–D5 from the SDK-design doctrine):
+//   - Schema-level feature flag: absence of `setTransformBox` input
+//     = no chrome. Setting null mid-session clears hover state too.
+//   - Quad geometry: corners project through transform + container
+//     rotation + origin.
+//   - Hit asymmetry (D3): side hit strip (12px) STRICTLY contains the
+//     visible stroke (1px). Corner hit (16×16) STRICTLY contains the
+//     corner point. This IS the Layer-B-doctrine litmus test.
+//   - Hover: 1:1 mapping from action → hover variant; no modifier
+//     branches (unlike padding's `mirror_side`).
+//   - Translate intent: body drag → `op.type === "translate"`,
+//     `transform[*][2]` updates by `delta/size`.
+//   - Scale-side intent: side drag → `op.type === "scale_side"`,
+//     `op.side` matches; only that side's corners move in box-space.
+//   - Rotate intent: corner drag → `op.type === "rotate"`, rigid-body
+//     rotation (distances preserved).
+//   - Container rotation: pointer doc-delta is de-rotated before
+//     reducing; intent `transform` stays in box-relative space.
+//   - Classifier: all 3 hit kinds → HandleTransformBoxDrag; readonly
+//     → all → Noop.
+//   - Equality: hoversEqual symmetry + hoverFromAction round-trip.
+
+import { describe, it, expect } from "vitest";
+import cmath from "@grida/cmath";
+import {
+  buildTransformBox,
+  getTransformBoxDocCorners,
+  TRANSFORM_BOX_BODY_PRIORITY,
+  TRANSFORM_BOX_SIDE_PRIORITY,
+  TRANSFORM_BOX_CORNER_PRIORITY,
+  TRANSFORM_BOX_CORNER_HIT_SIZE,
+  TRANSFORM_BOX_SIDE_HIT_THICKNESS,
+  type TransformBoxInput,
+  type TransformBoxHover,
+  type TransformBoxActiveOp,
+} from "../../../classes/transform-box";
+import type { AffineTransform } from "../../../primitives/transform-box";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import { classifyScenario, Scenario } from "../../../event/decision";
+import { NO_MODS } from "../../../event/event";
+import { SurfaceState } from "../../../event/state";
+import type { OverlayElement } from "../../../event/overlay";
+import type { Intent } from "../../../event/intent";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────────
+
+const IDENTITY_AFFINE: AffineTransform = [
+  [1, 0, 0],
+  [0, 1, 0],
+];
+
+const IDENTITY_T: cmath.Transform = [
+  [1, 0, 0],
+  [0, 1, 0],
+];
+
+function basicInput(
+  partial: Partial<TransformBoxInput> = {}
+): TransformBoxInput {
+  return {
+    id: "tb-1",
+    transform: IDENTITY_AFFINE,
+    size: [200, 100],
+    origin: [0, 0],
+    rotation: 0,
+    ...partial,
+  };
+}
+
+function build(
+  overlay: TransformBoxInput,
+  opts: {
+    hover?: TransformBoxHover | null;
+    transform?: cmath.Transform;
+    active_op?: TransformBoxActiveOp;
+  } = {}
+): OverlayElement[] {
+  return buildTransformBox({
+    overlay,
+    style: DEFAULT_STYLE,
+    hover: opts.hover ?? null,
+    transform: opts.transform ?? IDENTITY_T,
+    active_op: opts.active_op,
+  });
+}
+
+function bodyOf(els: readonly OverlayElement[]): OverlayElement | undefined {
+  return els.find((e) => e.action.kind === "transform_box_body");
+}
+function sidesOf(els: readonly OverlayElement[]): readonly OverlayElement[] {
+  return els.filter((e) => e.action.kind === "transform_box_side");
+}
+function cornersOf(els: readonly OverlayElement[]): readonly OverlayElement[] {
+  return els.filter((e) => e.action.kind === "transform_box_corner");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Feature flag
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — feature flag", () => {
+  it("emits 1 body + 4 sides + 4 corners for a default input", () => {
+    const els = build(basicInput());
+    expect(bodyOf(els)).toBeDefined();
+    expect(sidesOf(els).length).toBe(4);
+    expect(cornersOf(els).length).toBe(4);
+  });
+
+  it("setTransformBox(null) clears chrome AND hover state", () => {
+    const state = new SurfaceState();
+    state.setTransformBox(basicInput());
+    // Simulate hover state via direct setter — the test pins the
+    // observable contract: setting null clears the field.
+    // (The pointer-move hover wire-up is exercised by §4 / §9.)
+    expect(state.getTransformBox()).not.toBeNull();
+    state.setTransformBox(null);
+    expect(state.getTransformBox()).toBeNull();
+    expect(state.getTransformBoxHover()).toBeNull();
+  });
+
+  it("renders correctly for a non-zero origin", () => {
+    const els = build(basicInput({ origin: [50, 75] }));
+    const body = bodyOf(els);
+    expect(body).toBeDefined();
+    // The body hit rect should be screen-space; with identity camera,
+    // doc → screen is 1:1, and the quad sits at origin+size.
+    if (!body || body.hit.kind !== "screen_aabb") {
+      throw new Error("expected body with screen_aabb hit");
+    }
+    expect(body.hit.rect.x).toBeCloseTo(50);
+    expect(body.hit.rect.y).toBeCloseTo(75);
+    expect(body.hit.rect.width).toBeCloseTo(200);
+    expect(body.hit.rect.height).toBeCloseTo(100);
+  });
+
+  it("handles size [0, 0] without throwing (degenerate but defensive)", () => {
+    expect(() => build(basicInput({ size: [0, 0] }))).not.toThrow();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. Quad geometry
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — quad geometry", () => {
+  it("identity transform → axis-aligned quad through (0,0)–(w,h)", () => {
+    const c = getTransformBoxDocCorners(basicInput());
+    expect(c.nw).toEqual([0, 0]);
+    expect(c.ne).toEqual([200, 0]);
+    expect(c.se).toEqual([200, 100]);
+    expect(c.sw).toEqual([0, 100]);
+  });
+
+  it("scaled transform → smaller centered quad", () => {
+    const scaled: AffineTransform = [
+      [0.5, 0, 0.25],
+      [0, 0.5, 0.25],
+    ];
+    const c = getTransformBoxDocCorners(basicInput({ transform: scaled }));
+    expect(c.nw[0]).toBeCloseTo(50, 1);
+    expect(c.se[0]).toBeCloseTo(150, 1);
+    expect(c.nw[1]).toBeCloseTo(25, 1);
+    expect(c.se[1]).toBeCloseTo(75, 1);
+  });
+
+  it("container rotation 90° rotates the quad in doc-space", () => {
+    const c = getTransformBoxDocCorners(basicInput({ rotation: 90 }));
+    // 90° rotation: x → +y, y → -x. nw stays at origin; ne goes from
+    // (200,0) to (0, 200); se from (200,100) to (-100, 200); sw from
+    // (0,100) to (-100, 0).
+    expect(c.nw[0]).toBeCloseTo(0, 5);
+    expect(c.nw[1]).toBeCloseTo(0, 5);
+    expect(c.ne[0]).toBeCloseTo(0, 5);
+    expect(c.ne[1]).toBeCloseTo(200, 5);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. Hit asymmetry (D3) — Layer-B litmus test
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — hit asymmetry (D3)", () => {
+  it("side hit strip thickness strictly exceeds the visible stroke", () => {
+    // Visible stroke is `selectionOutlineWidth` (1px); side hit strip
+    // is TRANSFORM_BOX_SIDE_HIT_THICKNESS (12px). Fitts'-reach.
+    expect(TRANSFORM_BOX_SIDE_HIT_THICKNESS).toBeGreaterThan(
+      DEFAULT_STYLE.selectionOutlineWidth
+    );
+  });
+
+  it("corner hit AABB strictly contains the corner point (≥ MIN_HIT_SIZE)", () => {
+    const els = build(basicInput());
+    const corner = cornersOf(els)[0];
+    if (corner.hit.kind !== "screen_rect_at_doc") {
+      throw new Error("expected screen_rect_at_doc hit");
+    }
+    expect(corner.hit.width).toBeGreaterThanOrEqual(16);
+    expect(corner.hit.height).toBeGreaterThanOrEqual(16);
+    expect(corner.hit.width).toBe(TRANSFORM_BOX_CORNER_HIT_SIZE);
+  });
+
+  it("priority ladder: corner > side > body (lower wins)", () => {
+    expect(TRANSFORM_BOX_CORNER_PRIORITY).toBeLessThan(
+      TRANSFORM_BOX_SIDE_PRIORITY
+    );
+    expect(TRANSFORM_BOX_SIDE_PRIORITY).toBeLessThan(
+      TRANSFORM_BOX_BODY_PRIORITY
+    );
+  });
+
+  it("transform-box corner wins over corner-radius (15)", () => {
+    // corner_radius_handle uses HUDHitPriority.CornerRadiusHandle = 15.
+    expect(TRANSFORM_BOX_CORNER_PRIORITY).toBeLessThan(15);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. Hover
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — hover + cursors", () => {
+  it("body hover → cursor move", () => {
+    const els = build(basicInput());
+    expect(bodyOf(els)?.cursor).toBe("move");
+  });
+
+  it("side hover (top/bottom) → ns-resize with baseAngle", () => {
+    const els = build(basicInput());
+    const top = sidesOf(els).find(
+      (e) => e.action.kind === "transform_box_side" && e.action.side === "top"
+    );
+    expect(top?.cursor).toEqual({
+      kind: "resize",
+      direction: "n",
+      baseAngle: 0,
+    });
+  });
+
+  it("side hover (left/right) → ew-resize with baseAngle", () => {
+    const els = build(basicInput());
+    const right = sidesOf(els).find(
+      (e) => e.action.kind === "transform_box_side" && e.action.side === "right"
+    );
+    expect(right?.cursor).toEqual({
+      kind: "resize",
+      direction: "w",
+      baseAngle: 0,
+    });
+  });
+
+  it("corner hover → rotate cursor (gesture IS rotate)", () => {
+    const els = build(basicInput());
+    expect(cornersOf(els)[0].cursor).toMatchObject({
+      kind: "rotate",
+      baseAngle: 0,
+    });
+  });
+
+  it("container rotation tilts cursor baseAngle on sides + corners", () => {
+    const els = build(basicInput({ rotation: 30 }));
+    const top = sidesOf(els).find(
+      (e) => e.action.kind === "transform_box_side" && e.action.side === "top"
+    );
+    const corner = cornersOf(els)[0];
+    const expected = (30 * Math.PI) / 180;
+    expect(
+      (top?.cursor as { baseAngle: number } | undefined)?.baseAngle
+    ).toBeCloseTo(expected, 5);
+    expect(
+      (corner?.cursor as { baseAngle: number } | undefined)?.baseAngle
+    ).toBeCloseTo(expected, 5);
+  });
+
+  it("inner transform rotation composes with container into baseAngle", () => {
+    // Inner ~45° + container 30° → baseAngle ≈ 75° (rad).
+    const cos45 = Math.cos(Math.PI / 4);
+    const sin45 = Math.sin(Math.PI / 4);
+    const rotated: AffineTransform = [
+      [cos45, -sin45, 0],
+      [sin45, cos45, 0],
+    ];
+    const els = build(basicInput({ transform: rotated, rotation: 30 }));
+    const corner = cornersOf(els)[0];
+    const expected = (75 * Math.PI) / 180;
+    expect(
+      (corner?.cursor as { baseAngle: number } | undefined)?.baseAngle
+    ).toBeCloseTo(expected, 3);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Translate intent
+// ───────────────────────────────────────────────────────────────────────────
+
+function newState(input: TransformBoxInput): {
+  state: SurfaceState;
+  intents: Intent[];
+} {
+  const state = new SurfaceState();
+  state.setTransformBox(input);
+  const intents: Intent[] = [];
+  // Inject the bound id into the hit_regions so pointer-down can
+  // intercept. The chrome builder normally does this on draw; for
+  // unit tests we wire the gesture state directly.
+  return { state, intents };
+}
+
+function gestureWith(
+  state: SurfaceState,
+  input: TransformBoxInput,
+  op: TransformBoxActiveOp,
+  start_doc: cmath.Vector2
+): void {
+  // Seed the gesture as `pointer_down` would. The dispatcher then
+  // streams `pointer_move` previews from `state.gesture`.
+  (state as unknown as { gesture: unknown }).gesture = {
+    kind: "transform_box",
+    id: input.id,
+    op,
+    size: input.size,
+    rotation: input.rotation ?? 0,
+    base_transform: input.transform,
+    start_doc,
+    last_doc: start_doc,
+    transform: input.transform,
+    dragged: false,
+  };
+}
+
+describe("transform-box — translate intent", () => {
+  it("body drag emits transform_box preview with op.type translate", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "translate" }, [0, 0]);
+    state.dispatch(
+      { kind: "pointer_move", x: 40, y: 20, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box") {
+      throw new Error(`expected transform_box intent, got ${last.kind}`);
+    }
+    expect(last.op.type).toBe("translate");
+    expect(last.phase).toBe("preview");
+    // 40 / 200 = 0.2; 20 / 100 = 0.2 — box-relative normalized.
+    expect(last.transform[0][2]).toBeCloseTo(0.2, 3);
+    expect(last.transform[1][2]).toBeCloseTo(0.2, 3);
+  });
+
+  it("pointer_up after drag emits a single commit", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "translate" }, [0, 0]);
+    const deps = {
+      pick: () => null,
+      shapeOf: () => null,
+      emitIntent: (i: Intent) => intents.push(i),
+    };
+    state.dispatch({ kind: "pointer_move", x: 40, y: 20, mods: NO_MODS }, deps);
+    state.dispatch(
+      { kind: "pointer_up", x: 40, y: 20, button: "primary", mods: NO_MODS },
+      deps
+    );
+    const commits = intents.filter(
+      (i) => i.kind === "transform_box" && i.phase === "commit"
+    );
+    expect(commits.length).toBe(1);
+  });
+
+  it("click-no-drag emits NO commit (dragged guard)", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "translate" }, [0, 0]);
+    const deps = {
+      pick: () => null,
+      shapeOf: () => null,
+      emitIntent: (i: Intent) => intents.push(i),
+    };
+    // No pointer_move — straight to up.
+    state.dispatch(
+      { kind: "pointer_up", x: 0, y: 0, button: "primary", mods: NO_MODS },
+      deps
+    );
+    expect(intents.length).toBe(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Scale-side intent
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — scale-side intent", () => {
+  it("right-side drag emits transform_box with op.type scale_side, side right", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "scale_side", side: "right" }, [200, 50]);
+    state.dispatch(
+      { kind: "pointer_move", x: 220, y: 50, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box" || last.op.type !== "scale_side") {
+      throw new Error("expected transform_box/scale_side intent");
+    }
+    expect(last.op.side).toBe("right");
+  });
+
+  it("delta=0 produces identity reduction (still emits)", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "scale_side", side: "right" }, [200, 50]);
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 50, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box") {
+      throw new Error(`expected transform_box intent, got ${last.kind}`);
+    }
+    // Reducer returns the base transform when delta projects to zero.
+    expect(last.transform[0][0]).toBeCloseTo(1);
+    expect(last.transform[1][1]).toBeCloseTo(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. Rotate intent
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — rotate intent", () => {
+  it("corner drag emits transform_box with op.type rotate, corner matches", () => {
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "rotate", corner: "ne" }, [200, 0]);
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 20, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box" || last.op.type !== "rotate") {
+      throw new Error("expected transform_box/rotate intent");
+    }
+    expect(last.op.corner).toBe("ne");
+  });
+
+  it("live cursor baseAngle tracks the box rotation during the drag", () => {
+    // Same precedent as the selection-box rotate gesture
+    // (`initial_cursor_angle + delta` set via `setCursor` per move).
+    // Pin: after a meaningful rotation drag, the surface cursor's
+    // `baseAngle` is close to the box's new effective rotation, NOT
+    // stuck at the gesture-start value.
+    const input = basicInput();
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "rotate", corner: "ne" }, [200, 0]);
+    state.dispatch(
+      { kind: "pointer_move", x: 200, y: 40, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i: Intent) => intents.push(i),
+      }
+    );
+    // After a rotation drag, the cursor's `baseAngle` should be
+    // non-zero — the gesture set it via setCursor on pointer_move.
+    const cursor = (state as unknown as { cursor: unknown }).cursor;
+    if (
+      !cursor ||
+      typeof cursor !== "object" ||
+      (cursor as { kind?: string }).kind !== "rotate"
+    ) {
+      throw new Error(`expected rotate cursor, got ${JSON.stringify(cursor)}`);
+    }
+    const ba = (cursor as { baseAngle: number }).baseAngle;
+    expect(Math.abs(ba)).toBeGreaterThan(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 8. Container rotation de-rotation
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — container rotation", () => {
+  it("quad renders rotated by container rotation", () => {
+    const c = getTransformBoxDocCorners(basicInput({ rotation: 30 }));
+    // 30° rotation: nw stays at origin; ne goes from (200, 0) to
+    // (200*cos30, 200*sin30) ≈ (173.2, 100).
+    expect(c.ne[0]).toBeCloseTo(173.2, 1);
+    expect(c.ne[1]).toBeCloseTo(100, 1);
+  });
+
+  it("intent transform stays in box-relative space when container is rotated", () => {
+    // With container rotation=90° CCW: box's local +X axis points
+    // along doc +Y, so doc +X is box -Y. A doc-delta of [+40, 0]
+    // de-rotates by -90° to box-local [0, -40], producing a
+    // box-relative ty of -40/100 = -0.4 on Y, tx of 0 on X.
+    const input = basicInput({ rotation: 90 });
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "translate" }, [0, 0]);
+    state.dispatch(
+      { kind: "pointer_move", x: 40, y: 0, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box") {
+      throw new Error(`expected transform_box intent, got ${last.kind}`);
+    }
+    expect(last.transform[0][2]).toBeCloseTo(0, 3);
+    expect(last.transform[1][2]).toBeCloseTo(-0.4, 3);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 9. Decision classifier
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — classifier", () => {
+  const baseClassifyInput = {
+    hovered_id: null,
+    selection_ids: [] as readonly string[],
+    modifiers: NO_MODS,
+    click_count: 1,
+    readonly: false,
+    in_content_edit: false,
+  };
+
+  it("body action → HandleTransformBoxDrag", () => {
+    const s = classifyScenario({
+      ...baseClassifyInput,
+      ui_action: { kind: "transform_box_body", id: "tb-1" },
+    });
+    expect(s).toBe(Scenario.HandleTransformBoxDrag);
+  });
+
+  it("side action → HandleTransformBoxDrag", () => {
+    const s = classifyScenario({
+      ...baseClassifyInput,
+      ui_action: {
+        kind: "transform_box_side",
+        id: "tb-1",
+        side: "top",
+        base_angle: 0,
+      },
+    });
+    expect(s).toBe(Scenario.HandleTransformBoxDrag);
+  });
+
+  it("corner action → HandleTransformBoxDrag", () => {
+    const s = classifyScenario({
+      ...baseClassifyInput,
+      ui_action: {
+        kind: "transform_box_corner",
+        id: "tb-1",
+        corner: "nw",
+        base_angle: 0,
+      },
+    });
+    expect(s).toBe(Scenario.HandleTransformBoxDrag);
+  });
+
+  it("readonly mode → all 3 kinds → Noop", () => {
+    for (const ui_action of [
+      { kind: "transform_box_body" as const, id: "tb-1" },
+      {
+        kind: "transform_box_side" as const,
+        id: "tb-1",
+        side: "top" as cmath.RectangleSide,
+        base_angle: 0,
+      },
+      {
+        kind: "transform_box_corner" as const,
+        id: "tb-1",
+        corner: "nw" as cmath.IntercardinalDirection,
+        base_angle: 0,
+      },
+    ]) {
+      const s = classifyScenario({
+        ...baseClassifyInput,
+        ui_action,
+        readonly: true,
+      });
+      expect(s).toBe(Scenario.Noop);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 10. Equality + ID echo
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("transform-box — id echo through intent", () => {
+  it("intent echoes the input's id, not a synthesized value", () => {
+    const input = basicInput({ id: "custom-id-42" });
+    const { state, intents } = newState(input);
+    gestureWith(state, input, { type: "translate" }, [0, 0]);
+    state.dispatch(
+      { kind: "pointer_move", x: 10, y: 10, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const last = intents[intents.length - 1];
+    if (last.kind !== "transform_box") {
+      throw new Error(`expected transform_box intent, got ${last.kind}`);
+    }
+    expect(last.id).toBe("custom-id-42");
+  });
+});

--- a/packages/grida-canvas-hud/__tests__/classes/vector-path/gesture.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/vector-path/gesture.test.ts
@@ -5,10 +5,10 @@
 // in vector-chrome-extended.test.ts.
 
 import { describe, it, expect } from "vitest";
-import { SurfaceState, type StateDeps } from "../event/state";
-import type { Intent } from "../event/intent";
-import { NO_MODS } from "../event/event";
-import { HitRegions } from "../event/hit-regions";
+import { SurfaceState, type StateDeps } from "../../../event/state";
+import type { Intent } from "../../../event/intent";
+import { NO_MODS } from "../../../event/event";
+import { HitRegions } from "../../../event/hit-regions";
 
 function makeDeps(): { deps: StateDeps; intents: Intent[] } {
   const intents: Intent[] = [];
@@ -644,9 +644,7 @@ describe("segment_strip / ghost_handle pointer-down — select / split / bend", 
   });
 
   // UX spec: default segment-body drag (no modifier) is a TRANSLATE of
-  // the sub-selection, NOT a bend. Mirrors the main editor's default
-  // cursor-tool behavior (`ve.onDragStart()` in
-  // `surface-vector-editor.tsx:339`). Bend is reserved for Meta-down
+  // the sub-selection, NOT a bend. Bend is reserved for Meta-down
   // (covered below).
   it("segment-body drag WITHOUT Meta promotes to translate_vector_selection + emits preview", () => {
     const state = new SurfaceState();
@@ -708,8 +706,7 @@ describe("segment_strip / ghost_handle pointer-down — select / split / bend", 
   });
 
   // UX spec: holding Meta during a segment-body drag switches the
-  // promotion to `bend_segment`. Mirrors the main editor's bend-tool
-  // keybind (`hotkeys.tsx:200-224`).
+  // promotion to `bend_segment`.
   it("segment-body drag WITH Meta promotes to bend_segment + emits preview", () => {
     const state = new SurfaceState();
     const { deps, intents } = makeDeps();
@@ -815,8 +812,7 @@ describe("segment_strip / ghost_handle pointer-down — select / split / bend", 
 // inserted. Matches Figma's pen/segment-add behaviour.
 describe("ghost split-and-drag (eager insert + translate)", () => {
   // Test fixture: a host that echoes setVectorSelection synchronously
-  // when it sees a split_segment intent. Mirrors svg-editor's actual
-  // `handle_split_segment` behaviour, which inserts the new vertex AND
+  // when it sees a split_segment intent — inserts the new vertex AND
   // pushes the selection mirror back to the HUD in the same call stack.
   function makeSplitEchoingDeps(state: SurfaceState): {
     deps: StateDeps;

--- a/packages/grida-canvas-hud/__tests__/classes/vector-path/region.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/vector-path/region.test.ts
@@ -1,0 +1,638 @@
+// Tests for vector region chrome — closed-loop body overlays during path
+// content-edit.
+//
+// Pins:
+//   - Schema-level feature flag: absence of `VectorOverlay.regions` =
+//     no region overlays. Presence enables.
+//   - Hit-test: AABB plus `customHitTest` (point-in-polygon) — inside
+//     loop hits, outside misses.
+//   - Hit-priority slot: REGION_PRIORITY (9), strictly above
+//     SEGMENT_STRIP_PRIORITY (8); region loses to every specific control
+//     within its bbox.
+//   - Hover / selected paint: `vectorRegionHoverPaint` / `vectorRegionSelectedPaint`
+//     from HUDStyle. Hover wins over selected.
+//   - Idle = no render (transparent body).
+//   - Action carries `region`, `segments`, `vertices` for the drag-promotion
+//     path.
+//   - Decision: classifies as HandleRegionReplace / HandleRegionAdd;
+//     dispatches `immediate_select_region` with `translate_vector_selection`
+//     drag promotion seeded with the loop's endpoint vertex indices.
+//   - SurfaceState integration: pointer_down emits `select_region` eagerly.
+
+import { describe, it, expect } from "vitest";
+import cmath from "@grida/cmath";
+import { buildVectorChrome } from "../../../classes/vector-path";
+import type { VectorOverlay } from "../../../classes/vector-path";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import {
+  classifyScenario,
+  decidePointerDown,
+  Scenario,
+  type PointerDownDecision,
+  type PointerDownInput,
+} from "../../../event/decision";
+import { NO_MODS } from "../../../event/event";
+import { SurfaceState } from "../../../event/state";
+import type { OverlayElement } from "../../../event/overlay";
+import type { Intent } from "../../../event/intent";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Square loop, 4 segments, vertices 0..3 in CCW order. */
+function squareOverlay(): VectorOverlay {
+  return {
+    vertices: [
+      [0, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100],
+    ],
+    segments: [
+      { a: 0, b: 1, a_control: [0, 0], b_control: [100, 0] }, // top
+      { a: 1, b: 2, a_control: [100, 0], b_control: [100, 100] }, // right
+      { a: 2, b: 3, a_control: [100, 100], b_control: [0, 100] }, // bottom
+      { a: 3, b: 0, a_control: [0, 100], b_control: [0, 0] }, // left
+    ],
+    regions: [{ segments: [0, 1, 2, 3] }],
+  };
+}
+
+/** Annulus — outer square loop (segments 0..3) + inner square loop
+ *  (segments 4..7). Two regions; the inner loop's interior is a "hole"
+ *  in the outer ring. */
+function annulusOverlay(): VectorOverlay {
+  return {
+    vertices: [
+      // outer
+      [0, 0],
+      [100, 0],
+      [100, 100],
+      [0, 100],
+      // inner (40..60 box, inset 40px)
+      [40, 40],
+      [60, 40],
+      [60, 60],
+      [40, 60],
+    ],
+    segments: [
+      { a: 0, b: 1, a_control: [0, 0], b_control: [100, 0] },
+      { a: 1, b: 2, a_control: [100, 0], b_control: [100, 100] },
+      { a: 2, b: 3, a_control: [100, 100], b_control: [0, 100] },
+      { a: 3, b: 0, a_control: [0, 100], b_control: [0, 0] },
+      { a: 4, b: 5, a_control: [40, 40], b_control: [60, 40] },
+      { a: 5, b: 6, a_control: [60, 40], b_control: [60, 60] },
+      { a: 6, b: 7, a_control: [60, 60], b_control: [40, 60] },
+      { a: 7, b: 4, a_control: [40, 60], b_control: [40, 40] },
+    ],
+    regions: [
+      { segments: [0, 1, 2, 3] }, // outer
+      { segments: [4, 5, 6, 7] }, // inner
+    ],
+  };
+}
+
+function emptySelection(node_id = "n1") {
+  return { node_id, vertices: [], segments: [], tangents: [] };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. Feature flag — schema-level opt-in
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — feature flag (schema-level)", () => {
+  it("emits NO region overlays when `regions` is undefined", () => {
+    const overlay: VectorOverlay = squareOverlay();
+    delete (overlay as { regions?: unknown }).regions;
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: overlay,
+      style: DEFAULT_STYLE,
+    });
+    expect(overlays.find((o) => o.action.kind === "region")).toBeUndefined();
+  });
+
+  it("emits NO region overlays when `regions` is empty array", () => {
+    const overlay = { ...squareOverlay(), regions: [] };
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: overlay,
+      style: DEFAULT_STYLE,
+    });
+    expect(overlays.find((o) => o.action.kind === "region")).toBeUndefined();
+  });
+
+  it("emits one region overlay per entry in `regions`", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const regions = overlays.filter((o) => o.action.kind === "region");
+    expect(regions.length).toBe(1);
+  });
+
+  it("emits N overlays for multi-region overlay", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: annulusOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const regions = overlays.filter((o) => o.action.kind === "region");
+    expect(regions.length).toBe(2);
+  });
+
+  it("requires `segments` to be present (no segments = no region chrome)", () => {
+    // Regions reference segment indices — without segment data, chrome
+    // can't reconstruct the cubic loop. Region emission gated by both.
+    const overlay: VectorOverlay = {
+      vertices: [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+      ],
+      regions: [{ segments: [0, 1, 2] }],
+    };
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: overlay,
+      style: DEFAULT_STYLE,
+    });
+    expect(overlays.find((o) => o.action.kind === "region")).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. Hit-test geometry
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — hit-test", () => {
+  function regionEl(o: OverlayElement | undefined) {
+    if (!o) throw new Error("no region overlay");
+    if (o.hit.kind !== "screen_aabb") throw new Error("expected screen_aabb");
+    return { hit: o.hit, customHitTest: o.customHitTest! };
+  }
+
+  it("hit AABB encloses the square loop in screen-space (identity transform)", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const r = regionEl(overlays.find((o) => o.action.kind === "region"));
+    // Square 0..100 with 1px AABB pad → -1..101.
+    expect(r.hit.rect.x).toBeLessThanOrEqual(0);
+    expect(r.hit.rect.y).toBeLessThanOrEqual(0);
+    expect(r.hit.rect.x + r.hit.rect.width).toBeGreaterThanOrEqual(100);
+    expect(r.hit.rect.y + r.hit.rect.height).toBeGreaterThanOrEqual(100);
+  });
+
+  it("customHitTest accepts a point inside the loop", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const r = regionEl(overlays.find((o) => o.action.kind === "region"));
+    expect(r.customHitTest([50, 50])).toBe(true);
+  });
+
+  it("customHitTest rejects a point outside the loop", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const r = regionEl(overlays.find((o) => o.action.kind === "region"));
+    expect(r.customHitTest([-10, -10])).toBe(false);
+    expect(r.customHitTest([200, 50])).toBe(false);
+  });
+
+  it("annulus: outer region hit by [50, 50] AND inner [50, 50] (both contain it)", () => {
+    // Both overlays are emitted — the registry's priority resolves at
+    // hit-time; here we just assert each loop's polygon contains [50, 50]
+    // (the annulus center).
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: annulusOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const regions = overlays.filter((o) => o.action.kind === "region");
+    expect(regions.length).toBe(2);
+    for (const o of regions) {
+      expect(o.customHitTest!([50, 50])).toBe(true);
+    }
+  });
+
+  it("inner-only point — annulus outer accepts, outer-only point — annulus inner rejects", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: annulusOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const regions = overlays.filter((o) => o.action.kind === "region");
+    const outer = regions[0];
+    const inner = regions[1];
+    // [10, 50] is inside outer (0..100), outside inner (40..60).
+    expect(outer.customHitTest!([10, 50])).toBe(true);
+    expect(inner.customHitTest!([10, 50])).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. Hit-priority — region loses to specific controls, wins over miss
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — hit priority", () => {
+  it("region priority is strictly above segment-strip priority (lower wins)", () => {
+    // We don't export the constants directly, but priority is observable
+    // on the emitted OverlayElement. The plan: REGION_PRIORITY = 9,
+    // SEGMENT_STRIP_PRIORITY = 8 → segment numerically lower → wins.
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    const segment_strip = overlays.find(
+      (o) => o.label.startsWith("segment:") && !o.label.startsWith("segment_")
+    )!;
+    expect(segment_strip.priority).toBeLessThan(region.priority);
+  });
+
+  it("region priority is strictly above vertex / tangent / ghost priorities", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    const vertex = overlays.find((o) => o.action.kind === "vertex_handle")!;
+    expect(vertex.priority).toBeLessThan(region.priority);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. Paint states — idle / hover / selected
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — paint states", () => {
+  function findRegionRender(
+    overlay: VectorOverlay,
+    opts: {
+      selected?: readonly number[];
+      hovered?: number;
+    }
+  ) {
+    const { overlays } = buildVectorChrome({
+      vector_selection: {
+        ...emptySelection(),
+        regions: opts.selected,
+      },
+      vector_overlay: overlay,
+      style: DEFAULT_STYLE,
+      vector_hover:
+        opts.hovered !== undefined
+          ? { kind: "region", node_id: "n1", region: opts.hovered }
+          : null,
+    });
+    return overlays.find((o) => o.action.kind === "region");
+  }
+
+  it("idle: no render — transparent body, hit-only", () => {
+    const r = findRegionRender(squareOverlay(), {});
+    expect(r).toBeDefined();
+    expect(r!.render).toBeUndefined();
+  });
+
+  it("hovered: render with vectorRegionHoverPaint", () => {
+    const r = findRegionRender(squareOverlay(), { hovered: 0 });
+    expect(r!.render).toBeDefined();
+    if (r!.render?.kind !== "doc_polyline") throw new Error("kind");
+    expect(r!.render.fill).toBe(true);
+    expect(r!.render.fillPaint).toBe(DEFAULT_STYLE.vectorRegionHoverPaint);
+  });
+
+  it("selected (not hovered): render with vectorRegionSelectedPaint", () => {
+    const r = findRegionRender(squareOverlay(), { selected: [0] });
+    if (r!.render?.kind !== "doc_polyline") throw new Error("kind");
+    expect(r!.render.fillPaint).toBe(DEFAULT_STYLE.vectorRegionSelectedPaint);
+  });
+
+  it("hovered AND selected: hover wins (precedence with other vector overlays)", () => {
+    const r = findRegionRender(squareOverlay(), { hovered: 0, selected: [0] });
+    if (r!.render?.kind !== "doc_polyline") throw new Error("kind");
+    expect(r!.render.fillPaint).toBe(DEFAULT_STYLE.vectorRegionHoverPaint);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Closed loop — polyline closes
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — render polyline closes", () => {
+  it("last point equals first point (closed loop)", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+      vector_hover: { kind: "region", node_id: "n1", region: 0 },
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    if (region.render?.kind !== "doc_polyline") throw new Error("kind");
+    const pts = region.render.points;
+    expect(pts[0]).toEqual(pts[pts.length - 1]);
+  });
+
+  it("polyline has more than 3 samples per segment (curved loops render smoothly)", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+      vector_hover: { kind: "region", node_id: "n1", region: 0 },
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    if (region.render?.kind !== "doc_polyline") throw new Error("kind");
+    // 4 segments × N samples + 1 closing point. At least 4 × 4 = 16.
+    expect(region.render.points.length).toBeGreaterThan(16);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Action payload — segments + vertices carried for host routing
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — action payload", () => {
+  it("carries node_id, region index, and segment list", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    expect(region.action.kind).toBe("region");
+    if (region.action.kind !== "region") return;
+    expect(region.action.node_id).toBe("n1");
+    expect(region.action.region).toBe(0);
+    expect(region.action.segments).toEqual([0, 1, 2, 3]);
+  });
+
+  it("vertices field carries the union of segment endpoint indices", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    if (region.action.kind !== "region") return;
+    // Square has 4 distinct vertices (0..3).
+    expect(region.action.vertices.length).toBe(4);
+    expect(new Set(region.action.vertices)).toEqual(new Set([0, 1, 2, 3]));
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. Decision module — classifier + dispatch
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("decision — region pointer-down", () => {
+  const action = {
+    kind: "region" as const,
+    node_id: "n1",
+    region: 0,
+    segments: [0, 1, 2, 3] as readonly number[],
+    vertices: [0, 1, 2, 3] as readonly number[],
+  };
+
+  function input(overrides: Partial<PointerDownInput>): PointerDownInput {
+    return {
+      ui_action: action,
+      hovered_id: null,
+      selection_ids: [],
+      modifiers: NO_MODS,
+      click_count: 1,
+      readonly: false,
+      ...overrides,
+    };
+  }
+
+  it("no-shift: classifies HandleRegionReplace", () => {
+    expect(classifyScenario(input({}))).toBe(Scenario.HandleRegionReplace);
+  });
+
+  it("shift: classifies HandleRegionAdd", () => {
+    expect(
+      classifyScenario(input({ modifiers: { ...NO_MODS, shift: true } }))
+    ).toBe(Scenario.HandleRegionAdd);
+  });
+
+  it("readonly: classifies Noop (no mutation)", () => {
+    expect(classifyScenario(input({ readonly: true }))).toBe(Scenario.Noop);
+  });
+
+  it("dispatches immediate_select_region with mode 'replace'", () => {
+    const d = decidePointerDown(input({})) as Extract<
+      PointerDownDecision,
+      { kind: "immediate_select_region" }
+    >;
+    expect(d.kind).toBe("immediate_select_region");
+    expect(d.node_id).toBe("n1");
+    expect(d.region).toBe(0);
+    expect(d.mode).toBe("replace");
+  });
+
+  it("dispatches immediate_select_region with mode 'toggle' under shift", () => {
+    const d = decidePointerDown(
+      input({ modifiers: { ...NO_MODS, shift: true } })
+    ) as Extract<PointerDownDecision, { kind: "immediate_select_region" }>;
+    expect(d.mode).toBe("toggle");
+  });
+
+  it("drag-promotion seeds translate_vector_selection with loop vertices", () => {
+    const d = decidePointerDown(input({})) as Extract<
+      PointerDownDecision,
+      { kind: "immediate_select_region" }
+    >;
+    expect(d.pending.promote_to?.kind).toBe("translate_vector_selection");
+    if (d.pending.promote_to?.kind !== "translate_vector_selection") return;
+    expect(d.pending.promote_to.additional_vertex_indices).toEqual([
+      0, 1, 2, 3,
+    ]);
+  });
+
+  it("dblclick on region in content-edit does NOT exit content-edit", () => {
+    // Region is a vector-control overlay — dblclick stays inside content-edit
+    // and routes through the regular pointer-down path. The Tier-0 ExitEdit
+    // rule should NOT fire for a region hit.
+    const i = input({ in_content_edit: true, click_count: 2 });
+    expect(classifyScenario(i)).not.toBe(Scenario.ExitEdit);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 8. SurfaceState integration — emit select_region on pointer_down
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("SurfaceState — region pointer_down emits select_region eagerly", () => {
+  function setup() {
+    const state = new SurfaceState();
+    // Push a vector mirror so the surface knows we're in content-edit.
+    state.setVectorSelection({
+      node_id: "n1",
+      vertices: [],
+      segments: [],
+      tangents: [],
+    });
+    // Register a region hit region directly (bypass chrome — we're
+    // testing dispatch).
+    const regions = state.hitRegions();
+    regions.push({
+      label: "region:0",
+      priority: 9,
+      rect: { x: 0, y: 0, width: 200, height: 200 },
+      customHitTest: (pt) =>
+        cmath.polygon.pointInPolygon(pt, [
+          [0, 0],
+          [100, 0],
+          [100, 100],
+          [0, 100],
+        ]),
+      action: {
+        kind: "region",
+        node_id: "n1",
+        region: 0,
+        segments: [0, 1, 2, 3],
+        vertices: [0, 1, 2, 3],
+      },
+    });
+    return state;
+  }
+
+  it("emits select_region intent on pointer_down inside the loop", () => {
+    const state = setup();
+    const intents: Intent[] = [];
+    state.dispatch(
+      { kind: "pointer_down", x: 50, y: 50, button: "primary", mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const r = intents.find((i) => i.kind === "select_region");
+    expect(r).toBeDefined();
+    if (r?.kind !== "select_region") return;
+    expect(r.node_id).toBe("n1");
+    expect(r.region).toBe(0);
+    expect(r.mode).toBe("replace");
+  });
+
+  it("emits with mode 'toggle' under shift", () => {
+    const state = setup();
+    const intents: Intent[] = [];
+    state.dispatch(
+      {
+        kind: "pointer_down",
+        x: 50,
+        y: 50,
+        button: "primary",
+        mods: { ...NO_MODS, shift: true },
+      },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    const r = intents.find((i) => i.kind === "select_region");
+    if (r?.kind !== "select_region") throw new Error("missing");
+    expect(r.mode).toBe("toggle");
+  });
+
+  it("does NOT emit select_region when pointer_down lands outside the loop", () => {
+    const state = setup();
+    const intents: Intent[] = [];
+    state.dispatch(
+      {
+        kind: "pointer_down",
+        x: 500,
+        y: 500,
+        button: "primary",
+        mods: NO_MODS,
+      },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: (i) => intents.push(i),
+      }
+    );
+    expect(intents.find((i) => i.kind === "select_region")).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 9. Hover — vectorHoverFromAction
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("SurfaceState — region hover", () => {
+  it("pointer_move over a region action sets vector_hover.kind = 'region'", () => {
+    const state = new SurfaceState();
+    state.setVectorSelection({
+      node_id: "n1",
+      vertices: [],
+      segments: [],
+      tangents: [],
+    });
+    state.hitRegions().push({
+      label: "region:0",
+      priority: 9,
+      rect: { x: 0, y: 0, width: 200, height: 200 },
+      customHitTest: (pt) =>
+        cmath.polygon.pointInPolygon(pt, [
+          [0, 0],
+          [100, 0],
+          [100, 100],
+          [0, 100],
+        ]),
+      action: {
+        kind: "region",
+        node_id: "n1",
+        region: 0,
+        segments: [0, 1, 2, 3],
+        vertices: [0, 1, 2, 3],
+      },
+    });
+    state.dispatch(
+      { kind: "pointer_move", x: 50, y: 50, mods: NO_MODS },
+      {
+        pick: () => null,
+        shapeOf: () => null,
+        emitIntent: () => {},
+      }
+    );
+    const h = state.getVectorHover();
+    expect(h).toBeDefined();
+    expect(h?.kind).toBe("region");
+    if (h?.kind !== "region") return;
+    expect(h.region).toBe(0);
+    expect(h.node_id).toBe("n1");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 10. Group propagation — semantic group flows to the region overlay
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("region — semantic group", () => {
+  it("propagates the input `group` to the emitted overlay", () => {
+    const { overlays } = buildVectorChrome({
+      vector_selection: emptySelection(),
+      vector_overlay: squareOverlay(),
+      style: DEFAULT_STYLE,
+      group: "vectorChrome",
+    });
+    const region = overlays.find((o) => o.action.kind === "region")!;
+    expect(region.group).toBe("vectorChrome");
+  });
+});

--- a/packages/grida-canvas-hud/__tests__/classes/vector-path/segment-render.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/vector-path/segment-render.test.ts
@@ -4,9 +4,9 @@
 // variants.
 
 import { describe, it, expect } from "vitest";
-import { buildVectorChrome } from "../surface/vector-chrome";
-import { DEFAULT_STYLE } from "../surface/style";
-import type { VectorOverlay } from "../surface/vector-chrome";
+import { buildVectorChrome } from "../../../classes/vector-path";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import type { VectorOverlay } from "../../../classes/vector-path";
 
 const SEG_OVERLAY: VectorOverlay = {
   vertices: [

--- a/packages/grida-canvas-hud/__tests__/classes/vector-path/surface-extended.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/vector-path/surface-extended.test.ts
@@ -6,9 +6,9 @@
 // - Segment hit-strip emission (VIRTUAL — no render, only hit regions)
 
 import { describe, it, expect } from "vitest";
-import { buildVectorChrome } from "../surface/vector-chrome";
-import { DEFAULT_STYLE } from "../surface/style";
-import type { VectorOverlay } from "../surface/vector-chrome";
+import { buildVectorChrome } from "../../../classes/vector-path";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import type { VectorOverlay } from "../../../classes/vector-path";
 
 // A single cubic segment from (0,0) → (10,0) with both tangents pointing
 // up by 5 px → produces an arc-shaped curve.
@@ -120,10 +120,10 @@ describe("buildVectorChrome — tangent emission", () => {
   });
 
   it("tangent knobs render as a diamond — smaller than vertex knobs", () => {
-    // UX rule (mirrors the main editor): tangent knobs render as a 45°-
-    // rotated square ("diamond") at ~0.75× the vertex knob size, so the user
-    // can tell tangents apart from vertices at a glance. Shape stays "rect"
-    // (the renderer rotates it); circle is reserved for vertices.
+    // UX rule: tangent knobs render as a 45°-rotated square ("diamond")
+    // at ~0.75× the vertex knob size, so the user can tell tangents apart
+    // from vertices at a glance. Shape stays "rect" (the renderer rotates
+    // it); circle is reserved for vertices.
     const { overlays } = buildVectorChrome({
       vector_selection: {
         node_id: "n1",

--- a/packages/grida-canvas-hud/__tests__/classes/vector-path/surface.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/vector-path/surface.test.ts
@@ -5,10 +5,10 @@
 // hit region strictly contains the render rect on each axis (Fitts').
 
 import { describe, it, expect } from "vitest";
-import { buildVectorChrome } from "../surface/vector-chrome";
-import { DEFAULT_STYLE } from "../surface/style";
-import { MIN_HIT_SIZE } from "../event/overlay";
-import type { VectorOverlay } from "../surface/vector-chrome";
+import { buildVectorChrome } from "../../../classes/vector-path";
+import { DEFAULT_STYLE } from "../../../surface/style";
+import { MIN_HIT_SIZE } from "../../../event/overlay";
+import type { VectorOverlay } from "../../../classes/vector-path";
 
 function rectFromHit(
   hit: ReturnType<typeof buildVectorChrome>["overlays"][number]["hit"]

--- a/packages/grida-canvas-hud/__tests__/composition/README.md
+++ b/packages/grida-canvas-hud/__tests__/composition/README.md
@@ -55,7 +55,7 @@ A matrix-row test for a **flicker probe** (diagonal cell, multi-instance of the 
 
 ## Test layout
 
-```
+```text
 __tests__/composition/
 ├── README.md           # this file
 ├── co-target.test.ts   # the matrix — lands with the first per-class migration into classes/

--- a/packages/grida-canvas-hud/__tests__/composition/README.md
+++ b/packages/grida-canvas-hud/__tests__/composition/README.md
@@ -1,0 +1,76 @@
+# `__tests__/composition/` — co-target test matrix
+
+This folder hosts the tests that enforce the [composition contract](../../README.md#composition-contract) — the package's central guarantee that any combination of named classes co-targeting the same logical thing via a shared `id` resolves to a deterministic, coherent hover/hit/cursor/intent stream.
+
+`co-target.test.ts` exists today with the **first cell** of the matrix — `padding × transform-box`. Five assertions: documented priority ladder holds, both classes co-exist in one registry, transform-box-only hit returns the tb action (no padding phantom-hit), empty-space returns null, adding transform-box does not shift padding's hit results. Subsequent migrations grow the matrix: each new class adds one row + one column. The matrix is verbose but mechanical; the value is the coverage, not the elegance.
+
+This README documents the planned full matrix shape so each migration knows what cells to add.
+
+## Why a matrix
+
+Hover, hit-test, and cursor are _cross-class_ concerns. They cannot be unit-tested inside any single class — by construction, a class's tests only see its own overlays. The composition contract is the SDK's promise that _no combination_ of classes produces a phantom hit, a flickering hover, a stuck cursor, or a non-deterministic intent. The only way to enforce that promise is a matrix that exercises every pair (and later, every triple where co-targeting on one `id` is realistic).
+
+A class that ships without a matrix row for every existing class is shipping unverified composition behavior. The promotion contract makes this a gate: a migration PR doesn't merge until its matrix rows do.
+
+## Matrix shape
+
+Rows and columns are classes. Each off-diagonal cell describes what happens when both classes target the same `id` and both their hit regions overlap at the pointer.
+
+The matrix is symmetric in the sense that the _contract_ it enforces is symmetric (no phantom hits in either direction), but the _expected resolution_ may differ per direction (e.g. corner-radius wins inside the corner, padding wins outside it — the cell records the winner from the pointer's perspective).
+
+Diagonal cells (class × itself) capture multi-instance behavior — two instances of the same class with different `id`s, hit regions touching. Tests assert that hover identity is stable (no flicker between the two `id`s on a pixel-stable pointer position) and that intents stream from the resolved-winner's `id`.
+
+## Initial matrix (post-migration target)
+
+Once all the candidate migrations under [`classes/README.md`](../../classes/README.md#promotion-bar-dry-run) land, the matrix below is what `co-target.test.ts` covers. Cells marked **N/A** are class pairs that cannot share an `id` in practice (e.g. vector-path requires a path; padding requires a rect).
+
+**N/A cells require no test code, only an entry in the matrix above.** The promotion contract is satisfied by marking the cell N/A with a one-line justification — the matrix exists so reviewers can confirm the impossibility, not as a checkbox exercise. A class can promote with all of its row's cells being N/A as long as each is explicitly marked.
+
+|                       | padding                     | corner-radius                                                                   | transform-box                                                                                                      | parametric-handle                                                             | vector-path                                                                                                        | resize-box                                                                                                                                                                                                       | selection-outline                                          | marquee                                                                           | lasso                                          |
+| --------------------- | --------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **padding**           | flicker probe (2 instances) | corner wins inside corner; padding wins along sides; no flicker on the boundary | scale-side beats padding-handle on the same side (transform-box is the active edit; padding is the passive layout) | parametric-handle wins on its knob; padding wins on side regions              | N/A                                                                                                                | resize-handle wins on corner/side knobs; padding wins between knobs; no double-commit on shared region                                                                                                           | outline draws under both classes; no hit contribution      | starts only from empty space — N/A unless host puts padding overlay on empty area | same as marquee — N/A                          |
+| **corner-radius**     | (mirror of above)           | flicker probe                                                                   | corner-of-corner-radius vs corner-of-transform-box on the same corner — transform-box wins (priority 13 < 15)      | both are knob classes; pick deterministically by priority + declaration order | N/A                                                                                                                | resize-handle on the corner beats corner-radius (resize-handle is the immediate selection chrome)                                                                                                                | outline under both                                         | N/A                                                                               | N/A                                            |
+| **transform-box**     | (mirror)                    | (mirror)                                                                        | flicker probe (2 instances should not happen in practice but the test pins behavior)                               | transform-box corner/side wins over parametric on the rect's perimeter        | N/A — transform-box edits an inner affine on a rectangular region; vector-path edits a path. Cannot share an `id`. | **decision: same model question.** When both classes exist, audit folds may merge them. Until then: resize-handle priority dominates on the outer rect; transform-box on the inner affine. Two `id`s, never one. | outline under both                                         | N/A                                                                               | N/A                                            |
+| **parametric-handle** | (mirror)                    | (mirror)                                                                        | (mirror)                                                                                                           | flicker probe (multiple knobs on the same id — already the default usage)     | parametric knob inside a vector path region resolves to the knob (knob priority < region)                          | resize-handle beats parametric on the rect's corners; parametric wins elsewhere                                                                                                                                  | outline under both                                         | N/A                                                                               | N/A                                            |
+| **vector-path**       | N/A                         | N/A                                                                             | N/A                                                                                                                | (mirror)                                                                      | flicker probe (2 paths overlapping in screen-space)                                                                | N/A — vector-path is its own edit mode; resize-box does not apply during path edit                                                                                                                               | outline under both                                         | N/A                                                                               | N/A                                            |
+| **resize-box**        | (mirror)                    | (mirror)                                                                        | (mirror)                                                                                                           | (mirror)                                                                      | N/A                                                                                                                | flicker probe (2 selections; multi-select group is one resize-box)                                                                                                                                               | outline under both — resize-box knobs always above outline | starts from empty space — N/A                                                     | starts from empty space — N/A                  |
+| **selection-outline** | passive — never wins a hit  | passive                                                                         | passive                                                                                                            | passive                                                                       | passive                                                                                                            | passive                                                                                                                                                                                                          | flicker probe (2 outlines from a 2-id selection)           | passive under marquee                                                             | passive under lasso                            |
+| **marquee**           | (mirror)                    | (mirror)                                                                        | (mirror)                                                                                                           | (mirror)                                                                      | (mirror)                                                                                                           | (mirror)                                                                                                                                                                                                         | (mirror)                                                   | flicker probe (cannot have 2 active marquees)                                     | mutually exclusive — only one active at a time |
+| **lasso**             | (mirror)                    | (mirror)                                                                        | (mirror)                                                                                                           | (mirror)                                                                      | (mirror)                                                                                                           | (mirror)                                                                                                                                                                                                         | (mirror)                                                   | (mirror)                                                                          | flicker probe                                  |
+
+The cells are written from the perspective of "the pointer is somewhere both classes register a hit at the same `id`." The cell describes the resolved winner and (where relevant) the no-flicker constraint at the boundary between the two regions.
+
+## What each test asserts
+
+A matrix-row test for class pair (A, B) covers four properties:
+
+1. **Deterministic hover.** Move the pointer along a path that crosses A's region, then the (A ∩ B) overlap, then B's region. Hover identity reads cleanly: `A → A or B (specified by cell) → B`. No intermediate `null`, no oscillation.
+2. **Deterministic cursor.** Cursor at each pointer position derives from the hover; same path produces the same cursor stream.
+3. **Independent intents.** Drag-from-A emits only A's intent kind; drag-from-B emits only B's. Even when the drag traverses the overlap, the gesture commits to whichever class won at pointer-down — no mid-gesture handoff.
+4. **No phantom hits.** At pointer positions outside both A's and B's visible chrome, no overlay-tier hit resolves. Falls through to the host's `pick`.
+
+A matrix-row test for a **flicker probe** (diagonal cell, multi-instance of the same class) covers:
+
+- Two instances with different `id`s, hit regions adjacent. Pointer at the boundary picks one consistently (declaration order in the input array breaks ties). Pixel-stable pointer does not oscillate between the two `id`s on subsequent `pointer_move` events.
+
+## Test layout
+
+```
+__tests__/composition/
+├── README.md           # this file
+├── co-target.test.ts   # the matrix — lands with the first per-class migration into classes/
+└── fixtures.ts         # shared helpers for building (class A input × class B input) over a shared id
+```
+
+The fixtures helper centralizes the "two-class scaffold" so each cell's test is short — typically ~10 lines per cell, mostly assertion. The matrix is verbose but mechanical; the value is the coverage, not the elegance.
+
+## Maintenance
+
+When a new named class is promoted into `classes/<name>/`, that PR:
+
+1. Adds a row and a column to the matrix above (this README).
+2. Adds one cell-test per existing class in `co-target.test.ts`.
+3. Adds one flicker-probe test in the diagonal cell.
+4. The matrix grows by one row and one column; new cells are filled by the PR; existing cells are not changed.
+
+When two classes fold (the doctrine's preferred outcome under rule #1), the matrix shrinks: their row/column merges; existing cell-tests for the absorbed class either delete (if redundant) or migrate to the absorbing class with renames. The PR that performs the fold owns the matrix update.

--- a/packages/grida-canvas-hud/__tests__/composition/co-target.test.ts
+++ b/packages/grida-canvas-hud/__tests__/composition/co-target.test.ts
@@ -1,0 +1,173 @@
+// Co-target test matrix — enforces the composition contract:
+// "any combination of named classes contributing to the same HitRegions
+// registry resolves to deterministic hover/hit/cursor; no phantom hits."
+//
+// This is the FIRST cell of the matrix (padding × transform-box).
+// Subsequent migrations grow it: every new class adds one row + one
+// column. See __tests__/composition/README.md for the planned shape.
+//
+// What this cell pins:
+//   - Both classes can co-exist in one HitRegions registry.
+//   - Hit-test at a point where only ONE class registers returns that
+//     class's action — the other class's overlays do not phantom-hit.
+//   - Hit-test at empty space returns null — no class leaks overlays
+//     outside its declared geometry.
+//   - Priority sort wins when both classes' regions overlap (this
+//     synthetic case uses overlapping handles for a clean assertion;
+//     real-world overlap is rarer but the machinery is the same).
+
+import { describe, it, expect } from "vitest";
+import {
+  buildPaddingOverlay,
+  PADDING_HANDLE_PRIORITY,
+  type PaddingOverlayInput,
+} from "../../classes/padding";
+import {
+  buildTransformBox,
+  TRANSFORM_BOX_CORNER_PRIORITY,
+  type TransformBoxInput,
+} from "../../classes/transform-box";
+import { DEFAULT_STYLE } from "../../surface/style";
+import { fanOverlays } from "../../surface/chrome";
+import { HitRegions } from "../../event/hit-regions";
+import { IDENTITY } from "../../event/transform";
+
+function paddingFixture(): PaddingOverlayInput {
+  return {
+    node_id: "n1",
+    rect: { x: 100, y: 100, width: 200, height: 200 },
+    padding: { top: 40, right: 40, bottom: 40, left: 40 },
+  };
+}
+
+function transformBoxFixture(): TransformBoxInput {
+  return {
+    id: "tb-1",
+    transform: [
+      [1, 0, 0],
+      [0, 1, 0],
+    ],
+    size: [200, 200],
+    origin: [100, 100],
+  };
+}
+
+describe("co-target: padding × transform-box", () => {
+  // Sanity — confirm the priority ladder the rest of the test relies on.
+  it("documented priority ladder holds (padding-handle < transform-box-corner)", () => {
+    expect(PADDING_HANDLE_PRIORITY).toBeLessThan(TRANSFORM_BOX_CORNER_PRIORITY);
+  });
+
+  it("both classes' overlays co-exist in one HitRegions registry", () => {
+    const padding_overlays = buildPaddingOverlay({
+      overlay: paddingFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      alt_held: false,
+      transform: IDENTITY,
+    });
+    const tb_overlays = buildTransformBox({
+      overlay: transformBoxFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      transform: IDENTITY,
+    });
+
+    const regions = new HitRegions();
+    fanOverlays([...padding_overlays, ...tb_overlays], IDENTITY, regions);
+
+    // Registry holds entries from both classes — no fan corruption.
+    const labels = regions.toArray().map((r) => r.label);
+    expect(labels.some((l) => l.startsWith("padding_"))).toBe(true);
+    expect(labels.some((l) => l.startsWith("transform_box_"))).toBe(true);
+  });
+
+  it("hit at a point inside only the transform-box body returns the tb action — padding does not phantom-hit", () => {
+    // Padding regions cover the OUTER 40px strips of the rect. The
+    // inner core [140..260, 140..260] has NO padding hit but IS inside
+    // the transform-box body.
+    const padding_overlays = buildPaddingOverlay({
+      overlay: paddingFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      alt_held: false,
+      transform: IDENTITY,
+    });
+    const tb_overlays = buildTransformBox({
+      overlay: transformBoxFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      transform: IDENTITY,
+    });
+
+    const regions = new HitRegions();
+    fanOverlays([...padding_overlays, ...tb_overlays], IDENTITY, regions);
+
+    const action = regions.hitTest([200, 200]);
+    expect(action).not.toBeNull();
+    expect(action?.kind).toBe("transform_box_body");
+  });
+
+  it("hit at empty space (outside both classes' rects) returns null", () => {
+    const padding_overlays = buildPaddingOverlay({
+      overlay: paddingFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      alt_held: false,
+      transform: IDENTITY,
+    });
+    const tb_overlays = buildTransformBox({
+      overlay: transformBoxFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      transform: IDENTITY,
+    });
+
+    const regions = new HitRegions();
+    fanOverlays([...padding_overlays, ...tb_overlays], IDENTITY, regions);
+
+    // Way outside the rect [100..300] — no class should claim it.
+    expect(regions.hitTest([1000, 1000])).toBeNull();
+  });
+
+  it("adding transform-box does not shift padding's hit results (class independence)", () => {
+    const padding_overlays = buildPaddingOverlay({
+      overlay: paddingFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      alt_held: false,
+      transform: IDENTITY,
+    });
+
+    // Padding-only registry.
+    const padding_only = new HitRegions();
+    fanOverlays(padding_overlays, IDENTITY, padding_only);
+    const padding_top_handle = padding_overlays.find(
+      (o) => o.label === "padding_handle:top"
+    );
+    expect(padding_top_handle).toBeDefined();
+    const handle_anchor =
+      padding_top_handle!.hit.kind === "screen_rect_at_doc"
+        ? padding_top_handle!.hit.anchor_doc
+        : null;
+    expect(handle_anchor).not.toBeNull();
+    const padding_only_hit = padding_only.hitTest(handle_anchor!);
+
+    // Combined registry — add transform-box on top.
+    const tb_overlays = buildTransformBox({
+      overlay: transformBoxFixture(),
+      style: DEFAULT_STYLE,
+      hover: null,
+      transform: IDENTITY,
+    });
+    const combined = new HitRegions();
+    fanOverlays([...padding_overlays, ...tb_overlays], IDENTITY, combined);
+    const combined_hit = combined.hitTest(handle_anchor!);
+
+    // Same kind wins in both registries. Padding handle priority (12) is
+    // lower than any transform-box hit at the same point — combined hit
+    // matches padding-only hit. No co-target interference.
+    expect(padding_only_hit?.kind).toBe("padding_handle");
+    expect(combined_hit?.kind).toBe("padding_handle");
+  });
+});

--- a/packages/grida-canvas-hud/__tests__/lasso-gesture.test.ts
+++ b/packages/grida-canvas-hud/__tests__/lasso-gesture.test.ts
@@ -146,8 +146,7 @@ describe("lasso gesture — host swaps selection mode to lasso", () => {
   });
 
   it("Shift propagates to additive on both preview and commit", () => {
-    // Why: matches the additive semantics of marquee + main editor
-    // (event-target.reducer.ts:455).
+    // Why: matches the additive semantics of marquee selection.
     const state = new SurfaceState();
     const { deps, intents } = makeDeps();
     state.setVectorSelectionMode("lasso");

--- a/packages/grida-canvas-hud/__tests__/paint.test.ts
+++ b/packages/grida-canvas-hud/__tests__/paint.test.ts
@@ -234,7 +234,7 @@ describe("HUDPaint resolver", () => {
     // Stripes branch must build a tile and call ctx.createPattern with
     // repeat="repeat". The returned style is the CanvasPattern, not a
     // color string. Counter-CTM contract: setTransform is invoked with
-    // the inverse of the ctx's current transform.
+    // a composed pattern transform.
     const { ctx, patternCalls, setTransformArgs } = mockResolveCtx();
     const paint: HUDPaintStripes = { kind: "stripes", color: "#0a6" };
     const out = resolvePaint(ctx, paint, 1);
@@ -243,6 +243,67 @@ describe("HUDPaint resolver", () => {
       patternCalls.find((c) => c.op === "ctx:createPattern")?.args[1]
     ).toBe("repeat");
     expect(setTransformArgs.length).toBe(1);
+  });
+
+  it("stripes pattern transform composes rotate(-angle) · inverse(CTM)", () => {
+    // The tile is axis-aligned horizontal stripes (rotation is NOT
+    // baked in — that's the previous bug). resolvePaint applies the
+    // rotation in the pattern transform so the visible stripes appear
+    // at the configured angle in canvas space.
+    //
+    // For identity CTM and the default 45°, the expected matrix is just
+    // rotate(-45°): [a=cos45°, b=-sin45°, c=sin45°, d=cos45°, e=0, f=0].
+    // Numerically: a=d≈0.7071, b≈-0.7071, c≈0.7071, e=f=0.
+    const { ctx, setTransformArgs } = mockResolveCtx();
+    resolvePaint(ctx, { kind: "stripes", color: "#0a6" }, 1);
+    const m = setTransformArgs[0][0] as {
+      a: number;
+      b: number;
+      c: number;
+      d: number;
+      e: number;
+      f: number;
+    };
+    const SQRT2OVER2 = Math.SQRT2 / 2;
+    expect(m.a).toBeCloseTo(SQRT2OVER2, 6);
+    expect(m.b).toBeCloseTo(-SQRT2OVER2, 6);
+    expect(m.c).toBeCloseTo(SQRT2OVER2, 6);
+    expect(m.d).toBeCloseTo(SQRT2OVER2, 6);
+    expect(m.e).toBe(0);
+    expect(m.f).toBe(0);
+  });
+
+  it("stripes pattern transform is identity at angle=0 (axis-aligned)", () => {
+    // At 0°, no rotation should be applied; the pattern transform
+    // collapses to the inverse-CTM (here identity).
+    const { ctx, setTransformArgs } = mockResolveCtx();
+    resolvePaint(ctx, { kind: "stripes", color: "x", angle: 0 }, 1);
+    const m = setTransformArgs[0][0] as {
+      a: number;
+      b: number;
+      c: number;
+      d: number;
+      e: number;
+      f: number;
+    };
+    expect(m.a).toBeCloseTo(1, 9);
+    expect(m.b).toBeCloseTo(0, 9);
+    expect(m.c).toBeCloseTo(0, 9);
+    expect(m.d).toBeCloseTo(1, 9);
+    expect(m.e).toBe(0);
+    expect(m.f).toBe(0);
+  });
+
+  it("stripes tile is built unrotated, 1 × period (axis-aligned)", () => {
+    // The tile must be axis-aligned so `repeat` tiles it without lattice
+    // mismatch. Rotation lives in the pattern transform, not the tile.
+    // Concretely: no `tile:rotate` call, and the tile dimensions are
+    // `(1, ceil-rounded spacingPx)`.
+    const { tileCalls } = installOffscreenCanvasMock();
+    buildStripesTile({ kind: "stripes", color: "x" }, 1);
+    const construct = tileCalls.find((c) => c.op === "tile:new");
+    expect(construct?.args).toEqual([1, 8]);
+    expect(tileCalls.find((c) => c.op === "tile:rotate")).toBeUndefined();
   });
 
   it("stripes defaults pin the canonical design language (45° / 8px / 1.5px)", () => {

--- a/packages/grida-canvas-hud/__tests__/ruler.test.ts
+++ b/packages/grida-canvas-hud/__tests__/ruler.test.ts
@@ -671,8 +671,8 @@ describe("drawRuler", () => {
   // now reads as one continuous stroke crossing the strip boundary into
   // the canvas guide below, instead of being capped by a 1-px separator
   // painted on top. Every production editor (Figma, Sketch, XD,
-  // Illustrator, Affinity, our main editor's `@grida/ruler`) paints the
-  // separator under ticks; the hud now follows.
+  // Illustrator, Affinity) paints the separator under ticks; the hud
+  // now follows.
   //
   // Pin: the separator stroke (identified by its strokeStyle being set
   // to the borderColor and its moveTo landing at y = strip - 0.5) is

--- a/packages/grida-canvas-hud/__tests__/transform-box-math.test.ts
+++ b/packages/grida-canvas-hud/__tests__/transform-box-math.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import cmath from "@grida/cmath";
+import {
+  type AffineTransform,
+  reduceTransformBox,
+  getTransformBoxCorners,
+} from "../primitives/transform-box";
+
+describe("Original Direction Scaling Challenge", () => {
+  // NOTE: True original-direction scaling (scaling X/Y axes regardless of rotation)
+  // is a complex mathematical problem. The requirement is:
+  //
+  // "When dragging a side of a rotated shape, scale in the ORIGINAL direction
+  // (as if the rotation was not applied), not along the rotated axes."
+  //
+  // This requires advanced matrix manipulation that goes beyond simple
+  // decompose/compose operations.
+
+  it("should acknowledge the mathematical complexity", () => {
+    expect(true).toBe(true); // Acknowledge the limitation
+  });
+});
+
+describe("Transform Box Editor", () => {
+  const size: cmath.Vector2 = [200, 100];
+  const identity: AffineTransform = [
+    [1, 0, 0],
+    [0, 1, 0],
+  ];
+
+  describe("Basic functionality", () => {
+    it("should handle identity transform correctly", () => {
+      const corners = getTransformBoxCorners(identity, size);
+
+      expect(corners.nw).toEqual([0, 0]);
+      expect(corners.ne).toEqual([200, 0]);
+      expect(corners.se).toEqual([200, 100]);
+      expect(corners.sw).toEqual([0, 100]);
+    });
+
+    it("should handle centered scaling correctly", () => {
+      const centeredScale: AffineTransform = [
+        [0.5, 0, 0.25],
+        [0, 0.5, 0.25],
+      ];
+
+      const corners = getTransformBoxCorners(centeredScale, size);
+
+      expect(corners.nw[0]).toBeCloseTo(50, 1);
+      expect(corners.nw[1]).toBeCloseTo(25, 1);
+      expect(corners.ne[0]).toBeCloseTo(150, 1);
+      expect(corners.ne[1]).toBeCloseTo(25, 1);
+      expect(corners.se[0]).toBeCloseTo(150, 1);
+      expect(corners.se[1]).toBeCloseTo(75, 1);
+      expect(corners.sw[0]).toBeCloseTo(50, 1);
+      expect(corners.sw[1]).toBeCloseTo(75, 1);
+    });
+
+    it("should handle translation correctly", () => {
+      const pixelDelta: cmath.Vector2 = [40, 20];
+
+      const translated = reduceTransformBox(
+        identity,
+        { type: "translate", delta: pixelDelta },
+        { size }
+      );
+
+      expect(translated[0][2]).toBeCloseTo(0.2, 3); // 40/200
+      expect(translated[1][2]).toBeCloseTo(0.2, 3); // 20/100
+      expect(translated[0][0]).toBeCloseTo(1, 3);
+      expect(translated[1][1]).toBeCloseTo(1, 3);
+    });
+  });
+
+  describe("Rotation behavior", () => {
+    it("should preserve center during rotation", () => {
+      const baseTransform: AffineTransform = [
+        [1.5, 0, 0.1],
+        [0, 0.8, 0.2],
+      ];
+
+      const initialCorners = getTransformBoxCorners(baseTransform, size);
+      const initialCenter = cmath.vector2.multiply(
+        cmath.vector2.add(initialCorners.nw, initialCorners.se),
+        [0.5, 0.5]
+      );
+
+      const rotationAngle = Math.PI / 6; // 30 degrees
+      const rotatePoint = (point: cmath.Vector2): cmath.Vector2 => {
+        const relative = cmath.vector2.sub(point, initialCenter);
+        const cos = Math.cos(rotationAngle),
+          sin = Math.sin(rotationAngle);
+        return cmath.vector2.add(initialCenter, [
+          relative[0] * cos - relative[1] * sin,
+          relative[0] * sin + relative[1] * cos,
+        ]);
+      };
+
+      const expectedNE = rotatePoint(initialCorners.ne);
+      const rotationDelta = cmath.vector2.sub(expectedNE, initialCorners.ne);
+
+      const rotatedTransform = reduceTransformBox(
+        baseTransform,
+        { type: "rotate", corner: "ne", delta: rotationDelta },
+        { size }
+      );
+
+      const finalCorners = getTransformBoxCorners(rotatedTransform, size);
+      const finalCenter = cmath.vector2.multiply(
+        cmath.vector2.add(finalCorners.nw, finalCorners.se),
+        [0.5, 0.5]
+      );
+
+      expect(finalCenter[0]).toBeCloseTo(initialCenter[0], 1);
+      expect(finalCenter[1]).toBeCloseTo(initialCenter[1], 1);
+
+      expect(rotatedTransform).not.toEqual(baseTransform);
+    });
+
+    it("should preserve distances during rotation", () => {
+      const baseTransform: AffineTransform = [
+        [1.2, 0, 0.1],
+        [0, 0.8, 0.15],
+      ];
+
+      const initialCorners = getTransformBoxCorners(baseTransform, size);
+      const initialCenter = cmath.vector2.multiply(
+        cmath.vector2.add(initialCorners.nw, initialCorners.se),
+        [0.5, 0.5]
+      );
+
+      const initialWidth = cmath.vector2.distance(
+        initialCorners.ne,
+        initialCorners.nw
+      );
+      const initialHeight = cmath.vector2.distance(
+        initialCorners.nw,
+        initialCorners.sw
+      );
+
+      const rotationAngle = Math.PI / 4; // 45 degrees
+      const rotatePoint = (point: cmath.Vector2): cmath.Vector2 => {
+        const relative = cmath.vector2.sub(point, initialCenter);
+        const cos = Math.cos(rotationAngle),
+          sin = Math.sin(rotationAngle);
+        return cmath.vector2.add(initialCenter, [
+          relative[0] * cos - relative[1] * sin,
+          relative[0] * sin + relative[1] * cos,
+        ]);
+      };
+
+      const expectedNE = rotatePoint(initialCorners.ne);
+      const rotationDelta = cmath.vector2.sub(expectedNE, initialCorners.ne);
+
+      const rotatedTransform = reduceTransformBox(
+        baseTransform,
+        { type: "rotate", corner: "ne", delta: rotationDelta },
+        { size }
+      );
+
+      const finalCorners = getTransformBoxCorners(rotatedTransform, size);
+      const finalWidth = cmath.vector2.distance(
+        finalCorners.ne,
+        finalCorners.nw
+      );
+      const finalHeight = cmath.vector2.distance(
+        finalCorners.nw,
+        finalCorners.sw
+      );
+
+      expect(finalWidth).toBeCloseTo(initialWidth, 1);
+      expect(finalHeight).toBeCloseTo(initialHeight, 1);
+    });
+  });
+
+  describe("Side scaling behavior", () => {
+    it("should handle side scaling with current approach", () => {
+      const testDelta: cmath.Vector2 = [20, 10];
+
+      const result = reduceTransformBox(
+        identity,
+        { type: "scale-side", side: "right", delta: testDelta },
+        { size }
+      );
+
+      expect(result).toBeDefined();
+      expect(result).not.toEqual(identity); // Should change
+
+      const corners = getTransformBoxCorners(result, size);
+      expect(corners.nw).toBeDefined();
+      expect(corners.ne).toBeDefined();
+      expect(corners.se).toBeDefined();
+      expect(corners.sw).toBeDefined();
+    });
+
+    // NOTE: True original-direction scaling (scaling X/Y axes regardless of rotation)
+    // is a complex mathematical problem that requires advanced matrix manipulation.
+    // The current implementation provides reasonable scaling behavior for most use cases.
+  });
+
+  describe("Edge cases", () => {
+    it("should handle zero deltas gracefully", () => {
+      const result = reduceTransformBox(
+        identity,
+        { type: "translate", delta: [0, 0] },
+        { size }
+      );
+
+      expect(result).toEqual(identity);
+    });
+
+    it("should handle very small rotations", () => {
+      const result = reduceTransformBox(
+        identity,
+        { type: "rotate", corner: "ne", delta: [0.001, 0.001] },
+        { size }
+      );
+
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/grida-canvas-hud/__tests__/transform-box-math.test.ts
+++ b/packages/grida-canvas-hud/__tests__/transform-box-math.test.ts
@@ -16,9 +16,9 @@ describe("Original Direction Scaling Challenge", () => {
   // This requires advanced matrix manipulation that goes beyond simple
   // decompose/compose operations.
 
-  it("should acknowledge the mathematical complexity", () => {
-    expect(true).toBe(true); // Acknowledge the limitation
-  });
+  it.todo(
+    "scales side drags in original (unrotated) axis for rotated transforms"
+  );
 });
 
 describe("Transform Box Editor", () => {

--- a/packages/grida-canvas-hud/classes/README.md
+++ b/packages/grida-canvas-hud/classes/README.md
@@ -1,0 +1,78 @@
+# `classes/` — promoted named classes
+
+Tier-1 of the package's [two-tier doctrine](../README.md#what-this-package-is--two-tiers). Each subfolder under `classes/` is one promoted named class — a composed, opinionated interaction model with a closed gesture grammar, a dedicated intent contract, and a bounded feature surface.
+
+Three migrations have landed; the rest are pending. See the [promotion-bar dry-run](#promotion-bar-dry-run) below for each candidate's audit outcome and current state. The package-level [Named classes table](../README.md#named-classes) is the authoritative list of promoted classes.
+
+Landed:
+
+- [`padding/`](./padding/) — promoted from `surface/padding-overlay.ts`. Folder convention applied; tests at `__tests__/classes/padding/surface.test.ts`.
+- [`transform-box/`](./transform-box/) — promoted from `surface/transform-box.ts`. Math reducer stays in `primitives/transform-box.ts` (Tier 2). Tests at `__tests__/classes/transform-box/surface.test.ts`.
+- [`vector-path/`](./vector-path/) — promoted from `surface/vector-chrome.ts`. 10 vector intent variants extracted into `intent.ts`; the densest class in the package, still one model (a path) under one noun. 5 test files relocated to `__tests__/classes/vector-path/`. Co-target matrix rows still pending (see [the gap note](../README.md#named-classes)).
+
+Pending:
+
+- `corner-radius/` and `parametric-handle/` — chrome currently lives **inline** inside `surface/surface.ts` (corner-radius at lines 778–927, parametric-handle similarly). These migrations require extracting the chrome-build code out of the orchestrator, not just relocating a file. They also share `CORNER_RADIUS_PRIORITY` and renderer-side hooks (`hudCanvas.setCornerRadiusHandles` / `setParametricHandles`) — design pass needed on whether to keep per-class renderer setters, fold parametric-handle to absorb corner-radius (the dry-run's open audit), or both. Deferred for review.
+- `chrome.ts` split (resize-box / selection-outline / marquee / lasso / hover-overlay) — deferred per the doctrine; lands last.
+
+## Folder convention
+
+Each promoted class lives in its own subfolder. The shape is fixed — every reader knows where to look.
+
+```
+classes/<name>/
+├── surface.ts      # the chrome — build function that returns OverlayElement[]
+│                   # carries the anti-goals header (what this class is NOT)
+├── input.ts        # public input type, declared @unstable until rule #3 (two consumers) is satisfied
+├── intent.ts       # this class's intent variant(s); unioned by event/intent.ts
+├── priority.ts     # this class's priority constants (corner / side / body / …)
+├── index.ts        # re-exports the public surface (input type, priority constants, build fn if exported)
+├── hover.ts        # optional — only when hover derivation is non-trivial
+└── gesture.ts      # optional — only when gesture state outgrows event/gesture.ts's union
+```
+
+The shared dispatcher (`event/state.ts`, `event/decision.ts`, `event/cursor.ts`) stays unified across all classes. Hover/hit/cursor resolution is _cross-class_ — it must be — so the class subfolder contributes its intent variant and priority constants but does not own the dispatch loop.
+
+Per-class tests live under [`__tests__/classes/<name>/`](../__tests__/) and follow the [promotion contract](../README.md#promotion-contract). Co-target assertions (pair with every other class that may share an `id`) land in [`__tests__/composition/`](../__tests__/composition/).
+
+## Promotion-bar dry-run
+
+The verification step for the doctrine revision asks: do the five [promotion-bar rules](../README.md#what-justifies-a-new-named-class) actually classify the existing modules cleanly? This section records the dry-run. It is a sanity check, not a commitment — each module gets its own audit PR when migration starts.
+
+Rule numbering, for reference:
+
+1. **Model audit** — fold if model matches an existing class.
+2. **Closed gesture grammar** — must be a finite (target × gesture × modifier) → intent table.
+3. **Two consumers** (or one + adversarial demo) shape the contract.
+4. **Feature flags are capability flags**, not visual variants.
+5. **Stable identity** — one noun.
+
+| Candidate                                                                | Outcome                      | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `surface/padding-overlay.ts`                                             | **Migrated**                 | Model: 4 side numerics committed by side-handle drag. Gesture grammar: 4 side handles × drag × optional alt-mirror. Now lives at [`classes/padding/`](./padding/) with the full convention (input.ts, intent.ts, priority.ts, surface.ts, index.ts). 42 tests green at the new test path. Anti-goals header carried into `surface.ts`.                                                                                                                                                                                                                                                |
+| `surface/transform-box.ts` + `primitives/transform-box.ts`               | **Migrated** with split      | Chrome migrated to [`classes/transform-box/`](./transform-box/); math reducer stays in `primitives/transform-box.ts` (Tier 2 — genuinely reusable by external consumers). Model: 2×3 affine on a unit box. Gesture grammar: 4 corners (rotate) × 4 sides (scale) × body (translate). Tests green at the new test path. Anti-goals header carried into `surface.ts`.                                                                                                                                                                                                                   |
+| `primitives/corner-radius.ts` (chrome path) + `setCornerRadius`          | **Passes** with split        | Chrome promotes to `classes/corner-radius/`; geometry/math stays in `primitives/corner-radius.ts`. Model: 4 corner radii committed by knob drag (default branch + explicit anchor-locked branch with alt). Gesture grammar closed. Demo exists. Single noun.                                                                                                                                                                                                                                                                                                                          |
+| `primitives/parametric-handle.ts` (chrome path) + `setParametricHandles` | **Passes** with split        | Chrome promotes to `classes/parametric-handle/`; geometry stays in `primitives/parametric-handle.ts`. Model: scalar-on-curve committed by knob drag, value snapped to `domain.step`. Gesture grammar closed. Single noun. **Open audit:** corner-radius is arguably a specialization of this model (a 4-knob multi-instance over a fixed parametric curve). If a fold becomes the right call, this would absorb corner-radius — deferred until a real second consumer of `parametric-handle` lands and forces the question.                                                           |
+| `surface/vector-chrome.ts`                                               | **Migrated**                 | Densest class — 10 intent variants (`select_vertex`, `translate_vertices`, `translate_vector_selection`, `clear_vector_selection`, `select_segment`, `select_region`, `select_tangent`, `set_tangent`, `split_segment`, `bend_segment`) but **one model**: a path. Vertices, segments, tangents, regions are _features_ of the same model, not separate models. Now lives at [`classes/vector-path/`](./vector-path/). `enter_content_edit`/`exit_content_edit` stay in `event/intent.ts` — they're orchestration (mode entry/exit), not vector-class-bound. 5 test files relocated.  |
+| Selection chrome inside `surface/chrome.ts` — resize handles             | **Waits**                    | Same gesture grammar as `transform-box` (4 corners + 4 sides + body) but a different model: mutates the host's `(x, y, w, h, rotation)` directly, not an inner affine. The chrome differs (rendered handle pips vs invisible hit strips); per the doctrine, **chrome variance is not a model split** — but the model genuinely differs (outer rect vs inner affine binding-target). Rule #1 says: audit again when the migration actually starts. Two paths: (a) one class with a binding-target axis (outer vs inner); (b) two classes that share a math reducer. Decision deferred. |
+| Selection chrome inside `chrome.ts` — selection outline                  | **Waits + likely fold**      | Outline rendering recurs across padding, vector regions, transform-box, and selection — it's a _primitive concern_ (a styled stroke around a geometric region), not a class. The selection-specific outline is host-state-driven (which nodes are selected) but the rendering is generic. Likely outcome: outline rendering stays primitive (Tier 2), selection chrome promotes a thinner `classes/selection-outline/` that just declares "this id has a selection outline." Deferred.                                                                                                |
+| Selection chrome inside `chrome.ts` — rotate handles                     | **Folds into resize-box**    | Same model as resize handles' gesture variant (which corner is being dragged), same target geometry, different intent kind (`rotate` vs `resize`). Per rule #1: same model with a feature axis (rotate-mode toggled by modifier or by which corner sub-region is hit), not two classes. Folds with resize-box.                                                                                                                                                                                                                                                                        |
+| Selection chrome inside `chrome.ts` — hover overlay                      | **Waits + likely host code** | Hover outline for the currently-hovered node is host-state-driven but visually trivial (one outline). Rule #2 (closed gesture grammar) is N/A — there's no gesture, it's pure display. This may not deserve a class at all; could be a primitive-level emission tied directly to the surface's `hover()` getter. Deferred.                                                                                                                                                                                                                                                            |
+| Selection chrome inside `chrome.ts` — marquee                            | **Waits + likely class**     | Distinct model: rectangular selection over empty space. Closed gesture grammar (drag from empty → marquee → commit with `marquee_select` intent). Likely promotes to `classes/marquee/`.                                                                                                                                                                                                                                                                                                                                                                                              |
+| Selection chrome inside `chrome.ts` — lasso                              | **Waits + likely class**     | Same shape as marquee but polygon instead of rect. Distinct model (point-in-polygon vs AABB intersection), distinct gesture grammar (single mode-toggle from marquee). Either folds with marquee under a `selection-region` class with a shape-axis feature flag, or stays distinct. Deferred — the marquee/lasso fold-or-split decision is the same kind of question as resize-vs-transform-box.                                                                                                                                                                                     |
+
+Reading: every existing surface module either promotes (5 cases) or splits-from-`chrome.ts` and waits for its own audit (5 cases). No candidate fails rule #2 (none have open-ended customization). No candidate fails rule #5 (every name resolves to one noun). The bar is usable.
+
+## Migration cadence
+
+One class per PR. Each migration PR:
+
+1. Audits the candidate per the 5 rules; records the outcome in this file.
+2. Moves the module's files into `classes/<name>/` with the folder convention above.
+3. Updates imports in `index.ts`, `surface/surface.ts`, `event/intent.ts`, demo files.
+4. Relocates per-class tests from `__tests__/<name>.test.ts` to `__tests__/classes/<name>/`.
+5. Adds rows to [`__tests__/composition/co-target.test.ts`](../__tests__/composition/) for every (this-class, existing-class) pair that may share an `id`.
+6. Adds a row to the **Named classes** table in the package README.
+7. No behavior changes. Pure relocation + import updates.
+
+The selection-chrome split out of `chrome.ts` is deferred until the simpler migrations land — that file is the largest single consolidation and benefits from the contract being settled by the smaller cases first.

--- a/packages/grida-canvas-hud/classes/README.md
+++ b/packages/grida-canvas-hud/classes/README.md
@@ -19,7 +19,7 @@ Pending:
 
 Each promoted class lives in its own subfolder. The shape is fixed — every reader knows where to look.
 
-```
+```text
 classes/<name>/
 ├── surface.ts      # the chrome — build function that returns OverlayElement[]
 │                   # carries the anti-goals header (what this class is NOT)

--- a/packages/grida-canvas-hud/classes/padding/index.ts
+++ b/packages/grida-canvas-hud/classes/padding/index.ts
@@ -1,0 +1,24 @@
+// Padding — named-class entry point.
+//
+// Re-exports the class's public surface for consumers (package index,
+// Surface orchestrator, event/* dispatchers that need the input/hover
+// types). Internal split:
+//
+// - surface.ts   the chrome (build function + helpers + anti-goals)
+// - input.ts     PaddingOverlayInput + PaddingHover
+// - intent.ts    PaddingIntent variant (folded into Intent by event/intent.ts)
+// - priority.ts  priority slots + sizing constants
+
+export type { PaddingOverlayInput, PaddingHover } from "./input";
+export type { PaddingIntent } from "./intent";
+export {
+  PADDING_HANDLE_PRIORITY,
+  PADDING_REGION_PRIORITY,
+  PADDING_HANDLE_LENGTH,
+  PADDING_HANDLE_THICKNESS,
+} from "./priority";
+export {
+  buildPaddingOverlay,
+  paddingSideRect,
+  projectPaddingValue,
+} from "./surface";

--- a/packages/grida-canvas-hud/classes/padding/input.ts
+++ b/packages/grida-canvas-hud/classes/padding/input.ts
@@ -1,0 +1,66 @@
+// Padding — public input + hover types.
+//
+// `input.ts` carries the named-class's public contract: the host-pushed
+// input shape and the HUD-derived hover state. Both are `@unstable` until
+// a second independent integration ratifies the shape.
+
+import type cmath from "@grida/cmath";
+import type { NodeId, Rect } from "../../event/gesture";
+import type { HUDSemanticGroup } from "../../primitives/types";
+
+/**
+ * Input pushed by the host to enable padding chrome on a flex-parent
+ * container. Schema-level feature flag — pass `null` (or never call
+ * `setPaddingOverlay`) to disable. Hosts re-push on every padding /
+ * container-rect change.
+ *
+ * @unstable Public shape may change until a second independent integration
+ * ratifies it.
+ */
+export interface PaddingOverlayInput {
+  node_id: NodeId;
+  /** Container rect in doc-space (the node's bounding rect). */
+  rect: Rect;
+  /**
+   * Per-side padding in doc-space units. Absent or `<= 0` = side not
+   * drawn. Matches the 4-value model used by `layout_padding_{side}`.
+   */
+  padding: {
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
+  };
+  /**
+   * Optional semantic group for visibility policy. The full overlay
+   * fans out per-side rects + per-side handles; all carry the same
+   * group so a single `SurfaceVisibilityPolicy` toggle suppresses the
+   * whole model atomically.
+   */
+  group?: HUDSemanticGroup;
+}
+
+/**
+ * Hover state for the padding model — HUD-owned. The padding region's
+ * hover is set on every idle `pointer_move` from the hit-regions
+ * registry; the chrome reads it each frame to render the stripe fill.
+ *
+ * `mirror_side` is non-null when alt is held AND the pointer is on a
+ * `padding_region` — the renderer paints both the hovered side and its
+ * opposite. Cleared on alt release on the next pointer-move (modifier
+ * events alone don't re-derive hover; that's an acceptable v1 cost —
+ * the user will be moving the mouse over the region to see the effect
+ * anyway).
+ */
+export type PaddingHover =
+  | {
+      kind: "padding_region";
+      node_id: NodeId;
+      side: cmath.RectangleSide;
+      mirror_side?: cmath.RectangleSide;
+    }
+  | {
+      kind: "padding_handle";
+      node_id: NodeId;
+      side: cmath.RectangleSide;
+    };

--- a/packages/grida-canvas-hud/classes/padding/intent.ts
+++ b/packages/grida-canvas-hud/classes/padding/intent.ts
@@ -1,0 +1,31 @@
+// Padding — intent variant.
+//
+// `intent.ts` carries this named-class's contribution to the shared `Intent`
+// union. `event/intent.ts` imports `PaddingIntent` and folds it into the
+// union; consumers always pattern-match on the union as a whole.
+
+import type cmath from "@grida/cmath";
+import type { IntentPhase } from "../../event/intent";
+import type { NodeId } from "../../event/gesture";
+
+/**
+ * Drag of a padding handle on a flex-parent container's side. The host
+ * applies the new `value` to the node's `layout_padding_{side}` field.
+ * When `mirror` is true (alt-held), host also applies the same value to
+ * the opposite side; HUD paints both sides "selected" for the duration of
+ * the gesture.
+ *
+ * The intent carries the resolved next padding value — not a pointer
+ * delta. HUD owns the math; the host commits the outcome (D1).
+ *
+ * `value` is in doc-space units. The HUD clamps to 0 (no negative padding);
+ * hosts wanting different clamps post-process.
+ */
+export type PaddingIntent = {
+  kind: "padding_handle";
+  node_id: NodeId;
+  side: cmath.RectangleSide;
+  value: number;
+  mirror: boolean;
+  phase: IntentPhase;
+};

--- a/packages/grida-canvas-hud/classes/padding/priority.ts
+++ b/packages/grida-canvas-hud/classes/padding/priority.ts
@@ -1,0 +1,36 @@
+// Padding — priority + sizing constants.
+//
+// `priority.ts` holds the class's hit-priority slots and the size constants
+// the chrome ladder depends on. Owned by the SDK; never exposed to the host
+// as a knob (per the doctrine's "priority overrides — deferred" rule).
+
+/**
+ * Padding drag-handle priority slot. Lower wins.
+ *
+ * 12 — wins over corner-radius (15), every resize control (≥30), translate
+ * body (40), rotate (50). The handle sits at the inner edge of the padding
+ * rect; in practice it doesn't overlap perimeter resize/rotate but the
+ * priority is insurance.
+ */
+export const PADDING_HANDLE_PRIORITY = 12;
+
+/**
+ * Padding hover-region priority slot. Lower wins.
+ *
+ * 35 — wins over translate body (40), loses to all resize controls (30/31).
+ * Clicking inside the padding zone of a selected flex container fires
+ * padding hover instead of translate; clicking a corner still resizes.
+ * The padding overlay paints over the selection chrome but loses to
+ * the corner resize handles.
+ */
+export const PADDING_REGION_PRIORITY = 35;
+
+/**
+ * Screen-px length of the drag-handle's long axis. The short axis is
+ * `PADDING_HANDLE_THICKNESS`. The 16×2 pill is sized for Fitts'-reach
+ * without dominating the inset side rect visually.
+ */
+export const PADDING_HANDLE_LENGTH = 16;
+
+/** Screen-px thickness of the drag-handle's short axis. */
+export const PADDING_HANDLE_THICKNESS = 2;

--- a/packages/grida-canvas-hud/classes/padding/surface.ts
+++ b/packages/grida-canvas-hud/classes/padding/surface.ts
@@ -1,0 +1,285 @@
+// Padding — named-class chrome.
+//
+// What this draws — four inset side rects (only the sides whose value > 0)
+// with a diagonal-stripe hover/selected fill, plus four mid-edge drag
+// handles for resizing each side.
+//
+// Anti-goals (what this class is NOT):
+//
+// - **Not a layout engine.** This class draws chrome over a host-owned
+//   padding value; it does not compute layout, push children, or know about
+//   flex / grid semantics. The host commits the new padding; the host's
+//   layout pipeline recomputes children.
+// - **Not a padding-style picker.** No per-corner radii, no per-side
+//   stroke style, no opacity-per-side. The model is four scalars.
+// - **Not a multi-rect padding model.** One container per input. Hosts
+//   with N flex parents push N inputs (the class scales by `id`).
+// - **Not a gap chrome.** Gap (spacing between children) is a different
+//   model — different geometry (N-1 dividers between siblings, not 4 sides
+//   of one rect). See the doctrine's gap/sort iter for the audit.
+// - **Not undo-aware.** Intents stream `phase: "preview"`; host wraps in
+//   its own history.
+
+import cmath from "@grida/cmath";
+import type { OverlayElement, RenderShape } from "../../event/overlay";
+import { MIN_HIT_SIZE } from "../../event/overlay";
+import type { Rect } from "../../event/gesture";
+import { docRectToScreenAABB } from "../../primitives/projection";
+import type { HUDStyle } from "../../surface/style";
+import type { PaddingHover, PaddingOverlayInput } from "./input";
+import {
+  PADDING_HANDLE_LENGTH,
+  PADDING_HANDLE_PRIORITY,
+  PADDING_HANDLE_THICKNESS,
+  PADDING_REGION_PRIORITY,
+} from "./priority";
+
+const SIDES: readonly cmath.RectangleSide[] = [
+  "top",
+  "right",
+  "bottom",
+  "left",
+];
+
+/**
+ * Build per-side inset rect (doc-space) for one side of a container
+ * rect. Returns `null` when the side has no padding (value <= 0).
+ *
+ * The geometry mirrors [surface-padding-overlay.tsx:58–123] — top
+ * occupies the full container width across `padding.top`; right
+ * occupies the full container height across the right padding strip;
+ * bottom/left symmetric.
+ */
+export function paddingSideRect(
+  rect: Rect,
+  padding: PaddingOverlayInput["padding"],
+  side: cmath.RectangleSide
+): Rect | null {
+  const top = padding.top ?? 0;
+  const right = padding.right ?? 0;
+  const bottom = padding.bottom ?? 0;
+  const left = padding.left ?? 0;
+  switch (side) {
+    case "top":
+      return top > 0
+        ? { x: rect.x, y: rect.y, width: rect.width, height: top }
+        : null;
+    case "right":
+      return right > 0
+        ? {
+            x: rect.x + rect.width - right,
+            y: rect.y,
+            width: right,
+            height: rect.height,
+          }
+        : null;
+    case "bottom":
+      return bottom > 0
+        ? {
+            x: rect.x,
+            y: rect.y + rect.height - bottom,
+            width: rect.width,
+            height: bottom,
+          }
+        : null;
+    case "left":
+      return left > 0
+        ? { x: rect.x, y: rect.y, width: left, height: rect.height }
+        : null;
+  }
+}
+
+function sideHandleAnchor(side_rect: Rect): cmath.Vector2 {
+  return [
+    side_rect.x + side_rect.width / 2,
+    side_rect.y + side_rect.height / 2,
+  ];
+}
+
+/**
+ * Build the per-frame padding overlay primitives.
+ *
+ * Emits one `OverlayElement` per side rect (hover-only, no intent) and
+ * one per drag handle (per-side `padding_handle` action). The two are
+ * keyed by side and share the same semantic `group`.
+ *
+ * Paint resolution:
+ *   - idle → no render (transparent body; hit still active)
+ *   - hover → `style.paddingHoverPaint`
+ *   - selected (= side === active_side, OR alt and side === opposite of
+ *     active_side) → outline stroke (no stripe)
+ *
+ * The drag handles are suppressed while any padding drag is in flight —
+ * don't paint knobs the user can't grab.
+ *
+ * The region's hit shape is pre-projected to **screen-space AABB** here
+ * — `transform` is needed so the hit area scales with zoom.
+ */
+export function buildPaddingOverlay(input: {
+  overlay: PaddingOverlayInput;
+  style: HUDStyle;
+  hover: PaddingHover | null;
+  alt_held: boolean;
+  transform: cmath.Transform;
+  active_side?: cmath.RectangleSide;
+}): OverlayElement[] {
+  const { overlay, style, hover, alt_held, transform, active_side } = input;
+  const { node_id, rect, padding, group } = overlay;
+  const out: OverlayElement[] = [];
+
+  const hover_on_this_node = hover !== null && hover.node_id === node_id;
+  const hover_opposite_side = hover
+    ? cmath.rect.getOppositeSide(hover.side)
+    : null;
+  const active_opposite_side = active_side
+    ? cmath.rect.getOppositeSide(active_side)
+    : null;
+  const drag_in_flight = active_side !== undefined;
+
+  for (let i = 0; i < SIDES.length; i++) {
+    const side = SIDES[i];
+    const side_rect = paddingSideRect(rect, padding, side);
+    if (!side_rect) continue;
+
+    const hover_targets_this = hover_on_this_node && hover!.side === side;
+    const is_mirror_hover =
+      alt_held && hover_on_this_node && hover_opposite_side === side;
+    const is_selected =
+      active_side !== undefined &&
+      (active_side === side || (alt_held && active_opposite_side === side));
+
+    const points: ReadonlyArray<readonly [number, number]> = [
+      [side_rect.x, side_rect.y],
+      [side_rect.x + side_rect.width, side_rect.y],
+      [side_rect.x + side_rect.width, side_rect.y + side_rect.height],
+      [side_rect.x, side_rect.y + side_rect.height],
+      [side_rect.x, side_rect.y],
+    ];
+    const render: RenderShape | undefined = is_selected
+      ? {
+          kind: "doc_polyline",
+          points,
+          stroke: true,
+          fill: false,
+          color: style.paddingSelectedStroke,
+          strokeWidth: style.selectionOutlineWidth,
+        }
+      : hover_targets_this || is_mirror_hover
+        ? {
+            kind: "doc_polyline",
+            points,
+            stroke: false,
+            fill: true,
+            fillPaint: style.paddingHoverPaint,
+          }
+        : undefined;
+
+    out.push({
+      label: `padding_region:${side}`,
+      group,
+      action: { kind: "padding_region", node_id, side },
+      hit: {
+        kind: "screen_aabb",
+        rect: docRectToScreenAABB(side_rect, transform),
+      },
+      render,
+      priority: PADDING_REGION_PRIORITY,
+      cursor: "pointer",
+    });
+
+    if (drag_in_flight) continue;
+
+    const anchor = sideHandleAnchor(side_rect);
+    const is_horizontal = side === "top" || side === "bottom";
+    const w = is_horizontal ? PADDING_HANDLE_LENGTH : PADDING_HANDLE_THICKNESS;
+    const h = is_horizontal ? PADDING_HANDLE_THICKNESS : PADDING_HANDLE_LENGTH;
+
+    out.push({
+      label: `padding_handle:${side}`,
+      group,
+      action: {
+        kind: "padding_handle",
+        node_id,
+        side,
+        rect,
+        initial_value: padding[side] ?? 0,
+      },
+      hit: {
+        kind: "screen_rect_at_doc",
+        anchor_doc: anchor,
+        width: Math.max(w, MIN_HIT_SIZE),
+        height: Math.max(h, MIN_HIT_SIZE),
+        placement: "center",
+      },
+      render: {
+        kind: "screen_rect",
+        anchor_doc: anchor,
+        width: w,
+        height: h,
+        placement: "center",
+        fill: true,
+        stroke: true,
+        fillColor: style.paddingHandleFill,
+        strokeColor: style.paddingHandleStroke,
+      },
+      priority: PADDING_HANDLE_PRIORITY,
+      cursor: is_horizontal
+        ? { kind: "resize", direction: "n" }
+        : { kind: "resize", direction: "w" },
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Project a cursor's doc-space position to a new padding value for
+ * `side`, given the container rect. Clamps to `[0, container_size_on_axis]`.
+ *
+ * **The handle is anchored at the CENTER of the side rect** (e.g. top
+ * handle sits at `y = padding.top / 2`). For the visual handle to track
+ * the cursor 1:1 during a drag, the padding value must change at 2× the
+ * cursor displacement: handle position = padding / 2, so padding =
+ * 2 × handle position from rect edge.
+ *
+ * Concretely (per side):
+ *
+ *   - `top`     → value = 2 × (cursor_y - rect.y)
+ *   - `right`   → value = 2 × ((rect.x + rect.width) - cursor_x)
+ *   - `bottom`  → value = 2 × ((rect.y + rect.height) - cursor_y)
+ *   - `left`    → value = 2 × (cursor_x - rect.x)
+ *
+ * Click-no-drag check: at `cursor = handle_center = initial / 2`,
+ * `value = 2 × (initial / 2) = initial`. ✓
+ *
+ * Used by the `padding_handle` gesture in `event/state.ts`.
+ */
+export function projectPaddingValue(
+  rect: Rect,
+  side: cmath.RectangleSide,
+  cursor_doc: cmath.Vector2
+): number {
+  let v: number;
+  let max: number;
+  switch (side) {
+    case "top":
+      v = 2 * (cursor_doc[1] - rect.y);
+      max = rect.height;
+      break;
+    case "right":
+      v = 2 * (rect.x + rect.width - cursor_doc[0]);
+      max = rect.width;
+      break;
+    case "bottom":
+      v = 2 * (rect.y + rect.height - cursor_doc[1]);
+      max = rect.height;
+      break;
+    case "left":
+      v = 2 * (cursor_doc[0] - rect.x);
+      max = rect.width;
+      break;
+  }
+  if (v < 0) return 0;
+  if (v > max) return max;
+  return v;
+}

--- a/packages/grida-canvas-hud/classes/transform-box/index.ts
+++ b/packages/grida-canvas-hud/classes/transform-box/index.ts
@@ -1,0 +1,20 @@
+// Transform-box — named-class entry point.
+
+export type {
+  TransformBoxInput,
+  TransformBoxHover,
+  TransformBoxActiveOp,
+} from "./input";
+export type { TransformBoxIntent } from "./intent";
+export {
+  TRANSFORM_BOX_CORNER_PRIORITY,
+  TRANSFORM_BOX_SIDE_PRIORITY,
+  TRANSFORM_BOX_BODY_PRIORITY,
+  TRANSFORM_BOX_CORNER_HIT_SIZE,
+  TRANSFORM_BOX_SIDE_HIT_THICKNESS,
+} from "./priority";
+export {
+  buildTransformBox,
+  docDeltaToBoxLocal,
+  getTransformBoxDocCorners,
+} from "./surface";

--- a/packages/grida-canvas-hud/classes/transform-box/input.ts
+++ b/packages/grida-canvas-hud/classes/transform-box/input.ts
@@ -1,0 +1,86 @@
+// Transform-box — public input + hover + active-op types.
+//
+// The math primitive lives at `primitives/transform-box.ts` (reusable
+// by external Tier-2 consumers). This class is the chrome + gesture
+// wiring on top.
+
+import type cmath from "@grida/cmath";
+import type { AffineTransform } from "../../primitives/transform-box";
+import type { HUDSemanticGroup } from "../../primitives/types";
+
+/**
+ * Input pushed by the host to enable transform-box chrome.
+ * Schema-level feature flag — pass `null` (or never call
+ * `setTransformBox`) to disable.
+ *
+ * @unstable Public shape may change as the transform-box model
+ * stabilises. The contract is shaped by a single integration today;
+ * a second independent consumer will ratify it.
+ */
+export interface TransformBoxInput {
+  /**
+   * Host-defined identity, echoed back on every intent so the host
+   * can correlate (e.g. `"node-1:fill[2]"` for an image-paint
+   * transform, `"node-1:local"` for a free-transform). NOT a NodeId
+   * — the granularity is "one transform" per setter call.
+   */
+  id: string;
+
+  /**
+   * Box-relative affine — same shape as AffineTransform (2×3).
+   * Translation components ([0][2], [1][2]) are normalized [0..1]
+   * against `size`.
+   */
+  transform: AffineTransform;
+
+  /** Box size in doc-space units. */
+  size: cmath.Vector2;
+
+  /**
+   * Doc-space anchor for the box's [0,0]. Combined with `rotation`
+   * to project box-local → doc-space. The box's local frame is
+   * rotated by `+rotation` around `origin` to land in doc-space.
+   */
+  origin: cmath.Vector2;
+
+  /**
+   * Container rotation in degrees (CCW). When non-zero, the
+   * gesture's doc-space cursor delta is de-rotated by `-rotation`
+   * before being fed to the math reducer.
+   */
+  rotation?: number;
+
+  /**
+   * Optional semantic group for visibility policy. All emitted
+   * overlays carry the same group so a single `SurfaceVisibilityPolicy`
+   * toggle suppresses the whole model atomically.
+   */
+  group?: HUDSemanticGroup;
+}
+
+/**
+ * Hover state for the transform-box model — HUD-owned. The chrome
+ * reads this each frame; in the current model nothing differs
+ * visually per hover (handles are transparent by default), but the
+ * cursor mapping reads it (`grab` for corner, `ns/ew-resize` for
+ * sides, `move` for body). Cleared on pointer-out / blur.
+ */
+export type TransformBoxHover =
+  | { kind: "transform_box_body"; id: string }
+  | { kind: "transform_box_side"; id: string; side: cmath.RectangleSide }
+  | {
+      kind: "transform_box_corner";
+      id: string;
+      corner: cmath.IntercardinalDirection;
+    };
+
+/**
+ * Active gesture descriptor that the host's chrome rebuilder uses to
+ * suppress handles during a drag (mirrors padding-overlay). The
+ * Surface derives this from `state.gesture` when the gesture matches
+ * this input's `id`.
+ */
+export type TransformBoxActiveOp =
+  | { type: "translate" }
+  | { type: "scale_side"; side: cmath.RectangleSide }
+  | { type: "rotate"; corner: cmath.IntercardinalDirection };

--- a/packages/grida-canvas-hud/classes/transform-box/intent.ts
+++ b/packages/grida-canvas-hud/classes/transform-box/intent.ts
@@ -1,0 +1,29 @@
+// Transform-box — intent variant.
+
+import type cmath from "@grida/cmath";
+import type { IntentPhase } from "../../event/intent";
+import type { AffineTransform } from "../../primitives/transform-box";
+
+/**
+ * Drag of a transform-box handle. HUD has already reduced the gesture;
+ * the host commits `transform` to whatever field it bound the input to
+ * (image-fit paint transform, free-transform node local transform, …).
+ *
+ * `op` carries the gesture's TYPE and TARGET so the host can
+ * route / log / debug, but never the pointer delta — the host doesn't
+ * need to re-reduce. HUD's reduction is the public outcome (D1 —
+ * subscribe to outcomes, not events).
+ *
+ * `transform` is box-relative (translation normalized [0..1] against
+ * `TransformBoxInput.size`).
+ */
+export type TransformBoxIntent = {
+  kind: "transform_box";
+  id: string;
+  op:
+    | { type: "translate" }
+    | { type: "scale_side"; side: cmath.RectangleSide }
+    | { type: "rotate"; corner: cmath.IntercardinalDirection };
+  transform: AffineTransform;
+  phase: IntentPhase;
+};

--- a/packages/grida-canvas-hud/classes/transform-box/priority.ts
+++ b/packages/grida-canvas-hud/classes/transform-box/priority.ts
@@ -1,0 +1,27 @@
+// Transform-box — priority + sizing constants.
+//
+// Hit-priority slots (lower wins). See the doctrine note on
+// priority-overrides being deferred — these are SDK-internal.
+
+/**
+ * 13 — wins over corner-radius (15) and everything below; loses to
+ * padding-handle (12). Rotate grab should win over corner-radius if
+ * both models overlap on the same node (free-transform case).
+ */
+export const TRANSFORM_BOX_CORNER_PRIORITY = 13;
+
+/** 14 — peer to corners on this model; wins over corner-radius (15). */
+export const TRANSFORM_BOX_SIDE_PRIORITY = 14;
+
+/**
+ * 38 — body translate beats marquee start (40) and selection-translate
+ * body (40); loses to padding-region (35), every resize control (30/31),
+ * and every other handle.
+ */
+export const TRANSFORM_BOX_BODY_PRIORITY = 38;
+
+/** Screen-px size of a corner knob (the rotate hit AABB). */
+export const TRANSFORM_BOX_CORNER_HIT_SIZE = 16;
+
+/** Screen-px thickness of a side mid-edge hit strip. */
+export const TRANSFORM_BOX_SIDE_HIT_THICKNESS = 12;

--- a/packages/grida-canvas-hud/classes/transform-box/surface.ts
+++ b/packages/grida-canvas-hud/classes/transform-box/surface.ts
@@ -1,0 +1,275 @@
+// Transform-box — named-class chrome.
+//
+// What this draws — a four-corner quad (the box outline) plus invisible
+// hit AABBs: 4 corner knobs (rotate), 4 side mid-edges (scale that side),
+// and the body interior (translate). The quad outline is the only visible
+// chrome in idle. Handles are transparent by default (Fitts'-reach via hit
+// AABB > visible target).
+//
+// Anti-goals (what this class is NOT):
+//
+// - **Not an image-paint editor.** First consumer is image-fit; second
+//   consumer is free-transform. The chrome doesn't know about either —
+//   the host binds the box's `transform` to whatever field it owns.
+// - **Not a shear/skew editor.** The reducer in
+//   `primitives/transform-box.ts` doesn't model shear; adding handle
+//   kinds here would be off-spec.
+// - **Not a multi-touch transform.** Single pointer only; no two-finger
+//   rotate. The HUD's gesture state assumes single-stream input.
+// - **Not a host of handle styles.** Style tokens recolor; no per-handle
+//   shape registry, no plugin slot for new handle kinds.
+// - **Not undo-aware.** Host wraps `phase: "preview"` / `"commit"` in
+//   its own history.
+// - **No true original-direction scaling.** Inherited from the math
+//   primitive's `applyScaling` TODO. Stays geometry-based until a host
+//   needs it and pays for the work.
+
+import cmath from "@grida/cmath";
+import type { Rect } from "../../event/gesture";
+import type {
+  HitShape,
+  OverlayElement,
+  RenderShape,
+} from "../../event/overlay";
+import { docToScreen } from "../../event/transform";
+import {
+  decompose,
+  getTransformBoxCorners,
+} from "../../primitives/transform-box";
+import type { HUDStyle } from "../../surface/style";
+import type {
+  TransformBoxActiveOp,
+  TransformBoxHover,
+  TransformBoxInput,
+} from "./input";
+import {
+  TRANSFORM_BOX_BODY_PRIORITY,
+  TRANSFORM_BOX_CORNER_HIT_SIZE,
+  TRANSFORM_BOX_CORNER_PRIORITY,
+  TRANSFORM_BOX_SIDE_HIT_THICKNESS,
+  TRANSFORM_BOX_SIDE_PRIORITY,
+} from "./priority";
+
+const SIDES: readonly cmath.RectangleSide[] = [
+  "top",
+  "right",
+  "bottom",
+  "left",
+];
+const CORNERS: readonly cmath.IntercardinalDirection[] = [
+  "nw",
+  "ne",
+  "se",
+  "sw",
+];
+
+/**
+ * Doc-space point → un-rotated pixel-space within the container. Used
+ * by the gesture dispatcher to de-rotate doc-space cursor deltas before
+ * feeding the math reducer.
+ *
+ * The "pixel-space" output is what `reduceTransformBox` expects for
+ * its `delta` field — i.e. NOT box-local [0..size]; it's the un-
+ * rotated pixel-space the math reducer operates in.
+ */
+export function docDeltaToBoxLocal(
+  input: TransformBoxInput,
+  doc_delta: cmath.Vector2
+): cmath.Vector2 {
+  const rotation = input.rotation ?? 0;
+  if (rotation === 0) return doc_delta;
+  const rad = (-rotation * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return [
+    doc_delta[0] * cos - doc_delta[1] * sin,
+    doc_delta[0] * sin + doc_delta[1] * cos,
+  ];
+}
+
+function rotatePixelToDoc(
+  input: TransformBoxInput,
+  pixel: cmath.Vector2
+): cmath.Vector2 {
+  const { origin, rotation = 0 } = input;
+  if (rotation === 0) {
+    return [pixel[0] + origin[0], pixel[1] + origin[1]];
+  }
+  const rad = (rotation * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return [
+    origin[0] + pixel[0] * cos - pixel[1] * sin,
+    origin[1] + pixel[0] * sin + pixel[1] * cos,
+  ];
+}
+
+/**
+ * Project the 4 transform-box corners through the input pipeline
+ * into doc-space. Returns them in NW/NE/SE/SW order.
+ */
+export function getTransformBoxDocCorners(input: TransformBoxInput): {
+  nw: cmath.Vector2;
+  ne: cmath.Vector2;
+  se: cmath.Vector2;
+  sw: cmath.Vector2;
+} {
+  const corners = getTransformBoxCorners(input.transform, input.size);
+  return {
+    nw: rotatePixelToDoc(input, corners.nw),
+    ne: rotatePixelToDoc(input, corners.ne),
+    se: rotatePixelToDoc(input, corners.se),
+    sw: rotatePixelToDoc(input, corners.sw),
+  };
+}
+
+function sideScreenEndpoints(
+  screen_corners: Record<cmath.IntercardinalDirection, cmath.Vector2>,
+  side: cmath.RectangleSide
+): [cmath.Vector2, cmath.Vector2] {
+  switch (side) {
+    case "top":
+      return [screen_corners.nw, screen_corners.ne];
+    case "right":
+      return [screen_corners.ne, screen_corners.se];
+    case "bottom":
+      return [screen_corners.sw, screen_corners.se];
+    case "left":
+      return [screen_corners.nw, screen_corners.sw];
+  }
+}
+
+/**
+ * Build the per-frame transform-box overlay primitives.
+ *
+ * Emits:
+ *   - 1 quad outline (visible — `HUDPolyline` stroke).
+ *   - 1 body hit polygon (invisible, fill transparent; intercepts events).
+ *   - 4 corner hits (invisible 16×16 rects centered on each corner).
+ *   - 4 side hit strips (invisible 12px-thick rotated rects along each side).
+ */
+export function buildTransformBox(input: {
+  overlay: TransformBoxInput;
+  style: HUDStyle;
+  /** Reserved — handles are invisible today, so hover does not drive
+   *  render. Kept on the contract for the eventual visible-handle
+   *  variant (debug overlay, themed knobs). */
+  hover: TransformBoxHover | null;
+  transform: cmath.Transform;
+  /** Reserved — see `hover`. */
+  active_op?: TransformBoxActiveOp;
+}): OverlayElement[] {
+  const { overlay, style, transform } = input;
+
+  const { id, group } = overlay;
+  const out: OverlayElement[] = [];
+
+  const doc_corners = getTransformBoxDocCorners(overlay);
+
+  const inner_rotation_deg = decompose(overlay.transform).rotation;
+  const base_angle =
+    ((overlay.rotation ?? 0) + inner_rotation_deg) * (Math.PI / 180);
+
+  const quad_points: ReadonlyArray<readonly [number, number]> = [
+    [doc_corners.nw[0], doc_corners.nw[1]],
+    [doc_corners.ne[0], doc_corners.ne[1]],
+    [doc_corners.se[0], doc_corners.se[1]],
+    [doc_corners.sw[0], doc_corners.sw[1]],
+    [doc_corners.nw[0], doc_corners.nw[1]],
+  ];
+
+  const quad_render: RenderShape = {
+    kind: "doc_polyline",
+    points: quad_points,
+    stroke: true,
+    fill: false,
+    color: style.transformBoxStroke,
+    strokeWidth: style.selectionOutlineWidth,
+  };
+
+  // Project every corner once — body AABB and side endpoints both read
+  // from this cache. 8 doc-corner→screen projections collapse to 4.
+  const screen_corners: Record<cmath.IntercardinalDirection, cmath.Vector2> = {
+    nw: docToScreen(transform, doc_corners.nw[0], doc_corners.nw[1]),
+    ne: docToScreen(transform, doc_corners.ne[0], doc_corners.ne[1]),
+    se: docToScreen(transform, doc_corners.se[0], doc_corners.se[1]),
+    sw: docToScreen(transform, doc_corners.sw[0], doc_corners.sw[1]),
+  };
+  const body_hit_rect: Rect = cmath.rect.fromPoints([
+    screen_corners.nw,
+    screen_corners.ne,
+    screen_corners.se,
+    screen_corners.sw,
+  ]);
+
+  out.push({
+    label: `transform_box_body:${id}`,
+    group,
+    action: { kind: "transform_box_body", id },
+    hit: { kind: "screen_aabb", rect: body_hit_rect },
+    render: quad_render,
+    priority: TRANSFORM_BOX_BODY_PRIORITY,
+    cursor: "move",
+  });
+
+  for (const side of SIDES) {
+    const endpoints = sideScreenEndpoints(screen_corners, side);
+    const [sax, say] = endpoints[0];
+    const [sbx, sby] = endpoints[1];
+    const mid: cmath.Vector2 = [(sax + sbx) / 2, (say + sby) / 2];
+    const dx = sbx - sax;
+    const dy = sby - say;
+    const length = Math.hypot(dx, dy);
+    if (length <= 0) continue;
+    const angle = Math.atan2(dy, dx);
+
+    const cos = Math.cos(-angle);
+    const sin = Math.sin(-angle);
+    const inverse_transform: cmath.Transform = [
+      [cos, -sin, mid[0] - cos * mid[0] + sin * mid[1]],
+      [sin, cos, mid[1] - sin * mid[0] - cos * mid[1]],
+    ];
+    const hit_rect: Rect = {
+      x: mid[0] - length / 2,
+      y: mid[1] - TRANSFORM_BOX_SIDE_HIT_THICKNESS / 2,
+      width: length,
+      height: TRANSFORM_BOX_SIDE_HIT_THICKNESS,
+    };
+    const hit: HitShape = {
+      kind: "screen_obb",
+      rect: hit_rect,
+      inverse_transform,
+    };
+    out.push({
+      label: `transform_box_side:${id}:${side}`,
+      group,
+      action: { kind: "transform_box_side", id, side, base_angle },
+      hit,
+      priority: TRANSFORM_BOX_SIDE_PRIORITY,
+      cursor:
+        side === "top" || side === "bottom"
+          ? { kind: "resize", direction: "n", baseAngle: base_angle }
+          : { kind: "resize", direction: "w", baseAngle: base_angle },
+    });
+  }
+
+  for (const corner of CORNERS) {
+    const p = doc_corners[corner];
+    out.push({
+      label: `transform_box_corner:${id}:${corner}`,
+      group,
+      action: { kind: "transform_box_corner", id, corner, base_angle },
+      hit: {
+        kind: "screen_rect_at_doc",
+        anchor_doc: p,
+        width: TRANSFORM_BOX_CORNER_HIT_SIZE,
+        height: TRANSFORM_BOX_CORNER_HIT_SIZE,
+        placement: "center",
+      },
+      priority: TRANSFORM_BOX_CORNER_PRIORITY,
+      cursor: { kind: "rotate", corner, baseAngle: base_angle },
+    });
+  }
+
+  return out;
+}

--- a/packages/grida-canvas-hud/classes/vector-path/index.ts
+++ b/packages/grida-canvas-hud/classes/vector-path/index.ts
@@ -1,0 +1,14 @@
+// Vector-path — named-class entry point.
+//
+// One model (a path), one chrome (segment outlines + vertex knobs +
+// tangent handles + region bodies + ghost insertion knob), one closed
+// gesture grammar across 10 intent variants. Densest class in the
+// package; still one identity, one noun (`vector-path`).
+
+export type {
+  VectorOverlay,
+  VectorChromeInput,
+  VectorChromeOutput,
+} from "./input";
+export type { VectorPathIntent } from "./intent";
+export { buildVectorChrome } from "./surface";

--- a/packages/grida-canvas-hud/classes/vector-path/input.ts
+++ b/packages/grida-canvas-hud/classes/vector-path/input.ts
@@ -1,0 +1,98 @@
+// Vector-path — public input types.
+//
+// The host-pushed shape that drives the chrome. The chrome reads
+// `vector_overlay` (geometry), `vector_selection` (sub-selection mirror),
+// and `vector_hover` (HUD-owned hover state).
+
+import type { HUDSemanticGroup } from "../../primitives/types";
+import type { VectorHover, VectorSubSelection } from "../../event/state";
+import type { OverlayElement } from "../../event/overlay";
+import type { Transform } from "../../event/transform";
+import type { HUDStyle } from "../../surface/style";
+
+/**
+ * Doc-space POJO returned by the host's `vectorOf` callback. The HUD never
+ * imports `@grida/vn` — this minimal shape carries everything chrome needs.
+ *
+ * All coordinates are in doc-space (the HUD's container CSS-px frame). The
+ * host is responsible for projecting from its local frame (e.g. SVG viewBox)
+ * through the camera CTM before handing the data over.
+ */
+export interface VectorOverlay {
+  /** Vertex positions in doc-space. Index === VertexId. */
+  vertices: ReadonlyArray<readonly [number, number]>;
+  /** Optional — present when the host wants segment chrome, tangent
+   *  handles, and segment hit-strips. Each segment carries the four
+   *  cubic control points in doc-space (already projected). */
+  segments?: ReadonlyArray<{
+    a: number;
+    b: number;
+    /** Absolute doc-space position of the first cubic control point
+     *  (= vertices[a] + ta_local, projected through the host's CTM). */
+    a_control: readonly [number, number];
+    /** Absolute doc-space position of the second cubic control point
+     *  (= vertices[b] + tb_local, projected). */
+    b_control: readonly [number, number];
+  }>;
+  /** Vertices whose tangent handles should render. The host computes
+   *  this — selected vertices ∪ their 1-hop neighbours (see
+   *  `PathModel.neighbouringVertices`). Empty list = no tangent handles
+   *  rendered. Spelled `neighbours` (not `neighbouring_vertices`) for
+   *  brevity and so it doesn't collide with the main canvas editor's
+   *  `selection_neighbouring_vertices` state field — if/when the main
+   *  editor adopts this overlay shape, no field-name friction. */
+  neighbours?: ReadonlyArray<number>;
+  /**
+   * Optional — closed-loop "regions" of the path. Each entry names the
+   * segment indices forming one closed loop, in traversal order. The
+   * loop must close (each segment's `b` must match the next segment's
+   * `a`, and the last segment's `b` must match the first's `a`); the
+   * HUD does not validate.
+   *
+   * Schema-level feature flag: absence of this field = backend doesn't
+   * enumerate loops, no region chrome renders. Hosts that can derive
+   * loops (e.g. via `vn.VectorNetworkEditor.getLoops()`) populate it
+   * and pick up the chrome + intent + selection mirror for free.
+   */
+  regions?: ReadonlyArray<{
+    segments: ReadonlyArray<number>;
+  }>;
+  /** Doc-space offset to add to local vertex coords before rendering.
+   *  For hosts that already project to doc-space (most), pass `[0, 0]`. */
+  origin?: readonly [number, number];
+}
+
+export interface VectorChromeInput {
+  /** Sub-selection mirror pushed by the host via `setVectorSelection`.
+   *  Same type the surface stores internally — chrome reads it each draw. */
+  vector_selection: VectorSubSelection;
+  vector_overlay: VectorOverlay;
+  style: HUDStyle;
+  /** Current vector hover (from `SurfaceState.getVectorHover()`). Drives
+   *  hover affordance on segments, vertices, and tangent knobs. */
+  vector_hover?: VectorHover | null;
+  /** Current view transform. Used to compute screen-space cubic control
+   *  points for the per-segment projection-based hit-test (so the
+   *  threshold stays at the same screen-px regardless of zoom). Defaults
+   *  to identity (1:1 doc-screen) when omitted — convenient for tests
+   *  that don't exercise zoom-dependent behavior. */
+  transform?: Transform;
+  /**
+   * True when the user is mid-interaction (pending pointer-down OR
+   * non-idle gesture). When true, the chrome suppresses preview-only
+   * affordances — overlays that exist to suggest "what idle hover would
+   * do" and would compete with the user's actual intent. Currently
+   * gates the ghost insertion knob; reused for any future hover-derived
+   * preview overlay.
+   *
+   * Defaults to `false` so static chrome-render tests behave like idle.
+   * In production, the surface threads `SurfaceState.isInteracting()`
+   * here on every draw.
+   */
+  is_interacting?: boolean;
+  group?: HUDSemanticGroup;
+}
+
+export interface VectorChromeOutput {
+  overlays: OverlayElement[];
+}

--- a/packages/grida-canvas-hud/classes/vector-path/intent.ts
+++ b/packages/grida-canvas-hud/classes/vector-path/intent.ts
@@ -1,0 +1,156 @@
+// Vector-path — intent variants.
+//
+// 10 variants total, all `phase: "preview" | "commit"` where applicable.
+// `enter_content_edit` / `exit_content_edit` stay in `event/intent.ts`
+// — they're orchestration (mode entry/exit), not vector-class-bound.
+
+import type cmath from "@grida/cmath";
+import type { NodeId } from "../../event/gesture";
+import type { IntentPhase, SelectMode } from "../../event/intent";
+
+export type VectorPathIntent =
+  | {
+      /**
+       * Select a single vertex within a path under content-edit. Mode
+       * mirrors the node-level `select` intent. Hosts dispatch to their
+       * path-edit session's sub-selection state.
+       */
+      kind: "select_vertex";
+      node_id: NodeId;
+      index: number;
+      mode: SelectMode;
+    }
+  | {
+      /**
+       * Translate one or more vertices of a path under content-edit. The
+       * delta is in document-space, measured from gesture start to the
+       * current frame. Hosts apply the delta to each indexed vertex.
+       */
+      kind: "translate_vertices";
+      node_id: NodeId;
+      indices: number[];
+      dx: number;
+      dy: number;
+      phase: IntentPhase;
+    }
+  | {
+      /**
+       * Translate the path-edit sub-selection. The host expands its
+       * authoritative sub-selection (selected vertices ∪ endpoints of
+       * selected segments) and UNIONs with `additional_vertex_indices`
+       * before translating. Used by segment-body drag (default — Meta
+       * switches to bend) so a drag of an unselected segment can still
+       * translate its endpoints, and a drag of any item within a multi-
+       * selection translates the whole selection coherently.
+       */
+      kind: "translate_vector_selection";
+      node_id: NodeId;
+      additional_vertex_indices: readonly number[];
+      dx: number;
+      dy: number;
+      phase: IntentPhase;
+    }
+  | {
+      /**
+       * Clear the path-edit sub-selection (vertices / segments / tangents)
+       * WITHOUT exiting content-edit mode and WITHOUT touching the
+       * host's node-level selection.
+       *
+       * Fires when the user single-clicks empty space while in content-
+       * edit. Mirrors the dblclick `exit_content_edit` pattern — same
+       * "click outside to back off" gesture, one fewer step. Without this
+       * the user has no mouse way to drop a vertex sub-selection short of
+       * leaving content-edit entirely.
+       */
+      kind: "clear_vector_selection";
+    }
+  | {
+      /**
+       * Select a single segment within a path under content-edit. Mode
+       * mirrors the node-level `select` intent. Fires when the user clicks
+       * a segment OFF the ghost insertion knob — clicking the ghost itself
+       * fires `split_segment` instead.
+       */
+      kind: "select_segment";
+      node_id: NodeId;
+      segment: number;
+      mode: SelectMode;
+    }
+  | {
+      /**
+       * Select a single closed-loop "region" within a path under
+       * content-edit. Fires when the user clicks the interior body of
+       * a closed loop (no vertex / tangent / segment-strip control
+       * intercepted the click). Mode mirrors the node-level `select`
+       * intent.
+       *
+       * Subsequent drag (if any) promotes to `translate_vector_selection`
+       * — the host applies the delta to the loop's segments and their
+       * endpoint vertices, the same way segment-body drag works today.
+       * No new translate intent kind.
+       *
+       * The host's region commit policy is its own choice: typical
+       * hosts also push the loop's segment indices into
+       * `VectorSubSelection.segments` (so segment chrome highlights too)
+       * and the picked region's id into `VectorSubSelection.regions`
+       * (so the region's `selected` paint shows). The HUD doesn't
+       * presume — it only reports "the user clicked region N."
+       */
+      kind: "select_region";
+      node_id: NodeId;
+      region: number;
+      mode: SelectMode;
+    }
+  | {
+      /**
+       * Select a single tangent within a path under content-edit. Mode
+       * mirrors the node-level `select` intent.
+       */
+      kind: "select_tangent";
+      node_id: NodeId;
+      /** `[vertex_idx, 0]` = ta on segment whose a===v; `[v, 1]` = tb where b===v. */
+      tangent: readonly [number, 0 | 1];
+      mode: SelectMode;
+    }
+  | {
+      /**
+       * Move a single tangent control point to a new doc-space position.
+       * The host applies the mirror policy (`auto` infers from current
+       * smooth-join state, `none` only moves the one tangent, `angle`
+       * mirrors the opposite tangent's angle while preserving its length,
+       * `all` mirrors both angle and length).
+       */
+      kind: "set_tangent";
+      node_id: NodeId;
+      tangent: readonly [number, 0 | 1];
+      pos: cmath.Vector2;
+      mirror: "auto" | "none" | "angle" | "all";
+      phase: IntentPhase;
+    }
+  | {
+      /**
+       * Insert a new vertex on segment `segment` at parametric position
+       * `t ∈ [0,1]`. The split halves inherit the original's verb if
+       * possible; arc groups are broken. Fires once per click — no
+       * preview phase (split is atomic).
+       */
+      kind: "split_segment";
+      node_id: NodeId;
+      segment: number;
+      t: number;
+    }
+  | {
+      /**
+       * Bend segment `segment` by dragging a point originally at parameter
+       * `ca` toward a doc-space target `cb`. The host re-solves the
+       * segment's tangents to put `B(ca) === cb`, holding the endpoints
+       * fixed. `phase` lets the host bracket a history preview the same
+       * way translate does.
+       */
+      kind: "bend_segment";
+      node_id: NodeId;
+      segment: number;
+      ca: number;
+      cb: cmath.Vector2;
+      phase: IntentPhase;
+    };

--- a/packages/grida-canvas-hud/classes/vector-path/priority.ts
+++ b/packages/grida-canvas-hud/classes/vector-path/priority.ts
@@ -1,0 +1,44 @@
+// Vector-path — priority ladder.
+//
+// Hit-priority slots for vector chrome. Lower wins.
+//
+// - Tangents must outrank vertices (the tangent knob is usually OFFSET
+//   from the vertex, so they rarely overlap; when they do — broken handles
+//   collapsed onto the vertex — the user grabbed the more specific
+//   control).
+// - Vertices must outrank segments (clicking a vertex shouldn't
+//   accidentally split the connected segment).
+// - Segment strips are the lowest of the three (they cover the entire
+//   path body and should lose to any specific control).
+//
+// Set below `HUDHitPriority.ENDPOINT_HANDLE` (10) so vector chrome wins
+// during content-edit mode.
+
+export const TANGENT_HANDLE_PRIORITY = 4;
+export const VERTEX_HANDLE_PRIORITY = 5;
+
+/**
+ * Ghost insertion knob — sits between vertex (real, wins) and segment
+ * (body, loses). The ghost is a transient control born of segment hover,
+ * so a real vertex collapsed onto it should win, but ANY segment-body
+ * click that lands on the knob should snap to the ghost's split action.
+ */
+export const GHOST_HANDLE_PRIORITY = 7;
+
+export const SEGMENT_STRIP_PRIORITY = 8;
+
+/**
+ * Closed-loop "region" body — the lowest-priority vector control. Loses
+ * to every specific control (vertex / tangent / ghost / segment-strip)
+ * so a click on a control within the loop's bbox still reaches the
+ * control. Wins over the implicit "no overlay" miss, so an empty-body
+ * click selects the region instead of falling through to the empty-
+ * space marquee.
+ */
+export const REGION_PRIORITY = 9;
+
+/**
+ * Highest priority value = loses to everything — used for decorative
+ * segment outlines and tangent lines that should never absorb input.
+ */
+export const DECORATIVE_PRIORITY = 1000;

--- a/packages/grida-canvas-hud/classes/vector-path/surface.ts
+++ b/packages/grida-canvas-hud/classes/vector-path/surface.ts
@@ -1,4 +1,4 @@
-// Vector chrome — overlays for path content-edit mode.
+// Vector-path — named-class chrome.
 //
 // Rendered when `SurfaceState.getVectorSelection()` is non-null AND the host
 // provided a `vectorOf` callback that resolves the active path's geometry.
@@ -13,7 +13,6 @@
 //                          region is N small samples along the curve.
 //                          Idle: gray, 1px. Hover: chrome color, 3px @
 //                          50% opacity. Selected: chrome color, 3px solid.
-//                          Mirrors the main editor's segment chrome.
 //   2. Vertex knobs      — PAIRED. Small circle render, padded square hit.
 //   3. Tangent handles   — PAIRED knob (small diamond render — a 45°-
 //                          rotated square so it reads as a different
@@ -22,82 +21,53 @@
 //                          to control point. Only emitted for vertices
 //                          in `neighbours`. Selected-tangent line
 //                          renders at a thicker width.
+//   4. Region bodies     — PAIRED. Closed-loop polygons rasterised from
+//                          the segment list; hit-tested via screen-space
+//                          point-in-polygon.
+//   5. Ghost insertion knob — VIRTUAL preview while hovering a segment;
+//                              click commits a `split_segment` intent.
 //
 // Disagreement-by-design: visible knobs are small (legibility), hit
 // regions are padded to MIN_HIT_SIZE (Fitts').
+//
+// Anti-goals (what this class is NOT):
+//
+// - **Not a path editor.** The host owns the path data — vertices,
+//   segments, regions, the model of "what a curve is." This class draws
+//   chrome over a host-supplied `VectorOverlay` POJO and emits intents
+//   describing what the user did to it. The host's commit logic decides
+//   what to do.
+// - **Not a sub-selection store.** Selected vertices / segments / regions
+//   are mirrored via `setVectorSelection`; the chrome reads it each frame.
+//   No internal selection authority.
+// - **Not a constraint solver.** Bend and tangent intents carry resolved
+//   geometry; the host's path-edit session decides whether to re-solve
+//   smooth joins, project to grids, snap to siblings, etc.
+// - **Not multi-path.** One `VectorOverlay` per setter call (the
+//   currently-edited path). Multi-path editing isn't a model this
+//   class supports.
+// - **Not undo-aware.** Intents stream `phase: "preview"`; host owns
+//   history.
 
-import type { OverlayElement, RenderShape } from "../event/overlay";
-import { MIN_HIT_SIZE } from "../event/overlay";
-import type { NodeId } from "../event/gesture";
-import type { VectorHover, VectorSubSelection } from "../event/state";
-import { docToScreen, IDENTITY, type Transform } from "../event/transform";
-import type { HUDStyle } from "./style";
-import type { HUDSemanticGroup } from "../primitives/types";
 import cmath from "@grida/cmath";
+import type { NodeId } from "../../event/gesture";
+import type { OverlayElement, RenderShape } from "../../event/overlay";
+import { MIN_HIT_SIZE } from "../../event/overlay";
+import { docToScreen, IDENTITY } from "../../event/transform";
+import type { HUDSemanticGroup } from "../../primitives/types";
+import type { HUDStyle } from "../../surface/style";
+import type { VectorChromeInput, VectorChromeOutput } from "./input";
+import {
+  DECORATIVE_PRIORITY,
+  GHOST_HANDLE_PRIORITY,
+  REGION_PRIORITY,
+  SEGMENT_STRIP_PRIORITY,
+  TANGENT_HANDLE_PRIORITY,
+  VERTEX_HANDLE_PRIORITY,
+} from "./priority";
 
-/**
- * Doc-space POJO returned by the host's `vectorOf` callback. The HUD never
- * imports `@grida/vn` — this minimal shape carries everything chrome needs.
- *
- * All coordinates are in doc-space (the HUD's container CSS-px frame). The
- * host is responsible for projecting from its local frame (e.g. SVG viewBox)
- * through the camera CTM before handing the data over.
- */
-export interface VectorOverlay {
-  /** Vertex positions in doc-space. Index === VertexId. */
-  vertices: ReadonlyArray<readonly [number, number]>;
-  /** Optional — present when the host wants segment chrome, tangent
-   *  handles, and segment hit-strips. Each segment carries the four
-   *  cubic control points in doc-space (already projected). */
-  segments?: ReadonlyArray<{
-    a: number;
-    b: number;
-    /** Absolute doc-space position of the first cubic control point
-     *  (= vertices[a] + ta_local, projected through the host's CTM). */
-    a_control: readonly [number, number];
-    /** Absolute doc-space position of the second cubic control point
-     *  (= vertices[b] + tb_local, projected). */
-    b_control: readonly [number, number];
-  }>;
-  /** Vertices whose tangent handles should render. The host computes
-   *  this — selected vertices ∪ their 1-hop neighbours (see
-   *  `PathModel.neighbouringVertices`). Empty list = no tangent handles
-   *  rendered. Spelled `neighbours` (not `neighbouring_vertices`) for
-   *  brevity and so it doesn't collide with the main canvas editor's
-   *  `selection_neighbouring_vertices` state field — if/when the main
-   *  editor adopts this overlay shape, no field-name friction. */
-  neighbours?: ReadonlyArray<number>;
-  /** Doc-space offset to add to local vertex coords before rendering.
-   *  For hosts that already project to doc-space (most), pass `[0, 0]`. */
-  origin?: readonly [number, number];
-}
-
-/**
- * Hit-priority ladder for vector chrome. Lower wins.
- *
- * - Tangents must outrank vertices (the tangent knob is usually OFFSET
- *   from the vertex, so they rarely overlap; when they do — broken handles
- *   collapsed onto the vertex — the user grabbed the more specific
- *   control).
- * - Vertices must outrank segments (clicking a vertex shouldn't
- *   accidentally split the connected segment).
- * - Segment strips are the lowest of the three (they cover the entire
- *   path body and should lose to any specific control).
- *
- * Set below `HUDHitPriority.ENDPOINT_HANDLE` (10) so vector chrome wins
- * during content-edit mode.
- */
-const TANGENT_HANDLE_PRIORITY = 4;
-const VERTEX_HANDLE_PRIORITY = 5;
-/** Ghost insertion knob — sits between vertex (real, wins) and segment
- *  (body, loses). The ghost is a transient control born of segment hover,
- *  so a real vertex collapsed onto it should win, but ANY segment-body
- *  click that lands on the knob should snap to the ghost's split action. */
-const GHOST_HANDLE_PRIORITY = 7;
-const SEGMENT_STRIP_PRIORITY = 8;
-/** Highest priority value = loses to everything — used for decorative
- *  segment outlines and tangent lines that should never absorb input. */
-const DECORATIVE_PRIORITY = 1000;
+// VectorOverlay / VectorChromeInput / VectorChromeOutput types live in
+// ./input.ts. Priority constants live in ./priority.ts.
 
 /** Per-segment sample count for the visual outline ONLY.
  *
@@ -106,6 +76,14 @@ const DECORATIVE_PRIORITY = 1000;
  * which projects the cursor onto the cubic exactly (mirrors the main
  * editor's `cmath.bezier.project`-based model). */
 const SEGMENT_SAMPLES = 24;
+
+/** Per-segment sample count for region polygon flattening. Used both
+ *  for the rasterised polygon the region uses to render its fill AND
+ *  for the screen-space polygon its `customHitTest` runs
+ *  `pointInPolygon` against. Higher than `SEGMENT_SAMPLES` because the
+ *  polygon is consumed by hit-test, not just rendered — a coarse
+ *  rasterisation would leak clicks near a curved boundary. */
+const REGION_SAMPLES = 32;
 
 /** Distance threshold (screen-px) for "the cursor is near this segment."
  *  Applied inside the segment's customHitTest after AABB containment.
@@ -117,41 +95,6 @@ const SEGMENT_HIT_THRESHOLD_PX = MIN_HIT_SIZE / 2;
  *  insertion point while the cursor hovers a segment. Smaller than a real
  *  vertex knob so the user can tell preview from committed. */
 const GHOST_VERTEX_SIZE = 6;
-
-export interface VectorChromeInput {
-  /** Sub-selection mirror pushed by the host via `setVectorSelection`.
-   *  Same type the surface stores internally — chrome reads it each draw. */
-  vector_selection: VectorSubSelection;
-  vector_overlay: VectorOverlay;
-  style: HUDStyle;
-  /** Current vector hover (from `SurfaceState.getVectorHover()`). Drives
-   *  hover affordance on segments, vertices, and tangent knobs. */
-  vector_hover?: VectorHover | null;
-  /** Current view transform. Used to compute screen-space cubic control
-   *  points for the per-segment projection-based hit-test (so the
-   *  threshold stays at the same screen-px regardless of zoom). Defaults
-   *  to identity (1:1 doc-screen) when omitted — convenient for tests
-   *  that don't exercise zoom-dependent behavior. */
-  transform?: Transform;
-  /**
-   * True when the user is mid-interaction (pending pointer-down OR
-   * non-idle gesture). When true, the chrome suppresses preview-only
-   * affordances — overlays that exist to suggest "what idle hover would
-   * do" and would compete with the user's actual intent. Currently
-   * gates the ghost insertion knob; reused for any future hover-derived
-   * preview overlay.
-   *
-   * Defaults to `false` so static chrome-render tests behave like idle.
-   * In production, the surface threads `SurfaceState.isInteracting()`
-   * here on every draw.
-   */
-  is_interacting?: boolean;
-  group?: HUDSemanticGroup;
-}
-
-export interface VectorChromeOutput {
-  overlays: OverlayElement[];
-}
 
 function offset_point(
   p: readonly [number, number],
@@ -179,10 +122,10 @@ function make_segment_action(
     segment,
     a_idx,
     b_idx,
-    a: [a[0], a[1]] as readonly [number, number],
-    b: [b[0], b[1]] as readonly [number, number],
-    a_control: [a_control[0], a_control[1]] as readonly [number, number],
-    b_control: [b_control[0], b_control[1]] as readonly [number, number],
+    a,
+    b,
+    a_control,
+    b_control,
   };
 }
 
@@ -240,8 +183,149 @@ export function buildVectorChrome(
       : null;
   const hovered_segment =
     vector_hover && vector_hover.kind === "segment" ? vector_hover.segment : -1;
+  const hovered_region =
+    vector_hover && vector_hover.kind === "region" ? vector_hover.region : -1;
 
   const segments = vector_overlay.segments;
+  const regions = vector_overlay.regions;
+  const selected_region_set = new Set(vector_selection.regions ?? []);
+
+  // ─── Regions (closed-loop body chrome) ─────────────────────────────────
+  //
+  // Schema-level feature flag: emitted iff `vector_overlay.regions` is
+  // present AND `vector_overlay.segments` is present (regions reference
+  // segment indices — without segment data there's nothing to flatten).
+  //
+  // For each region we emit ONE overlay:
+  //
+  //   - hit:    screen-space AABB + customHitTest running `pointInPolygon`
+  //             against the rasterised screen-space loop polygon.
+  //             Mirrors the segment-strip's AABB+refinement model.
+  //
+  //   - render: doc-space closed `doc_polyline` (the cubic samples for
+  //             each segment, concatenated, last point === first). Painted
+  //             with `fill: true` + `fillPaint = vectorRegionHoverPaint`
+  //             (hover state) or `vectorRegionSelectedPaint` (selected
+  //             state). Idle = no fill (render omitted entirely).
+  //
+  // Priority `REGION_PRIORITY` loses to every specific vector control,
+  // wins over the empty-space miss — the body of a closed loop becomes
+  // clickable without claiming pixels owned by vertices, tangents,
+  // ghost, or segment strips.
+  //
+  // Painted FIRST so vertex / tangent / segment / ghost chrome render
+  // visually on top of the region's hover fill.
+  if (regions && segments) {
+    for (let ri = 0; ri < regions.length; ri++) {
+      const region = regions[ri];
+      if (region.segments.length === 0) continue;
+
+      // Rasterise the cubic loop in DOC space (for render) and SCREEN
+      // space (for hit-test). Concatenate per-segment samples; the loop's
+      // closing edge is implicit (last sample === first by construction
+      // when the loop is well-formed; we still write `last = first`
+      // explicitly at the end so the polyline closes even on malformed
+      // input).
+      const loop_doc: [number, number][] = [];
+      const loop_screen: cmath.Vector2[] = [];
+      // Union of endpoint vertex indices — registered on the action so
+      // a drag promotion can seed `translate_vector_selection.additional_vertex_indices`.
+      const vertices_in_loop = new Set<number>();
+      for (let li = 0; li < region.segments.length; li++) {
+        const si = region.segments[li];
+        if (si < 0 || si >= segments.length) continue;
+        const seg = segments[si];
+        const a_doc = offset_point(vector_overlay.vertices[seg.a], origin);
+        const b_doc = offset_point(vector_overlay.vertices[seg.b], origin);
+        const ta_abs_doc = offset_point(seg.a_control, origin);
+        const tb_abs_doc = offset_point(seg.b_control, origin);
+        const ta_rel_doc: cmath.Vector2 = [
+          ta_abs_doc[0] - a_doc[0],
+          ta_abs_doc[1] - a_doc[1],
+        ];
+        const tb_rel_doc: cmath.Vector2 = [
+          tb_abs_doc[0] - b_doc[0],
+          tb_abs_doc[1] - b_doc[1],
+        ];
+        vertices_in_loop.add(seg.a);
+        vertices_in_loop.add(seg.b);
+        // Sample i = 0..N-1 (exclusive end). The next segment's i = 0
+        // duplicates this segment's i = N, so dropping the closing
+        // endpoint here avoids duplicate vertices in the polygon —
+        // matters for `pointInPolygon` consistency.
+        for (let i = 0; i < REGION_SAMPLES; i++) {
+          const t = i / REGION_SAMPLES;
+          const p = cmath.bezier.evaluate(
+            a_doc,
+            b_doc,
+            ta_rel_doc,
+            tb_rel_doc,
+            t
+          );
+          loop_doc.push([p[0], p[1]]);
+          const [sx, sy] = docToScreen(transform, p[0], p[1]);
+          loop_screen.push([sx, sy]);
+        }
+      }
+      if (loop_doc.length < 3) continue;
+      // Explicit closing point — last === first — so the doc_polyline
+      // renderer's `closePath()` produces a clean closed shape.
+      loop_doc.push([loop_doc[0][0], loop_doc[0][1]]);
+
+      // Screen-space AABB of the rasterised polygon. Padded by 1 px so
+      // an exact-boundary hit (the pointInPolygon "onEdge" branch)
+      // still passes the AABB containment check upstream.
+      const aabb_pad = 1;
+      const bbox = cmath.rect.fromPoints(loop_screen);
+      const hit_rect = {
+        x: bbox.x - aabb_pad,
+        y: bbox.y - aabb_pad,
+        width: bbox.width + 2 * aabb_pad,
+        height: bbox.height + 2 * aabb_pad,
+      };
+
+      const is_selected = selected_region_set.has(ri);
+      const is_hovered = hovered_region === ri;
+      // Hover wins over selected — matches every other vector overlay's
+      // precedence (vertex / segment / tangent / ghost knobs).
+      const fill_paint = is_hovered
+        ? style.vectorRegionHoverPaint
+        : is_selected
+          ? style.vectorRegionSelectedPaint
+          : undefined;
+
+      // Closure captures the screen-space polygon by reference. The
+      // chrome is rebuilt every frame so the polygon never goes stale
+      // beyond one frame's worth of pan/zoom.
+      const polygon_screen = loop_screen;
+
+      overlays.push({
+        label: `region:${ri}`,
+        group,
+        action: {
+          kind: "region",
+          node_id,
+          region: ri,
+          segments: region.segments,
+          vertices: Array.from(vertices_in_loop),
+        },
+        hit: { kind: "screen_aabb", rect: hit_rect },
+        customHitTest: (screen_point) =>
+          cmath.polygon.pointInPolygon(screen_point, polygon_screen),
+        render: fill_paint
+          ? ({
+              kind: "doc_polyline",
+              points: loop_doc,
+              stroke: false,
+              fill: true,
+              fillPaint: fill_paint,
+            } satisfies Extract<RenderShape, { kind: "doc_polyline" }>)
+          : undefined,
+        priority: REGION_PRIORITY,
+        cursor: "pointer",
+      });
+    }
+  }
 
   // ─── Segments ───────────────────────────────────────────────────────────
   //
@@ -259,9 +343,9 @@ export function buildVectorChrome(
   //        re-projects on demand to get the live `t` (for hover preview
   //        and for split/bend down-time).
   //
-  // This mirrors the main editor's `snapped_segment_p` model: one
-  // candidate insertion point per segment per cursor position, computed
-  // exactly via `cmath.bezier.project` — NOT pre-sampled.
+  // Single-candidate insertion model: one candidate insertion point per
+  // segment per cursor position, computed exactly via `cmath.bezier.project`
+  // — NOT pre-sampled.
   if (segments) {
     for (let si = 0; si < segments.length; si++) {
       const seg = segments[si];
@@ -563,7 +647,7 @@ export function buildVectorChrome(
   // ─── 4. Vertex knobs (PAIRED) ──────────────────────────────────────────
   //
   // Painted LAST so they appear on top of segment outlines and tangent
-  // lines — matches the main editor's z-order.
+  // lines.
   for (let i = 0; i < vector_overlay.vertices.length; i++) {
     const v = vector_overlay.vertices[i];
     const anchor_doc = offset_point(v, origin);
@@ -685,7 +769,7 @@ function emit_tangent_handle(args: {
   }
 
   // (a) DECORATIVE line from vertex to control point. No hit region.
-  //     Width 1 idle, width 2 selected — matches the main editor.
+  //     Width 1 idle, width 2 selected (per `style.tangentLine*Width`).
   overlays.push({
     label: `tangent_line:${vertex_idx}:${end}`,
     group,

--- a/packages/grida-canvas-hud/event/decision.ts
+++ b/packages/grida-canvas-hud/event/decision.ts
@@ -141,6 +141,21 @@ export const enum Scenario {
   HandleSegmentNarrowOrDrag = "HandleSegmentNarrowOrDrag",
   HandleSegmentToggleOrDrag = "HandleSegmentToggleOrDrag",
   /**
+   * Closed-loop "region" pointer-down. Eager `select_region` at down-time
+   * (parity with segment / vertex / tangent on the "not yet in axis-set"
+   * branch); drag-promotes to `translate_vector_selection` with the
+   * loop's endpoint vertices seeded into `additional_vertex_indices`.
+   *
+   * Region selection has no axis-set "narrow/toggle" branch — regions
+   * are derived data (loops are recomputed when geometry changes), so
+   * the host's region-selection state is not the source of truth the way
+   * a vertex/segment id set is. The HUD reports "user clicked region N";
+   * the host decides whether to keep it, narrow to it, or toggle. Shift
+   * still flows through as `mode: "toggle"` for the host's discretion.
+   */
+  HandleRegionReplace = "HandleRegionReplace",
+  HandleRegionAdd = "HandleRegionAdd",
+  /**
    * Ghost-handle pointer-down — cursor is on the half-point insertion knob.
    *
    * EAGER: the press immediately splits the segment AND grabs the inserted
@@ -154,6 +169,23 @@ export const enum Scenario {
    * singleton-this segment-body case.
    */
   HandleGhostSplit = "HandleGhostSplit",
+  /**
+   * Pointer-down on a padding-overlay drag handle. Opens a
+   * `padding_handle` gesture eagerly in `state.ts` BEFORE the
+   * classifier runs — this scenario exists for classification
+   * inspection only (tests / docs). Dispatch returns `noop`
+   * because the eager intercept already handled the state
+   * transition.
+   */
+  HandlePaddingDrag = "HandlePaddingDrag",
+  /**
+   * Pointer-down on a transform-box hit region (body/side/corner).
+   * Opens a `transform_box` gesture eagerly in `state.ts` BEFORE the
+   * classifier runs — this scenario exists for classification
+   * inspection only (tests / docs). Dispatch returns `noop` because
+   * the eager intercept already handled the state transition.
+   */
+  HandleTransformBoxDrag = "HandleTransformBoxDrag",
 
   // ── Empty space ─────────────────────────────────────────────────────────
   EmptyDeselectThenMarquee = "EmptyDeselectThenMarquee",
@@ -221,9 +253,8 @@ export interface PointerDownInput {
   /**
    * Parametric `t` for the bend gesture's pivot `ca` — **always** the
    * cursor's geometry-aware projection onto the cubic at pointer-down,
-   * mode-INDEPENDENT. Mirrors the main editor's
-   * `t0Ref = cmath.bezier.project(point)` in
-   * `surface-vector-editor.tsx:337`.
+   * mode-INDEPENDENT. The pivot follows the cursor regardless of
+   * insertion mode.
    *
    * Kept separate from `segment_split_t` because the two `t`s answer
    * different questions: split-`t` is "where will the new vertex go?"
@@ -314,8 +345,7 @@ export type PendingPromote =
        * `start_translate_tangent` gesture (absolute "curve" semantics,
        * mirror modifiers applicable at gesture level). Used only when
        * the tangent ∈ sub-selection AND the sub-selection is exactly
-       * this one tangent (singleton-this). Mirrors main editor's
-       * "curve" gesture (`use-sub-vector-network-editor.ts:141-149`).
+       * this one tangent (singleton-this).
        *
        * The deferred `select_tangent` is cancelled at drag-promote per
        * the standard rule — no select intent fires.
@@ -451,6 +481,23 @@ export type PointerDownDecision =
       mode: SelectMode;
       pending: PendingPlan;
     }
+  | {
+      /**
+       * Eagerly emit a `select_region` intent AND open a pending pointer-down
+       * for drag-promotion. Mirrors `immediate_select_segment` for closed-loop
+       * region picks: the region is selected at pointer-down; a drag promotes
+       * to `translate_vector_selection` over the loop's endpoint vertices.
+       *
+       * Click-no-drag leaves the region selected (the host's commit policy
+       * decides whether that also promotes the loop's segments into the
+       * sub-selection mirror — the HUD doesn't presume).
+       */
+      kind: "immediate_select_region";
+      node_id: NodeId;
+      region: number;
+      mode: SelectMode;
+      pending: PendingPlan;
+    }
   | { kind: "pend"; pending: PendingPlan }
   | {
       kind: "start_marquee_pend";
@@ -504,7 +551,8 @@ export function classifyScenario(input: PointerDownInput): Scenario {
       (ui_action.kind === "vertex_handle" ||
         ui_action.kind === "tangent_handle" ||
         ui_action.kind === "segment_strip" ||
-        ui_action.kind === "ghost_handle");
+        ui_action.kind === "ghost_handle" ||
+        ui_action.kind === "region");
     if (!is_vector_control) return Scenario.ExitEdit;
   }
 
@@ -541,6 +589,34 @@ export function classifyScenario(input: PointerDownInput): Scenario {
       }
       case "ghost_handle":
         return readonly ? Scenario.Noop : Scenario.HandleGhostSplit;
+      case "padding_handle":
+        // The padding-handle gesture is opened eagerly in state.ts
+        // (before classifyScenario runs). This case is reached only
+        // when classification is exercised directly (tests / inspectors).
+        return readonly ? Scenario.Noop : Scenario.HandlePaddingDrag;
+      case "transform_box_body":
+      case "transform_box_side":
+      case "transform_box_corner":
+        // Transform-box gestures are opened eagerly in state.ts (before
+        // classifyScenario runs) for all 3 hit kinds. This case is
+        // reached only when classification is exercised directly
+        // (tests / inspectors).
+        return readonly ? Scenario.Noop : Scenario.HandleTransformBoxDrag;
+      case "padding_region":
+        // Body of a padding-overlay side is **event-transparent**: it
+        // wins the hit-test only to drive the hover stripe paint, NOT
+        // to intercept clicks. Fall out of the switch and let Tier-2 /
+        // empty-space classification fire as if there were no UI hit
+        // — clicks on the body translate the underlying selection (or
+        // marquee, etc.), exactly like clicks on the rest of the
+        // container's body. The handle (at higher priority) is the
+        // sole interactive padding overlay.
+        break;
+      case "region":
+        if (readonly) return Scenario.Noop;
+        return modifiers.shift
+          ? Scenario.HandleRegionAdd
+          : Scenario.HandleRegionReplace;
 
       case "select_node": {
         // Treated like Tier-2 content: it's a content-representative click.
@@ -657,9 +733,8 @@ const SEGMENT_VARIANT_TO_SCENARIO: Record<AxisVariant, Scenario> = {
  * bend." Singleton-this is therefore a strict equality, not a
  * cardinality check.
  *
- * Mirrors main editor's `use-sub-vector-network-editor.ts:141-149`
- * branch: `multi > 1` (mixed or multiple) → translate-vector-controls;
- * else → curve/bend gesture.
+ * The branching rule: `multi > 1` (mixed or multiple) → delta-translate
+ * the whole selection; else → curve/bend gesture for this single target.
  */
 function isSingletonThisSegment(
   segment: number,
@@ -826,8 +901,7 @@ function dispatch(
     //     `start_translate_tangent` (curve/set_tangent gesture).
     //   - else (multi/mixed) → `translate_vector_selection` (delta-translate
     //     the whole sub-selection; host applies delta to selected tangents
-    //     too, with parent-vertex exclusion — see svg-editor's
-    //     `handle_translate_vector_selection`).
+    //     too, with parent-vertex exclusion).
     case Scenario.HandleTangentReplace:
     case Scenario.HandleTangentAdd: {
       const a = ui_action as Extract<OverlayAction, { kind: "tangent_handle" }>;
@@ -955,6 +1029,42 @@ function dispatch(
         },
       };
     }
+    case Scenario.HandleRegionReplace:
+    case Scenario.HandleRegionAdd: {
+      const a = ui_action as Extract<OverlayAction, { kind: "region" }>;
+      return {
+        kind: "immediate_select_region",
+        node_id: a.node_id,
+        region: a.region,
+        mode: modifiers.shift ? "toggle" : "replace",
+        pending: {
+          ids_at_down: [],
+          // Drag from a region body translates the loop's segments and
+          // their endpoint vertices. The HUD seeds the additional
+          // vertex indices from the action so the host can translate
+          // the loop even before its `setVectorSelection` echoes the
+          // region select back into the sub-selection mirror.
+          promote_to: {
+            kind: "translate_vector_selection",
+            node_id: a.node_id,
+            additional_vertex_indices: a.vertices,
+          },
+        },
+      };
+    }
+    case Scenario.HandlePaddingDrag:
+      // The eager intercept in `state.ts:onPointerDown` handles this
+      // scenario; the classifier reaches here only when invoked
+      // directly (tests / inspectors). Returning `noop` here keeps the
+      // dispatch table total without duplicating gesture-open logic.
+      return { kind: "noop" };
+
+    case Scenario.HandleTransformBoxDrag:
+      // Same pattern as HandlePaddingDrag — the gesture is opened
+      // eagerly in `state.ts:onPointerDown` for all 3 hit kinds. This
+      // dispatch arm is reached only by direct classifier invocation.
+      return { kind: "noop" };
+
     case Scenario.HandleGhostSplit: {
       const a = ui_action as Extract<OverlayAction, { kind: "ghost_handle" }>;
       // Cursor is ON the ghost insertion knob — eager dispatch. The
@@ -1122,6 +1232,47 @@ export function decideIdleCursor(input: {
       case "ghost_handle":
         // On the half-point insertion knob: click splits, drag bends.
         return "pointer";
+      case "region":
+        // Hovering a closed-loop body — click selects the region,
+        // drag translates the loop. `pointer` reads like every other
+        // vector control's idle cursor; switching to `move` would
+        // suggest "drag-only," which isn't the contract here.
+        return "pointer";
+      case "padding_region":
+        // Body is event-transparent. Defer to the underlying scene's
+        // cursor — falls through to the post-switch logic below.
+        break;
+      case "padding_handle":
+        // Mid-edge drag knob on a padding-overlay side. Axis-aligned:
+        // top/bottom → vertical resize cursor; left/right → horizontal.
+        return ui_action.side === "top" || ui_action.side === "bottom"
+          ? { kind: "resize", direction: "n" }
+          : { kind: "resize", direction: "w" };
+      case "transform_box_body":
+        // Body of a transform-box: translate. Same `move` cursor as
+        // translate_handle. (Visually consistent with the rest of the
+        // "drag the body to translate" affordance.)
+        return "move";
+      case "transform_box_side":
+        // Side of a transform-box: scale on that axis. `base_angle`
+        // tilts the resize arrow to match the visible box rotation —
+        // mirrors `resize_handle.baseAngle` so the cursor never drifts
+        // off-axis when the box rotates.
+        return {
+          kind: "resize",
+          direction:
+            ui_action.side === "top" || ui_action.side === "bottom" ? "n" : "w",
+          baseAngle: ui_action.base_angle,
+        };
+      case "transform_box_corner":
+        // Corner of a transform-box: rotate. Use the rotate-arc cursor
+        // (the gesture IS a rotate) tilted by `base_angle`. Mirrors
+        // `rotate_handle.baseAngle`.
+        return {
+          kind: "rotate",
+          corner: ui_action.corner,
+          baseAngle: ui_action.base_angle,
+        };
     }
   }
   if (hovered_id && selection_ids.includes(hovered_id)) {
@@ -1136,13 +1287,12 @@ export function decideIdleCursor(input: {
  *
  * Used by `decideIdleCursor` and by the rotate-gesture cursor compositor
  * so the resize / rotate cursor always tilts to match the selection's
- * orientation — without requiring the HUD's camera to be axis-aligned
- * for the doc-space angle to be the right thing to render (the renderer
- * draws the cursor in screen px, and in svg-editor the camera contributes
- * scale + translate only, so doc-space == screen-space rotation).
+ * orientation — without requiring the HUD's camera to be axis-aligned.
+ * Hosts whose camera contributes scale + translate only get
+ * doc-space == screen-space rotation here.
  *
  * For hosts that ROTATE the HUD camera, this should compose with the
- * camera's angle at consume time. Not relevant for svg-editor.
+ * camera's angle at consume time.
  */
 function shape_screen_angle_rad(shape: SelectionShape): number {
   if (shape.kind !== "transformed") return 0;

--- a/packages/grida-canvas-hud/event/decision.ts
+++ b/packages/grida-canvas-hud/event/decision.ts
@@ -285,6 +285,13 @@ export interface PointerDownInput {
     vertices: readonly number[];
     segments: readonly number[];
     tangents: readonly (readonly [number, 0 | 1])[];
+    /**
+     * Selected region indices. Optional for back-compat with callers that
+     * pre-date the vector-path `regions` axis; future region-axis
+     * scenarios (narrow/toggle/drag, mirroring the other sub-selection
+     * axes) will read this slot. Treat absent as empty.
+     */
+    regions?: readonly number[];
   };
   /**
    * Sticky-bend override (default `"auto"`). When `"always"`, the

--- a/packages/grida-canvas-hud/event/gesture.ts
+++ b/packages/grida-canvas-hud/event/gesture.ts
@@ -1,4 +1,5 @@
 import cmath from "@grida/cmath";
+import type { AffineTransform } from "../primitives/transform-box";
 import type { ResizeDirection, RotationCorner } from "./cursor";
 // Type-only import — `SelectionShape` is defined in `./shape`, which itself
 // imports `NodeId` and `Rect` from this file. TS resolves cyclic type imports
@@ -291,6 +292,71 @@ export type SurfaceGesture =
        *  Pointer-up skips commit on click-only interactions because
        *  `value` is seeded from the inset-padded knob position at
        *  pointer-down. */
+      dragged: boolean;
+    }
+  | {
+      /**
+       * Drag of a `padding_handle` knob (padding named class). Opened
+       * eagerly from a `padding_handle` overlay action; emits
+       * `padding_handle` intents on every move + commit.
+       *
+       * `mirror` is NOT latched at gesture start — read live on each
+       * frame from `state.modifiers.alt`. Per the doctrine: "modifier
+       * change mid-gesture updates `mirror` on subsequent previews."
+       *
+       * The container `rect` and starting value are captured at
+       * pointer_down so subsequent value projection (`projectPaddingValue`)
+       * stays exact through camera moves — value math runs in doc-space
+       * against the rect snapshot, not the live geometry.
+       */
+      kind: "padding_handle";
+      node_id: NodeId;
+      side: cmath.RectangleSide;
+      /** Container rect snapshot at gesture start (doc-space). */
+      rect: Rect;
+      /** Initial padding value at gesture start (doc-space units). */
+      initial_value: number;
+      /** Most-recent doc-space pointer. */
+      last_doc: cmath.Vector2;
+      /** Most-recent computed value (doc-space units, clamped to [0, max]). */
+      value: number;
+      /** Flips to `true` the first time `pointer_move` advances the
+       *  gesture state. Pointer-up skips commit on click-only
+       *  interactions — `value === initial_value` on first frame. */
+      dragged: boolean;
+    }
+  | {
+      /**
+       * Drag of a transform-box handle (transform-box named class).
+       * Opened eagerly from a `transform_box_{body,side,corner}` overlay
+       * action; emits `transform_box` intents on every move + commit.
+       *
+       * `base_transform` is the transform at gesture start (frozen);
+       * each preview reduces from `base_transform` against the
+       * cumulative doc-space delta. `size` and `rotation` are the
+       * container parameters at gesture start (frozen — container
+       * doesn't change shape mid-gesture).
+       */
+      kind: "transform_box";
+      id: string;
+      op:
+        | { type: "translate" }
+        | { type: "scale_side"; side: cmath.RectangleSide }
+        | { type: "rotate"; corner: cmath.IntercardinalDirection };
+      /** Box size in doc-space units (frozen at gesture start). */
+      size: cmath.Vector2;
+      /** Container rotation (degrees) at gesture start. Used to de-rotate
+       *  doc-space cursor delta into box-local frame before reducing. */
+      rotation: number;
+      /** Transform at gesture start (frozen). */
+      base_transform: AffineTransform;
+      /** Pointer-down doc-space position. */
+      start_doc: cmath.Vector2;
+      /** Most-recent doc-space pointer. */
+      last_doc: cmath.Vector2;
+      /** Most-recent reduced transform (used for the commit emit). */
+      transform: AffineTransform;
+      /** Flips to `true` once `pointer_move` advances. Click-no-drag → no commit. */
       dragged: boolean;
     };
 

--- a/packages/grida-canvas-hud/event/hit-regions.ts
+++ b/packages/grida-canvas-hud/event/hit-regions.ts
@@ -84,12 +84,12 @@ export type OverlayAction =
        * t (cursor → nearest point on curve). Drag → start a bend gesture
        * with `ca` frozen to that same projected t.
        *
-       * Mirrors the main editor's `snapped_segment_p` model: at any cursor
-       * position there is EXACTLY ONE candidate insertion point per
-       * segment — the point on the cubic closest to the cursor. The action
-       * carries the segment's four doc-space control points; the consumer
-       * (`event/state.ts`) computes `t` on demand via `cmath.bezier.project`
-       * at the cursor's current doc-space position. No pre-sampled grid.
+       * Single-candidate insertion model: at any cursor position there is
+       * EXACTLY ONE candidate insertion point per segment — the point on
+       * the cubic closest to the cursor. The action carries the segment's
+       * four doc-space control points; `event/state.ts` computes `t` on
+       * demand via `cmath.bezier.project` at the cursor's current doc-space
+       * position. No pre-sampled grid.
        */
       kind: "segment_strip";
       node_id: NodeId;
@@ -195,6 +195,114 @@ export type OverlayAction =
        */
       a?: readonly [number, number];
       b?: readonly [number, number];
+    }
+  | {
+      /**
+       * Closed-loop "region" body within a path under content-edit. The
+       * user can click the interior of a closed sub-path to select that
+       * region. Drag from the region body promotes to
+       * `translate_vector_selection` over the loop's segments.
+       *
+       * Hit detection is **polygon-in-screen-space**: the chrome
+       * builder rasterises the cubic loop to N samples per segment,
+       * registers the screen-space AABB of the rasterised polygon,
+       * and pairs it with a `customHitTest` closure that runs
+       * `pointInPolygon`. Mirrors the segment-strip's AABB-plus-
+       * refinement model — see `surface/vector-chrome.ts`.
+       *
+       * Hit-priority (`REGION_PRIORITY = 9` in vector-chrome.ts):
+       * sits just below `SEGMENT_STRIP_PRIORITY` (8), so any vertex /
+       * tangent / ghost / segment-strip control within the loop wins.
+       * The region claims only the "empty body" of the loop.
+       */
+      kind: "region";
+      node_id: NodeId;
+      /** Region index within `VectorOverlay.regions`. */
+      region: number;
+      /** Segment indices forming the closed loop (carried so the host
+       *  can route a region select intent to its segment-aware
+       *  selection state without a separate lookup). */
+      segments: readonly number[];
+      /** Union of the loop's endpoint vertex indices. Used by drag
+       *  promotion to seed `translate_vector_selection.additional_vertex_indices`
+       *  so the gesture can translate the whole loop even before the
+       *  host has echoed the select_region back into the sub-selection
+       *  mirror. */
+      vertices: readonly number[];
+    }
+  | {
+      /**
+       * Body of a padding-overlay side on a flex-parent container. The
+       * user can hover the inset rect to see the diagonal-stripe affordance
+       * (HUD-owned hover paint). Click without drag is a no-op; drag is
+       * claimed by the paired `padding_handle` action at higher priority.
+       *
+       * The region itself emits no intent; only the handle does.
+       */
+      kind: "padding_region";
+      node_id: NodeId;
+      side: cmath.RectangleSide;
+    }
+  | {
+      /**
+       * Mid-edge drag knob on a padding-overlay side. Pointer-down opens
+       * a `padding_handle` gesture; drag emits `padding_handle` intents
+       * with the current `value` (clamped at 0) and `mirror` flag (alt
+       * latched per frame). Click-no-drag is a no-op (no commit).
+       *
+       * Carries the container `rect` and the dragged `side` so the gesture
+       * can project the cursor onto the axis and derive `value` without
+       * an extra round-trip through the chrome builder.
+       */
+      kind: "padding_handle";
+      node_id: NodeId;
+      side: cmath.RectangleSide;
+      /** Container rect at chrome build time (doc-space). */
+      rect: Rect;
+      /** Initial padding value at chrome build time (doc-space units). */
+      initial_value: number;
+    }
+  | {
+      /**
+       * Body interior of a transform-box. Click + drag emits the
+       * `translate` op for the bound transform; pointer-down without
+       * drag is a no-op (no commit).
+       *
+       * `id` is host-defined and echoes back on the intent — see
+       * `TransformBoxInput.id`.
+       */
+      kind: "transform_box_body";
+      id: string;
+    }
+  | {
+      /**
+       * Side mid-edge of a transform-box. Drag emits the `scale_side`
+       * op. Hit AABB is 12px-thick × side-length, Fitts'-
+       * reach over the visible 1px stroke (D3 — asymmetric outputs).
+       *
+       * `base_angle` is the box's effective screen-space rotation in
+       * RADIANS (CCW positive), i.e. `container.rotation +
+       * decompose(transform).rotation`. The cursor branch in
+       * `decideIdleCursor` passes it through to the `resize` cursor so
+       * the arrow tilts with the visual axis instead of staying
+       * axis-aligned. Mirrors `resize_handle.initial_shape` → cursor
+       * baseAngle.
+       */
+      kind: "transform_box_side";
+      id: string;
+      side: cmath.RectangleSide;
+      base_angle: number;
+    }
+  | {
+      /**
+       * Corner knob of a transform-box. Drag emits the `rotate` op.
+       * Hit AABB is 16×16 screen-px, Fitts'-reach over the invisible
+       * corner point. `base_angle` — see `transform_box_side`.
+       */
+      kind: "transform_box_corner";
+      id: string;
+      corner: cmath.IntercardinalDirection;
+      base_angle: number;
     }
   | {
       /**

--- a/packages/grida-canvas-hud/event/intent.ts
+++ b/packages/grida-canvas-hud/event/intent.ts
@@ -1,4 +1,7 @@
 import type cmath from "@grida/cmath";
+import type { PaddingIntent } from "../classes/padding/intent";
+import type { TransformBoxIntent } from "../classes/transform-box/intent";
+import type { VectorPathIntent } from "../classes/vector-path/intent";
 import type { ResizeDirection } from "./cursor";
 import type { NodeId, Rect } from "./gesture";
 import type { SelectionShape } from "./shape";
@@ -82,10 +85,9 @@ export type Intent =
        * for vector content-edit the predicate is
        * `cmath.polygon.pointInPolygon` against `polygon`.
        *
-       * Per the main editor's decision (event-target.reducer.ts:629–641 +
-       * vector.ts:163–291), lasso targets vertices and tangents only —
-       * segments are NOT tested against the polygon. The host enforces
-       * that constraint; the HUD just delivers the polygon.
+       * Lasso targets vertices and tangents only — segments are NOT tested
+       * against the polygon. The host enforces that constraint; the HUD
+       * just delivers the polygon.
        */
       kind: "lasso_select";
       /**
@@ -125,136 +127,7 @@ export type Intent =
        */
       kind: "exit_content_edit";
     }
-  | {
-      /**
-       * Select a single vertex within a path under content-edit. Mode
-       * mirrors the node-level `select` intent. Hosts dispatch to their
-       * path-edit session's sub-selection state.
-       */
-      kind: "select_vertex";
-      /** Path node id under content-edit. */
-      node_id: NodeId;
-      /** Vertex index. */
-      index: number;
-      mode: SelectMode;
-    }
-  | {
-      /**
-       * Translate one or more vertices of a path under content-edit. The
-       * delta is in document-space, measured from gesture start to the
-       * current frame. Hosts apply the delta to each indexed vertex.
-       */
-      kind: "translate_vertices";
-      /** Path node id under content-edit. */
-      node_id: NodeId;
-      /** Vertex indices to translate. */
-      indices: number[];
-      dx: number;
-      dy: number;
-      phase: IntentPhase;
-    }
-  | {
-      /**
-       * Translate the path-edit sub-selection. The host expands its
-       * authoritative sub-selection (selected vertices ∪ endpoints of
-       * selected segments) and UNIONs with `additional_vertex_indices`
-       * before translating. Used by segment-body drag (default — Meta
-       * switches to bend) so a drag of an unselected segment can still
-       * translate its endpoints, and a drag of any item within a multi-
-       * selection translates the whole selection coherently.
-       */
-      kind: "translate_vector_selection";
-      node_id: NodeId;
-      /** Vertex indices the host UNIONs with its sub-selection before
-       *  translating. Carries the dragged segment's endpoints when the
-       *  drag originated off-selection; empty otherwise. */
-      additional_vertex_indices: readonly number[];
-      dx: number;
-      dy: number;
-      phase: IntentPhase;
-    }
-  | {
-      /**
-       * Clear the path-edit sub-selection (vertices / segments / tangents)
-       * WITHOUT exiting content-edit mode and WITHOUT touching the
-       * host's node-level selection.
-       *
-       * Fires when the user single-clicks empty space while in content-
-       * edit. Mirrors the dblclick `exit_content_edit` pattern — same
-       * "click outside to back off" gesture, one fewer step. Without this
-       * the user has no mouse way to drop a vertex sub-selection short of
-       * leaving content-edit entirely.
-       */
-      kind: "clear_vector_selection";
-    }
-  | {
-      /**
-       * Select a single segment within a path under content-edit. Mode
-       * mirrors the node-level `select` intent. Fires when the user clicks
-       * a segment OFF the ghost insertion knob — clicking the ghost itself
-       * fires `split_segment` instead.
-       */
-      kind: "select_segment";
-      node_id: NodeId;
-      segment: number;
-      mode: SelectMode;
-    }
-  | {
-      /**
-       * Select a single tangent within a path under content-edit. Mode
-       * mirrors the node-level `select` intent.
-       */
-      kind: "select_tangent";
-      node_id: NodeId;
-      /** `[vertex_idx, 0]` = ta on segment whose a===v; `[v, 1]` = tb where b===v. */
-      tangent: readonly [number, 0 | 1];
-      mode: SelectMode;
-    }
-  | {
-      /**
-       * Move a single tangent control point to a new doc-space position.
-       * The host applies the mirror policy (`auto` infers from current
-       * smooth-join state, `none` only moves the one tangent, `angle`
-       * mirrors the opposite tangent's angle while preserving its length,
-       * `all` mirrors both angle and length).
-       */
-      kind: "set_tangent";
-      node_id: NodeId;
-      tangent: readonly [number, 0 | 1];
-      /** New doc-space position of the tangent's control point. */
-      pos: cmath.Vector2;
-      mirror: "auto" | "none" | "angle" | "all";
-      phase: IntentPhase;
-    }
-  | {
-      /**
-       * Insert a new vertex on segment `segment` at parametric position
-       * `t ∈ [0,1]`. The split halves inherit the original's verb if
-       * possible; arc groups are broken. Fires once per click — no
-       * preview phase (split is atomic).
-       */
-      kind: "split_segment";
-      node_id: NodeId;
-      segment: number;
-      t: number;
-    }
-  | {
-      /**
-       * Bend segment `segment` by dragging a point originally at parameter
-       * `ca` toward a doc-space target `cb`. The host re-solves the
-       * segment's tangents to put `B(ca) === cb`, holding the endpoints
-       * fixed. `phase` lets the host bracket a history preview the same
-       * way translate does.
-       */
-      kind: "bend_segment";
-      node_id: NodeId;
-      segment: number;
-      /** Frozen parametric position of the point being dragged. */
-      ca: number;
-      /** Target doc-space position the bent point should reach. */
-      cb: cmath.Vector2;
-      phase: IntentPhase;
-    }
+  | VectorPathIntent
   | {
       /**
        * Drag of a corner-radius handle on `rect` geometry, default
@@ -338,6 +211,8 @@ export type Intent =
       modifiers: { alt: boolean; shift: boolean };
       phase: IntentPhase;
     }
+  | PaddingIntent
+  | TransformBoxIntent
   | {
       kind: "cancel_gesture";
     };

--- a/packages/grida-canvas-hud/event/overlay.ts
+++ b/packages/grida-canvas-hud/event/overlay.ts
@@ -1,5 +1,5 @@
 import type cmath from "@grida/cmath";
-import type { HUDSemanticGroup } from "../primitives/types";
+import type { HUDPaint, HUDSemanticGroup } from "../primitives/types";
 import type { CursorIcon } from "./cursor";
 import type { Rect } from "./gesture";
 import type { OverlayAction } from "./hit-regions";
@@ -156,9 +156,10 @@ export type RenderShape =
       color?: string;
     }
   /** Doc-space polyline — used to draw an open curve as a sequence of
-   *  flattened samples. Stroke width is in screen-px (the renderer
-   *  divides by zoom). Used by vector chrome to outline each segment of
-   *  a path under content-edit. */
+   *  flattened samples, or a closed polygon when `points[last] === points[0]`.
+   *  Stroke width is in screen-px (the renderer divides by zoom). Used by
+   *  vector chrome to outline each segment of a path under content-edit,
+   *  and to fill closed-loop regions with `HUDPaint` (stripes / solid). */
   | {
       kind: "doc_polyline";
       points: ReadonlyArray<readonly [number, number]>;
@@ -169,6 +170,15 @@ export type RenderShape =
       strokeWidth?: number;
       dashed?: boolean;
       color?: string;
+      /**
+       * Paint applied to the fill. When set, takes precedence over
+       * `color` + `fillOpacity` for the fill. Used by closed-loop
+       * region overlays to apply `HUDPaintStripes` for hover / selected
+       * affordance.
+       *
+       * @unstable
+       */
+      fillPaint?: HUDPaint;
     };
 
 // ─── OverlayElement — the unit of overlay UI ──────────────────────────────

--- a/packages/grida-canvas-hud/event/state.ts
+++ b/packages/grida-canvas-hud/event/state.ts
@@ -1354,6 +1354,7 @@ export class SurfaceState {
             vertices: this.vector_selection.vertices,
             segments: this.vector_selection.segments,
             tangents: this.vector_selection.tangents,
+            regions: this.vector_selection.regions ?? [],
           }
         : undefined,
       // Sticky-bend override. `"always"` is the host's bend tool talking

--- a/packages/grida-canvas-hud/event/state.ts
+++ b/packages/grida-canvas-hud/event/state.ts
@@ -1,4 +1,15 @@
 import cmath from "@grida/cmath";
+import type { PaddingHover } from "../classes/padding/input";
+import { projectPaddingValue } from "../classes/padding/surface";
+import type {
+  TransformBoxHover,
+  TransformBoxInput,
+} from "../classes/transform-box/input";
+import { docDeltaToBoxLocal } from "../classes/transform-box/surface";
+import {
+  decompose as decomposeTransformBox,
+  reduceTransformBox,
+} from "../primitives/transform-box";
 import {
   type SurfaceEvent,
   type SurfaceResponse,
@@ -90,6 +101,16 @@ export interface VectorSubSelection {
   /** `[vertex_idx, 0]` for ta on segment whose a === vertex_idx;
    *  `[vertex_idx, 1]` for tb where b === vertex_idx. */
   tangents: readonly (readonly [number, 0 | 1])[];
+  /**
+   * Selected region indices (= closed-loop ids in
+   * `VectorOverlay.regions`). Optional for backward compat — hosts that
+   * don't enumerate regions (or don't push a region mirror) leave it
+   * undefined; the chrome treats `undefined` and `[]` identically.
+   *
+   * Drives the region's `selected` visual state. The chrome reads it
+   * each frame.
+   */
+  regions?: readonly number[];
 }
 
 /**
@@ -117,7 +138,16 @@ export type VectorHover =
    * the ghost render in HOVER state and gates the split-on-click: only
    * this hover variant deferred-clicks to `split_segment`.
    */
-  | { kind: "ghost"; node_id: NodeId; segment: number; t: number };
+  | { kind: "ghost"; node_id: NodeId; segment: number; t: number }
+  /**
+   * Cursor is inside a closed-loop "region" (a body hit, not a control
+   * knob). Drives the region's hover paint (diagonal stripes). Loses
+   * priority to vertex / tangent / ghost / segment-strip controls
+   * within the same loop's bbox — those win on overlap so the user can
+   * always reach a specific control without the region claiming the
+   * pixel.
+   */
+  | { kind: "region"; node_id: NodeId; region: number };
 
 const DRAG_THRESHOLD_PX = 3;
 
@@ -175,26 +205,48 @@ export class SurfaceState {
    */
   private vector_hover: VectorHover | null = null;
   /**
+   * Which padding-overlay control is currently under the pointer (or
+   * null). Updated on every idle `pointer_move` from the hit_regions
+   * registry. The padding chrome reads this each frame to render hover
+   * affordances (per-side stripe paint, alt-held mirror paint on the
+   * opposite side). Owned by the HUD — mirrors the vector_hover pattern.
+   */
+  private padding_hover: PaddingHover | null = null;
+  /**
+   * Which transform-box control is currently under the pointer (or
+   * null). Updated on every idle `pointer_move` from the hit_regions
+   * registry. The chrome reads this each frame; cursor mapping reads
+   * it on idle. Owned by the HUD — mirrors padding_hover.
+   */
+  private transform_box_hover: TransformBoxHover | null = null;
+  /**
+   * Active transform-box input pushed via `setTransformBox`. The chrome
+   * builder reads this and re-emits overlays on every draw; the gesture
+   * intercept reads it for `size`, `rotation`, and `base_transform` at
+   * pointer-down. `null` = chrome off (schema-level feature flag).
+   */
+  private transform_box_input: TransformBoxInput | null = null;
+  /**
    * How `t` is computed for segment hovers/clicks. `"midpoint"` = always
    * 0.5 (the predictable default — ghost preview pinned to the segment's
    * midpoint regardless of cursor); `"projected"` = `cmath.bezier.project`
-   * of the cursor (mirrors the main editor — ghost tracks the cursor).
+   * of the cursor (ghost tracks the cursor along the segment).
    */
   private vector_insertion_mode: "midpoint" | "projected" = "midpoint";
   /**
    * Which gesture an empty-space drag promotes to. `"marquee"` (default)
    * draws a rectangle; `"lasso"` draws a freeform polygon. The HUD doesn't
-   * own the tool toggle — the host (svg-editor) pushes this whenever its
-   * own tool model flips (e.g. Q-key swap). The only branch that reads it
-   * is the pending → drag promotion in `pointer_move`.
+   * own the tool toggle — the host pushes this whenever its own tool model
+   * flips. The only branch that reads it is the pending → drag promotion
+   * in `pointer_move`.
    */
   private vector_selection_mode: "marquee" | "lasso" = "marquee";
   /**
    * Sticky-bend toggle for segment-body drag. `"auto"` (default) defers to
    * `modifiers.meta` (no Meta → translate, Meta → bend); `"always"` forces
-   * the bend branch as if Meta were held. The host (svg-editor) sets this
-   * when its bend tool is active. Same pattern as `vector_selection_mode`
-   * — the HUD doesn't own the tool toggle, just exposes the dispatch knob.
+   * the bend branch as if Meta were held. The host sets this when its bend
+   * tool is active. Same pattern as `vector_selection_mode` — the HUD
+   * doesn't own the tool toggle, just exposes the dispatch knob.
    */
   private vector_bend_mode: "auto" | "always" = "auto";
 
@@ -212,11 +264,11 @@ export class SurfaceState {
    * Push a new selection from the host. Accepts either:
    *
    * - **A flat `NodeId[]`** — each id becomes its own single-member group
-   *   with shape resolved via `shapeOf(id)` at chrome build time. Simple
-   *   hosts (e.g. svg-editor v1) use this overload.
+   *   with shape resolved via `shapeOf(id)` at chrome build time. Hosts
+   *   that don't pre-group by parent use this overload.
    * - **A `SelectionGroup[]`** — pre-computed groups (typically grouped by
    *   parent), each with its own pre-unioned shape. Hosts that already
-   *   compute groups (e.g. the main editor) use this overload.
+   *   compute groups use this overload.
    *
    * The flat-ids form is resolved lazily — `shapeOf` is called by the chrome
    * builder, not here. This keeps `setSelection` cheap and lets host shape
@@ -276,6 +328,35 @@ export class SurfaceState {
   /** Read-only access to the current vector hover (for chrome). */
   getVectorHover(): VectorHover | null {
     return this.vector_hover;
+  }
+
+  /** Read-only access to the current padding hover (for chrome). */
+  getPaddingHover(): PaddingHover | null {
+    return this.padding_hover;
+  }
+
+  /**
+   * Push a transform-box input from the host. Pass `null` to clear
+   * (schema-level feature flag). Surface reads this on every draw to
+   * emit chrome via `buildTransformBox`.
+   */
+  setTransformBox(input: TransformBoxInput | null): void {
+    this.transform_box_input = input;
+    // If the input is cleared mid-hover, the hover would point at a
+    // now-invisible region — clear it to avoid stale cursor state.
+    if (input === null && this.transform_box_hover !== null) {
+      this.transform_box_hover = null;
+    }
+  }
+
+  /** Read-only access to the current transform-box input (for chrome). */
+  getTransformBox(): TransformBoxInput | null {
+    return this.transform_box_input;
+  }
+
+  /** Read-only access to the current transform-box hover (for chrome). */
+  getTransformBoxHover(): TransformBoxHover | null {
+    return this.transform_box_hover;
   }
 
   /**
@@ -507,6 +588,23 @@ export class SurfaceState {
           point_doc,
           this.vector_insertion_mode
         );
+        // Padding hover — derived from the SAME ui_action under a
+        // separate identity space (vector_hover and padding_hover never
+        // co-exist; vector chrome only shows during content-edit, padding
+        // only on flex parents in non-content-edit). Reads `alt` to
+        // populate `mirror_side` when over a region body.
+        const next_ph = paddingHoverFromAction(ui_action, this.modifiers.alt);
+        if (!paddingHoversEqual(this.padding_hover, next_ph)) {
+          this.padding_hover = next_ph;
+          response.needsRedraw = true;
+        }
+        // Transform-box hover — same shape (separate identity space,
+        // separate cursor mapping). HUD-owned; redraw on change.
+        const next_th = transformBoxHoverFromAction(ui_action);
+        if (!transformBoxHoversEqual(this.transform_box_hover, next_th)) {
+          this.transform_box_hover = next_th;
+          response.needsRedraw = true;
+        }
         if (!vectorHoversEqual(this.vector_hover, next_vh)) {
           this.vector_hover = next_vh;
           response.needsRedraw = true;
@@ -897,6 +995,113 @@ export class SurfaceState {
         this.gesture = { kind: "pan", prev_screen: [sx, sy] };
         return response;
       }
+      case "padding_handle": {
+        const g = this.gesture;
+        const value = projectPaddingValue(g.rect, g.side, point_doc);
+        this.gesture = { ...g, last_doc: point_doc, value, dragged: true };
+        deps.emitIntent({
+          kind: "padding_handle",
+          node_id: g.node_id,
+          side: g.side,
+          value,
+          // Read alt LIVE — modifier change mid-gesture updates mirror
+          // on subsequent previews.
+          mirror: this.modifiers.alt,
+          phase: "preview",
+        });
+        response.needsRedraw = true;
+        return response;
+      }
+      case "transform_box": {
+        const g = this.gesture;
+        // Compute doc-space delta from gesture start, de-rotate by
+        // -rotation to get the un-rotated pixel-space delta the math
+        // reducer expects, then call `reduceTransformBox` to reduce
+        // from `base_transform` (NOT from the previous frame's
+        // `transform` — frame-accumulation would drift on a slow
+        // reducer).
+        const doc_delta: cmath.Vector2 = [
+          point_doc[0] - g.start_doc[0],
+          point_doc[1] - g.start_doc[1],
+        ];
+        // Synthesize a TransformBoxInput shape for `docDeltaToBoxLocal`.
+        // The de-rotation only needs `rotation`; we don't need the
+        // origin/size for the delta transform.
+        const box_delta = docDeltaToBoxLocal(
+          {
+            id: g.id,
+            transform: g.base_transform,
+            size: g.size,
+            origin: [0, 0],
+            rotation: g.rotation,
+          },
+          doc_delta
+        );
+        const action =
+          g.op.type === "translate"
+            ? { type: "translate" as const, delta: box_delta }
+            : g.op.type === "scale_side"
+              ? {
+                  type: "scale-side" as const,
+                  side: g.op.side,
+                  delta: box_delta,
+                }
+              : {
+                  type: "rotate" as const,
+                  corner: g.op.corner,
+                  delta: box_delta,
+                };
+        const next_transform = reduceTransformBox(g.base_transform, action, {
+          size: g.size,
+        });
+        this.gesture = {
+          ...g,
+          last_doc: point_doc,
+          transform: next_transform,
+          dragged: true,
+        };
+        deps.emitIntent({
+          kind: "transform_box",
+          id: g.id,
+          op: g.op,
+          transform: next_transform,
+          phase: "preview",
+        });
+        // Live cursor tracking — same pattern as the selection-box
+        // rotate gesture (`initial_cursor_angle + delta`): compose the
+        // container rotation with the inner transform's *live* rotation
+        // so the cursor stays aligned to the visible box throughout the
+        // drag, not just at gesture start. `cursorEquals` buckets the
+        // angle so this only re-emits on real motion.
+        const live_angle_rad =
+          ((decomposeTransformBox(next_transform).rotation + g.rotation) *
+            Math.PI) /
+          180;
+        if (g.op.type === "translate") {
+          this.setCursor("move", response);
+        } else if (g.op.type === "scale_side") {
+          this.setCursor(
+            {
+              kind: "resize",
+              direction:
+                g.op.side === "top" || g.op.side === "bottom" ? "n" : "w",
+              baseAngle: live_angle_rad,
+            },
+            response
+          );
+        } else {
+          this.setCursor(
+            {
+              kind: "rotate",
+              corner: g.op.corner,
+              baseAngle: live_angle_rad,
+            },
+            response
+          );
+        }
+        response.needsRedraw = true;
+        return response;
+      }
     }
     return response;
   }
@@ -1044,15 +1249,76 @@ export class SurfaceState {
       return response;
     }
 
+    // Padding handle intercept. Opens a `padding_handle` gesture
+    // eagerly at pointer_down; on drag the gesture emits
+    // `padding_handle` intents per move + commit. Click-no-drag is a
+    // no-op (no commit) — matches corner-radius's `dragged` guard
+    // pattern.
+    if (ui_action && ui_action.kind === "padding_handle") {
+      if (this.readonly) return response;
+      this.gesture = {
+        kind: "padding_handle",
+        node_id: ui_action.node_id,
+        side: ui_action.side,
+        rect: ui_action.rect,
+        initial_value: ui_action.initial_value,
+        last_doc: point_doc,
+        value: ui_action.initial_value,
+        dragged: false,
+      };
+      response.needsRedraw = true;
+      return response;
+    }
+
+    // Transform-box intercept. Opens a `transform_box` gesture eagerly
+    // at pointer_down for any of the 3 hit kinds (body, side, corner).
+    // Click-no-drag is a no-op — matches padding-handle / corner-
+    // radius. The gesture reads `transform_box_input` for `size`,
+    // `rotation`, and the base
+    // transform — frozen at gesture start, the chrome rebuild
+    // doesn't re-derive them.
+    if (
+      ui_action &&
+      (ui_action.kind === "transform_box_body" ||
+        ui_action.kind === "transform_box_side" ||
+        ui_action.kind === "transform_box_corner")
+    ) {
+      if (this.readonly) return response;
+      const input = this.transform_box_input;
+      // Defensive: if the host cleared the input between chrome build
+      // and pointer-down (race), don't open a gesture against stale
+      // hit data. Mirrors the corner-radius's input-presence check.
+      if (input === null || input.id !== ui_action.id) return response;
+      const op =
+        ui_action.kind === "transform_box_body"
+          ? ({ type: "translate" } as const)
+          : ui_action.kind === "transform_box_side"
+            ? ({ type: "scale_side", side: ui_action.side } as const)
+            : ({ type: "rotate", corner: ui_action.corner } as const);
+      this.gesture = {
+        kind: "transform_box",
+        id: input.id,
+        op,
+        size: input.size,
+        rotation: input.rotation ?? 0,
+        base_transform: input.transform,
+        start_doc: point_doc,
+        last_doc: point_doc,
+        transform: input.transform,
+        dragged: false,
+      };
+      response.needsRedraw = true;
+      return response;
+    }
+
     // For segment_strip hits, resolve `t` per `vector_insertion_mode` and
     // pass it to the decision module. Used by BOTH:
     //   - segment_strip → select_segment (no t needed for select)
     //   - ghost_handle  → split_segment.t (mode-dependent — "midpoint"
     //                     pins 0.5; "projected" projects the cursor)
     //   - either        → bend_segment.ca (ALWAYS projected at cursor,
-    //                     mode-INDEPENDENT — matches the main editor's
-    //                     `t0Ref = cmath.bezier.project(point)` in
-    //                     `surface-vector-editor.tsx:337`)
+    //                     mode-INDEPENDENT — bend pivot follows the cursor
+    //                     regardless of insertion mode)
     //
     // The two `t`s are computed separately. Conflating them was the
     // "bend pivot pinned to 0.5 in midpoint mode" bug — insertion mode
@@ -1225,9 +1491,8 @@ export class SurfaceState {
       case "start_split_and_translate": {
         // Press on the ghost insertion knob — eager split-and-drag.
         //
-        // 1. Emit `split_segment`. The host (svg-editor's
-        //    `handle_split_segment`) commits the split AND pushes the
-        //    new vertex into the selection mirror via
+        // 1. Emit `split_segment`. The host commits the split AND
+        //    pushes the new vertex into the selection mirror via
         //    `setVectorSelection({ vertices: [new_idx], … })`. That
         //    push can happen SYNCHRONOUSLY (within `emitIntent`) OR in
         //    a follow-up tick (microtask / RAF / React commit) —
@@ -1280,6 +1545,23 @@ export class SurfaceState {
         deps.emitIntent({
           kind: "select",
           ids: [...decision.select_ids],
+          mode: decision.mode,
+        });
+        response.needsRedraw = true;
+        this.pending = {
+          anchor_doc: point_doc,
+          anchor_screen: screen,
+          ids_at_down: decision.pending.ids_at_down,
+          deferred: decision.pending.deferred,
+          promote_to: decision.pending.promote_to,
+        };
+        return response;
+
+      case "immediate_select_region":
+        deps.emitIntent({
+          kind: "select_region",
+          node_id: decision.node_id,
+          region: decision.region,
           mode: decision.mode,
         });
         response.needsRedraw = true;
@@ -1650,6 +1932,50 @@ export class SurfaceState {
         response.needsRedraw = true;
         break;
       }
+      case "padding_handle": {
+        const g = this.gesture;
+        // Click-no-drag: no commit. `value === initial_value` so a
+        // commit would be a no-op for the host anyway, but emitting
+        // it would still drive a history entry. Skip to keep the
+        // history clean — matches corner-radius / parametric handle.
+        if (!g.dragged) {
+          this.gesture = IDLE;
+          response.needsRedraw = true;
+          break;
+        }
+        deps.emitIntent({
+          kind: "padding_handle",
+          node_id: g.node_id,
+          side: g.side,
+          value: g.value,
+          mirror: this.modifiers.alt,
+          phase: "commit",
+        });
+        this.gesture = IDLE;
+        response.needsRedraw = true;
+        break;
+      }
+      case "transform_box": {
+        const g = this.gesture;
+        // Click-no-drag: no commit. `transform === base_transform`
+        // so a commit would be identity for the host. Matches the
+        // padding-handle / corner-radius `dragged` guard pattern.
+        if (!g.dragged) {
+          this.gesture = IDLE;
+          response.needsRedraw = true;
+          break;
+        }
+        deps.emitIntent({
+          kind: "transform_box",
+          id: g.id,
+          op: g.op,
+          transform: g.transform,
+          phase: "commit",
+        });
+        this.gesture = IDLE;
+        response.needsRedraw = true;
+        break;
+      }
     }
     return response;
   }
@@ -1664,6 +1990,14 @@ export class SurfaceState {
     }
     if (this.vector_hover !== null) {
       this.vector_hover = null;
+      response.needsRedraw = true;
+    }
+    if (this.padding_hover !== null) {
+      this.padding_hover = null;
+      response.needsRedraw = true;
+    }
+    if (this.transform_box_hover !== null) {
+      this.transform_box_hover = null;
       response.needsRedraw = true;
     }
     return response;
@@ -1793,6 +2127,12 @@ function vectorHoverFromAction(
         // action's cubic geometry to stay zero-lag in projected mode.
         t: segmentTForMode(action, point_doc, mode),
       };
+    case "region":
+      return {
+        kind: "region",
+        node_id: action.node_id,
+        region: action.region,
+      };
     default:
       return null;
   }
@@ -1824,6 +2164,10 @@ function vectorHoversEqual(
     case "ghost":
       return (
         (b as Extract<VectorHover, { kind: "ghost" }>).segment === a.segment
+      );
+    case "region":
+      return (
+        (b as Extract<VectorHover, { kind: "region" }>).region === a.region
       );
   }
 }
@@ -2064,6 +2408,103 @@ function trackTangent01(
   if (track.radius === 0) return [1, 0];
   const dir = track.to >= track.from ? 1 : -1;
   return [-Math.sin(track.from) * dir, Math.cos(track.from) * dir];
+}
+
+// ─── Padding-overlay hover helpers ────────────────────────────────────────
+
+/**
+ * Derive a `PaddingHover` from the current `OverlayAction` (or null).
+ * Reads `alt_held` to populate `mirror_side` on region hovers — the
+ * renderer paints both the hovered side and its opposite when alt is
+ * down.
+ */
+function paddingHoverFromAction(
+  action: OverlayAction | null,
+  alt_held: boolean
+): PaddingHover | null {
+  if (!action) return null;
+  switch (action.kind) {
+    case "padding_region":
+      return {
+        kind: "padding_region",
+        node_id: action.node_id,
+        side: action.side,
+        mirror_side: alt_held
+          ? cmath.rect.getOppositeSide(action.side)
+          : undefined,
+      };
+    case "padding_handle":
+      return {
+        kind: "padding_handle",
+        node_id: action.node_id,
+        side: action.side,
+      };
+    default:
+      return null;
+  }
+}
+
+function paddingHoversEqual(
+  a: PaddingHover | null,
+  b: PaddingHover | null
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.kind !== b.kind) return false;
+  if (a.node_id !== b.node_id) return false;
+  if (a.side !== b.side) return false;
+  if (a.kind === "padding_region" && b.kind === "padding_region") {
+    return a.mirror_side === b.mirror_side;
+  }
+  return true;
+}
+
+// ─── Transform-box hover helpers ──────────────────────────────────────────
+
+/**
+ * Derive a `TransformBoxHover` from the current `OverlayAction` (or null).
+ * Transform-box hover has no modifier-sensitive variants (unlike
+ * padding's `mirror_side`); the 1:1 mapping below is the entire policy.
+ */
+function transformBoxHoverFromAction(
+  action: OverlayAction | null
+): TransformBoxHover | null {
+  if (!action) return null;
+  switch (action.kind) {
+    case "transform_box_body":
+      return { kind: "transform_box_body", id: action.id };
+    case "transform_box_side":
+      return {
+        kind: "transform_box_side",
+        id: action.id,
+        side: action.side,
+      };
+    case "transform_box_corner":
+      return {
+        kind: "transform_box_corner",
+        id: action.id,
+        corner: action.corner,
+      };
+    default:
+      return null;
+  }
+}
+
+function transformBoxHoversEqual(
+  a: TransformBoxHover | null,
+  b: TransformBoxHover | null
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.kind !== b.kind) return false;
+  if (a.id !== b.id) return false;
+  if (a.kind === "transform_box_side" && b.kind === "transform_box_side") {
+    return a.side === b.side;
+  }
+  if (a.kind === "transform_box_corner" && b.kind === "transform_box_corner") {
+    return a.corner === b.corner;
+  }
+  return true;
 }
 
 /** Re-exports for convenience. */

--- a/packages/grida-canvas-hud/index.ts
+++ b/packages/grida-canvas-hud/index.ts
@@ -110,7 +110,43 @@ export type { SelectionShape, SelectionGroup } from "./event/shape";
 export type { OverlayElement, HitShape, RenderShape } from "./event/overlay";
 export { MIN_HIT_SIZE, MIN_CHROME_VISIBLE_SIZE } from "./event/overlay";
 export type { VectorSubSelection, VectorHover } from "./event/state";
-export type { VectorOverlay } from "./surface/vector-chrome";
+export type { VectorOverlay } from "./classes/vector-path";
+export {
+  buildPaddingOverlay,
+  PADDING_HANDLE_PRIORITY,
+  PADDING_REGION_PRIORITY,
+  PADDING_HANDLE_LENGTH,
+  PADDING_HANDLE_THICKNESS,
+  type PaddingOverlayInput,
+  type PaddingHover,
+} from "./classes/padding";
+
+// Transform-box (named class).
+export {
+  buildTransformBox,
+  TRANSFORM_BOX_CORNER_PRIORITY,
+  TRANSFORM_BOX_SIDE_PRIORITY,
+  TRANSFORM_BOX_BODY_PRIORITY,
+  TRANSFORM_BOX_CORNER_HIT_SIZE,
+  TRANSFORM_BOX_SIDE_HIT_THICKNESS,
+  type TransformBoxInput,
+  type TransformBoxHover,
+  type TransformBoxActiveOp,
+} from "./classes/transform-box";
+// Transform-box math primitive — class-bound math reducer factored out
+// for testability. Lives in `primitives/` for code organization; the
+// chrome that consumes it lives in `classes/transform-box/`.
+export {
+  reduceTransformBox,
+  getTransformBoxCorners,
+  cornersToBoxTransform,
+  decompose as decomposeTransformBox,
+  compose as composeTransformBox,
+  type AffineTransform,
+  type TransformBoxAction,
+  type TransformBoxOptions,
+  type TransformBoxCorners,
+} from "./primitives/transform-box";
 
 // Selection-controls — pure-geometry model + priority ladder (UX rule).
 export {

--- a/packages/grida-canvas-hud/primitives/paint.ts
+++ b/packages/grida-canvas-hud/primitives/paint.ts
@@ -167,11 +167,20 @@ export function buildStripesTile(
   // (drawn at y = size - half, just above the seam). After `repeat`
   // tiling, the two halves merge into a single band straddling each
   // tile boundary — no clip artifact, no doubling.
+  //
+  // Edge case: when `thicknessPx >= size`, the two halves would meet (or
+  // overlap) in the middle but the gap geometry above paints only the
+  // outer two strips, leaving the centre transparent. Fill the whole
+  // tile in that case so a full-thickness band renders as solid.
   const half = Math.min(thicknessPx / 2, size / 2);
   if (half > 0) {
-    ctx.fillRect(0, 0, 1, half);
-    if (size - half > half) {
-      ctx.fillRect(0, size - half, 1, half);
+    if (thicknessPx >= size) {
+      ctx.fillRect(0, 0, 1, size);
+    } else {
+      ctx.fillRect(0, 0, 1, half);
+      if (size - half > half) {
+        ctx.fillRect(0, size - half, 1, half);
+      }
     }
   }
 

--- a/packages/grida-canvas-hud/primitives/paint.ts
+++ b/packages/grida-canvas-hud/primitives/paint.ts
@@ -38,32 +38,38 @@ export interface ResolvedPaint {
 }
 
 /**
- * Pure geometry for a stripes tile. Computes the period (tile size) and
- * the per-stripe parameters in device pixels. Separated from the
- * rasterizer so the math is testable in Node.
+ * Pure geometry for a stripes tile. Computes the cross-stripe period
+ * (tile height) and the per-stripe parameters in device pixels.
+ * Separated from the rasterizer so the math is testable in Node.
  *
- * The tile is a square whose side equals one stripe period along the
- * pattern's principal axis; when tiled with `repeat` and rotated by
- * `angle`, it produces an infinite stripe field.
+ * The tile is `1 × size`: one horizontal stripe period, axis-aligned.
+ * Rotation is applied at draw time via `CanvasPattern.setTransform`,
+ * NOT baked into the rasterized tile — baking rotation would force the
+ * tile's axis-aligned period to `spacing / sin(angle)`, irrational for
+ * the canonical 45° case, and produce visible breaks within each
+ * rendered stripe (the previous behavior).
  *
  * To keep stripes screen-aligned regardless of viewport zoom, the tile
- * is built in *device pixels* and the consumer applies a counter-CTM
- * via `CanvasPattern.setTransform` at draw time.
+ * is built in *device pixels* and the consumer composes a counter-CTM
+ * with the rotation in `setTransform`.
  */
 export function computeStripesTileGeometry(
   paint: HUDPaintStripes,
   dpr: number
 ): {
+  /**
+   * Tile height in device pixels — one cross-stripe period. The tile's
+   * width is fixed at 1 (the stripe is constant along the stripe
+   * direction; horizontal width doesn't carry information).
+   */
   size: number;
   spacingPx: number;
   thicknessPx: number;
   angleRad: number;
 } {
-  // Guard non-positive / non-finite inputs — `spacingPx` is used as
-  // the step of a `for (offset += spacingPx)` loop in `buildStripesTile`
-  // and would loop forever at zero or negative values. Fall back to
-  // the documented defaults rather than silently producing an empty
-  // pattern, so a misconfigured paint still renders something.
+  // Guard non-positive / non-finite inputs. Fall back to the documented
+  // defaults rather than silently producing an empty pattern, so a
+  // misconfigured paint still renders something.
   const spacingRaw = paint.spacing ?? DEFAULT_STRIPES_SPACING_PX;
   const thicknessRaw = paint.thickness ?? DEFAULT_STRIPES_THICKNESS_PX;
   const spacing =
@@ -81,12 +87,11 @@ export function computeStripesTileGeometry(
   const thicknessPx = thickness * safeDpr;
   const angleRad = (angleDeg * Math.PI) / 180;
 
-  // The tile is a square sized to one stripe period, expanded enough that
-  // rotation doesn't reveal seams. For a rotated stripe pattern the tile
-  // must be a multiple of the period along the perpendicular-to-stripes
-  // axis. A square of side = ceil(spacingPx) is sufficient for the
-  // standard 45° / 8px / 1.5px config; we use that as the period.
-  const size = Math.max(1, Math.ceil(spacingPx));
+  // Tile height = one cross-stripe period in device pixels, rounded to
+  // the nearest integer (OffscreenCanvas requires integer dimensions).
+  // For typical configs (integer spacing, dpr ∈ {1, 2, 3}) `spacingPx`
+  // is already integer.
+  const size = Math.max(1, Math.round(spacingPx));
 
   return { size, spacingPx, thicknessPx, angleRad };
 }
@@ -134,49 +139,41 @@ function getOrBuildStripesTile(
 }
 
 /**
- * Rasterize a single-period stripes tile (device pixels) with the
- * angle baked into the bitmap. Consumers tile it axis-aligned via
- * `ctx.createPattern(tile, "repeat")` — no draw-time rotation needed,
- * which leaves `CanvasPattern.setTransform` free for the counter-CTM
- * that keeps stripes screen-aligned.
+ * Rasterize an unrotated, axis-aligned stripes tile (device pixels).
+ * The tile is `1 × size` — one horizontal stripe band wrapping the
+ * `y=0` / `y=size` seam, so it tiles cleanly under `repeat`.
+ *
+ * Rotation is applied at draw time via the pattern transform in
+ * `resolvePaint`. Baking rotation here would force the axis-aligned
+ * tile dimensions to align with the rotated stripe lattice — irrational
+ * for the canonical 45° case — and produce visible breaks within each
+ * rendered stripe.
  */
 export function buildStripesTile(
   paint: HUDPaintStripes,
   dpr: number
 ): OffscreenCanvas {
-  const { size, spacingPx, thicknessPx, angleRad } = computeStripesTileGeometry(
-    paint,
-    dpr
-  );
-  const canvas = new OffscreenCanvas(size, size);
+  const { size, thicknessPx } = computeStripesTileGeometry(paint, dpr);
+  const canvas = new OffscreenCanvas(1, size);
   const ctx = canvas.getContext("2d");
   if (!ctx) {
     throw new Error("OffscreenCanvas 2d context unavailable");
   }
-  ctx.clearRect(0, 0, size, size);
+  ctx.clearRect(0, 0, 1, size);
   ctx.fillStyle = paint.color;
 
-  // Draw stripes by walking perpendicular-to-stripe direction and
-  // emitting filled rectangles of width = thicknessPx along the stripe.
-  // For the canonical 45° / 8px / 1.5px case: one stripe per tile.
-  // The tile is rotated about its center.
-  ctx.save();
-  ctx.translate(size / 2, size / 2);
-  ctx.rotate(angleRad);
-  // After rotation, draw a horizontal stripe band centered on the origin.
-  // Draw across a length sufficient to cover the rotated square — its
-  // diagonal is `size * sqrt(2)`. Use `2 * size` for safety.
-  const drawLen = 2 * size;
-  const half = thicknessPx / 2;
-  // Center stripe
-  ctx.fillRect(-drawLen / 2, -half, drawLen, thicknessPx);
-  // Additional stripes at integer multiples of `spacingPx`, in case the
-  // tile is sized to fit more than one period.
-  for (let offset = spacingPx; offset < size; offset += spacingPx) {
-    ctx.fillRect(-drawLen / 2, offset - half, drawLen, thicknessPx);
-    ctx.fillRect(-drawLen / 2, -offset - half, drawLen, thicknessPx);
+  // One stripe band, centered on the y=0 / y=size seam. Split into a
+  // "top half" (above the seam, drawn at y=0) and a "bottom half"
+  // (drawn at y = size - half, just above the seam). After `repeat`
+  // tiling, the two halves merge into a single band straddling each
+  // tile boundary — no clip artifact, no doubling.
+  const half = Math.min(thicknessPx / 2, size / 2);
+  if (half > 0) {
+    ctx.fillRect(0, 0, 1, half);
+    if (size - half > half) {
+      ctx.fillRect(0, size - half, 1, half);
+    }
   }
-  ctx.restore();
 
   return canvas;
 }
@@ -204,17 +201,40 @@ export function resolvePaint(
     if (!pattern) {
       throw new Error("createPattern returned null");
     }
-    // Counter the current CTM so the tile maps 1:1 to device pixels.
-    // Without this the tile would scale with the viewport zoom.
+    // Pattern transform = rotate(-angle) · inverse(CTM).
     //
-    // Note: `createPattern` + `getTransform().inverse()` runs per call.
-    // For N striped primitives sharing one paint, that's N pattern
-    // objects + N inverses per draw. The tile itself is cached. When a
-    // consumer (vector-edit rehost) stripes-fills many primitives in
-    // one draw, add a per-draw `(tileKey, ctm) → CanvasPattern`
-    // scratchpad on `HUDCanvas`. Premature today — §0 demo emits 2.
-    const m = ctx.getTransform();
-    pattern.setTransform(m.inverse());
+    //   - inverse(CTM) maps canvas-space sample positions back to device
+    //     pixels, so the tile period stays in device pixels regardless of
+    //     viewport zoom (counter-CTM, screen-aligned chrome).
+    //   - rotate(-angle) then rotates the device-pixel sample point. The
+    //     tile itself is axis-aligned horizontal stripes; rotating the
+    //     sample point by -angle makes the displayed stripes appear at
+    //     +angle in canvas space.
+    //
+    // Composing both into one DOMMatrixInit avoids any dependency on
+    // browser-only `DOMMatrix.rotate` / `.multiply` (Node tests use a
+    // plain-object inverse).
+    //
+    // Note: `createPattern` + `getTransform()` runs per call. For N
+    // striped primitives sharing one paint, that's N pattern objects +
+    // N CTM reads per draw. The tile itself is cached. When a consumer
+    // stripes-fills many primitives in one draw, add a per-draw
+    // `(tileKey, ctm) → CanvasPattern` scratchpad on `HUDCanvas`.
+    // Premature today.
+    const inv = ctx.getTransform().inverse();
+    const angleRad =
+      ((paint.angle ?? DEFAULT_STRIPES_ANGLE_DEG) * Math.PI) / 180;
+    const c = Math.cos(angleRad);
+    const s = Math.sin(angleRad);
+    const t: DOMMatrixInit = {
+      a: c * inv.a + s * inv.b,
+      b: -s * inv.a + c * inv.b,
+      c: c * inv.c + s * inv.d,
+      d: -s * inv.c + c * inv.d,
+      e: c * inv.e + s * inv.f,
+      f: -s * inv.e + c * inv.f,
+    };
+    pattern.setTransform(t);
     return { style: pattern, opacity: paint.opacity ?? 1 };
   }
   // Closed-taxonomy enforcement: no silent passthrough for unknown kinds.

--- a/packages/grida-canvas-hud/primitives/pixel-grid.ts
+++ b/packages/grida-canvas-hud/primitives/pixel-grid.ts
@@ -16,9 +16,9 @@ export interface PixelGridConfig {
    * Optional camera transform used to space the grid. Hosts that drive the
    * HUD canvas's own `setTransform` can omit this — the pixel grid falls
    * back to the canvas's chrome transform. Hosts that keep the HUD at
-   * identity (e.g. `@grida/svg-editor`, which applies the camera as a CSS
-   * transform on the `<svg>` element) must supply this explicitly and
-   * update it on every camera change via `setPixelGridTransform`.
+   * identity (applying the camera elsewhere — e.g. as a CSS transform on
+   * an outer element) must supply this explicitly and update it on every
+   * camera change via `setPixelGridTransform`.
    */
   transform?: cmath.Transform;
   color?: string;

--- a/packages/grida-canvas-hud/primitives/projection.ts
+++ b/packages/grida-canvas-hud/primitives/projection.ts
@@ -1,0 +1,33 @@
+// Doc-space → screen-space AABB projection helper.
+//
+// Used by class chrome builders to register screen-space hit AABBs for
+// doc-space rectangles (padding side regions, transform-box body,
+// vector-path region bbox). Centralised so the projection convention
+// stays consistent across classes.
+
+import type cmath from "@grida/cmath";
+import type { Rect } from "../event/gesture";
+import { docToScreen } from "../event/transform";
+
+/**
+ * Project a doc-space rect's two diagonal corners through the camera
+ * and return an axis-aligned screen-space rect. The output is normalised
+ * (non-negative `width` / `height`) regardless of transform orientation.
+ */
+export function docRectToScreenAABB(
+  rect: Rect,
+  transform: cmath.Transform
+): Rect {
+  const [sx0, sy0] = docToScreen(transform, rect.x, rect.y);
+  const [sx1, sy1] = docToScreen(
+    transform,
+    rect.x + rect.width,
+    rect.y + rect.height
+  );
+  return {
+    x: Math.min(sx0, sx1),
+    y: Math.min(sy0, sy1),
+    width: Math.abs(sx1 - sx0),
+    height: Math.abs(sy1 - sy0),
+  };
+}

--- a/packages/grida-canvas-hud/primitives/projection.ts
+++ b/packages/grida-canvas-hud/primitives/projection.ts
@@ -10,24 +10,29 @@ import type { Rect } from "../event/gesture";
 import { docToScreen } from "../event/transform";
 
 /**
- * Project a doc-space rect's two diagonal corners through the camera
- * and return an axis-aligned screen-space rect. The output is normalised
- * (non-negative `width` / `height`) regardless of transform orientation.
+ * Project all four doc-space rect corners through the camera and return
+ * the screen-space AABB that covers them. Projecting all four (not just
+ * two diagonals) is required for rotated / sheared transforms — the
+ * diagonal pair would shrink the AABB and miss valid hover/hit pixels.
  */
 export function docRectToScreenAABB(
   rect: Rect,
   transform: cmath.Transform
 ): Rect {
-  const [sx0, sy0] = docToScreen(transform, rect.x, rect.y);
-  const [sx1, sy1] = docToScreen(
-    transform,
-    rect.x + rect.width,
-    rect.y + rect.height
-  );
+  const x1 = rect.x + rect.width;
+  const y1 = rect.y + rect.height;
+  const [s0x, s0y] = docToScreen(transform, rect.x, rect.y);
+  const [s1x, s1y] = docToScreen(transform, x1, rect.y);
+  const [s2x, s2y] = docToScreen(transform, x1, y1);
+  const [s3x, s3y] = docToScreen(transform, rect.x, y1);
+  const minX = Math.min(s0x, s1x, s2x, s3x);
+  const minY = Math.min(s0y, s1y, s2y, s3y);
+  const maxX = Math.max(s0x, s1x, s2x, s3x);
+  const maxY = Math.max(s0y, s1y, s2y, s3y);
   return {
-    x: Math.min(sx0, sx1),
-    y: Math.min(sy0, sy1),
-    width: Math.abs(sx1 - sx0),
-    height: Math.abs(sy1 - sy0),
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
   };
 }

--- a/packages/grida-canvas-hud/primitives/transform-box.ts
+++ b/packages/grida-canvas-hud/primitives/transform-box.ts
@@ -177,19 +177,26 @@ export function compose(
   ];
 }
 
+// Degenerate-size guard. Translation is normalised by `size`, so a 0-axis
+// would produce Infinity/NaN and corrupt the host's bound transform.
+// Scale-side projects onto a corner-derived axis whose length collapses
+// to ~0 in the same degenerate case. EPSILON is a pixel-scale floor —
+// any size smaller than this is treated as a no-op axis.
+const SIZE_EPSILON = 1e-8;
+
 function applyTranslation(
   base: AffineTransform,
   pixelDelta: cmath.Vector2,
   size: cmath.Vector2
 ): AffineTransform {
-  const boxDelta: cmath.Vector2 = [
-    pixelDelta[0] / size[0],
-    pixelDelta[1] / size[1],
-  ];
-
+  const sx = Math.abs(size[0]) > SIZE_EPSILON ? size[0] : 0;
+  const sy = Math.abs(size[1]) > SIZE_EPSILON ? size[1] : 0;
+  if (sx === 0 && sy === 0) return base;
+  const dx = sx === 0 ? 0 : pixelDelta[0] / sx;
+  const dy = sy === 0 ? 0 : pixelDelta[1] / sy;
   return [
-    [base[0][0], base[0][1], base[0][2] + boxDelta[0]],
-    [base[1][0], base[1][1], base[1][2] + boxDelta[1]],
+    [base[0][0], base[0][1], base[0][2] + dx],
+    [base[1][0], base[1][1], base[1][2] + dy],
   ];
 }
 
@@ -214,6 +221,10 @@ function applyScaling(
     side === "left" || side === "right"
       ? cmath.vector2.sub(corners.ne, corners.nw)
       : cmath.vector2.sub(corners.sw, corners.nw);
+
+  // Degenerate axis → projection denominator is 0; bail rather than emit
+  // a transform full of NaN.
+  if (Math.hypot(axis[0], axis[1]) < SIZE_EPSILON) return base;
 
   const projected = cmath.vector2.project(pixelDelta, axis);
 

--- a/packages/grida-canvas-hud/primitives/transform-box.ts
+++ b/packages/grida-canvas-hud/primitives/transform-box.ts
@@ -1,0 +1,325 @@
+// Transform-box — class-bound math reducer for the `transform-box`
+// named class. Lives in `primitives/` for code organization (one file
+// per math domain, pure-function tests without mounting the chrome);
+// not Tier 2 in the audience sense — its closure of valid actions IS
+// the transform-box chrome's gesture grammar. See the package README
+// section "Tier 2 — Primitives (the open building blocks)".
+//
+// Pure mathematical reducer for a 2×3 affine transform manipulated by
+// three op kinds: translate, scale-side, rotate. Operates on a unit box
+// [0,0]→[1,1] with size in pixel-space. Translation components of the
+// transform are normalized [0..1] against `size`.
+//
+// Lifted verbatim from the editor's image-paint editor math
+// ([editor/grida-canvas-react/viewport/ui/__math/image-transform.ts]).
+// The model is NOT image-specific — image-fit is just the first consumer.
+//
+// CENTER DEFINITION:
+//   Center = center of (rect * transform). Rect corners are transformed
+//   by the matrix to get the visual center (used as the rotation pivot).
+//
+// MATHEMATICS:
+//   Each corner is a pure projection of a box corner through the
+//   transform matrix. No back-solving from points — pure mathematical
+//   projection.
+
+import cmath from "@grida/cmath";
+
+/**
+ * 2×3 affine transform. Structurally compatible with `AffineTransform`
+ * from `@grida/cg` — the HUD package keeps a local alias to avoid
+ * acquiring a `@grida/cg` workspace dep just for the type.
+ */
+export type AffineTransform = [
+  [number, number, number],
+  [number, number, number],
+];
+
+export type TransformBoxAction =
+  | {
+      type: "translate";
+      delta: cmath.Vector2;
+    }
+  | {
+      type: "scale-side";
+      side: cmath.RectangleSide;
+      delta: cmath.Vector2;
+    }
+  | {
+      type: "rotate";
+      corner: cmath.IntercardinalDirection;
+      delta: cmath.Vector2;
+    };
+
+export interface TransformBoxOptions {
+  size: cmath.Vector2;
+}
+
+export type TransformBoxCorners = {
+  nw: cmath.Vector2;
+  ne: cmath.Vector2;
+  se: cmath.Vector2;
+  sw: cmath.Vector2;
+};
+
+const EPSILON = 1e-10;
+
+/**
+ * Reduces a transform-box affine in response to a UI action.
+ */
+export function reduceTransformBox(
+  base: AffineTransform,
+  action: TransformBoxAction,
+  options: TransformBoxOptions
+): AffineTransform {
+  const { size } = options;
+
+  switch (action.type) {
+    case "translate":
+      return applyTranslation(base, action.delta, size);
+    case "scale-side":
+      return applyScaling(base, action.side, action.delta, size);
+    case "rotate":
+      return applyRotation(base, action.corner, action.delta, size);
+  }
+}
+
+/**
+ * Given a transform-box matrix and the box size, returns the four
+ * transformed corners in pixel space.
+ *
+ *   Each corner = transform * box_corner
+ */
+export function getTransformBoxCorners(
+  transform: AffineTransform,
+  size: cmath.Vector2
+): TransformBoxCorners {
+  const width = size[0] || 1;
+  const height = size[1] || 1;
+
+  const boxCorners: cmath.Vector2[] = [
+    [0, 0],
+    [width, 0],
+    [width, height],
+    [0, height],
+  ];
+
+  // Transform matrix in pixel space — translation columns denormalized
+  // by (width, height).
+  const pixelTransform: cmath.Transform = [
+    [transform[0][0], transform[0][1], transform[0][2] * width],
+    [transform[1][0], transform[1][1], transform[1][2] * height],
+  ];
+
+  const corners = boxCorners.map((corner) =>
+    cmath.vector2.transform(corner, pixelTransform)
+  );
+
+  return {
+    nw: corners[0],
+    ne: corners[1],
+    se: corners[2],
+    sw: corners[3],
+  };
+}
+
+/**
+ * Decomposes an affine transform into rotation (deg), scale [sx, sy],
+ * and translation [tx, ty] components.
+ */
+export function decompose(transform: AffineTransform): {
+  rotation: number;
+  scale: cmath.Vector2;
+  translation: cmath.Vector2;
+} {
+  const matrix: cmath.Transform = [
+    [transform[0][0], transform[0][1], transform[0][2]],
+    [transform[1][0], transform[1][1], transform[1][2]],
+  ];
+
+  return {
+    rotation: cmath.transform.angle(matrix),
+    scale: cmath.transform.getScale(matrix),
+    translation: cmath.transform.getTranslate(matrix),
+  };
+}
+
+/**
+ * Composes rotation (deg), scale, and translation into an affine
+ * transform, anchored so the supplied `center` is preserved.
+ */
+export function compose(
+  rotation: number,
+  scale: cmath.Vector2,
+  translation: cmath.Vector2,
+  center: cmath.Vector2
+): AffineTransform {
+  const rad = (rotation * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+
+  const a = scale[0] * cos;
+  const b = -scale[1] * sin;
+  const c = scale[0] * sin;
+  const d = scale[1] * cos;
+
+  const rotatedScaledCenter = [
+    a * center[0] + b * center[1],
+    c * center[0] + d * center[1],
+  ];
+
+  const tx = center[0] - rotatedScaledCenter[0] + translation[0];
+  const ty = center[1] - rotatedScaledCenter[1] + translation[1];
+
+  return [
+    [a, b, tx],
+    [c, d, ty],
+  ];
+}
+
+function applyTranslation(
+  base: AffineTransform,
+  pixelDelta: cmath.Vector2,
+  size: cmath.Vector2
+): AffineTransform {
+  const boxDelta: cmath.Vector2 = [
+    pixelDelta[0] / size[0],
+    pixelDelta[1] / size[1],
+  ];
+
+  return [
+    [base[0][0], base[0][1], base[0][2] + boxDelta[0]],
+    [base[1][0], base[1][1], base[1][2] + boxDelta[1]],
+  ];
+}
+
+/**
+ * Side scaling.
+ *
+ * TODO: true original-direction scaling (scaling pure X/Y axes
+ * regardless of current rotation) is unimplemented. The current
+ * implementation falls back to a geometry-based approach — scaling
+ * follows the current rotated axes. This was inherited from the
+ * editor's image-paint editor and ships as-is.
+ */
+function applyScaling(
+  base: AffineTransform,
+  side: cmath.RectangleSide,
+  pixelDelta: cmath.Vector2,
+  size: cmath.Vector2
+): AffineTransform {
+  const corners = getTransformBoxCorners(base, size);
+
+  const axis =
+    side === "left" || side === "right"
+      ? cmath.vector2.sub(corners.ne, corners.nw)
+      : cmath.vector2.sub(corners.sw, corners.nw);
+
+  const projected = cmath.vector2.project(pixelDelta, axis);
+
+  switch (side) {
+    case "left": {
+      corners.nw = cmath.vector2.add(corners.nw, projected);
+      corners.sw = cmath.vector2.add(corners.sw, projected);
+      break;
+    }
+    case "right": {
+      corners.ne = cmath.vector2.add(corners.ne, projected);
+      corners.se = cmath.vector2.add(corners.se, projected);
+      break;
+    }
+    case "top": {
+      corners.nw = cmath.vector2.add(corners.nw, projected);
+      corners.ne = cmath.vector2.add(corners.ne, projected);
+      break;
+    }
+    case "bottom": {
+      corners.sw = cmath.vector2.add(corners.sw, projected);
+      corners.se = cmath.vector2.add(corners.se, projected);
+      break;
+    }
+  }
+
+  return cornersToBoxTransform(corners, size);
+}
+
+/**
+ * Convert pixel-space corners back to a box-relative transform.
+ */
+export function cornersToBoxTransform(
+  corners: TransformBoxCorners,
+  size: cmath.Vector2
+): AffineTransform {
+  const width = size[0] || 1;
+  const height = size[1] || 1;
+
+  const { nw, ne, sw } = corners;
+
+  const widthVector = cmath.vector2.sub(ne, nw);
+  const heightVector = cmath.vector2.sub(sw, nw);
+
+  return [
+    [widthVector[0] / width, heightVector[0] / height, nw[0] / width],
+    [widthVector[1] / width, heightVector[1] / height, nw[1] / height],
+  ];
+}
+
+/**
+ * Rigid-body rotation of the transformed geometry (rect × transform)
+ * around its center. Preserves corner distances and keeps pre/post
+ * centers aligned.
+ */
+function applyRotation(
+  base: AffineTransform,
+  corner: cmath.IntercardinalDirection,
+  pixelDelta: cmath.Vector2,
+  size: cmath.Vector2
+): AffineTransform {
+  const corners = getTransformBoxCorners(base, size);
+  const center = cmath.vector2.multiply(
+    cmath.vector2.add(corners.nw, corners.se),
+    [0.5, 0.5]
+  );
+
+  const cornerPoint = corners[corner];
+  const target = cmath.vector2.add(cornerPoint, pixelDelta);
+  const baseVector = cmath.vector2.sub(cornerPoint, center);
+  const targetVector = cmath.vector2.sub(target, center);
+
+  const baseLength = Math.hypot(baseVector[0], baseVector[1]);
+  if (baseLength < EPSILON) return base;
+
+  const targetLength = Math.hypot(targetVector[0], targetVector[1]);
+  if (targetLength < EPSILON) return base;
+
+  const normalizedTarget = [
+    (targetVector[0] / targetLength) * baseLength,
+    (targetVector[1] / targetLength) * baseLength,
+  ] as cmath.Vector2;
+
+  const dot = cmath.vector2.dot(baseVector, normalizedTarget);
+  const cross = cmath.vector2.cross(baseVector, normalizedTarget);
+  const angle = Math.atan2(cross, dot);
+
+  if (Math.abs(angle) < EPSILON) return base;
+
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const rotatePoint = (point: cmath.Vector2): cmath.Vector2 => {
+    const relative = cmath.vector2.sub(point, center);
+    return cmath.vector2.add(center, [
+      relative[0] * cos - relative[1] * sin,
+      relative[0] * sin + relative[1] * cos,
+    ]);
+  };
+
+  const rotatedCorners = {
+    nw: rotatePoint(corners.nw),
+    ne: rotatePoint(corners.ne),
+    se: rotatePoint(corners.se),
+    sw: rotatePoint(corners.sw),
+  };
+
+  return cornersToBoxTransform(rotatedCorners, size);
+}

--- a/packages/grida-canvas-hud/primitives/transform-box.ts
+++ b/packages/grida-canvas-hud/primitives/transform-box.ts
@@ -209,6 +209,44 @@ function applyTranslation(
  * follows the current rotated axes. This was inherited from the
  * editor's image-paint editor and ships as-is.
  */
+// Direction-of-axis fallback for `applyScaling`. The base transform's
+// 2×2 linear part encodes rotation × scale; when one scale collapses,
+// the corresponding column of [[a, b], [c, d]] is the zero vector and
+// the corner-derived axis collapses with it. We recover the local-axis
+// direction from the other column (perpendicular rotated ±90°), then
+// scale it by `size` so the projection magnitude is comparable to the
+// non-degenerate case. Returns the zero vector iff both columns and
+// `size` are fully collapsed — caller handles that as a true no-op.
+function degenerateAxisFallback(
+  base: AffineTransform,
+  side: cmath.RectangleSide,
+  size: cmath.Vector2
+): cmath.Vector2 {
+  const a = base[0][0];
+  const b = base[0][1];
+  const c = base[1][0];
+  const d = base[1][1];
+  const sx = Math.hypot(a, c);
+  const sy = Math.hypot(b, d);
+  let ux: cmath.Vector2;
+  let uy: cmath.Vector2;
+  if (sx > SIZE_EPSILON) {
+    ux = [a / sx, c / sx];
+    uy = [-c / sx, a / sx];
+  } else if (sy > SIZE_EPSILON) {
+    uy = [b / sy, d / sy];
+    ux = [d / sy, -b / sy];
+  } else {
+    ux = [1, 0];
+    uy = [0, 1];
+  }
+  const w = Math.abs(size[0]) > SIZE_EPSILON ? size[0] : 0;
+  const h = Math.abs(size[1]) > SIZE_EPSILON ? size[1] : 0;
+  return side === "left" || side === "right"
+    ? [ux[0] * w, ux[1] * w]
+    : [uy[0] * h, uy[1] * h];
+}
+
 function applyScaling(
   base: AffineTransform,
   side: cmath.RectangleSide,
@@ -217,14 +255,25 @@ function applyScaling(
 ): AffineTransform {
   const corners = getTransformBoxCorners(base, size);
 
-  const axis =
+  let axis =
     side === "left" || side === "right"
       ? cmath.vector2.sub(corners.ne, corners.nw)
       : cmath.vector2.sub(corners.sw, corners.nw);
 
-  // Degenerate axis → projection denominator is 0; bail rather than emit
-  // a transform full of NaN.
-  if (Math.hypot(axis[0], axis[1]) < SIZE_EPSILON) return base;
+  // Recovery from a collapsed side: once a drag has driven the box's
+  // width or height to ~0, the corner-derived axis is the zero vector
+  // and projecting `pixelDelta` onto it would yield NaN. Bailing out
+  // here would also strand the user — the box could never re-expand
+  // because every subsequent drag on that axis would no-op. Fall back
+  // to the box's local axis direction, derived from whichever column
+  // of the base's linear part is still non-degenerate (one collapse
+  // axis at a time is the common case; full collapse is the exception
+  // and we keep the bail-out for that).
+  if (Math.hypot(axis[0], axis[1]) < SIZE_EPSILON) {
+    const fallback = degenerateAxisFallback(base, side, size);
+    if (Math.hypot(fallback[0], fallback[1]) < SIZE_EPSILON) return base;
+    axis = fallback;
+  }
 
   const projected = cmath.vector2.project(pixelDelta, axis);
 

--- a/packages/grida-canvas-hud/primitives/types.ts
+++ b/packages/grida-canvas-hud/primitives/types.ts
@@ -228,7 +228,7 @@ export interface HUDPolyline extends HUDSemantic {
   /** Opacity of the fill color, 0–1 (default: 1). Ignored when `fill` is falsy. */
   fillOpacity?: number;
   /** Stroke opacity, 0–1 (default: 1). Used for hovered-but-not-selected
-   *  affordances (the main editor's "50% opacity" segment hover state). */
+   *  affordances (e.g. segment hover at 50% opacity). */
   strokeOpacity?: number;
   /** Stroke width in screen-space CSS px. Falls back to the canvas default
    *  (1px / zoom) when absent. Required for the path-edit chrome's

--- a/packages/grida-canvas-hud/surface/chrome.ts
+++ b/packages/grida-canvas-hud/surface/chrome.ts
@@ -749,6 +749,7 @@ export function fanOverlays(
         strokeWidth: el.render.strokeWidth,
         dashed: el.render.dashed,
         color: el.render.color,
+        fillPaint: el.render.fillPaint,
         group: el.group,
       });
     }

--- a/packages/grida-canvas-hud/surface/style.ts
+++ b/packages/grida-canvas-hud/surface/style.ts
@@ -1,3 +1,5 @@
+import type { HUDPaint } from "../primitives/types";
+
 /**
  * HUD style — colors, sizes, and offsets for the surface-owned chrome.
  *
@@ -26,7 +28,7 @@ export interface HUDStyle {
    * Color used for IDLE vector segment outlines. Painted as a thin overlay
    * stroke on top of each segment to indicate "you are in path edit mode
    * and these segments are interactive" — independent of the document's
-   * own stroke style. Mirrors the main editor's gray-400 affordance stroke.
+   * own stroke style. Default is a neutral gray affordance stroke.
    */
   segmentIdleColor: string;
   /** Stroke width (screen-px) for IDLE segment outlines. */
@@ -48,6 +50,64 @@ export interface HUDStyle {
   /** Stroke width (screen-px) for tangent lines when their tangent IS
    *  selected. */
   tangentLineActiveWidth: number;
+
+  // ─── Vector regions (closed-loop body chrome) ──────────────────────────
+  /**
+   * Paint applied to a region's interior when the cursor is hovering
+   * the loop body (no other vector control claimed the pixel). Hosts
+   * typically use `HUDPaintStripes` here — the canonical
+   * "highlighted region, not committed selection" affordance.
+   *
+   * @see {@link HUDPaintStripes}
+   */
+  vectorRegionHoverPaint: HUDPaint;
+  /**
+   * Paint applied to a region's interior when the loop is in the
+   * host-pushed `VectorSubSelection.regions` array. Same shape vocabulary
+   * as `vectorRegionHoverPaint`; conventionally a brighter / higher-
+   * opacity variant so selected reads stronger than hover. Hover wins
+   * over selected when both apply (existing precedence in vector chrome).
+   */
+  vectorRegionSelectedPaint: HUDPaint;
+
+  // ─── Padding overlay (named class) ─────────────────────────────────────
+  /**
+   * Paint applied to a padding-overlay side rect when the cursor is
+   * hovering it (HUD-owned; reads modifier state for axis-mirror).
+   *
+   * @see {@link HUDPaintStripes}
+   */
+  paddingHoverPaint: HUDPaint;
+  /**
+   * Stroke color for the padding-overlay side rect when a `padding_handle`
+   * gesture is in flight (HUD-derived from `state.gesture`). Painted as an
+   * outline of the side rect — communicating "this is the padding box at
+   * the current value" — instead of the hover stripe pattern. Cleaner read
+   * during the drag than stripes, which clutter the geometry.
+   *
+   * Stroke width: `selectionOutlineWidth`. Fill: none.
+   *
+   * With axis-mirror on (alt-held), the opposite side also outlines.
+   */
+  paddingSelectedStroke: string;
+  /** Fill color for the padding mid-edge drag handle (visual knob). */
+  paddingHandleFill: string;
+  /** Stroke color (ring) for the padding mid-edge drag handle. */
+  paddingHandleStroke: string;
+
+  /**
+   * Stroke color for the transform-box quad outline. The quad is the
+   * only visible chrome of the transform-box model in idle — handles
+   * are invisible hit-only by default.
+   *
+   * Default `#a3a3a3` (neutral-400) — a muted stroke that reads as
+   * "transform target boundary" without competing with selection chrome.
+   */
+  transformBoxStroke: string;
+  /** Fill color for the (invisible by default) transform-box handles. */
+  transformBoxHandleFill: string;
+  /** Stroke color for transform-box handles (visible only in debug). */
+  transformBoxHandleStroke: string;
 }
 
 export const DEFAULT_STYLE: HUDStyle = {
@@ -59,9 +119,8 @@ export const DEFAULT_STYLE: HUDStyle = {
   selectionOutlineWidth: 1,
   hoverOutlineWidth: 2,
   showRotationHandles: false,
-  // Vector chrome defaults — derived from the main editor's tokens:
-  //   stroke-gray-400  → #9ca3af
-  //   stroke-workbench-accent-sky → use the chrome color (host-themable)
+  // Vector chrome defaults — idle = gray-400 affordance, active = chrome
+  // color (host-themable).
   segmentIdleColor: "#9ca3af",
   segmentIdleWidth: 1,
   segmentActiveColor: "#2563eb",
@@ -70,6 +129,43 @@ export const DEFAULT_STYLE: HUDStyle = {
   tangentLineColor: "#9ca3af",
   tangentLineIdleWidth: 1,
   tangentLineActiveWidth: 2,
+  // Region defaults — diagonal stripes. Hover ≈ accent-sky/50, selected
+  // ≈ accent-sky/70. Hosts can override per theme by passing partial
+  // HUDStyle.
+  vectorRegionHoverPaint: {
+    kind: "stripes",
+    color: "#0ea5e9",
+    opacity: 0.5,
+    angle: 45,
+    spacing: 8,
+    thickness: 1.5,
+  },
+  vectorRegionSelectedPaint: {
+    kind: "stripes",
+    color: "#0ea5e9",
+    opacity: 0.7,
+    angle: 45,
+    spacing: 8,
+    thickness: 1.5,
+  },
+  // Padding defaults — diagonal stripes at accent-sky/50.
+  paddingHoverPaint: {
+    kind: "stripes",
+    color: "#0ea5e9",
+    opacity: 0.5,
+    angle: 45,
+    spacing: 8,
+    thickness: 1.5,
+  },
+  paddingSelectedStroke: "#0ea5e9",
+  paddingHandleFill: "#3b82f6",
+  paddingHandleStroke: "#ffffff",
+  // Transform-box defaults — quad outline in neutral-400 (muted stroke).
+  // Handles are transparent by default; the visible affordance is
+  // cursor + bounding-quad (Fitts'-reach via hit AABB).
+  transformBoxStroke: "#a3a3a3",
+  transformBoxHandleFill: "transparent",
+  transformBoxHandleStroke: "#a3a3a3",
 };
 
 export function mergeStyle(

--- a/packages/grida-canvas-hud/surface/surface.ts
+++ b/packages/grida-canvas-hud/surface/surface.ts
@@ -39,7 +39,15 @@ import {
   mergeDraws,
   type SurfaceChromeGroups,
 } from "./chrome";
-import { buildVectorChrome, type VectorOverlay } from "./vector-chrome";
+import { buildVectorChrome, type VectorOverlay } from "../classes/vector-path";
+import {
+  buildPaddingOverlay,
+  type PaddingOverlayInput,
+} from "../classes/padding";
+import {
+  buildTransformBox,
+  type TransformBoxInput,
+} from "../classes/transform-box";
 import type { OverlayElement } from "../event/overlay";
 import type { VectorSubSelection } from "../event/state";
 
@@ -117,8 +125,7 @@ export interface SurfaceOptions {
    *   and matches the "owning segment hovers → midpoint becomes visible"
    *   mental model.
    * - `"projected"` — at the nearest point on the curve to the cursor
-   *   (`cmath.bezier.project`). Mirrors the main editor's
-   *   `snapped_segment_p` model — the ghost tracks the cursor along the
+   *   (`cmath.bezier.project`). The ghost tracks the cursor along the
    *   curve. More expressive but adds a "where exactly will this land?"
    *   cognitive step.
    *
@@ -132,11 +139,10 @@ export interface SurfaceOptions {
    * - `"marquee"` (default) — axis-aligned rect selection.
    * - `"lasso"` — freeform polygon selection.
    *
-   * Pushed by the host alongside its own tool toggle (e.g. Q key in the
-   * svg-editor swaps cursor ↔ lasso tools and calls
-   * `setVectorSelectionMode`). The HUD reads it only at empty-space drag
-   * promotion; no other branch consults it. Symmetric with
-   * `vectorInsertionMode`.
+   * Pushed by the host alongside its own tool toggle (e.g. when the host
+   * swaps cursor ↔ lasso tools) via `setVectorSelectionMode`. The HUD reads
+   * it only at empty-space drag promotion; no other branch consults it.
+   * Symmetric with `vectorInsertionMode`.
    */
   vectorSelectionMode?: VectorSelectionMode;
   /**
@@ -187,6 +193,12 @@ export class Surface {
    */
   private cornerRadius: readonly CornerRadiusInput[] = [];
   private parametricHandles: readonly ParametricHandleInput[] = [];
+  /**
+   * Padding-overlay input. `null` = no chrome drawn. Hosts push on
+   * flex-parent selection; clear on deselect / mode exit. See
+   * `setPaddingOverlay`.
+   */
+  private paddingOverlay: PaddingOverlayInput | null = null;
   // Explicit host color override; when set, beats `style.chromeColor` in
   // every paint until cleared via `setColor(null)`.
   private colorOverride: string | undefined;
@@ -339,6 +351,53 @@ export class Surface {
   }
 
   /**
+   * Configure or clear the built-in padding-overlay chrome — the
+   * `padding` named class for flex-parent container padding editing.
+   *
+   * Pass an input to enable the chrome (four inset side rects with
+   * diagonal-stripe hover/selected paint + four mid-edge drag handles).
+   * Pass `null` to disable. Schema-level feature flag — absence is the
+   * off-state, no separate boolean to drift.
+   *
+   * The HUD owns hover (including alt-held axis-mirror visual), reads
+   * the `alt` modifier directly for the intent's `mirror` flag, and
+   * emits `padding_handle` intents on drag (preview-stream + commit).
+   * The host applies the value to its node's `layout_padding_{side}`
+   * field and pushes a re-rendered input back via `setPaddingOverlay`
+   * so the chrome reflects the new value.
+   *
+   * Mid-gesture state mirror: hosts SHOULD push `active_side` while a
+   * `padding_handle` gesture is in flight so the dragged side paints
+   * with the "selected" stripe variant (and the opposite side too,
+   * when alt is held). Clear `active_side` on commit.
+   *
+   * See `@grida/hud/classes/padding` for the input shape and
+   * paint/hit/priority details.
+   */
+  setPaddingOverlay(input: PaddingOverlayInput | null): void {
+    this.paddingOverlay = input;
+  }
+
+  /**
+   * Push a transform-box input — the `transform-box` named class for
+   * a 2×3 affine transform manipulated via quad outline + 4 corners +
+   * 4 sides + body. `null` = no chrome drawn (schema-level feature
+   * flag).
+   *
+   * Hosts re-push input whenever the bound transform / size / origin
+   * / rotation changes (driven by the host's reducer applying the
+   * `transform_box` intent). The chrome rebuilds every draw.
+   *
+   * See `@grida/hud/classes/transform-box` for the input shape and
+   * hit/priority/anti-goals details.
+   *
+   * @unstable
+   */
+  setTransformBox(input: TransformBoxInput | null): void {
+    this.state.setTransformBox(input);
+  }
+
+  /**
    * Update just the ruler's transform. Cheap to call per camera tick.
    * No-op when no ruler config is set.
    */
@@ -480,6 +539,49 @@ export class Surface {
         // priority value via the priority field, not push order).
         for (const o of vector_chrome.overlays) overlays.push(o);
       }
+    }
+
+    // Padding overlay. Emitted ABOVE selection chrome (it's a content
+    // control set) and BELOW resize handles via the priority ladder
+    // (`PADDING_REGION_PRIORITY` loses to resize; the handle wins). The
+    // HUD owns the active-drag visual: when the gesture state is
+    // `padding_handle`, that side's stripe paints with the `selected`
+    // token — no host-pushed `active_side` shadow.
+    if (this.paddingOverlay) {
+      const g = this.state.gesture;
+      const active_side =
+        g.kind === "padding_handle" && g.node_id === this.paddingOverlay.node_id
+          ? g.side
+          : undefined;
+      const padding_overlays = buildPaddingOverlay({
+        overlay: this.paddingOverlay,
+        style: this.style,
+        hover: this.state.getPaddingHover(),
+        alt_held: this.state.modifiers.alt,
+        transform: this.state.getTransform(),
+        active_side,
+      });
+      for (const o of padding_overlays) overlays.push(o);
+    }
+
+    // Transform-box overlay. Same z-band as padding (only one of these
+    // classes is active at a time in practice — image-fit content-edit
+    // doesn't co-exist with flex-parent overlay). Hit-priority ordering
+    // (corner=13, side=14, body=38) does the real arbitration, push
+    // order is just visual.
+    const tb_input = this.state.getTransformBox();
+    if (tb_input) {
+      const g = this.state.gesture;
+      const active_op =
+        g.kind === "transform_box" && g.id === tb_input.id ? g.op : undefined;
+      const tb_overlays = buildTransformBox({
+        overlay: tb_input,
+        style: this.style,
+        hover: this.state.getTransformBoxHover(),
+        transform: this.state.getTransform(),
+        active_op,
+      });
+      for (const o of tb_overlays) overlays.push(o);
     }
 
     const hidden = this.opts.visibility?.({

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -171,9 +171,30 @@ const editor = createSvgEditor({
 });
 ```
 
-`createSvgEditor` is the only constructor. The returned `SvgEditor` is the only object consumers ever hold.
+`createSvgEditor` is the only **editor** constructor. The returned `SvgEditor` is the only editor instance consumers ever hold. A small set of Layer-A geometry primitives (see [Geometry primitives](#geometry-primitives) below) is also exported for callers that need canonical SVG geometry without mounting an editor — those are not editor instances and have no lifecycle.
 
 The editor core is **headless**. It parses the SVG, owns the document IR, accepts commands, and emits state — but it does not import, reference, or call into `window`, `document`, `HTMLElement`, or any DOM type. To render or take input, the host attaches a `Surface` (next section).
+
+### Geometry primitives
+
+A small set of Layer-A primitives is exported for callers that want canonical SVG geometry without mounting an editor. These are not part of the editor lifecycle, do not subscribe, and do not produce diffs against an `SvgDocument` — they are pure value classes over the bytes you hand them.
+
+#### `PathModel`
+
+Models a single SVG path's vector network for callers that want path geometry without an editor. Construct from a `d` string, observe vertex/segment shape, compute a bbox, serialize back to `d`. No editor, no document, no DOM.
+
+```ts
+import { PathModel } from "@grida/svg-editor";
+
+const m = PathModel.fromSvgPathD("M 10 10 L 100 10 L 100 100 Z");
+m.vertexCount(); // 3
+m.segmentCount(); // 3
+m.snapshot(); // { vertices, segments } — POJO
+m.bbox(); // { x, y, width, height }
+m.toSvgPathD(); // canonical d
+```
+
+`@experimental` — the externally-stable contract for v0 is construction (`fromSvgPathD`) plus `snapshot()` / `bbox()` / `vertexCount()` / `segmentCount()` / `toSvgPathD()`. Mutation methods on the class exist for the editor's internal use and are not part of the documented public surface.
 
 ### Surface
 
@@ -210,6 +231,8 @@ Geometry (world-space bboxes, screen ↔ local projection) is exposed via `edito
 `@grida/svg-editor/dom` exports `attach_dom_surface(editor, { container, ... })` as the default DOM implementation, plus the surface-scoped types (`Camera`, `Gestures`, `SnapOptions`, `MemoizedGeometryProvider`, `DomComputedResolver`) that callers writing alternative surfaces or advanced integrations may need. It mounts the SVG into the container, wires pointer / keyboard listeners scoped to that container, and uses native `getBBox` / `getScreenCTM` for geometry. It is the only place in this package that imports DOM types.
 
 The container is **exclusively owned** by the surface. Render toolbars, layer lists, inspectors, and any other interactive chrome as **siblings** of the container, not children. Children of the container interfere with pointer routing (capture redirects, hit-test ordering) and produce silent click breakage. The shipped `SvgEditorCanvas` React component enforces this by creating its own internal div; hosts using `domSurface` / `keynote.attach` directly are responsible for the same discipline. In development, the surface emits a `console.warn` at attach time when the container is non-empty.
+
+**Attention gate.** The DOM surface installs document- and window-level keydown listeners (so a user with focus on a side-panel button can still hit editor shortcuts while the pointer is on the canvas). Those listeners are gated by an internal attention predicate: a key is claimed (and `preventDefault()`-ed) only when **focus is inside the container's subtree OR the pointer is over the container**. Body-focus alone — the natural state when the surface is embedded as a block in a longer document — is not attended, so the editor stays out of the way of page-level shortcuts (Space / arrows to scroll, Cmd+= to zoom, etc.). Passive observation listeners (modifier mirrors, blur resets) are not gated — they don't call `preventDefault()` and need to stay live across focus boundaries.
 
 ### Lifecycle
 

--- a/packages/grida-svg-editor/__tests__/attention-gate.test.ts
+++ b/packages/grida-svg-editor/__tests__/attention-gate.test.ts
@@ -1,0 +1,304 @@
+// Attention gate — pins the contract that prevents the surface from claiming
+// page-level keyboard shortcuts when nothing signals interest in it.
+//
+// Two layers covered here:
+//   1. `create_attention_tracker(container)` — the standalone predicate that
+//      reports whether focus is inside the container's subtree or the
+//      pointer is over the container.
+//   2. The default keydown-claiming gesture bindings (`KEYBOARD_ZOOM`,
+//      `SPACE_DRAG_PAN`) — assert they consult `is_attended` before
+//      calling `preventDefault()`.
+//
+// The package's test config is node-only (no jsdom), so this file builds
+// minimal fakes that implement only the surface the code under test reads.
+// Tests must read as "given this DOM state, this listener does/doesn't
+// preventDefault" — no consumer is named.
+
+import { describe, expect, it } from "vitest";
+import { create_attention_tracker } from "../src/util/attention";
+
+// ─── Fake DOM scaffolding ────────────────────────────────────────────────
+
+type FakeListener = (e: unknown) => void;
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<FakeListener>>();
+  addEventListener(name: string, fn: FakeListener): void {
+    const set = this.listeners.get(name) ?? new Set();
+    set.add(fn);
+    this.listeners.set(name, set);
+  }
+  removeEventListener(name: string, fn: FakeListener): void {
+    this.listeners.get(name)?.delete(fn);
+  }
+  /** Test-only — fire a synthetic event into installed listeners. */
+  fire(name: string, payload: unknown = {}): void {
+    for (const fn of this.listeners.get(name) ?? new Set()) fn(payload);
+  }
+  /** Test-only — does anything listen on this name? */
+  has(name: string): boolean {
+    return (this.listeners.get(name)?.size ?? 0) > 0;
+  }
+}
+
+class FakeContainer extends FakeEventTarget {
+  // Properties read by the tracker / gesture installers.
+  readonly style: { cursor: string } = { cursor: "" };
+  readonly children = [] as const;
+  readonly ownerDocument: FakeOwnerDocument;
+  /** Whether `contains(active)` should return true. Set by tests. */
+  private focused_descendants = new Set<object>();
+
+  constructor() {
+    super();
+    this.ownerDocument = new FakeOwnerDocument(this);
+  }
+
+  contains(node: object | null): boolean {
+    if (!node) return false;
+    if (node === this) return true;
+    return this.focused_descendants.has(node);
+  }
+  /** Test-only — register `el` as a descendant of `container`. */
+  add_descendant(el: object): void {
+    this.focused_descendants.add(el);
+  }
+  /** Required by `SPACE_DRAG_PAN` cursor handling; harmless stub. */
+  setPointerCapture(): void {
+    /* no-op */
+  }
+  getBoundingClientRect() {
+    return { left: 0, top: 0, width: 0, height: 0 };
+  }
+}
+
+class FakeOwnerDocument extends FakeEventTarget {
+  body = { tagName: "BODY" } as unknown as Element;
+  activeElement: Element | null;
+  readonly defaultView: FakeWindow;
+  constructor(private readonly container: FakeContainer) {
+    super();
+    // Default reading state: focus is on body, no other signal.
+    this.activeElement = this.body;
+    this.defaultView = new FakeWindow();
+  }
+}
+
+class FakeWindow extends FakeEventTarget {}
+
+// ─── Predicate ───────────────────────────────────────────────────────────
+
+describe("create_attention_tracker", () => {
+  it("is NOT attended when focus is on body and pointer is not over the container", () => {
+    const c = new FakeContainer();
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    // Default state set up by FakeOwnerDocument.
+    expect(t.is_attended()).toBe(false);
+    t.dispose();
+  });
+
+  it("is attended when focus is inside the container subtree", () => {
+    const c = new FakeContainer();
+    const child = { tagName: "DIV" };
+    c.add_descendant(child);
+    c.ownerDocument.activeElement = child as unknown as Element;
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    expect(t.is_attended()).toBe(true);
+    t.dispose();
+  });
+
+  it("is attended when the container itself is the focused element", () => {
+    const c = new FakeContainer();
+    c.ownerDocument.activeElement = c as unknown as Element;
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    expect(t.is_attended()).toBe(true);
+    t.dispose();
+  });
+
+  it("is NOT attended when focus is on a sibling element outside the subtree", () => {
+    const c = new FakeContainer();
+    const sibling = { tagName: "BUTTON" };
+    // NOT added as descendant — contains(sibling) returns false.
+    c.ownerDocument.activeElement = sibling as unknown as Element;
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    expect(t.is_attended()).toBe(false);
+    t.dispose();
+  });
+
+  it("becomes attended on pointerenter and un-attended on pointerleave", () => {
+    const c = new FakeContainer();
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    expect(t.is_attended()).toBe(false);
+    c.fire("pointerenter");
+    expect(t.is_attended()).toBe(true);
+    c.fire("pointerleave");
+    expect(t.is_attended()).toBe(false);
+    t.dispose();
+  });
+
+  it("focus-inside wins even when pointer is not over the container", () => {
+    const c = new FakeContainer();
+    const child = { tagName: "INPUT" };
+    c.add_descendant(child);
+    c.ownerDocument.activeElement = child as unknown as Element;
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    // No pointerenter fired.
+    expect(t.is_attended()).toBe(true);
+    t.dispose();
+  });
+
+  it("dispose() removes the pointer listeners — subsequent fires don't flip state", () => {
+    const c = new FakeContainer();
+    const t = create_attention_tracker(c as unknown as HTMLElement);
+    c.fire("pointerenter");
+    expect(t.is_attended()).toBe(true);
+    t.dispose();
+    c.fire("pointerleave"); // no-op now
+    // Activate again — listener is gone, state stays as last seen.
+    c.fire("pointerenter");
+    // Without pointer-over going true again, attended is computed from
+    // (focus inside ∨ last_known_pointer_over). After dispose() neither
+    // listener mutates the closure — but the stale state is fine for the
+    // contract: the post-dispose predicate is undefined behavior and the
+    // surface always disposes the tracker as part of teardown.
+    // The assertion we care about is: removeEventListener was actually
+    // called for both. Verify by counting set sizes.
+    // (Indirect: the fake's `has` tells us whether anyone listens.)
+    expect(c.has("pointerenter")).toBe(false);
+    expect(c.has("pointerleave")).toBe(false);
+  });
+});
+
+// ─── Gesture-level: KEYBOARD_ZOOM ────────────────────────────────────────
+//
+// Construct the binding's install context with a mock `is_attended` and
+// assert the listener's preventDefault gate. The binding lives in the
+// default set; we import the module and pull the binding by id so the
+// test breaks if it's removed or renamed.
+
+import { DEFAULT_GESTURE_BINDINGS } from "../src/gestures/defaults";
+import type { GestureBinding, GestureContext } from "../src/gestures";
+
+function find_binding(id: string): GestureBinding {
+  const b = DEFAULT_GESTURE_BINDINGS.find((x) => x.id === id);
+  if (!b) throw new Error(`gesture binding "${id}" not found`);
+  return b;
+}
+
+function fake_context(
+  container: FakeContainer,
+  is_attended: () => boolean
+): GestureContext {
+  // Most fields are unused by the listeners under test. We provide
+  // permissive stubs and rely on the binding's documented surface.
+  const camera = {
+    zoom: 1,
+    pan: () => {},
+    set_zoom: () => {},
+    zoom_at: () => {},
+    fit: () => {},
+    reset: () => {},
+  };
+  return {
+    container: container as unknown as HTMLElement,
+    svg_root: () => null,
+    hud_canvas: null as unknown as HTMLCanvasElement,
+    camera: camera as unknown as GestureContext["camera"],
+    editor: null as unknown as GestureContext["editor"],
+    handle: { detach: () => {} },
+    is_attended,
+  };
+}
+
+function mk_kbd_event(
+  init: Partial<{
+    code: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+    repeat: boolean;
+    key: string;
+  }>
+): KeyboardEvent {
+  let prevented = false;
+  return {
+    code: init.code ?? "",
+    metaKey: !!init.metaKey,
+    ctrlKey: !!init.ctrlKey,
+    shiftKey: !!init.shiftKey,
+    altKey: !!init.altKey,
+    repeat: !!init.repeat,
+    key: init.key ?? "",
+    preventDefault() {
+      prevented = true;
+    },
+    get defaultPrevented() {
+      return prevented;
+    },
+  } as unknown as KeyboardEvent;
+}
+
+describe("keyboard-zoom gesture — attention gate", () => {
+  it("ignores Shift+0 when the surface is not attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("keyboard-zoom");
+    const uninstall = binding.install(fake_context(c, () => false));
+    const e = mk_kbd_event({ code: "Digit0", shiftKey: true });
+    c.ownerDocument.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(false);
+    uninstall();
+  });
+
+  it("ignores Cmd+= when the surface is not attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("keyboard-zoom");
+    const uninstall = binding.install(fake_context(c, () => false));
+    const e = mk_kbd_event({ code: "Equal", metaKey: true });
+    c.ownerDocument.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(false);
+    uninstall();
+  });
+
+  it("claims Shift+0 when the surface IS attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("keyboard-zoom");
+    const uninstall = binding.install(fake_context(c, () => true));
+    const e = mk_kbd_event({ code: "Digit0", shiftKey: true });
+    c.ownerDocument.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(true);
+    uninstall();
+  });
+
+  it("claims Cmd+= when the surface IS attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("keyboard-zoom");
+    const uninstall = binding.install(fake_context(c, () => true));
+    const e = mk_kbd_event({ code: "Equal", metaKey: true });
+    c.ownerDocument.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(true);
+    uninstall();
+  });
+});
+
+describe("space-drag-pan gesture — attention gate", () => {
+  it("does NOT preventDefault on Space when the surface is not attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("space-drag-pan");
+    const uninstall = binding.install(fake_context(c, () => false));
+    const e = mk_kbd_event({ code: "Space" });
+    c.ownerDocument.defaultView.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(false);
+    uninstall();
+  });
+
+  it("preventDefaults Space when the surface IS attended", () => {
+    const c = new FakeContainer();
+    const binding = find_binding("space-drag-pan");
+    const uninstall = binding.install(fake_context(c, () => true));
+    const e = mk_kbd_event({ code: "Space" });
+    c.ownerDocument.defaultView.fire("keydown", e);
+    expect(e.defaultPrevented).toBe(true);
+    uninstall();
+  });
+});

--- a/packages/grida-svg-editor/__tests__/path-model-public.test.ts
+++ b/packages/grida-svg-editor/__tests__/path-model-public.test.ts
@@ -1,0 +1,96 @@
+// Public-surface contract for `PathModel`.
+//
+// `PathModel` is re-exported from the package's top-level entry as a
+// Layer-A geometry primitive for callers that want canonical SVG path
+// geometry without mounting an editor. These tests lock the externally-
+// observable contract of that re-export — independent of any caller —
+// so that internal refactors that would silently break the public
+// surface fail here first.
+//
+// The import path is the package's PUBLIC entry (`src/index`), NOT the
+// internal module. These tests would not catch a regression if they
+// reached for `src/core/...` directly — the whole point of the contract
+// is that the symbols are visible at the top-level barrel.
+
+import { describe, expect, it } from "vitest";
+import { PathModel } from "../src/index";
+import type { PathSnapshot, SegmentId, Verb, VertexId } from "../src/index";
+
+describe("PathModel — public re-export from package entry", () => {
+  it("is a constructible class with a static `fromSvgPathD` factory", () => {
+    expect(typeof PathModel).toBe("function");
+    expect(typeof PathModel.fromSvgPathD).toBe("function");
+  });
+
+  it("fromSvgPathD parses a closed polyline path; counts match the d-string", () => {
+    const m = PathModel.fromSvgPathD("M 10 10 L 100 10 L 100 100 L 10 100 Z");
+    expect(m.vertexCount()).toBe(4);
+    expect(m.segmentCount()).toBe(4);
+  });
+
+  it("is constructible without any document, editor, or surface context", () => {
+    // The constructor path must not require any host-side state. The
+    // call below runs in a plain Node test process with no DOM, no
+    // editor, no document — if construction reaches for any of those,
+    // this throws and the test fails.
+    expect(() => PathModel.fromSvgPathD("M 0 0 L 10 10")).not.toThrow();
+
+    const m = PathModel.fromSvgPathD("M 0 0 L 10 10");
+    expect(m).toBeInstanceOf(PathModel);
+  });
+
+  it("snapshot() returns a POJO with vertices and segments arrays", () => {
+    const m = PathModel.fromSvgPathD("M 0 0 L 10 10 L 20 0");
+    const snap: PathSnapshot = m.snapshot();
+    expect(Array.isArray(snap.vertices)).toBe(true);
+    expect(Array.isArray(snap.segments)).toBe(true);
+    expect(snap.vertices.length).toBe(m.vertexCount());
+    expect(snap.segments.length).toBe(m.segmentCount());
+    // Every segment exposes vertex-index endpoints plus tangent control
+    // tuples — the canonical vector-network shape.
+    for (const seg of snap.segments) {
+      expect(typeof seg.a).toBe("number");
+      expect(typeof seg.b).toBe("number");
+      expect(seg.ta.length).toBe(2);
+      expect(seg.tb.length).toBe(2);
+    }
+  });
+
+  it("bbox() returns a numeric rectangle for a non-degenerate path", () => {
+    const m = PathModel.fromSvgPathD("M 0 0 L 100 0 L 100 50 L 0 50 Z");
+    const box = m.bbox();
+    expect(box.x).toBe(0);
+    expect(box.y).toBe(0);
+    expect(box.width).toBe(100);
+    expect(box.height).toBe(50);
+  });
+
+  it("toSvgPathD round-trips structurally through fromSvgPathD", () => {
+    // Exact byte-equality of the d-string is NOT part of the contract —
+    // the emitter is allowed to normalize spacing/encoding. What IS
+    // contractually stable is that parsing the re-emitted d-string
+    // yields a model with the same structural counts.
+    const original = "M 0 0 C 10 0 20 10 20 20";
+    const m = PathModel.fromSvgPathD(original);
+    const re = PathModel.fromSvgPathD(m.toSvgPathD());
+    expect(re.vertexCount()).toBe(m.vertexCount());
+    expect(re.segmentCount()).toBe(m.segmentCount());
+  });
+
+  it("the publicly-named types resolve and are usable as type annotations", () => {
+    // This test exists to keep the re-exported type names load-bearing.
+    // If any of `PathSnapshot`, `Verb`, `VertexId`, `SegmentId` is
+    // dropped from the public surface, this file fails to typecheck.
+    const m = PathModel.fromSvgPathD("M 0 0 L 5 5");
+    const snap: PathSnapshot = m.snapshot();
+    const v: VertexId = snap.segments[0].a;
+    const s: SegmentId = 0;
+    const maybe_verb: Verb | undefined = snap.segments[0].source_verb;
+    expect(typeof v).toBe("number");
+    expect(typeof s).toBe("number");
+    // `source_verb` is optional; both branches are allowed.
+    expect(maybe_verb === undefined || typeof maybe_verb === "string").toBe(
+      true
+    );
+  });
+});

--- a/packages/grida-svg-editor/src/core/vector-edit/model.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/model.ts
@@ -120,6 +120,26 @@ type ArcMeta = {
 
 // ─── PathModel class ───────────────────────────────────────────────────────
 
+/**
+ * Canonical vector-network model for a single SVG path's `d` string.
+ *
+ * `PathModel` is a self-contained geometry primitive — it parses an SVG
+ * path `d` into a vertex/segment graph (with verb hints preserved for
+ * round-trip honesty), exposes POJO observers, and serializes back to
+ * `d`. It does not hold or reference an `SvgDocument`, an editor
+ * instance, the DOM, or any host. It is safe to construct in any
+ * environment that can run the package.
+ *
+ * Public re-exported as a top-level Layer-A primitive from
+ * `@grida/svg-editor` for callers that want canonical path geometry
+ * without mounting an editor. The full mutation surface (translate /
+ * bend / set-tangent / split, etc.) is package-internal and may shift;
+ * the publicly-stable contract for external callers is the construction
+ * + serialization + observation methods documented at the entry point.
+ *
+ * @experimental Surface shape is v0; signatures may change before the
+ * package reaches semver stability.
+ */
 export class PathModel {
   private readonly _network: vn.VectorNetwork;
   private readonly _meta: ReadonlyArray<SegmentMeta>;

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -2308,16 +2308,19 @@ class DomSurface implements Surface {
     // swallow the preview cancel.
     if (e.code === "Escape") {
       const canceled = this.cancel_in_flight();
+      // Escape only routes into the keymap/preventDefault path AND
+      // exits the vector-edit session when the surface is attended —
+      // otherwise gesture-cancel ran above and we leave the platform
+      // default (and the editor's own mode) alone. An unattended Escape
+      // belongs to whatever host UI the user is interacting with (modal
+      // close, page-level dialog, etc.).
+      if (!this.attention.is_attended()) return;
       // If nothing in-flight got canceled AND we're in vector-edit mode,
       // Esc exits the vector-edit session entirely (matches text-edit's
-      // "Esc to leave the mode" UX, and main-editor's vector mode).
+      // "Esc to leave the mode" UX).
       if (!canceled && this.vector_edit) {
         this.exit_vector_edit();
       }
-      // Escape only routes into the keymap/preventDefault path when the
-      // surface is attended — otherwise gesture-cancel ran above and we
-      // leave the platform default alone.
-      if (!this.attention.is_attended()) return;
     }
 
     // A non-Escape key fired mid-gesture would land its history step

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -76,6 +76,10 @@ import { insertions, type DragModifiers } from "./core/insertions";
 import { paint } from "./core/paint";
 import { Gestures } from "./gestures/gestures";
 import { applyDefaultGestures } from "./gestures/defaults";
+import {
+  create_attention_tracker,
+  type AttentionTracker,
+} from "./util/attention";
 import { SvgTextSurface } from "./text-surface";
 import {
   PathModel,
@@ -275,6 +279,11 @@ class DomSurface implements Surface {
   private fit_on_attach: boolean;
   /** Container element (cached from options). */
   private readonly container: HTMLElement;
+  /** Pointer/focus-attention tracker — gates the doc/window-level keydown
+   *  listeners that call `preventDefault()` so the surface doesn't claim
+   *  page-level shortcuts (Space, arrows, Cmd+=, Shift+0, …) when nothing
+   *  signals interest in the surface. See `util/attention.ts`. */
+  private readonly attention: AttentionTracker;
   /** Surface-side handle on the memoized geometry provider — drives both
    *  `bounds_of` reads and the fat-hit picker's AABB pre-filter. Same
    *  instance the editor core sees via `_internal.set_geometry`. */
@@ -443,6 +452,8 @@ class DomSurface implements Surface {
     this.container = options.container;
     const container = this.container;
     this.fit_on_attach = options.fit === true;
+    this.attention = create_attention_tracker(container);
+    this.teardown.push(() => this.attention.dispose());
     // The container is exclusively owned by the surface — interactive
     // children break pointer routing (capture redirects pointerup off
     // them, so the browser never synthesizes a click). Surface the
@@ -681,6 +692,7 @@ class DomSurface implements Surface {
       // stub here that matches the SurfaceHandle shape — replaced by the
       // attach_dom_surface caller via setter below.
       handle: { detach: () => {} },
+      is_attended: () => this.attention.is_attended(),
     });
     if (options.gestures !== false) {
       applyDefaultGestures(this.gestures);
@@ -2276,6 +2288,20 @@ class DomSurface implements Surface {
   private on_keydown(e: KeyboardEvent) {
     if (this.text_edit) return;
 
+    // Attention gate — when the surface isn't attended (focus outside the
+    // container subtree AND pointer not over the container), do not claim
+    // any key. The doc-level keydown listener is broad by design (so a
+    // user holding focus in a host-rendered side panel can still hit
+    // editor shortcuts while the pointer is on the canvas), but a host
+    // that mounts the surface as one block in a larger scrollable
+    // document gets the embedded-reader state by default: body-focused,
+    // pointer in the page margin. In that state the editor must stay
+    // out of the way (page scroll, browser zoom, etc.). One exception:
+    // Escape always reaches the gesture-cancel path, because an in-flight
+    // gesture takes attention regardless of focus / pointer location.
+    // See util/attention.ts for the predicate.
+    if (e.code !== "Escape" && !this.attention.is_attended()) return;
+
     // Host-specific concern: Escape cancels any in-flight preview
     // regardless of whether the keymap consumes the event. Run before
     // dispatch so a "deselect when nothing is selected" no-op doesn't
@@ -2288,6 +2314,10 @@ class DomSurface implements Surface {
       if (!canceled && this.vector_edit) {
         this.exit_vector_edit();
       }
+      // Escape only routes into the keymap/preventDefault path when the
+      // surface is attended — otherwise gesture-cancel ran above and we
+      // leave the platform default alone.
+      if (!this.attention.is_attended()) return;
     }
 
     // A non-Escape key fired mid-gesture would land its history step

--- a/packages/grida-svg-editor/src/gestures/defaults.ts
+++ b/packages/grida-svg-editor/src/gestures/defaults.ts
@@ -96,7 +96,7 @@ function begin_drag_pan(
 /** space-drag-pan: hold Space + drag to pan (hand tool). */
 const SPACE_DRAG_PAN: GestureBinding = {
   id: "space-drag-pan",
-  install({ container, camera }) {
+  install({ container, camera, is_attended }) {
     let space_held = false;
     let prev_cursor: string | null = null;
     const set_cursor = (next: string | null) => {
@@ -108,6 +108,9 @@ const SPACE_DRAG_PAN: GestureBinding = {
     const on_keydown = (e: KeyboardEvent) => {
       if (e.code !== "Space" || e.repeat) return;
       if (is_text_input_focused()) return;
+      // Attention gate: don't steal Space from a host that's using us as
+      // an embedded block in a longer document. See util/attention.ts.
+      if (!is_attended()) return;
       space_held = true;
       set_cursor("grab");
       e.preventDefault();
@@ -168,15 +171,15 @@ const MIDDLE_MOUSE_PAN: GestureBinding = {
 /** keyboard-zoom: Shift+0 / Shift+1 / Shift+2 / Cmd+= / Cmd+- shortcuts. */
 const KEYBOARD_ZOOM: GestureBinding = {
   id: "keyboard-zoom",
-  install({ container, camera }) {
+  install({ container, camera, is_attended }) {
     const owner_doc = container.ownerDocument;
     const on_keydown = (e: KeyboardEvent) => {
-      // Doc-level listener gated to "this container's tree has focus" —
-      // surfaces in other windows / panels stay independent.
-      const active = owner_doc.activeElement;
-      if (active && active !== owner_doc.body && !container.contains(active)) {
-        return;
-      }
+      // Attention gate: focus inside the container subtree OR pointer over
+      // the container. Body-focus alone (embedded reading state) is NOT
+      // attended — this listener is doc-level and would otherwise steal
+      // Shift+0 / Cmd+= from a page hosting the editor as a block.
+      // See util/attention.ts.
+      if (!is_attended()) return;
       if (is_text_input_focused()) return;
       const mod = e.metaKey || e.ctrlKey;
       if (e.shiftKey && !mod && (e.code === "Digit0" || e.code === "Numpad0")) {

--- a/packages/grida-svg-editor/src/gestures/gestures.ts
+++ b/packages/grida-svg-editor/src/gestures/gestures.ts
@@ -33,6 +33,14 @@ export type GestureContext = {
   editor: SvgEditor;
   /** Handle for advanced bindings (e.g. wanting `camera.fit("<selection>")`). */
   handle: SurfaceHandle;
+  /**
+   * Predicate returning `true` iff the surface is currently "attended" —
+   * focus inside the container subtree OR pointer over the container.
+   * Gesture bindings whose keydown handlers call `preventDefault()` MUST
+   * consult this before claiming, so the surface doesn't steal page-level
+   * shortcuts when embedded in a larger document. See `util/attention.ts`.
+   */
+  is_attended: () => boolean;
 };
 
 export type GestureBinding = {

--- a/packages/grida-svg-editor/src/index.ts
+++ b/packages/grida-svg-editor/src/index.ts
@@ -51,3 +51,26 @@ export type {
 } from "./types";
 
 export { DEFAULT_STYLE, TOOL_CURSOR } from "./types";
+
+/**
+ * `PathModel` — canonical vector-network model for a single SVG `<path>`
+ * d-string. Public Layer-A primitive, distinct from the editor instance:
+ * models a single SVG path's vector network for callers that want path
+ * geometry without an editor.
+ *
+ * Construct with {@link PathModel.fromSvgPathD}; serialize back with
+ * `toSvgPathD()`; observe with `snapshot()` / `bbox()` / `vertexCount()` /
+ * `segmentCount()`. No `SvgDocument`, no editor lifecycle, no DOM access
+ * is involved at any step.
+ *
+ * @experimental Shape is v0 and may shift before the package reaches
+ * semver stability. Consumers that depend on this surface should pin a
+ * minor version and re-validate on upgrade.
+ */
+export { PathModel } from "./core/vector-edit/model";
+export type {
+  PathSnapshot,
+  SegmentId,
+  Verb,
+  VertexId,
+} from "./core/vector-edit/model";

--- a/packages/grida-svg-editor/src/util/attention.ts
+++ b/packages/grida-svg-editor/src/util/attention.ts
@@ -1,0 +1,94 @@
+// Attention tracker — gates document/window-level keydown listeners that call
+// `preventDefault()` so the editor doesn't claim page-level shortcuts (Space,
+// arrows, Cmd+=, Shift+0, …) when no user signal points at the editor.
+//
+// Why this exists. The DOM surface installs `keydown` on `owner_doc` and `win`
+// for keymap claims (`dom.ts:on_keydown`), keyboard zoom (`KEYBOARD_ZOOM`),
+// and Space-pan (`SPACE_DRAG_PAN`). All three call `preventDefault()` on
+// match. When the surface is mounted as a block inside a larger scrollable
+// document (article, dashboard, marketing page), the natural reading state is
+// `activeElement === <body>` and the pointer is in the article margin. The
+// unguarded listeners then steal Space (page scroll), arrows (page scroll),
+// Cmd+= (browser zoom), Shift+0 (no-op for browser, but our refit fires).
+// That's a producer concern: the surface owns its container exclusively
+// (README → Surface), and "exclusively" should not extend its keyboard claim
+// past the boundary the surface visibly draws on screen.
+//
+// What "attended" means here. The surface is attended when at least one of:
+//   - focus is inside the container's subtree (active element is the
+//     container or one of its descendants), OR
+//   - the pointer is currently over the container (`pointerenter` fired more
+//     recently than `pointerleave`).
+//
+// Body-focus alone (no descendant focused, no pointer over) is the embedded
+// reading state — the editor is one block among many — and is *not* attended.
+//
+// Predicate composition. This is purely additive over the existing
+// `is_text_input_focused()` guard: claim only when the surface is attended
+// AND the active element is not a text input. The two guards are independent:
+//   - `is_text_input_focused()` prevents stealing typing-shortcuts WHEN a
+//     text field is focused (could be inside or outside the surface).
+//   - `is_surface_attended()` prevents stealing anything WHEN nothing signals
+//     interest in the surface.
+//
+// Passive observation listeners — modifier mirror (`IS_MODIFIER_KEY` keydown /
+// keyup on `win`), `blur` resets, pointer-event listeners — are deliberately
+// NOT gated. They don't call `preventDefault()`; they only update the
+// surface's view of host state. Gating them would break "alt-hover paints
+// measurement chips while focus is in a side panel" and similar cross-host
+// flows where attention is signaled by the pointer alone.
+
+/** The runtime handle returned by `create_attention_tracker`. */
+export interface AttentionTracker {
+  /**
+   * `true` iff focus is inside `container`'s subtree OR the pointer is
+   * currently over `container`. See module doc for the rationale.
+   *
+   * Pure read; no DOM mutation. Cheap enough to call once per keydown.
+   */
+  is_attended(): boolean;
+  /** Detach the internal pointer-tracking listeners. */
+  dispose(): void;
+}
+
+/**
+ * Install pointer-tracking listeners on `container` and return the
+ * read-side handle. The tracker is owned by the surface and disposed
+ * alongside it; gesture bindings that need to consult it receive the
+ * read-only `is_attended` predicate through `GestureContext`.
+ */
+export function create_attention_tracker(
+  container: HTMLElement
+): AttentionTracker {
+  let pointer_over = false;
+  const on_enter = () => {
+    pointer_over = true;
+  };
+  const on_leave = () => {
+    pointer_over = false;
+  };
+  // Use pointerenter / pointerleave (no bubbling, no fire-on-child-cross) so
+  // we get a single transition per actual container boundary crossing.
+  container.addEventListener("pointerenter", on_enter);
+  container.addEventListener("pointerleave", on_leave);
+
+  const is_attended = (): boolean => {
+    const owner = container.ownerDocument;
+    if (!owner) return pointer_over;
+    const active = owner.activeElement;
+    // Focus inside the surface's subtree counts. `contains(self)` is true,
+    // so this also covers "the container itself is focused" (e.g. tabindex).
+    if (active && active !== owner.body && container.contains(active)) {
+      return true;
+    }
+    return pointer_over;
+  };
+
+  return {
+    is_attended,
+    dispose: () => {
+      container.removeEventListener("pointerenter", on_enter);
+      container.removeEventListener("pointerleave", on_leave);
+    },
+  };
+}


### PR DESCRIPTION
> **Demo:** https://grida.co/packages/@grida/hud
> **Follows:** [#745 — feat(canvas-hud): HUD primitives + demo page](https://github.com/gridaco/grida/pull/745)

## Summary

Introduces the Tier-1 `classes/` named-class architecture inside `@grida/hud` and lands three classes against it. Each promoted class lives in its own subfolder with a fixed shape (`input.ts`, `intent.ts`, `priority.ts`, `surface.ts`, `index.ts`) so a reader knows where to look without grepping.

Three classes ship:

- **`padding/`** — 4 side numerics committed by side-handle drag, with alt-mirror.
- **`transform-box/`** — 2×3 affine on a unit box, mutated by 4 corners (rotate) / 4 sides (scale) / body (translate). Math reducer stays in `primitives/transform-box.ts` (Tier 2).
- **`vector-path/`** — promoted from `surface/vector-chrome.ts`. Path under content-edit with 10 intent variants (`select_vertex`, `translate_vertices`, `translate_vector_selection`, `set_tangent`, `bend_segment`, `split_segment`, region selection, lasso, …) over one model.

Each class's `input.ts` is marked `@unstable` per the promotion contract — only the showcase consumes them today; a second independent integration will ratify the shape.

Adjacent producer surfaces also grew:

- `event/state.ts`, `event/decision.ts`, `event/intent.ts`, `event/hit-regions.ts`, `event/gesture.ts`, `event/overlay.ts` — per-class hover slots, gesture cases, intent union extensions, classifier rows.
- `surface/{surface,style,chrome}.ts` — setter forwarding, default theming (padding stripes, transform-box muted stroke, vector region paints).
- `primitives/{transform-box,projection}.ts` — new Tier-2 helpers used by the classes.
- `__tests__/composition/co-target.test.ts` — pins the cross-class co-target matrix.

`packages/grida-svg-editor` gains an **attention gate** for document/window keydown listeners so the editor doesn't claim page-level shortcuts (Space, arrows, Cmd+=) when nothing signals interest in the surface — important for embedded read-mode contexts where focus sits on `<body>`.

The `(dev)/ui/components/hud` showcase in the editor app exercises each new class end-to-end (image-fit and free-transform variants, padding hover/drag/alt-mirror, vector-path region chrome).

## Commits

1. `feat(hud): add transform-box reducer + doc→screen projection primitives`
2. `feat(hud): introduce classes/ named-class architecture (padding, transform-box, vector-path)`
3. `feat(hud): wire classes/ into event dispatch, setters, and public surface`
4. `feat(svg-editor): add attention gate for document-level keydown listeners`
5. `feat(editor): expand HUD showcase with padding, transform-box, vector-path demos`

## Test plan

- [x] `pnpm --filter @grida/hud test` — 526/526 passing (27 files, including new `__tests__/classes/{padding,transform-box,vector-path}/`, `__tests__/composition/co-target.test.ts`, `__tests__/transform-box-math.test.ts`).
- [x] `pnpm turbo test --filter='./packages/*'` — all package suites green (includes `@grida/svg-editor` attention-gate + path-model-public tests).
- [x] `pnpm typecheck` — 44 tasks, 0 errors.
- [x] `pnpm lint` — 6 warnings, 0 errors.
- [x] `just fmt` applied (oxfmt + cargo fmt).
- [ ] Manual: `/(dev)/ui/components/hud` showcase pages — exercise padding hover/drag with alt-mirror, transform-box translate/scale/rotate (image-fit + free-transform), vector-path region selection + ghost insertion split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Padding overlay editing (per-side regions & drag handles)
  * Transform-box chrome with corner/side move/scale/rotate controls
  * Vector region support for closed-loop paths and region selection/hover
  * Line endpoint dragging and a Line demo section
  * Public PathModel headless vector API and attention-gated keyboard behavior

* **Refactor**
  * Reorganized HUD class/module public APIs and surface layering

* **Documentation**
  * Updated HUD/class docs and showcase/demo text

* **Tests**
  * Added comprehensive tests for padding, transform-box, vector regions, math, attention gate, and PathModel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
