### PR TITLE
feat(ai-models): promote Claude Opus 4.8, flag 4.7 legacy

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -33,7 +33,7 @@ Models are organized into **tiers** based on capability and cost:
 | `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | 400K    | 128K       | $0.20          | $1.25           |
 | `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | 400K    | 128K       | $0.75          | $4.50           |
 | `pro`  | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | 1M      | 128K       | $3.00          | $15.00          |
-| `max`  | Claude Opus 4.7 (`anthropic/claude-opus-4.7`)     | 1M      | 128K       | $5.00          | $25.00          |
+| `max`  | Claude Opus 4.8 (`anthropic/claude-opus-4.8`)     | 1M      | 128K       | $5.00          | $25.00          |
 
 All tier models support **multimodal** inputs (text + images).
 
@@ -52,15 +52,16 @@ All tiers support prompt caching, which reduces cost for repeated context:
 
 Per 1M tokens.
 
-| Name                                              | Input  | Cache Write | Cache Read | Output  |
-| ------------------------------------------------- | ------ | ----------- | ---------- | ------- |
-| GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | $0.20  | —           | $0.02      | $1.25   |
-| GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | $0.75  | —           | $0.075     | $4.50   |
-| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | $3.00  | $3.75       | $0.30      | $15.00  |
-| Claude Opus 4.7 (`anthropic/claude-opus-4.7`)     | $5.00  | $6.25       | $0.50      | $25.00  |
-| GPT-5.5 (`openai/gpt-5.5`)                        | $5.00  | —           | $0.50      | $30.00  |
-| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                | $30.00 | —           | —          | $180.00 |
-| Gemini 3.5 Flash (`google/gemini-3.5-flash`)      | $1.50  | —           | $0.15      | $9.00   |
+| Name                                                     | Input  | Cache Write | Cache Read | Output  |
+| -------------------------------------------------------- | ------ | ----------- | ---------- | ------- |
+| GPT-5.4 Nano (`openai/gpt-5.4-nano`)                     | $0.20  | —           | $0.02      | $1.25   |
+| GPT-5.4 Mini (`openai/gpt-5.4-mini`)                     | $0.75  | —           | $0.075     | $4.50   |
+| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`)        | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Opus 4.8 (`anthropic/claude-opus-4.8`)            | $5.00  | $6.25       | $0.50      | $25.00  |
+| Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_ | $5.00  | $6.25       | $0.50      | $25.00  |
+| GPT-5.5 (`openai/gpt-5.5`)                               | $5.00  | —           | $0.50      | $30.00  |
+| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                       | $30.00 | —           | —          | $180.00 |
+| Gemini 3.5 Flash (`google/gemini-3.5-flash`)             | $1.50  | —           | $0.15      | $9.00   |
 
 ## Image Generation Models
 

--- a/editor/app/(www)/(ai)/ai/_page.tsx
+++ b/editor/app/(www)/(ai)/ai/_page.tsx
@@ -36,6 +36,7 @@ import {
   PromptInputTools,
   type PromptInputMessage,
 } from "@/components/ai-elements/prompt-input";
+import models, { type ModelTier } from "@grida/ai-models";
 import { cn } from "@/components/lib/utils";
 import { resolveAiError } from "@/lib/ai/error";
 import { AiCredits, useAiCredits } from "@/lib/ai/credits";
@@ -53,12 +54,16 @@ type Props = {
 };
 
 // ---------------------------------------------------------------------------
-// Model picker — only the four tiered models (nano / mini / pro / max).
+// Model picker — only the four tiered models (nano / mini / pro / max),
+// derived from the `@grida/ai-models` catalogue (`models.text.byTier`) so
+// ids, labels, and pricing stay in lockstep with the source of truth.
 // Non-tiered catalog entries (e.g. gpt-5.5, gpt-5.5-pro) are intentionally
 // hidden — they're either too expensive for blanket exposure or reserved
-// for specific call sites. Tier → model mapping lives in lib/ai/models.ts.
+// for specific call sites.
+//
+// `@grida/ai-models` is a pure data package; `@/lib/ai/models` is NOT
+// imported here because it carries the server-only gateway/BYOK seam.
 // ---------------------------------------------------------------------------
-type ModelTier = "nano" | "mini" | "pro" | "max";
 type ModelOption = {
   id: string;
   label: string;
@@ -66,37 +71,23 @@ type ModelOption = {
   inputUsd: number;
   outputUsd: number;
 };
-const MODEL_OPTIONS: readonly ModelOption[] = [
-  {
-    id: "openai/gpt-5.4-nano",
-    label: "GPT-5.4 Nano",
-    tier: "nano",
-    inputUsd: 0.2,
-    outputUsd: 1.25,
-  },
-  {
-    id: "openai/gpt-5.4-mini",
-    label: "GPT-5.4 Mini",
-    tier: "mini",
-    inputUsd: 0.75,
-    outputUsd: 4.5,
-  },
-  {
-    id: "anthropic/claude-sonnet-4.6",
-    label: "Claude Sonnet 4.6",
-    tier: "pro",
-    inputUsd: 3,
-    outputUsd: 15,
-  },
-  {
-    id: "anthropic/claude-opus-4.7",
-    label: "Claude Opus 4.7",
-    tier: "max",
-    inputUsd: 5,
-    outputUsd: 25,
-  },
-] as const;
-const DEFAULT_MODEL_ID = "openai/gpt-5.4-mini";
+const TIER_ORDER = [
+  "nano",
+  "mini",
+  "pro",
+  "max",
+] as const satisfies readonly ModelTier[];
+const MODEL_OPTIONS: readonly ModelOption[] = TIER_ORDER.map((tier) => {
+  const spec = models.text.byTier[tier];
+  return {
+    id: spec.id,
+    label: spec.label,
+    tier,
+    inputUsd: spec.cost.input,
+    outputUsd: spec.cost.output,
+  };
+});
+const DEFAULT_MODEL_ID = models.text.byTier.mini.id;
 
 // ---------------------------------------------------------------------------
 // Debug flag — keyboard shortcut (Cmd/Ctrl+Shift+D) + `?debug=1` URL param.

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -86,6 +86,11 @@ export namespace models {
       outputLimit: number;
       /** Cost per 1M tokens in USD. */
       cost: ModelCostPerMillion;
+      /**
+       * Legacy/superseded marker. The model is still callable, but a newer
+       * sibling has taken its tier slot; UIs may hide or mark it.
+       */
+      deprecated?: boolean;
     }
 
     const catalogSpecs = {
@@ -129,6 +134,14 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
       },
+      "anthropic/claude-opus-4.8": {
+        id: "anthropic/claude-opus-4.8",
+        label: "Claude Opus 4.8",
+        multimodal: true,
+        contextWindow: 1_000_000,
+        outputLimit: 128_000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      },
       "anthropic/claude-opus-4.7": {
         id: "anthropic/claude-opus-4.7",
         label: "Claude Opus 4.7",
@@ -136,6 +149,7 @@ export namespace models {
         contextWindow: 1_000_000,
         outputLimit: 128_000,
         cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        deprecated: true,
       },
       // Google's cache model is read + hourly storage (no one-time write
       // premium that matches `cacheWrite` semantics), so the field is omitted.

--- a/packages/grida-ai-models/src/tiers.ts
+++ b/packages/grida-ai-models/src/tiers.ts
@@ -39,7 +39,7 @@ export const TIER_MODEL_IDS = {
   nano: "openai/gpt-5.4-nano",
   mini: "openai/gpt-5.4-mini",
   pro: "anthropic/claude-sonnet-4.6",
-  max: "anthropic/claude-opus-4.7",
+  max: "anthropic/claude-opus-4.8",
 } as const satisfies Record<ModelTier, models.text.CatalogId>;
 
 /** Literal union of tier-mapped model ids (values of {@link TIER_MODEL_IDS}). */


### PR DESCRIPTION
## Summary

- Add `anthropic/claude-opus-4.8` to the text catalogue (same pricing/context as 4.7) and repoint the `max` tier to it.
- Flag `anthropic/claude-opus-4.7` as legacy via a new optional `ModelSpec.deprecated` field — it stays catalogued so existing references still resolve.
- Refactor the `/ai` model picker to derive `MODEL_OPTIONS` from `@grida/ai-models` (`models.text.byTier`) instead of a hand-copied const, so ids/labels/pricing track the catalogue automatically.

## Notes

- Pricing is unchanged: input $5 / output $25 / cache read $0.50 / cache write $6.25 per 1M.
- The picker imports the **pure data package** `@grida/ai-models`, not `@/lib/ai/models` — the latter carries the server-only gateway/BYOK seam (GRIDA-SEC-003) and must not be bundled into a `"use client"` component. A comment in the file documents this.
- `docs/models/index.md` updated: `max` tier shows 4.8; "All Models" lists 4.8 active and 4.7 marked _(legacy)_.
- The docusaurus mirror at `apps/docs/docs/models/index.md` is intentionally not touched here (root `docs/` is source of truth).

## Test plan

- [x] `pnpm turbo build test --filter=@grida/ai-models` — build + 16 tests pass
- [x] `pnpm lint` — 0 errors
- [x] editor `tsc --noEmit` clean on touched files and `@grida/ai-models` consumers
- [ ] Visually confirm the `/ai` model picker lists Opus 4.8 under the `max` tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model picker now dynamically loads available models from the models catalogue instead of using fixed configurations.

* **Updates**
  * Upgraded Claude Opus model from version 4.7 to version 4.8 in the maximum tier.
  * Marked legacy Claude Opus 4.7 as deprecated in the catalogue.
  * Updated model pricing and documentation to reflect the latest offerings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->