### PR TITLE
feat(editor): add composer kit

### DIFF
--- a/editor/app/(dev)/ui/_nav.ts
+++ b/editor/app/(dev)/ui/_nav.ts
@@ -8,6 +8,7 @@ export const uiNavGroups: NavGroup[] = [
       { name: "Degree Control", href: "/ui/components/degree" },
       { name: "Spinner", href: "/ui/components/spinner" },
       { name: "Progress", href: "/ui/components/progress" },
+      { name: "Composer", href: "/ui/components/composer" },
       { name: "Rich Text Editor", href: "/ui/components/rich-text-editor" },
       { name: "Timeline", href: "/ui/components/timeline" },
       { name: "Property Controls", href: "/ui/components/property" },

--- a/editor/app/(dev)/ui/components/composer/demo-data.ts
+++ b/editor/app/(dev)/ui/components/composer/demo-data.ts
@@ -1,0 +1,255 @@
+import type {
+  ComposerAttachment,
+  ComposerAttachmentFilter,
+  ComposerCatalog,
+  ComposerFileReference,
+} from "@/kits/composer";
+
+export type MockFile = {
+  kind: "file";
+  id: string;
+  name: string;
+  path: string;
+  publicPath?: string;
+  mime: string;
+  size: number;
+  folder: string;
+};
+
+export type MockFolder = {
+  kind: "folder";
+  id: string;
+  name: string;
+  path: string;
+  mime: "inode/directory";
+  size: 0;
+  folder: string;
+};
+
+export type MockItem = MockFile | MockFolder;
+
+export type DropMode = "auto" | "inline" | "card";
+
+export type ResolvedDropMode = Exclude<DropMode, "auto">;
+
+export const folders: MockFolder[] = [
+  {
+    kind: "folder",
+    id: "folder-public-images",
+    name: "images",
+    path: "editor/public/images",
+    mime: "inode/directory",
+    size: 0,
+    folder: "public/images",
+  },
+  {
+    kind: "folder",
+    id: "folder-public-objects",
+    name: "template-grida-customer-upload-csv-example",
+    path: "editor/public/objects/template-grida-customer-upload-csv-example",
+    mime: "inode/directory",
+    size: 0,
+    folder: "public/objects",
+  },
+  {
+    kind: "folder",
+    id: "folder-public-examples-canvas",
+    name: "canvas",
+    path: "editor/public/examples/canvas",
+    mime: "inode/directory",
+    size: 0,
+    folder: "public/examples/canvas",
+  },
+];
+
+export const files: MockFile[] = [
+  {
+    kind: "file",
+    id: "public-abstract-placeholder",
+    name: "abstract-placeholder.jpg",
+    path: "editor/public/images/abstract-placeholder.jpg",
+    publicPath: "/images/abstract-placeholder.jpg",
+    mime: "image/jpeg",
+    size: 148734,
+    folder: "public/images",
+  },
+  {
+    kind: "file",
+    id: "public-brand-symbol",
+    name: "grida-symbol-240.svg",
+    path: "editor/public/brand/grida-symbol-240.svg",
+    publicPath: "/brand/grida-symbol-240.svg",
+    mime: "image/svg+xml",
+    size: 1852,
+    folder: "public/brand",
+  },
+  {
+    kind: "file",
+    id: "public-form-schema",
+    name: "form.schema.json",
+    path: "editor/public/schema/form.schema.json",
+    publicPath: "/schema/form.schema.json",
+    mime: "application/json",
+    size: 6312,
+    folder: "public/schema",
+  },
+  {
+    kind: "file",
+    id: "public-csv-basic",
+    name: "insert-example-basic.csv",
+    path: "editor/public/objects/template-grida-customer-upload-csv-example/insert-example-basic.csv",
+    publicPath:
+      "/objects/template-grida-customer-upload-csv-example/insert-example-basic.csv",
+    mime: "text/csv",
+    size: 324,
+    folder: "public/objects",
+  },
+  {
+    kind: "file",
+    id: "public-readme",
+    name: "readme.txt",
+    path: "editor/public/objects/template-grida-customer-upload-csv-example/readme.txt",
+    publicPath:
+      "/objects/template-grida-customer-upload-csv-example/readme.txt",
+    mime: "text/plain",
+    size: 1202,
+    folder: "public/objects",
+  },
+  {
+    kind: "file",
+    id: "public-canvas-example",
+    name: "poster-happy-new-year-2026.grida1",
+    path: "editor/public/examples/canvas/poster-happy-new-year-2026.grida1",
+    publicPath: "/examples/canvas/poster-happy-new-year-2026.grida1",
+    mime: "application/vnd.grida.canvas",
+    size: 7142,
+    folder: "public/examples/canvas",
+  },
+  {
+    kind: "file",
+    id: "public-thumbnail",
+    name: "image-01.png",
+    path: "editor/public/mock/thumbnails/image-01.png",
+    publicPath: "/mock/thumbnails/image-01.png",
+    mime: "image/png",
+    size: 288216,
+    folder: "public/mock/thumbnails",
+  },
+];
+
+export const sidebarItems: MockItem[] = [...folders, ...files];
+
+export const commands: ComposerCatalog["commands"] = [
+  {
+    id: "review",
+    title: "Review",
+    description: "Lower a code or design review request into a command part.",
+  },
+  {
+    id: "search",
+    title: "Search",
+    description: "Capture a search intent before the message reaches a model.",
+  },
+  {
+    id: "rewrite",
+    title: "Rewrite",
+    description: "Ask for a rewrite while preserving selected context.",
+  },
+];
+
+export const demoCatalog: ComposerCatalog = {
+  commands,
+  mentions: [
+    ...files.map((file) => ({
+      id: file.id,
+      kind: "file" as const,
+      label: file.name,
+      path: file.path,
+      description: file.path,
+    })),
+    ...folders.map((folder) => ({
+      id: folder.id,
+      kind: "folder" as const,
+      label: folder.name,
+      path: folder.path,
+      description: folder.path,
+    })),
+    {
+      id: "skill-canvas-docs-svg-kit",
+      kind: "skill",
+      label: "canvas-docs-svg-kit",
+      description: "SVG figures for canvas docs.",
+    },
+    {
+      id: "symbol-composer-core",
+      kind: "symbol",
+      label: "ComposerCore",
+      description: "Core class for the composer kit.",
+    },
+  ],
+};
+
+export const demoAttachmentFilters = {
+  byReference: ((incoming, existing) => {
+    const incomingKey = incoming.path ?? incoming.url ?? incoming.name;
+    return !existing.some((attachment) => {
+      const existingKey = attachment.path ?? attachment.url ?? attachment.name;
+      return existingKey === incomingKey;
+    });
+  }) satisfies ComposerAttachmentFilter,
+};
+
+export function toAttachment(file: MockItem): Omit<ComposerAttachment, "id"> {
+  return {
+    name: file.name,
+    path: file.path,
+    mime: file.mime,
+    size: file.size,
+    url: file.kind === "file" ? file.publicPath : undefined,
+  };
+}
+
+export function toFileReference(file: MockItem): ComposerFileReference {
+  return {
+    id: `inline-${file.id}`,
+    name: file.name,
+    path: file.path,
+    mime: file.mime,
+    size: file.size,
+    url: file.kind === "file" ? file.publicPath : undefined,
+  };
+}
+
+export function resolveDropMode(
+  file: MockItem,
+  mode: DropMode
+): ResolvedDropMode {
+  if (mode !== "auto") return mode === "card" ? "card" : "inline";
+  return isImageFile(file) ? "card" : "inline";
+}
+
+export const mockFileDragType = "application/x-grida-composer-file";
+
+export function readMockItem(payload: string): MockItem | null {
+  try {
+    const value = JSON.parse(payload) as Partial<MockItem>;
+    if (
+      (value.kind === "file" || value.kind === "folder") &&
+      typeof value.id === "string" &&
+      typeof value.name === "string" &&
+      typeof value.path === "string" &&
+      typeof value.mime === "string" &&
+      typeof value.size === "number" &&
+      typeof value.folder === "string"
+    ) {
+      return value as MockItem;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function isImageFile(file: MockItem): file is MockFile {
+  return file.kind === "file" && file.mime.startsWith("image/");
+}

--- a/editor/app/(dev)/ui/components/composer/demo-file-sidebar.tsx
+++ b/editor/app/(dev)/ui/components/composer/demo-file-sidebar.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { FileIcon, FolderIcon } from "lucide-react";
+import Image from "next/image";
+import {
+  isImageFile,
+  mockFileDragType,
+  resolveDropMode,
+  sidebarItems,
+  type DropMode,
+  type MockItem,
+} from "./demo-data";
+
+export function FileSidebar({
+  dropMode,
+  selectedItem,
+  selectedItemId,
+  setDropMode,
+  setSelectedItemId,
+}: {
+  dropMode: DropMode;
+  selectedItem: MockItem | undefined;
+  selectedItemId: string;
+  setDropMode: (mode: DropMode) => void;
+  setSelectedItemId: (id: string) => void;
+}) {
+  return (
+    <aside className="flex min-h-0 flex-col overflow-hidden bg-muted/20 p-4">
+      <h2 className="mb-3 font-semibold text-sm">Public files</h2>
+      <div className="mb-4 rounded-md border border-border bg-background p-2">
+        <div className="mb-2 px-1 font-medium text-xs">Drop as</div>
+        <div className="grid grid-cols-3 gap-1">
+          <DropModeButton
+            active={dropMode === "auto"}
+            label="Auto"
+            onClick={() => setDropMode("auto")}
+          />
+          <DropModeButton
+            active={dropMode === "inline"}
+            label="Ref"
+            onClick={() => setDropMode("inline")}
+          />
+          <DropModeButton
+            active={dropMode === "card"}
+            label="Card"
+            onClick={() => setDropMode("card")}
+          />
+        </div>
+        <p className="mt-2 px-1 text-muted-foreground text-xs">
+          Auto drops images as cards and other files as inline references.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-auto pr-1">
+        {groupItems(sidebarItems).map(([folder, group]) => (
+          <FileGroup
+            folder={folder}
+            items={group}
+            key={folder}
+            selectedItemId={selectedItemId}
+            setSelectedItemId={setSelectedItemId}
+          />
+        ))}
+      </div>
+
+      {selectedItem && (
+        <div className="mt-4 rounded-md border border-border bg-background p-3">
+          <div>
+            <div className="font-medium text-sm">{selectedItem.name}</div>
+            <div className="truncate text-muted-foreground text-xs">
+              {selectedItem.path}
+            </div>
+          </div>
+          <div className="mt-2 text-muted-foreground text-xs">
+            Drag this {selectedItem.kind} into the composer. Current target:{" "}
+            {resolveDropModeLabel(selectedItem, dropMode)}.
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function FileGroup({
+  folder,
+  items,
+  selectedItemId,
+  setSelectedItemId,
+}: {
+  folder: string;
+  items: MockItem[];
+  selectedItemId: string;
+  setSelectedItemId: (id: string) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2 text-muted-foreground text-xs">
+        <FolderIcon className="size-3.5" />
+        <span className="truncate">{folder}</span>
+      </div>
+      <div className="space-y-1">
+        {items.map((item) => (
+          <FileListItem
+            item={item}
+            key={item.id}
+            selected={selectedItemId === item.id}
+            setSelectedItemId={setSelectedItemId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FileListItem({
+  item,
+  selected,
+  setSelectedItemId,
+}: {
+  item: MockItem;
+  selected: boolean;
+  setSelectedItemId: (id: string) => void;
+}) {
+  return (
+    <button
+      className={`w-full cursor-grab rounded-md border px-3 py-2 text-left text-sm active:cursor-grabbing ${
+        selected
+          ? "border-primary bg-background"
+          : "border-border bg-background/60 hover:bg-background"
+      }`}
+      draggable
+      onClick={() => setSelectedItemId(item.id)}
+      onDragStart={(event) => {
+        event.dataTransfer.effectAllowed = "copy";
+        event.dataTransfer.setData(mockFileDragType, JSON.stringify(item));
+        event.dataTransfer.setData("text/plain", item.path);
+      }}
+      type="button"
+    >
+      <span className="flex items-center gap-2">
+        {isImageFile(item) && item.publicPath ? (
+          <Image
+            alt=""
+            className="size-6 shrink-0 rounded object-cover"
+            height={24}
+            src={item.publicPath}
+            unoptimized
+            width={24}
+          />
+        ) : (
+          <ItemIcon item={item} />
+        )}
+        <span className="min-w-0 flex-1 truncate">{item.name}</span>
+      </span>
+      <span className="mt-1 block truncate text-muted-foreground text-xs">
+        {item.path}
+      </span>
+    </button>
+  );
+}
+
+function DropModeButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={`rounded px-2 py-1.5 text-xs ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground"
+      }`}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function ItemIcon({ item }: { item: MockItem }) {
+  if (item.kind === "folder") {
+    return <FolderIcon className="size-4 text-muted-foreground" />;
+  }
+  return <FileIcon className="size-4 text-muted-foreground" />;
+}
+
+function groupItems(items: MockItem[]): [string, MockItem[]][] {
+  const groups = new Map<string, MockItem[]>();
+  for (const item of items) {
+    groups.set(item.folder, (groups.get(item.folder) ?? []).concat(item));
+  }
+  return Array.from(groups.entries());
+}
+
+function resolveDropModeLabel(file: MockItem, mode: DropMode): string {
+  if (resolveDropMode(file, mode) === "card") {
+    return "card attachment";
+  }
+  return "inline file reference";
+}

--- a/editor/app/(dev)/ui/components/composer/demo-file-sidebar.tsx
+++ b/editor/app/(dev)/ui/components/composer/demo-file-sidebar.tsx
@@ -170,6 +170,7 @@ function DropModeButton({
 }) {
   return (
     <button
+      aria-pressed={active}
       className={`rounded px-2 py-1.5 text-xs ${
         active
           ? "bg-primary text-primary-foreground"

--- a/editor/app/(dev)/ui/components/composer/demo-message-log.tsx
+++ b/editor/app/(dev)/ui/components/composer/demo-message-log.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import { FileIcon } from "lucide-react";
+import { useState } from "react";
+import type { ComposerMessage, ComposerPart } from "@/kits/composer";
+
+type MessageViewMode = "ui" | "raw";
+export type DemoMessage = ComposerMessage & { demo_id: string };
+
+export function MessageLog({ messages }: { messages: DemoMessage[] }) {
+  const [mode, setMode] = useState<MessageViewMode>("ui");
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 p-4 pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="font-semibold text-sm">Submitted messages</h2>
+          <MessageViewToggle mode={mode} setMode={setMode} />
+        </div>
+      </div>
+      <Conversation className="min-h-0">
+        <ConversationContent className="gap-3 p-4 pt-0">
+          {messages.length === 0 ? (
+            <ConversationEmptyState
+              className="min-h-48 rounded-md border border-dashed border-border p-6"
+              description="Submitted multipart messages will appear here."
+              title="No submitted messages"
+            />
+          ) : (
+            messages.map((message) =>
+              mode === "raw" ? (
+                <pre
+                  className="overflow-x-auto whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-4 text-xs"
+                  key={message.demo_id}
+                >
+                  {JSON.stringify(message, null, 2)}
+                </pre>
+              ) : (
+                <MessageBubble key={message.demo_id} message={message} />
+              )
+            )
+          )}
+        </ConversationContent>
+        <ConversationScrollButton className="bottom-3" />
+      </Conversation>
+    </div>
+  );
+}
+
+function MessageViewToggle({
+  mode,
+  setMode,
+}: {
+  mode: MessageViewMode;
+  setMode: (mode: MessageViewMode) => void;
+}) {
+  return (
+    <div className="flex rounded-md bg-muted p-0.5 text-xs">
+      {(["ui", "raw"] as const).map((value) => (
+        <button
+          className={`rounded px-2 py-1 ${
+            mode === value
+              ? "bg-background text-foreground shadow-xs"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          key={value}
+          onClick={() => setMode(value)}
+          type="button"
+        >
+          {value === "ui" ? "UI" : "Raw"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: DemoMessage }) {
+  const attachments = message.parts.filter(isMessageAttachmentPart);
+  const text = messageText(message.parts);
+
+  return (
+    <div className="ml-auto flex max-w-[85%] flex-col items-end gap-2">
+      {text && (
+        <article className="rounded-md bg-muted/60 px-3 py-2 text-sm">
+          <span className="whitespace-pre-wrap break-words">{text}</span>
+        </article>
+      )}
+      {attachments.length > 0 && <MessageAttachmentCards parts={attachments} />}
+    </div>
+  );
+}
+
+function messageText(parts: ComposerPart[]): string {
+  return parts
+    .map((part) => {
+      if (part.type === "text") return part.text;
+      if (part.type === "command") {
+        return `/${part.id}`;
+      }
+      if (part.type === "mention") return `@${part.target.label}`;
+      if (part.type === "file-ref") return part.ref.name ?? part.ref.path;
+      return "";
+    })
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+function MessageAttachmentCards({
+  parts,
+}: {
+  parts: Extract<ComposerPart, { type: "file-attachment" }>[];
+}) {
+  return (
+    <div className="flex max-w-full flex-wrap justify-end gap-2">
+      {parts.map((part, index) => (
+        <MessageAttachmentCard key={`${part.name}-${index}`} part={part} />
+      ))}
+    </div>
+  );
+}
+
+function MessageAttachmentCard({
+  part,
+}: {
+  part: Extract<ComposerPart, { type: "file-attachment" }>;
+}) {
+  return (
+    <span className="inline-flex max-w-48 items-center gap-2 rounded-md border border-border bg-background px-2 py-1 text-muted-foreground text-xs shadow-xs">
+      <FileIcon className="size-3" />
+      <span className="truncate">{part.name}</span>
+    </span>
+  );
+}
+
+function isMessageAttachmentPart(
+  part: ComposerPart
+): part is Extract<ComposerPart, { type: "file-attachment" }> {
+  return part.type === "file-attachment";
+}

--- a/editor/app/(dev)/ui/components/composer/demo-message-log.tsx
+++ b/editor/app/(dev)/ui/components/composer/demo-message-log.tsx
@@ -64,6 +64,7 @@ function MessageViewToggle({
     <div className="flex rounded-md bg-muted p-0.5 text-xs">
       {(["ui", "raw"] as const).map((value) => (
         <button
+          aria-pressed={mode === value}
           className={`rounded px-2 py-1 ${
             mode === value
               ? "bg-background text-foreground shadow-xs"

--- a/editor/app/(dev)/ui/components/composer/page.tsx
+++ b/editor/app/(dev)/ui/components/composer/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ArrowUpIcon, PlusIcon } from "lucide-react";
+import {
+  type DragEvent,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  ComposerAttachmentCards,
+  type ComposerController,
+  ComposerContent,
+  ComposerProvider,
+  ComposerTriggerMenu,
+  useComposer,
+  type ComposerMessage,
+} from "@/kits/composer";
+import {
+  demoAttachmentFilters,
+  demoCatalog,
+  mockFileDragType,
+  readMockItem,
+  resolveDropMode,
+  sidebarItems,
+  toAttachment,
+  toFileReference,
+  type DropMode,
+  type MockItem,
+} from "./demo-data";
+import { FileSidebar } from "./demo-file-sidebar";
+import { type DemoMessage, MessageLog } from "./demo-message-log";
+
+export default function ComposerPage() {
+  return (
+    <ComposerProvider catalog={demoCatalog}>
+      <ComposerDemo />
+    </ComposerProvider>
+  );
+}
+
+function ComposerDemo() {
+  const composer = useComposer();
+  const [selectedItemId, setSelectedItemId] = useState(sidebarItems[0].id);
+  const [dropMode, setDropMode] = useState<DropMode>("auto");
+  const [messages, setMessages] = useState<DemoMessage[]>([]);
+  const [isDraggingOverComposer, setIsDraggingOverComposer] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const objectUrls = useRef<string[]>([]);
+
+  const selectedItem = sidebarItems.find((item) => item.id === selectedItemId);
+
+  useEffect(() => {
+    return () => {
+      for (const url of objectUrls.current) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, []);
+
+  const submit = (readyMessage?: ComposerMessage | null) => {
+    const message =
+      readyMessage ?? composer.submit({ submitted_at: Date.now() });
+
+    if (!message) return;
+    setMessages((prev) =>
+      prev.concat({ ...message, demo_id: `message-${prev.length + 1}` })
+    );
+    composer.clear();
+  };
+
+  const addLocalFiles = (fileList: FileList | File[]) => {
+    for (const file of Array.from(fileList)) {
+      const url = URL.createObjectURL(file);
+      objectUrls.current.push(url);
+      composer.addAttachment({
+        name: file.name,
+        mime: file.type,
+        size: file.size,
+        url,
+      });
+    }
+  };
+
+  const onComposerDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDraggingOverComposer(false);
+
+    const payload = event.dataTransfer.getData(mockFileDragType);
+    if (payload) {
+      const item = readMockItem(payload);
+      if (item) {
+        applyDroppedItem(item, dropMode, composer);
+        return;
+      }
+    }
+
+    if (event.dataTransfer.files.length) {
+      addLocalFiles(event.dataTransfer.files);
+    }
+  };
+
+  return (
+    <main className="flex h-[100svh] w-full flex-col overflow-hidden">
+      <header className="shrink-0 border-b border-border px-6 py-4">
+        <h1 className="font-semibold text-2xl">Composer</h1>
+        <p className="text-muted-foreground text-sm">
+          Demo for the reusable Tiptap prompt composer kit.
+        </p>
+      </header>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <section className="flex min-h-0 flex-col border-r border-border">
+          <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col">
+            <MessageLog messages={messages} />
+            <DemoComposerInput
+              addLocalFiles={addLocalFiles}
+              fileInputRef={fileInputRef}
+              isDraggingOverComposer={isDraggingOverComposer}
+              onDrop={onComposerDrop}
+              onSubmit={submit}
+              setIsDraggingOverComposer={setIsDraggingOverComposer}
+            />
+          </div>
+        </section>
+
+        <FileSidebar
+          dropMode={dropMode}
+          selectedItem={selectedItem}
+          selectedItemId={selectedItemId}
+          setDropMode={setDropMode}
+          setSelectedItemId={setSelectedItemId}
+        />
+      </div>
+    </main>
+  );
+}
+
+function DemoComposerInput({
+  addLocalFiles,
+  fileInputRef,
+  isDraggingOverComposer,
+  onDrop,
+  onSubmit,
+  setIsDraggingOverComposer,
+}: {
+  addLocalFiles: (files: FileList | File[]) => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  isDraggingOverComposer: boolean;
+  onDrop: (event: DragEvent<HTMLDivElement>) => void;
+  onSubmit: (message?: ComposerMessage | null) => void;
+  setIsDraggingOverComposer: (value: boolean) => void;
+}) {
+  return (
+    <div className="shrink-0 p-4 pt-0">
+      <div
+        className={`relative rounded-lg border bg-background transition-colors ${
+          isDraggingOverComposer
+            ? "border-primary bg-primary/5"
+            : "border-border"
+        }`}
+        data-composer-dropzone
+        onDragEnterCapture={(event) => {
+          event.preventDefault();
+          setIsDraggingOverComposer(true);
+        }}
+        onDragLeave={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+            setIsDraggingOverComposer(false);
+          }
+        }}
+        onDragOverCapture={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onDropCapture={onDrop}
+      >
+        <ComposerTriggerMenu />
+        <ComposerAttachmentCards className="px-2 pt-2" />
+        <ComposerContent
+          autofocus
+          onSubmitRequest={() => onSubmit()}
+          placeholder="Type / for commands"
+        />
+        <ComposerFooter
+          addLocalFiles={addLocalFiles}
+          fileInputRef={fileInputRef}
+          onSubmit={onSubmit}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ComposerFooter({
+  addLocalFiles,
+  fileInputRef,
+  onSubmit,
+}: {
+  addLocalFiles: (files: FileList | File[]) => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 px-2 pb-2 pt-0">
+      <input
+        className="hidden"
+        multiple
+        onChange={(event) => {
+          if (event.currentTarget.files) {
+            addLocalFiles(event.currentTarget.files);
+            event.currentTarget.value = "";
+          }
+        }}
+        ref={fileInputRef}
+        type="file"
+      />
+      <ToolbarButton
+        label="Add file"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <PlusIcon className="size-4" />
+      </ToolbarButton>
+      <Button
+        aria-label="Submit"
+        className="ml-auto rounded-full"
+        onClick={() => onSubmit()}
+        size="icon-sm"
+        type="button"
+      >
+        <ArrowUpIcon className="size-4" />
+      </Button>
+    </div>
+  );
+}
+
+function ToolbarButton({
+  label,
+  children,
+  onClick,
+}: {
+  label: string;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      className="flex size-6 items-center justify-center rounded-md hover:bg-muted"
+      onClick={onClick}
+      onMouseDown={(event) => event.preventDefault()}
+      title={label}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function applyDroppedItem(
+  file: MockItem,
+  mode: DropMode,
+  composer: ComposerController
+) {
+  const resolved = resolveDropMode(file, mode);
+  if (
+    resolved === "inline" &&
+    composer.insertFileReference(toFileReference(file))
+  ) {
+    return;
+  }
+  composer.addAttachment(toAttachment(file), {
+    filter: demoAttachmentFilters.byReference,
+  });
+}

--- a/editor/app/(dev)/ui/components/composer/page.tsx
+++ b/editor/app/(dev)/ui/components/composer/page.tsx
@@ -17,6 +17,7 @@ import {
   ComposerProvider,
   ComposerTriggerMenu,
   useComposer,
+  type ComposerAttachment,
   type ComposerMessage,
 } from "@/kits/composer";
 import {
@@ -53,12 +54,21 @@ function ComposerDemo() {
 
   const selectedItem = sidebarItems.find((item) => item.id === selectedItemId);
 
+  const revokeTrackedObjectUrl = (url: string | undefined) => {
+    if (!url || !objectUrls.current.includes(url)) return;
+    URL.revokeObjectURL(url);
+    objectUrls.current = objectUrls.current.filter((item) => item !== url);
+  };
+
+  const revokeTrackedObjectUrls = () => {
+    for (const url of objectUrls.current) {
+      URL.revokeObjectURL(url);
+    }
+    objectUrls.current = [];
+  };
+
   useEffect(() => {
-    return () => {
-      for (const url of objectUrls.current) {
-        URL.revokeObjectURL(url);
-      }
-    };
+    return revokeTrackedObjectUrls;
   }, []);
 
   const submit = (readyMessage?: ComposerMessage | null) => {
@@ -70,6 +80,7 @@ function ComposerDemo() {
       prev.concat({ ...message, demo_id: `message-${prev.length + 1}` })
     );
     composer.clear();
+    revokeTrackedObjectUrls();
   };
 
   const addLocalFiles = (fileList: FileList | File[]) => {
@@ -121,6 +132,9 @@ function ComposerDemo() {
               addLocalFiles={addLocalFiles}
               fileInputRef={fileInputRef}
               isDraggingOverComposer={isDraggingOverComposer}
+              onRemoveAttachment={(attachment) =>
+                revokeTrackedObjectUrl(attachment.url)
+              }
               onDrop={onComposerDrop}
               onSubmit={submit}
               setIsDraggingOverComposer={setIsDraggingOverComposer}
@@ -144,6 +158,7 @@ function DemoComposerInput({
   addLocalFiles,
   fileInputRef,
   isDraggingOverComposer,
+  onRemoveAttachment,
   onDrop,
   onSubmit,
   setIsDraggingOverComposer,
@@ -151,6 +166,7 @@ function DemoComposerInput({
   addLocalFiles: (files: FileList | File[]) => void;
   fileInputRef: RefObject<HTMLInputElement | null>;
   isDraggingOverComposer: boolean;
+  onRemoveAttachment: (attachment: ComposerAttachment) => void;
   onDrop: (event: DragEvent<HTMLDivElement>) => void;
   onSubmit: (message?: ComposerMessage | null) => void;
   setIsDraggingOverComposer: (value: boolean) => void;
@@ -180,7 +196,10 @@ function DemoComposerInput({
         onDropCapture={onDrop}
       >
         <ComposerTriggerMenu />
-        <ComposerAttachmentCards className="px-2 pt-2" />
+        <ComposerAttachmentCards
+          className="px-2 pt-2"
+          onRemoveAttachment={onRemoveAttachment}
+        />
         <ComposerContent
           autofocus
           onSubmitRequest={() => onSubmit()}

--- a/editor/kits/AGENTS.md
+++ b/editor/kits/AGENTS.md
@@ -55,6 +55,7 @@ General conventions:
 
 | kit                        | description                                      | entry                             |
 | -------------------------- | ------------------------------------------------ | --------------------------------- |
+| `composer`                 | Prompt composer kit (Tiptap-based).              | `@/kits/composer`                 |
 | `minimal-tiptap`           | Opinionated rich-text editor kit (Tiptap-based). | `@/kits/minimal-tiptap`           |
 | `email-template-authoring` | Email-client-style template authoring UI.        | `@/kits/email-template-authoring` |
 

--- a/editor/kits/composer/README.md
+++ b/editor/kits/composer/README.md
@@ -111,6 +111,8 @@ Use CSS variables for the default editor skin:
 
 For custom UI, keep `ComposerProvider` and `ComposerContent`, then replace `ComposerTriggerMenu` and `ComposerAttachmentCards` with call-site components built on `useComposer()`.
 
+When using the default attachment cards with host-owned resources such as object URLs, pass `onRemoveAttachment` to release those resources when a card is removed.
+
 ## Boundaries
 
 This kit does not upload files, fetch mention results, own chat rendering, or bind to workbench/editor global state. Callers provide catalogs, attachments, editor contexts, and submission handling.

--- a/editor/kits/composer/README.md
+++ b/editor/kits/composer/README.md
@@ -1,0 +1,118 @@
+# Composer
+
+Tiptap-based prompt composer kit for collecting user intent, lightweight rich text, inline references, attachments, and editor context.
+
+The kit is headless by default at the composition layer: the core model owns message lowering and trigger state, while React components provide a provider/content shell plus small default UI pieces. Consumers decide where attachments, controls, and submitted messages render.
+
+## Install Surface
+
+Import from the kit entrypoint:
+
+```tsx
+import {
+  ComposerAttachmentCards,
+  ComposerContent,
+  ComposerProvider,
+  ComposerTriggerMenu,
+  useComposer,
+  type ComposerCatalog,
+  type ComposerMessage,
+} from "@/kits/composer";
+```
+
+`ComposerContent` imports the default editor CSS. The stable styling root is `.composer-content`; call sites can override the CSS variables on that element or pass `className`.
+
+## Basic Usage
+
+```tsx
+const catalog: ComposerCatalog = {
+  commands: [{ id: "review", title: "Review" }],
+  mentions: [{ id: "file-a", label: "a.ts", kind: "file", path: "src/a.ts" }],
+};
+
+function PromptComposer() {
+  return (
+    <ComposerProvider catalog={catalog}>
+      <ComposerBox />
+    </ComposerProvider>
+  );
+}
+
+function ComposerBox() {
+  const composer = useComposer();
+
+  const submit = () => {
+    const message = composer.submit({ submitted_at: Date.now() });
+    if (!message) return;
+    composer.clear();
+  };
+
+  return (
+    <div className="relative rounded-lg border">
+      <ComposerTriggerMenu />
+      <ComposerAttachmentCards className="px-2 pt-2" />
+      <ComposerContent
+        onSubmitRequest={submit}
+        placeholder="Type / for commands"
+      />
+      <button onClick={submit} type="button">
+        Send
+      </button>
+    </div>
+  );
+}
+```
+
+## Capabilities
+
+- Slash commands with keyboard selection.
+- Mentions from a caller-provided catalog.
+- File attachments as message parts.
+- Inline file references.
+- Minimal formatting: bullet lists, ordered lists, inline code, and code blocks.
+- Empty submissions are rejected by default.
+- Core accepts duplicate attachment inputs and assigns unique attachment ids; consumers can pass an attachment filter when they want deduping.
+
+## Public Model
+
+`composer.submit()` returns a `ComposerMessage | null`.
+
+Messages contain ordered `parts` such as:
+
+- `text`
+- `command`
+- `mention`
+- `file-ref`
+- `file-attachment`
+- `editor-context`
+
+The message `meta` intentionally includes only stable submission metadata: plain text, attachments, and `submitted_at`. Raw Tiptap HTML/JSON is not part of the public message contract.
+
+## Customization
+
+Use the provider/controller for behavior:
+
+- `addAttachment(input, { filter })`
+- `removeAttachment(id)`
+- `insertFileReference(reference)`
+- `setContexts(contexts)`
+- `submit({ submitted_at })`
+- `clear()`
+
+Use CSS variables for the default editor skin:
+
+```css
+.my-composer .composer-content {
+  --composer-content-min-height: 3.5rem;
+  --composer-editor-font-size: 0.875rem;
+  --composer-chip-color: var(--color-blue-600);
+}
+```
+
+For custom UI, keep `ComposerProvider` and `ComposerContent`, then replace `ComposerTriggerMenu` and `ComposerAttachmentCards` with call-site components built on `useComposer()`.
+
+## Boundaries
+
+This kit does not upload files, fetch mention results, own chat rendering, or bind to workbench/editor global state. Callers provide catalogs, attachments, editor contexts, and submission handling.
+
+The current home is `editor/kits/composer` because the API is reusable inside the editor but not yet promoted to a separately versioned package.

--- a/editor/kits/composer/composer-content.css
+++ b/editor/kits/composer/composer-content.css
@@ -1,0 +1,93 @@
+@reference "../../app/ui.css";
+
+.composer-content {
+  --composer-content-min-height: 4rem;
+  --composer-content-padding-block: 0.5rem;
+  --composer-content-padding-inline: 0.625rem;
+  --composer-editor-min-height: 2rem;
+  --composer-editor-font-size: 0.875rem;
+  --composer-paragraph-margin-block: 0.125rem;
+  --composer-code-padding: 0.5rem;
+  --composer-chip-margin-inline: 0.125rem;
+  --composer-chip-padding-block: 0.125rem;
+  --composer-chip-padding-inline: 0.25rem;
+  --composer-chip-radius: 0.25rem;
+  --composer-chip-color: var(--color-blue-600);
+  --composer-chip-background: var(--color-blue-50);
+
+  min-height: var(--composer-content-min-height);
+  padding-block: var(--composer-content-padding-block);
+  padding-inline: var(--composer-content-padding-inline);
+  font-size: var(--composer-editor-font-size);
+  font-weight: 400;
+}
+
+.composer-content [data-composer-editor] {
+  min-height: var(--composer-editor-min-height);
+  outline: none;
+}
+
+.composer-content [data-composer-editor] .is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+  color: var(--muted-foreground);
+}
+
+.composer-content [data-composer-editor] .composer-text-node {
+  margin-block: var(--composer-paragraph-margin-block);
+}
+
+.composer-content [data-composer-editor] .composer-code-block {
+  max-height: 7rem;
+  margin-block: 0.375rem;
+  overflow: auto;
+  border-radius: 0.375rem;
+  background: var(--muted);
+  padding: var(--composer-code-padding);
+}
+
+.composer-content [data-composer-editor] .composer-inline-code {
+  border-radius: 0.25rem;
+  background: var(--muted);
+  padding-inline: 0.25rem;
+}
+
+.composer-content [data-composer-editor] .composer-list-node {
+  margin-block: var(--composer-paragraph-margin-block);
+  padding-left: 1.25rem;
+}
+
+.composer-content [data-composer-editor] .composer-list-node-bullet {
+  list-style: disc;
+}
+
+.composer-content [data-composer-editor] .composer-list-node-ordered {
+  list-style: decimal;
+}
+
+.composer-content [data-composer-chip] {
+  display: inline-flex;
+  align-items: center;
+  margin-inline: var(--composer-chip-margin-inline);
+  border-radius: var(--composer-chip-radius);
+  padding-block: var(--composer-chip-padding-block);
+  padding-inline: var(--composer-chip-padding-inline);
+  color: var(--composer-chip-color);
+  font-family: var(--font-mono);
+}
+
+.composer-content [data-composer-chip]:hover,
+.composer-content [data-composer-chip].ProseMirror-selectednode {
+  background: var(--composer-chip-background);
+}
+
+.dark .composer-content {
+  --composer-chip-color: var(--color-blue-400);
+  --composer-chip-background: color-mix(
+    in oklab,
+    var(--color-blue-950) 60%,
+    transparent
+  );
+}

--- a/editor/kits/composer/composer-core.test.ts
+++ b/editor/kits/composer/composer-core.test.ts
@@ -44,6 +44,24 @@ describe("ComposerCore", () => {
     });
   });
 
+  it("clones editor contexts before storing them", () => {
+    const core = new ComposerCore();
+    const contexts = [
+      {
+        kind: "selection",
+        payload: { nested: { path: "src/a.ts" } },
+        emitted_at: 1,
+      },
+    ];
+
+    core.setContexts(contexts);
+    contexts[0].payload.nested = { path: "src/b.ts" };
+
+    expect(core.getSnapshot().contexts[0]).toMatchObject({
+      payload: { nested: { path: "src/a.ts" } },
+    });
+  });
+
   it("detects slash command triggers", () => {
     const core = new ComposerCore({
       commands: [{ id: "review", title: "Review" }],

--- a/editor/kits/composer/composer-core.test.ts
+++ b/editor/kits/composer/composer-core.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from "vitest";
+import { ComposerCore, type ComposerAttachmentFilter } from "./composer-core";
+
+describe("ComposerCore", () => {
+  it("rejects empty messages by default", () => {
+    const core = new ComposerCore();
+
+    expect(core.createMessage({ submitted_at: 1 })).toBeNull();
+
+    core.ingestDocument({
+      text: "   ",
+      document: {
+        type: "doc",
+        children: [{ type: "paragraph", children: [] }],
+      },
+    });
+
+    expect(core.createMessage({ submitted_at: 1 })).toBeNull();
+    expect(
+      core.createMessage({ submitted_at: 1, allow_empty: true })
+    ).toMatchObject({
+      role: "user",
+      parts: [],
+    });
+  });
+
+  it("does not count editor context alone as submit-worthy content", () => {
+    const core = new ComposerCore();
+
+    core.setContexts([
+      {
+        kind: "selection",
+        source: "mock",
+        payload: { path: "src/a.ts" },
+        emitted_at: 1,
+      },
+    ]);
+
+    expect(core.createMessage({ submitted_at: 1 })).toBeNull();
+    expect(
+      core.createMessage({ submitted_at: 1, allow_empty: true })
+    ).toMatchObject({
+      parts: [{ type: "editor-context", kind: "selection" }],
+    });
+  });
+
+  it("detects slash command triggers", () => {
+    const core = new ComposerCore({
+      commands: [{ id: "review", title: "Review" }],
+    });
+
+    core.inspectCursor("please /rev", 11);
+
+    expect(core.getSnapshot().trigger).toMatchObject({
+      kind: "command",
+      query: "rev",
+      range: { from: 7, to: 11 },
+      items: [{ id: "review" }],
+    });
+  });
+
+  it("moves trigger index inside the core state", () => {
+    const core = new ComposerCore({
+      commands: [
+        { id: "review", title: "Review" },
+        { id: "rewrite", title: "Rewrite" },
+      ],
+    });
+
+    core.inspectCursor("/", 1);
+    core.moveTriggerIndex(1);
+
+    expect(core.getSnapshot()).toMatchObject({
+      triggerIndex: 1,
+    });
+
+    core.moveTriggerIndex(1);
+
+    expect(core.getSnapshot()).toMatchObject({
+      triggerIndex: 0,
+    });
+  });
+
+  it("refreshes the active trigger when the catalog changes", () => {
+    const core = new ComposerCore({
+      commands: [{ id: "review", title: "Review" }],
+    });
+
+    core.inspectCursor("/re", 3);
+    core.setCatalog({
+      commands: [
+        { id: "review", title: "Review" },
+        { id: "rewrite", title: "Rewrite" },
+      ],
+    });
+
+    expect(core.getSnapshot().trigger?.items.map((item) => item.id)).toEqual([
+      "review",
+      "rewrite",
+    ]);
+  });
+
+  it("does not publish when ingested document and trigger are unchanged", () => {
+    const core = new ComposerCore({
+      commands: [{ id: "review", title: "Review" }],
+    });
+    let publishes = 0;
+    core.subscribe(() => {
+      publishes += 1;
+    });
+
+    const document = {
+      type: "doc" as const,
+      children: [
+        {
+          type: "paragraph" as const,
+          children: [{ type: "text" as const, text: "hi" }],
+        },
+      ],
+    };
+
+    core.ingestDocument({ text: "hi", document });
+    core.ingestDocument({ text: "hi", document });
+    core.inspectCursor("/rev", 4);
+    core.inspectCursor("/rev", 4);
+
+    expect(publishes).toBe(2);
+  });
+
+  it("lowers command, mention, file ref, attachment, and context parts", () => {
+    const core = new ComposerCore({
+      commands: [
+        {
+          id: "review",
+          title: "Review",
+        },
+      ],
+      mentions: [
+        {
+          id: "skill-canvas",
+          kind: "skill",
+          label: "canvas-docs-svg-kit",
+        },
+      ],
+    });
+
+    core.ingestDocument({
+      text: "/review @canvas",
+      document: {
+        type: "doc",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "command",
+                id: "review",
+              },
+              { type: "text", text: " src/a.ts critical " },
+              {
+                type: "mention",
+                id: "skill-canvas",
+                kind: "skill",
+                label: "canvas-docs-svg-kit",
+              },
+              { type: "text", text: " use " },
+              {
+                type: "file-ref",
+                path: "src/a.ts",
+                name: "a.ts",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    core.addAttachment({
+      id: "1",
+      name: "screen.png",
+      mime: "image/png",
+      size: 100,
+    });
+    core.setContexts([
+      {
+        kind: "selection",
+        source: "mock",
+        payload: { path: "src/a.ts" },
+        emitted_at: 1,
+      },
+    ]);
+
+    expect(core.createMessage({ submitted_at: 2 })).toMatchObject({
+      role: "user",
+      parts: [
+        {
+          type: "command",
+          id: "review",
+        },
+        { type: "text", text: "src/a.ts critical" },
+        {
+          type: "mention",
+          target: { kind: "skill", id: "skill-canvas" },
+        },
+        { type: "text", text: "use" },
+        { type: "file-ref", ref: { path: "src/a.ts", name: "a.ts" } },
+        { type: "file-attachment", name: "screen.png" },
+        { type: "editor-context", kind: "selection" },
+      ],
+      meta: { submitted_at: 2 },
+    });
+  });
+
+  it("preserves file mentions as mentions instead of converting them to references", () => {
+    const core = new ComposerCore({
+      mentions: [
+        {
+          id: "file-a",
+          kind: "file",
+          label: "a.ts",
+          path: "src/a.ts",
+        },
+      ],
+    });
+
+    core.ingestDocument({
+      text: "@a.ts",
+      document: {
+        type: "doc",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "mention",
+                id: "file-a",
+                kind: "file",
+                label: "a.ts",
+                path: "src/a.ts",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(core.createMessage({ submitted_at: 1 })).toMatchObject({
+      parts: [
+        {
+          type: "mention",
+          target: {
+            id: "file-a",
+            kind: "file",
+            label: "a.ts",
+            path: "src/a.ts",
+          },
+        },
+      ],
+    });
+  });
+
+  it("does not expose raw editor html or json in submitted message meta", () => {
+    const core = new ComposerCore();
+
+    core.ingestDocument({
+      text: "hello",
+      document: {
+        type: "doc",
+        children: [
+          { type: "paragraph", children: [{ type: "text", text: "hello" }] },
+        ],
+      },
+    });
+
+    const message = core.createMessage({ submitted_at: 1 });
+
+    expect(message?.meta).toMatchObject({ text: "hello", submitted_at: 1 });
+    expect(message?.meta).not.toHaveProperty("html");
+    expect(message?.meta).not.toHaveProperty("json");
+  });
+
+  it("allocates unique attachment ids while allowing duplicate inputs", () => {
+    const core = new ComposerCore();
+
+    const first = core.addAttachment({
+      name: "screen.png",
+      path: "screen.png",
+    });
+    const second = core.addAttachment({
+      name: "screen.png",
+      path: "screen.png",
+    });
+
+    expect(first?.id).toBe("attachment-1-screen-png");
+    expect(second?.id).toBe("attachment-2-screen-png");
+    expect(core.getSnapshot().attachments).toHaveLength(2);
+  });
+
+  it("lets consumers filter duplicate attachments", () => {
+    const core = new ComposerCore();
+    const filter: ComposerAttachmentFilter = (incoming, existing) =>
+      !existing.some((attachment) => attachment.path === incoming.path);
+
+    const first = core.addAttachment(
+      {
+        name: "screen.png",
+        path: "screen.png",
+      },
+      { filter }
+    );
+    const second = core.addAttachment(
+      {
+        name: "screen.png",
+        path: "screen.png",
+      },
+      { filter }
+    );
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(core.getSnapshot().attachments).toHaveLength(1);
+  });
+});

--- a/editor/kits/composer/composer-core.ts
+++ b/editor/kits/composer/composer-core.ts
@@ -343,8 +343,9 @@ export class ComposerCore {
   }
 
   setContexts(contexts: ComposerEditorContext[]): void {
-    if (this.snapshot.contexts === contexts) return;
-    this.snapshot = { ...this.snapshot, contexts };
+    const next = contexts.map((context) => this.cloneEditorContext(context));
+    if (this.contextsEqual(this.snapshot.contexts, next)) return;
+    this.snapshot = { ...this.snapshot, contexts: next };
     this.publish();
   }
 
@@ -490,6 +491,50 @@ export class ComposerCore {
     b: ComposerDocument.Root
   ): boolean {
     return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  private contextsEqual(
+    a: ComposerEditorContext[],
+    b: ComposerEditorContext[]
+  ): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  private cloneEditorContext(
+    context: ComposerEditorContext
+  ): ComposerEditorContext {
+    return {
+      ...context,
+      payload: this.clonePayload(context.payload),
+    };
+  }
+
+  private clonePayload(
+    payload: Record<string, unknown>
+  ): Record<string, unknown> {
+    if (typeof globalThis.structuredClone === "function") {
+      try {
+        return globalThis.structuredClone(payload) as Record<string, unknown>;
+      } catch {
+        // Fall back to cloning plain JSON-like payloads below.
+      }
+    }
+    return this.clonePlainValue(payload) as Record<string, unknown>;
+  }
+
+  private clonePlainValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.clonePlainValue(item));
+    }
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          this.clonePlainValue(item),
+        ])
+      );
+    }
+    return value;
   }
 
   private walkDocument(document: ComposerDocument.Root, state: LoweringState) {

--- a/editor/kits/composer/composer-core.ts
+++ b/editor/kits/composer/composer-core.ts
@@ -1,0 +1,625 @@
+export type ComposerCommand = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+export type ComposerMention = {
+  id: string;
+  label: string;
+  kind?: string;
+  description?: string;
+  path?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type ComposerAttachment = {
+  id: string;
+  name: string;
+  mime?: string;
+  size?: number;
+  path?: string;
+  url?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type ComposerAttachmentInput = Omit<ComposerAttachment, "id"> & {
+  id?: string;
+};
+
+export type ComposerAttachmentFilter = (
+  incoming: ComposerAttachmentInput,
+  existing: ComposerAttachment[]
+) => boolean;
+
+export type ComposerFileReference = {
+  id?: string;
+  name?: string;
+  path: string;
+  mime?: string;
+  size?: number;
+  url?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type ComposerEditorContext = {
+  kind: string;
+  source?: string;
+  payload: Record<string, unknown>;
+  emitted_at: number;
+};
+
+export type ComposerCatalog = {
+  commands: ComposerCommand[];
+  mentions: ComposerMention[];
+};
+
+export type ComposerTrigger = {
+  kind: "command" | "mention";
+  query: string;
+  range: { from: number; to: number };
+  items: (ComposerCommand | ComposerMention)[];
+};
+
+export type ComposerTextPart = {
+  type: "text";
+  text: string;
+};
+
+export type ComposerCommandPart = {
+  type: "command";
+  id: string;
+  title?: string;
+};
+
+export type ComposerMentionPart = {
+  type: "mention";
+  target: {
+    id: string;
+    label: string;
+    kind?: string;
+    path?: string;
+    payload?: Record<string, unknown>;
+  };
+};
+
+export type ComposerFileRefPart = {
+  type: "file-ref";
+  ref: {
+    kind: "path";
+    path: string;
+    name?: string;
+    mime?: string;
+    size?: number;
+    url?: string;
+    payload?: Record<string, unknown>;
+  };
+};
+
+export type ComposerFileAttachmentPart = {
+  type: "file-attachment";
+  id: string;
+  name: string;
+  mime?: string;
+  size?: number;
+  path?: string;
+  url?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type ComposerEditorContextPart = ComposerEditorContext & {
+  type: "editor-context";
+};
+
+export type ComposerPart =
+  | ComposerTextPart
+  | ComposerCommandPart
+  | ComposerMentionPart
+  | ComposerFileRefPart
+  | ComposerFileAttachmentPart
+  | ComposerEditorContextPart;
+
+export type ComposerMessage = {
+  role: "user";
+  parts: ComposerPart[];
+  meta: {
+    text: string;
+    attachments: ComposerAttachment[];
+    submitted_at: number;
+  };
+};
+
+export type ComposerSnapshot = {
+  text: string;
+  document: ComposerDocument.Root;
+  attachments: ComposerAttachment[];
+  contexts: ComposerEditorContext[];
+  trigger: ComposerTrigger | null;
+  triggerIndex: number;
+};
+
+export namespace ComposerDocument {
+  export type Root = {
+    type: "doc";
+    children: Node[];
+  };
+
+  export type Node =
+    | TextNode
+    | ParagraphNode
+    | CommandNode
+    | MentionNode
+    | FileReferenceNode
+    | CodeBlockNode
+    | ListNode;
+
+  export type TextNode = {
+    type: "text";
+    text: string;
+    code?: boolean;
+  };
+
+  export type ParagraphNode = {
+    type: "paragraph";
+    children: Node[];
+  };
+
+  export type CommandNode = {
+    type: "command";
+    id: string;
+    title?: string;
+  };
+
+  export type MentionNode = {
+    type: "mention";
+    id: string;
+    label: string;
+    kind?: string;
+    path?: string;
+    payload?: Record<string, unknown>;
+  };
+
+  export type FileReferenceNode = {
+    type: "file-ref";
+    path: string;
+    name?: string;
+    mime?: string;
+    size?: number;
+    url?: string;
+    payload?: Record<string, unknown>;
+  };
+
+  export type CodeBlockNode = {
+    type: "code-block";
+    text: string;
+  };
+
+  export type ListNode = {
+    type: "list";
+    ordered: boolean;
+    items: Node[][];
+  };
+
+  export function empty(): Root {
+    return {
+      type: "doc",
+      children: [],
+    };
+  }
+}
+
+type Listener = () => void;
+
+type LoweringState = {
+  buffer: string[];
+  parts: ComposerPart[];
+};
+
+export class ComposerCore {
+  private catalog: ComposerCatalog;
+  private snapshot: ComposerSnapshot;
+  private readonly listeners = new Set<Listener>();
+  private attachmentSequence = 0;
+  private cursor: { textBeforeCursor: string; position: number } | null = null;
+
+  constructor(catalog: Partial<ComposerCatalog> = {}) {
+    this.catalog = {
+      commands: catalog.commands ?? [],
+      mentions: catalog.mentions ?? [],
+    };
+    this.snapshot = {
+      text: "",
+      document: ComposerDocument.empty(),
+      attachments: [],
+      contexts: [],
+      trigger: null,
+      triggerIndex: 0,
+    };
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getSnapshot(): ComposerSnapshot {
+    return this.snapshot;
+  }
+
+  setCatalog(catalog: Partial<ComposerCatalog>): void {
+    const next = {
+      commands: catalog.commands ?? this.catalog.commands,
+      mentions: catalog.mentions ?? this.catalog.mentions,
+    };
+    if (
+      next.commands === this.catalog.commands &&
+      next.mentions === this.catalog.mentions
+    ) {
+      return;
+    }
+    this.catalog = {
+      commands: next.commands,
+      mentions: next.mentions,
+    };
+    const trigger = this.cursor
+      ? this.matchTrigger(this.cursor.textBeforeCursor, this.cursor.position)
+      : this.snapshot.trigger;
+    this.snapshot = {
+      ...this.snapshot,
+      trigger,
+      triggerIndex: this.normalizeTriggerIndex(
+        this.snapshot.triggerIndex,
+        trigger?.items.length ?? 0
+      ),
+    };
+    this.publish();
+  }
+
+  ingestDocument(input: {
+    text: string;
+    document: ComposerDocument.Root;
+  }): void {
+    if (
+      this.snapshot.text === input.text &&
+      this.documentEquals(this.snapshot.document, input.document)
+    ) {
+      return;
+    }
+    this.snapshot = {
+      ...this.snapshot,
+      text: input.text,
+      document: input.document,
+    };
+    this.publish();
+  }
+
+  inspectCursor(textBeforeCursor: string, cursorPosition: number): void {
+    this.cursor = { textBeforeCursor, position: cursorPosition };
+    const trigger = this.matchTrigger(textBeforeCursor, cursorPosition);
+    if (this.triggerEquals(this.snapshot.trigger, trigger)) {
+      return;
+    }
+    this.snapshot = { ...this.snapshot, trigger, triggerIndex: 0 };
+    this.publish();
+  }
+
+  setTriggerIndex(index: number): void {
+    const count = this.snapshot.trigger?.items.length ?? 0;
+    const next = this.normalizeTriggerIndex(index, count);
+    if (this.snapshot.triggerIndex === next) return;
+    this.snapshot = { ...this.snapshot, triggerIndex: next };
+    this.publish();
+  }
+
+  moveTriggerIndex(delta: number): void {
+    this.setTriggerIndex(this.snapshot.triggerIndex + delta);
+  }
+
+  addAttachment(
+    attachment: ComposerAttachmentInput,
+    input?: { filter?: ComposerAttachmentFilter }
+  ): ComposerAttachment | null {
+    if (input?.filter && !input.filter(attachment, this.snapshot.attachments)) {
+      return null;
+    }
+
+    const item = this.createAttachment(attachment);
+    this.snapshot = {
+      ...this.snapshot,
+      attachments: this.snapshot.attachments.concat(item),
+    };
+    this.publish();
+    return item;
+  }
+
+  removeAttachment(id: string): void {
+    this.snapshot = {
+      ...this.snapshot,
+      attachments: this.snapshot.attachments.filter((item) => item.id !== id),
+    };
+    this.publish();
+  }
+
+  setContexts(contexts: ComposerEditorContext[]): void {
+    if (this.snapshot.contexts === contexts) return;
+    this.snapshot = { ...this.snapshot, contexts };
+    this.publish();
+  }
+
+  clear(): void {
+    this.snapshot = {
+      ...this.snapshot,
+      text: "",
+      document: ComposerDocument.empty(),
+      attachments: [],
+      trigger: null,
+      triggerIndex: 0,
+    };
+    this.publish();
+  }
+
+  createMessage(input: {
+    submitted_at: number;
+    allow_empty?: boolean;
+  }): ComposerMessage | null {
+    const state: LoweringState = {
+      buffer: [],
+      parts: [],
+    };
+
+    this.walkDocument(this.snapshot.document, state);
+    this.flushText(state);
+    state.parts.push(...this.attachmentParts(), ...this.contextParts());
+
+    if (!input?.allow_empty && !this.hasUserContent(state.parts)) {
+      return null;
+    }
+
+    return {
+      role: "user",
+      parts: state.parts,
+      meta: {
+        text: this.snapshot.text,
+        attachments: this.snapshot.attachments,
+        submitted_at: input.submitted_at,
+      },
+    };
+  }
+
+  private hasUserContent(parts: ComposerPart[]): boolean {
+    return parts.some((part) => part.type !== "editor-context");
+  }
+
+  private matchTrigger(
+    textBeforeCursor: string,
+    cursorPosition: number
+  ): ComposerTrigger | null {
+    const match = /(^|\s)([/@])([^\s/@]*)$/.exec(textBeforeCursor);
+    if (!match) return null;
+
+    const token = `${match[2]}${match[3]}`;
+    const from = cursorPosition - token.length;
+    const query = match[3].toLowerCase();
+
+    if (match[2] === "/") {
+      return {
+        kind: "command",
+        query,
+        range: { from, to: cursorPosition },
+        items: this.catalog.commands.filter((command) =>
+          this.matches(query, command.id, command.title, command.description)
+        ),
+      };
+    }
+
+    return {
+      kind: "mention",
+      query,
+      range: { from, to: cursorPosition },
+      items: this.catalog.mentions.filter((mention) =>
+        this.matches(
+          query,
+          mention.id,
+          mention.label,
+          mention.kind,
+          mention.description,
+          mention.path
+        )
+      ),
+    };
+  }
+
+  private createAttachment(input: ComposerAttachmentInput): ComposerAttachment {
+    const id = input.id ?? this.nextAttachmentId(input);
+    if (!this.snapshot.attachments.some((attachment) => attachment.id === id)) {
+      return { ...input, id };
+    }
+
+    return {
+      ...input,
+      id: this.nextAttachmentId(input),
+    };
+  }
+
+  private nextAttachmentId(input: Pick<ComposerAttachment, "name">): string {
+    this.attachmentSequence += 1;
+    return `attachment-${this.attachmentSequence}-${this.slug(input.name)}`;
+  }
+
+  private slug(value: string): string {
+    return (
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 48) || "file"
+    );
+  }
+
+  private matches(query: string, ...values: (string | undefined)[]): boolean {
+    if (!query) return true;
+    return values.some((value) => value?.toLowerCase().includes(query));
+  }
+
+  private triggerEquals(
+    a: ComposerTrigger | null,
+    b: ComposerTrigger | null
+  ): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (
+      a.kind !== b.kind ||
+      a.query !== b.query ||
+      a.range.from !== b.range.from ||
+      a.range.to !== b.range.to ||
+      a.items.length !== b.items.length
+    ) {
+      return false;
+    }
+    return a.items.every((item, index) => item.id === b.items[index]?.id);
+  }
+
+  private normalizeTriggerIndex(index: number, count: number): number {
+    return count ? ((index % count) + count) % count : 0;
+  }
+
+  private documentEquals(
+    a: ComposerDocument.Root,
+    b: ComposerDocument.Root
+  ): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  private walkDocument(document: ComposerDocument.Root, state: LoweringState) {
+    for (const child of document.children) {
+      this.walkNode(child, state);
+    }
+  }
+
+  private walkNode(
+    node: ComposerDocument.Node | null | undefined,
+    state: LoweringState,
+    list?: { kind: "bullet" | "ordered"; index: number }
+  ): void {
+    if (!node) return;
+
+    if (node.type === "text") {
+      const value = node.code ? `\`${node.text}\`` : node.text;
+      state.buffer.push(value);
+      return;
+    }
+
+    if (node.type === "command") {
+      this.flushText(state);
+      const id = node.id;
+      const command = this.catalog.commands.find((item) => item.id === id);
+      state.parts.push({
+        type: "command",
+        id,
+        title: command?.title ?? node.title,
+      });
+      return;
+    }
+
+    if (node.type === "mention") {
+      this.flushText(state);
+      const mention = this.catalog.mentions.find((item) => item.id === node.id);
+
+      this.pushPart(state, {
+        type: "mention",
+        target: {
+          id: node.id,
+          label: node.label || mention?.label || node.id,
+          kind: node.kind || mention?.kind,
+          path: node.path || mention?.path,
+          payload: node.payload ?? mention?.payload,
+        },
+      });
+      return;
+    }
+
+    if (node.type === "file-ref") {
+      this.flushText(state);
+      this.pushPart(state, {
+        type: "file-ref",
+        ref: {
+          kind: "path",
+          path: node.path,
+          name: node.name ?? node.path,
+          mime: node.mime,
+          size: node.size,
+          url: node.url,
+          payload: node.payload,
+        },
+      });
+      return;
+    }
+
+    if (node.type === "code-block") {
+      if (node.text.trim()) {
+        state.buffer.push(`\n\`\`\`\n${node.text.trimEnd()}\n\`\`\`\n`);
+      }
+      return;
+    }
+
+    if (node.type === "list") {
+      const kind = node.ordered ? "ordered" : "bullet";
+      node.items.forEach((children, index) => {
+        state.buffer.push(kind === "ordered" ? `${index + 1}. ` : "- ");
+        children.forEach((child) =>
+          this.walkNode(child, state, { kind, index: index + 1 })
+        );
+        state.buffer.push("\n");
+      });
+      state.buffer.push("\n");
+      return;
+    }
+
+    if (node.type === "paragraph") {
+      node.children.forEach((child) => this.walkNode(child, state, list));
+      state.buffer.push("\n");
+    }
+  }
+
+  private flushText(state: LoweringState): void {
+    const text = state.buffer
+      .join("")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+    state.buffer.length = 0;
+    if (!text) return;
+    state.parts.push({ type: "text", text });
+  }
+
+  private pushPart(state: LoweringState, part: ComposerPart): void {
+    state.parts.push(part);
+  }
+
+  private attachmentParts(): ComposerFileAttachmentPart[] {
+    return this.snapshot.attachments.map((attachment) => ({
+      type: "file-attachment",
+      id: attachment.id,
+      name: attachment.name,
+      mime: attachment.mime,
+      size: attachment.size,
+      path: attachment.path,
+      url: attachment.url,
+      payload: attachment.payload,
+    }));
+  }
+
+  private contextParts(): ComposerEditorContextPart[] {
+    return this.snapshot.contexts.map((context) => ({
+      type: "editor-context",
+      ...context,
+    }));
+  }
+
+  private publish(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}

--- a/editor/kits/composer/composer-defaults.tsx
+++ b/editor/kits/composer/composer-defaults.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { cn } from "@/components/lib/utils/index";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { ImageIcon, XIcon } from "lucide-react";
+import Image from "next/image";
+import { type ReactNode, useEffect, useRef } from "react";
+import {
+  useComposer,
+  type ComposerAttachment,
+  type ComposerCommand,
+  type ComposerMention,
+} from "./composer-react";
+
+function isImageAttachment(
+  attachment: ComposerAttachment
+): attachment is ComposerAttachment & { url: string } {
+  return (
+    !!attachment.mime?.startsWith("image/") &&
+    attachment.mime !== "image/svg+xml" &&
+    !!attachment.url
+  );
+}
+
+function getAttachmentTypeLabel(attachment: ComposerAttachment): string {
+  const mimeSubtype = attachment.mime?.split("/")[1]?.split("+")[0];
+  const extension = attachment.name.includes(".")
+    ? attachment.name.split(".").pop()
+    : undefined;
+  return (mimeSubtype || extension || "file").toUpperCase();
+}
+
+export function ComposerTriggerMenu({
+  className,
+  id = "composer-trigger-menu",
+}: {
+  className?: string;
+  id?: string;
+}) {
+  const composer = useComposer();
+  const selectedRef = useRef<HTMLDivElement | null>(null);
+  const trigger = composer.trigger;
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [composer.triggerIndex, trigger?.kind, trigger?.query]);
+
+  if (!trigger || trigger.items.length === 0) return null;
+
+  const itemValues = trigger.items.map((item) => `${trigger.kind}:${item.id}`);
+  const selectedValue =
+    itemValues[composer.triggerIndex] ?? itemValues[0] ?? "";
+
+  return (
+    <div
+      className={cn(
+        "absolute right-0 bottom-full left-0 z-20 mb-2 overflow-hidden rounded-md border border-border bg-background shadow-lg",
+        className
+      )}
+      data-composer-trigger-menu
+    >
+      <Command
+        className="bg-transparent"
+        shouldFilter={false}
+        value={selectedValue}
+        onValueChange={(value) => {
+          const index = itemValues.indexOf(value);
+          if (index >= 0) composer.setTriggerIndex(index);
+        }}
+      >
+        <CommandList
+          aria-label={trigger.kind === "command" ? "Commands" : "Mentions"}
+          className="max-h-64 scroll-py-1 p-1"
+          id={id}
+        >
+          <CommandGroup className="p-0">
+            {trigger.items.map((item, index) => {
+              const description =
+                trigger.kind === "command"
+                  ? (item as ComposerCommand).description
+                  : getMentionDescription(item as ComposerMention);
+              return (
+                <CommandItem
+                  className="scroll-my-1 items-center py-1"
+                  id={`${id}-${trigger.kind}-${item.id}`}
+                  key={itemValues[index]}
+                  ref={index === composer.triggerIndex ? selectedRef : null}
+                  value={itemValues[index]}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onMouseMove={() => composer.setTriggerIndex(index)}
+                  onSelect={() => {
+                    composer.selectTriggerItem(index);
+                  }}
+                >
+                  <span className="min-w-0 flex items-baseline gap-2">
+                    <span className="font-mono text-muted-foreground">
+                      {trigger.kind === "command" ? "/" : "@"}
+                    </span>
+                    <span className="truncate font-normal">
+                      {trigger.kind === "command"
+                        ? (item as ComposerCommand).title
+                        : (item as ComposerMention).label}
+                    </span>
+                    {description && (
+                      <span className="truncate text-muted-foreground text-xs">
+                        {description}
+                      </span>
+                    )}
+                  </span>
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  );
+}
+
+export function ComposerAttachmentCards({
+  className,
+  renderAttachment,
+}: {
+  className?: string;
+  renderAttachment?: (
+    attachment: ComposerAttachment,
+    controls: { remove: () => void }
+  ) => ReactNode;
+}) {
+  const { snapshot, removeAttachment } = useComposer();
+
+  if (!snapshot.attachments.length) return null;
+
+  return (
+    <div className={cn("flex flex-wrap items-end gap-2", className)}>
+      {snapshot.attachments.map((attachment) => {
+        const controls = { remove: () => removeAttachment(attachment.id) };
+        return (
+          <div data-composer-attachment={attachment.id} key={attachment.id}>
+            {renderAttachment ? (
+              renderAttachment(attachment, controls)
+            ) : (
+              <ComposerAttachmentCard
+                attachment={attachment}
+                onRemove={controls.remove}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ComposerAttachmentCard({
+  attachment,
+  onRemove,
+}: {
+  attachment: ComposerAttachment;
+  onRemove: () => void;
+}) {
+  if (isImageAttachment(attachment)) {
+    return (
+      <div className="group relative size-20 overflow-hidden rounded-md border border-border bg-muted">
+        <Image
+          alt=""
+          className="object-cover"
+          fill
+          sizes="80px"
+          src={attachment.url}
+          unoptimized
+        />
+        <button
+          aria-label={`Remove ${attachment.name}`}
+          className="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground group-hover:opacity-100"
+          onClick={onRemove}
+          type="button"
+        >
+          <XIcon className="size-3" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-12 max-w-52 min-w-40 items-center gap-2 rounded-md border border-border bg-background px-2 py-1 shadow-xs">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-orange-600">
+        <ImageIcon className="size-4" />
+      </div>
+      <span className="min-w-0 flex-1">
+        <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-sm leading-tight">
+          {attachment.name}
+        </span>
+        <span className="mt-0.5 block text-muted-foreground text-xs leading-tight">
+          {getAttachmentTypeLabel(attachment)}
+        </span>
+      </span>
+      <button
+        aria-label={`Remove ${attachment.name}`}
+        className="self-start -mt-0.5 -mr-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-foreground text-background hover:opacity-80"
+        onClick={onRemove}
+        type="button"
+      >
+        <XIcon className="size-2.5" />
+      </button>
+    </div>
+  );
+}
+
+function getMentionDescription(mention: ComposerMention): string | undefined {
+  if (mention.kind === "file" || mention.kind === "folder") return undefined;
+  return mention.description;
+}

--- a/editor/kits/composer/composer-defaults.tsx
+++ b/editor/kits/composer/composer-defaults.tsx
@@ -11,6 +11,7 @@ import { ImageIcon, XIcon } from "lucide-react";
 import Image from "next/image";
 import { type ReactNode, useEffect, useRef } from "react";
 import {
+  useComposerInternals,
   useComposer,
   type ComposerAttachment,
   type ComposerCommand,
@@ -37,12 +38,14 @@ function getAttachmentTypeLabel(attachment: ComposerAttachment): string {
 
 export function ComposerTriggerMenu({
   className,
-  id = "composer-trigger-menu",
+  id,
 }: {
   className?: string;
   id?: string;
 }) {
   const composer = useComposer();
+  const { triggerMenuId } = useComposerInternals();
+  const resolvedId = id ?? triggerMenuId;
   const selectedRef = useRef<HTMLDivElement | null>(null);
   const trigger = composer.trigger;
 
@@ -65,6 +68,7 @@ export function ComposerTriggerMenu({
         className
       )}
       data-composer-trigger-menu
+      id={resolvedId}
     >
       <Command
         className="bg-transparent"
@@ -78,7 +82,6 @@ export function ComposerTriggerMenu({
         <CommandList
           aria-label={trigger.kind === "command" ? "Commands" : "Mentions"}
           className="max-h-64 scroll-py-1 p-1"
-          id={id}
         >
           <CommandGroup className="p-0">
             {trigger.items.map((item, index) => {
@@ -89,9 +92,15 @@ export function ComposerTriggerMenu({
               return (
                 <CommandItem
                   className="scroll-my-1 items-center py-1"
-                  id={`${id}-${trigger.kind}-${item.id}`}
                   key={itemValues[index]}
-                  ref={index === composer.triggerIndex ? selectedRef : null}
+                  ref={(node) => {
+                    if (node) {
+                      node.id = `${resolvedId}-${trigger.kind}-${item.id}`;
+                    }
+                    if (index === composer.triggerIndex) {
+                      selectedRef.current = node;
+                    }
+                  }}
                   value={itemValues[index]}
                   onMouseDown={(event) => {
                     event.preventDefault();
@@ -128,9 +137,11 @@ export function ComposerTriggerMenu({
 
 export function ComposerAttachmentCards({
   className,
+  onRemoveAttachment,
   renderAttachment,
 }: {
   className?: string;
+  onRemoveAttachment?: (attachment: ComposerAttachment) => void;
   renderAttachment?: (
     attachment: ComposerAttachment,
     controls: { remove: () => void }
@@ -143,7 +154,12 @@ export function ComposerAttachmentCards({
   return (
     <div className={cn("flex flex-wrap items-end gap-2", className)}>
       {snapshot.attachments.map((attachment) => {
-        const controls = { remove: () => removeAttachment(attachment.id) };
+        const controls = {
+          remove() {
+            onRemoveAttachment?.(attachment);
+            removeAttachment(attachment.id);
+          },
+        };
         return (
           <div data-composer-attachment={attachment.id} key={attachment.id}>
             {renderAttachment ? (
@@ -181,7 +197,7 @@ function ComposerAttachmentCard({
         />
         <button
           aria-label={`Remove ${attachment.name}`}
-          className="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground group-hover:opacity-100"
+          className="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring group-hover:opacity-100 group-focus-within:opacity-100"
           onClick={onRemove}
           type="button"
         >

--- a/editor/kits/composer/composer-react.tsx
+++ b/editor/kits/composer/composer-react.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { cn } from "@/components/lib/utils/index";
+import { EditorContent, useEditor, type Editor } from "@tiptap/react";
+import {
+  createContext,
+  type HTMLAttributes,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import {
+  ComposerCore,
+  type ComposerAttachment,
+  type ComposerCatalog,
+  type ComposerCommand,
+  type ComposerEditorContext,
+  type ComposerFileReference,
+  type ComposerMention,
+  type ComposerMessage,
+  type ComposerSnapshot,
+  type ComposerTrigger,
+} from "./composer-core";
+import { ComposerTiptap } from "./composer-tiptap";
+import "./composer-content.css";
+
+type ComposerContextValue = {
+  core: ComposerCore;
+  editor: Editor | null;
+  setEditor: (editor: Editor | null) => void;
+  snapshot: ComposerSnapshot;
+};
+
+export type ComposerController = {
+  snapshot: ComposerViewSnapshot;
+  trigger: ComposerTrigger | null;
+  triggerIndex: number;
+  addAttachment: ComposerCore["addAttachment"];
+  removeAttachment: ComposerCore["removeAttachment"];
+  setContexts: ComposerCore["setContexts"];
+  clear: () => void;
+  insertFileReference: (reference: ComposerFileReference) => boolean;
+  setTriggerIndex: (index: number) => void;
+  moveTriggerIndex: (delta: number) => void;
+  selectTriggerItem: (index: number) => boolean;
+  submit: (input: { submitted_at: number }) => ComposerMessage | null;
+};
+
+export type ComposerViewSnapshot = Pick<
+  ComposerSnapshot,
+  "attachments" | "contexts" | "text"
+>;
+
+const ComposerContext = createContext<ComposerContextValue | null>(null);
+
+export function ComposerProvider({
+  catalog,
+  children,
+}: PropsWithChildren<{
+  catalog: ComposerCatalog;
+}>) {
+  const core = useRef<ComposerCore | null>(null);
+  if (!core.current) {
+    core.current = new ComposerCore(catalog);
+  }
+  const coreValue = core.current;
+  const [editor, setEditor] = useState<Editor | null>(null);
+
+  useEffect(() => {
+    coreValue.setCatalog(catalog);
+  }, [catalog, coreValue]);
+
+  const snapshot = useSyncExternalStore(
+    (listener) => coreValue.subscribe(listener),
+    () => coreValue.getSnapshot(),
+    () => coreValue.getSnapshot()
+  );
+
+  const value = useMemo(
+    () => ({
+      core: coreValue,
+      editor,
+      setEditor,
+      snapshot,
+    }),
+    [coreValue, editor, snapshot]
+  );
+
+  return (
+    <ComposerContext.Provider value={value}>
+      {children}
+    </ComposerContext.Provider>
+  );
+}
+
+export function useComposer() {
+  const { core, editor, snapshot } = useComposerInternals();
+
+  return useMemo<ComposerController>(
+    () => ({
+      snapshot: toViewSnapshot(snapshot),
+      trigger: snapshot.trigger,
+      triggerIndex: snapshot.triggerIndex,
+      addAttachment: core.addAttachment.bind(core),
+      removeAttachment: core.removeAttachment.bind(core),
+      setContexts: core.setContexts.bind(core),
+      clear() {
+        editor?.commands.clearContent(true);
+        core.clear();
+      },
+      insertFileReference(reference) {
+        if (!editor) return false;
+        ComposerTiptap.insertFileReference(editor, reference);
+        return true;
+      },
+      setTriggerIndex(index) {
+        core.setTriggerIndex(index);
+      },
+      moveTriggerIndex(delta) {
+        core.moveTriggerIndex(delta);
+      },
+      selectTriggerItem(index) {
+        if (!editor || !snapshot.trigger) return false;
+        ComposerTiptap.selectTriggerItem(editor, snapshot.trigger, index);
+        return true;
+      },
+      submit(input) {
+        if (editor) {
+          ComposerTiptap.syncCore(core, editor);
+        }
+        return core.createMessage(input);
+      },
+    }),
+    [core, editor, snapshot]
+  );
+}
+
+export function useComposerInternals() {
+  const context = useContext(ComposerContext);
+  if (!context) {
+    throw new Error("useComposer must be used inside ComposerProvider.");
+  }
+  return context;
+}
+
+export function ComposerContent({
+  className,
+  editorClassName,
+  placeholder = "Compose...",
+  triggerMenuId = "composer-trigger-menu",
+  autofocus,
+  onSubmitRequest,
+  ...props
+}: Omit<HTMLAttributes<HTMLDivElement>, "onSubmit"> & {
+  placeholder?: string;
+  autofocus?: boolean;
+  editorClassName?: string;
+  triggerMenuId?: string;
+  onSubmitRequest?: () => void;
+}) {
+  const { core, setEditor, snapshot } = useComposerInternals();
+  const editorRef = useRef<Editor | null>(null);
+  const extensions = useMemo(
+    () => ComposerTiptap.extensions({ placeholder }),
+    [placeholder]
+  );
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions,
+    editorProps: {
+      attributes: {
+        "data-composer-editor": "",
+        "aria-autocomplete": "list",
+        "aria-controls": triggerMenuId,
+        "aria-expanded": "false",
+        class: cn("outline-none", editorClassName),
+      },
+      handleKeyDown(_view, event) {
+        return ComposerTiptap.handleKeyDown({
+          core,
+          editor: editorRef.current,
+          event,
+          triggerIndex: core.getSnapshot().triggerIndex,
+          moveTriggerIndex: (delta) => core.moveTriggerIndex(delta),
+          submit() {
+            onSubmitRequest?.();
+          },
+        });
+      },
+    },
+    onCreate({ editor }) {
+      editorRef.current = editor;
+      setEditor(editor);
+      ComposerTiptap.syncCore(core, editor);
+      if (autofocus) {
+        editor.commands.focus("end");
+      }
+    },
+    onUpdate({ editor }) {
+      ComposerTiptap.syncCore(core, editor);
+    },
+    onSelectionUpdate({ editor }) {
+      ComposerTiptap.inspectCore(core, editor);
+    },
+    onDestroy() {
+      editorRef.current = null;
+      setEditor(null);
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const selectedItem = snapshot.trigger?.items[snapshot.triggerIndex];
+    dom.setAttribute("aria-controls", triggerMenuId);
+    dom.setAttribute("aria-expanded", snapshot.trigger ? "true" : "false");
+    if (snapshot.trigger && selectedItem) {
+      dom.setAttribute(
+        "aria-activedescendant",
+        `${triggerMenuId}-${snapshot.trigger.kind}-${selectedItem.id}`
+      );
+    } else {
+      dom.removeAttribute("aria-activedescendant");
+    }
+  }, [editor, snapshot.trigger, snapshot.triggerIndex, triggerMenuId]);
+
+  return (
+    <div
+      {...props}
+      className={cn("composer-content", className)}
+      data-composer-content
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
+}
+
+function toViewSnapshot(snapshot: ComposerSnapshot): ComposerViewSnapshot {
+  return {
+    attachments: snapshot.attachments,
+    contexts: snapshot.contexts,
+    text: snapshot.text,
+  };
+}
+
+export type {
+  ComposerAttachment,
+  ComposerCatalog,
+  ComposerCommand,
+  ComposerEditorContext,
+  ComposerFileReference,
+  ComposerMention,
+  ComposerMessage,
+};

--- a/editor/kits/composer/composer-react.tsx
+++ b/editor/kits/composer/composer-react.tsx
@@ -8,6 +8,7 @@ import {
   type PropsWithChildren,
   useContext,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -33,6 +34,7 @@ type ComposerContextValue = {
   editor: Editor | null;
   setEditor: (editor: Editor | null) => void;
   snapshot: ComposerSnapshot;
+  triggerMenuId: string;
 };
 
 export type ComposerController = {
@@ -68,6 +70,11 @@ export function ComposerProvider({
     core.current = new ComposerCore(catalog);
   }
   const coreValue = core.current;
+  const reactId = useId();
+  const triggerMenuId = useMemo(
+    () => `composer-trigger-menu-${reactId.replace(/:/g, "")}`,
+    [reactId]
+  );
   const [editor, setEditor] = useState<Editor | null>(null);
 
   useEffect(() => {
@@ -86,8 +93,9 @@ export function ComposerProvider({
       editor,
       setEditor,
       snapshot,
+      triggerMenuId,
     }),
-    [coreValue, editor, snapshot]
+    [coreValue, editor, setEditor, snapshot, triggerMenuId]
   );
 
   return (
@@ -151,7 +159,7 @@ export function ComposerContent({
   className,
   editorClassName,
   placeholder = "Compose...",
-  triggerMenuId = "composer-trigger-menu",
+  triggerMenuId,
   autofocus,
   onSubmitRequest,
   ...props
@@ -162,7 +170,13 @@ export function ComposerContent({
   triggerMenuId?: string;
   onSubmitRequest?: () => void;
 }) {
-  const { core, setEditor, snapshot } = useComposerInternals();
+  const {
+    core,
+    setEditor,
+    snapshot,
+    triggerMenuId: defaultTriggerMenuId,
+  } = useComposerInternals();
+  const resolvedTriggerMenuId = triggerMenuId ?? defaultTriggerMenuId;
   const editorRef = useRef<Editor | null>(null);
   const extensions = useMemo(
     () => ComposerTiptap.extensions({ placeholder }),
@@ -175,7 +189,7 @@ export function ComposerContent({
       attributes: {
         "data-composer-editor": "",
         "aria-autocomplete": "list",
-        "aria-controls": triggerMenuId,
+        "aria-controls": resolvedTriggerMenuId,
         "aria-expanded": "false",
         class: cn("outline-none", editorClassName),
       },
@@ -216,17 +230,17 @@ export function ComposerContent({
     if (!editor) return;
     const dom = editor.view.dom;
     const selectedItem = snapshot.trigger?.items[snapshot.triggerIndex];
-    dom.setAttribute("aria-controls", triggerMenuId);
+    dom.setAttribute("aria-controls", resolvedTriggerMenuId);
     dom.setAttribute("aria-expanded", snapshot.trigger ? "true" : "false");
     if (snapshot.trigger && selectedItem) {
       dom.setAttribute(
         "aria-activedescendant",
-        `${triggerMenuId}-${snapshot.trigger.kind}-${selectedItem.id}`
+        `${resolvedTriggerMenuId}-${snapshot.trigger.kind}-${selectedItem.id}`
       );
     } else {
       dom.removeAttribute("aria-activedescendant");
     }
-  }, [editor, snapshot.trigger, snapshot.triggerIndex, triggerMenuId]);
+  }, [editor, resolvedTriggerMenuId, snapshot.trigger, snapshot.triggerIndex]);
 
   return (
     <div

--- a/editor/kits/composer/composer-tiptap.test.ts
+++ b/editor/kits/composer/composer-tiptap.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ComposerCore } from "./composer-core";
 import { ComposerTiptap } from "./composer-tiptap";
 
 describe("ComposerTiptap", () => {
@@ -100,5 +101,36 @@ describe("ComposerTiptap", () => {
         { type: "code-block", text: "const x = 1;" },
       ],
     });
+  });
+
+  it("does not submit or select trigger items during IME composition", () => {
+    const core = new ComposerCore({
+      commands: [{ id: "review", title: "Review" }],
+    });
+    core.inspectCursor("/", 1);
+    let prevented = false;
+    let submitted = false;
+
+    const handled = ComposerTiptap.handleKeyDown({
+      core,
+      editor: null,
+      event: {
+        isComposing: true,
+        key: "Enter",
+        preventDefault() {
+          prevented = true;
+        },
+        shiftKey: false,
+      } as KeyboardEvent,
+      triggerIndex: 0,
+      moveTriggerIndex() {},
+      submit() {
+        submitted = true;
+      },
+    });
+
+    expect(handled).toBe(false);
+    expect(prevented).toBe(false);
+    expect(submitted).toBe(false);
   });
 });

--- a/editor/kits/composer/composer-tiptap.test.ts
+++ b/editor/kits/composer/composer-tiptap.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { ComposerTiptap } from "./composer-tiptap";
+
+describe("ComposerTiptap", () => {
+  it("maps Tiptap command, mention, file ref, list, and code nodes to composer document nodes", () => {
+    expect(
+      ComposerTiptap.toDocument({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "composerCommand",
+                attrs: { id: "review", title: "Review" },
+              },
+              { type: "text", text: " check " },
+              {
+                type: "composerMention",
+                attrs: {
+                  id: "file-a",
+                  label: "a.ts",
+                  kind: "file",
+                  path: "src/a.ts",
+                  payload: JSON.stringify({ source: "mock" }),
+                },
+              },
+              {
+                type: "composerFileReference",
+                attrs: {
+                  path: "src/a.ts",
+                  name: "a.ts",
+                  mime: "text/typescript",
+                  size: 100,
+                  url: "/src/a.ts",
+                  payload: JSON.stringify({ ref: true }),
+                },
+              },
+            ],
+          },
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "one" }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "codeBlock",
+            content: [{ type: "text", text: "const x = 1;" }],
+          },
+        ],
+      })
+    ).toEqual({
+      type: "doc",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            { type: "command", id: "review", title: "Review" },
+            { type: "text", text: " check ", code: undefined },
+            {
+              type: "mention",
+              id: "file-a",
+              label: "a.ts",
+              kind: "file",
+              path: "src/a.ts",
+              payload: { source: "mock" },
+            },
+            {
+              type: "file-ref",
+              path: "src/a.ts",
+              name: "a.ts",
+              mime: "text/typescript",
+              size: 100,
+              url: "/src/a.ts",
+              payload: { ref: true },
+            },
+          ],
+        },
+        {
+          type: "list",
+          ordered: false,
+          items: [
+            [
+              {
+                type: "paragraph",
+                children: [{ type: "text", text: "one", code: undefined }],
+              },
+            ],
+          ],
+        },
+        { type: "code-block", text: "const x = 1;" },
+      ],
+    });
+  });
+});

--- a/editor/kits/composer/composer-tiptap.ts
+++ b/editor/kits/composer/composer-tiptap.ts
@@ -1,0 +1,433 @@
+import Placeholder from "@tiptap/extension-placeholder";
+import { Node, mergeAttributes, type JSONContent } from "@tiptap/core";
+import type { Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  ComposerCore,
+  type ComposerCommand,
+  type ComposerDocument,
+  type ComposerFileReference,
+  type ComposerMention,
+  type ComposerTrigger,
+} from "./composer-core";
+
+const ComposerCommandNode = Node.create({
+  name: "composerCommand",
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      id: { default: "" },
+      title: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-composer-command]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        "data-composer-command": HTMLAttributes.id,
+        "data-composer-chip": "command",
+        class: "composer-chip composer-command",
+      }),
+      `/${HTMLAttributes.id}`,
+    ];
+  },
+
+  renderText({ node }) {
+    return `/${node.attrs.id}`;
+  },
+});
+
+const ComposerMentionNode = Node.create({
+  name: "composerMention",
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      id: { default: "" },
+      label: { default: "" },
+      kind: { default: "" },
+      path: { default: "" },
+      payload: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-composer-mention]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        "data-composer-mention": HTMLAttributes.id,
+        "data-composer-chip": "mention",
+        class: "composer-chip composer-mention",
+      }),
+      `@${HTMLAttributes.label || HTMLAttributes.id}`,
+    ];
+  },
+
+  renderText({ node }) {
+    return `@${node.attrs.label || node.attrs.id}`;
+  },
+});
+
+const ComposerFileReferenceNode = Node.create({
+  name: "composerFileReference",
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      id: { default: "" },
+      name: { default: "" },
+      path: { default: "" },
+      mime: { default: "" },
+      size: { default: null },
+      url: { default: "" },
+      payload: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-composer-file-ref]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        "data-composer-file-ref": HTMLAttributes.path,
+        "data-composer-chip": "file-ref",
+        class: "composer-chip composer-file-ref",
+      }),
+      HTMLAttributes.name || HTMLAttributes.path,
+    ];
+  },
+
+  renderText({ node }) {
+    return node.attrs.name || node.attrs.path;
+  },
+});
+
+export namespace ComposerTiptap {
+  export function extensions(input: { placeholder: string }) {
+    return [
+      StarterKit.configure({
+        blockquote: false,
+        bold: false,
+        bulletList: {
+          HTMLAttributes: {
+            class: "composer-list-node composer-list-node-bullet",
+          },
+        },
+        code: {
+          HTMLAttributes: {
+            class: "composer-inline-code",
+          },
+        },
+        codeBlock: {
+          HTMLAttributes: {
+            class: "composer-code-block",
+          },
+        },
+        dropcursor: false,
+        gapcursor: false,
+        heading: false,
+        horizontalRule: false,
+        italic: false,
+        orderedList: {
+          HTMLAttributes: {
+            class: "composer-list-node composer-list-node-ordered",
+          },
+        },
+        paragraph: {
+          HTMLAttributes: {
+            class: "composer-text-node",
+          },
+        },
+        strike: false,
+      }),
+      Placeholder.configure({ placeholder: input.placeholder }),
+      ComposerCommandNode,
+      ComposerMentionNode,
+      ComposerFileReferenceNode,
+    ];
+  }
+
+  export function syncCore(core: ComposerCore, editor: Editor): void {
+    core.ingestDocument({
+      text: editor.getText({ blockSeparator: "\n" }),
+      document: toDocument(editor.getJSON()),
+    });
+    inspectCore(core, editor);
+  }
+
+  export function inspectCore(core: ComposerCore, editor: Editor): void {
+    const { from } = editor.state.selection;
+    const textBeforeCursor = editor.state.doc.textBetween(0, from, "\n", "\n");
+    core.inspectCursor(textBeforeCursor, from);
+  }
+
+  export function handleKeyDown(input: {
+    core: ComposerCore;
+    editor: Editor | null;
+    event: KeyboardEvent;
+    triggerIndex: number;
+    moveTriggerIndex: (delta: number) => void;
+    submit: () => void;
+  }): boolean {
+    const trigger = input.core.getSnapshot().trigger;
+    const triggerItemsCount = trigger?.items.length ?? 0;
+
+    if (trigger && triggerItemsCount > 0) {
+      if (input.event.key === "ArrowDown") {
+        input.event.preventDefault();
+        input.moveTriggerIndex(1);
+        return true;
+      }
+
+      if (input.event.key === "ArrowUp") {
+        input.event.preventDefault();
+        input.moveTriggerIndex(-1);
+        return true;
+      }
+
+      if (input.event.key === "Enter" && !input.event.shiftKey) {
+        if (!input.editor) return false;
+        input.event.preventDefault();
+        selectTriggerItem(input.editor, trigger, input.triggerIndex);
+        return true;
+      }
+    }
+
+    if (input.event.key === "Enter" && !input.event.shiftKey) {
+      input.event.preventDefault();
+      input.submit();
+      return true;
+    }
+
+    return false;
+  }
+
+  export function selectTriggerItem(
+    editor: Editor,
+    trigger: ComposerTrigger,
+    index: number
+  ): void {
+    const item = trigger.items[Math.min(index, trigger.items.length - 1)];
+    if (!item) return;
+    if (trigger.kind === "command") {
+      insertCommand(editor, trigger.range, item as ComposerCommand);
+    } else {
+      insertMention(editor, trigger.range, item as ComposerMention);
+    }
+  }
+
+  export function insertFileReference(
+    editor: Editor,
+    reference: ComposerFileReference
+  ): void {
+    editor
+      .chain()
+      .focus()
+      .insertContent([
+        {
+          type: "composerFileReference",
+          attrs: {
+            id: reference.id,
+            name: reference.name,
+            path: reference.path,
+            mime: reference.mime,
+            size: reference.size,
+            url: reference.url,
+            payload: encodePayload(reference.payload),
+          },
+        },
+        { type: "text", text: " " },
+      ])
+      .run();
+  }
+
+  export function toDocument(json: JSONContent): ComposerDocument.Root {
+    return {
+      type: "doc",
+      children: (json.content ?? []).flatMap(toNodes),
+    };
+  }
+
+  function insertCommand(
+    editor: Editor,
+    range: { from: number; to: number },
+    command: ComposerCommand
+  ): void {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .insertContent([
+        {
+          type: "composerCommand",
+          attrs: {
+            id: command.id,
+            title: command.title,
+          },
+        },
+        { type: "text", text: " " },
+      ])
+      .run();
+  }
+
+  function insertMention(
+    editor: Editor,
+    range: { from: number; to: number },
+    mention: ComposerMention
+  ): void {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(range)
+      .insertContent([
+        {
+          type: "composerMention",
+          attrs: {
+            ...mention,
+            payload: encodePayload(mention.payload),
+          },
+        },
+        { type: "text", text: " " },
+      ])
+      .run();
+  }
+
+  function toNodes(node: JSONContent): ComposerDocument.Node[] {
+    if (node.type === "text") {
+      return [
+        {
+          type: "text",
+          text: node.text ?? "",
+          code: node.marks?.some((mark) => mark.type === "code") || undefined,
+        },
+      ];
+    }
+
+    if (node.type === "paragraph") {
+      return [
+        {
+          type: "paragraph",
+          children: (node.content ?? []).flatMap(toNodes),
+        },
+      ];
+    }
+
+    if (node.type === "composerCommand") {
+      const id = readString(node.attrs?.id);
+      if (!id) return [];
+      return [
+        {
+          type: "command",
+          id,
+          title: readString(node.attrs?.title) || undefined,
+        },
+      ];
+    }
+
+    if (node.type === "composerMention") {
+      const id = readString(node.attrs?.id);
+      if (!id) return [];
+      return [
+        {
+          type: "mention",
+          id,
+          label: readString(node.attrs?.label) || id,
+          kind: readString(node.attrs?.kind) || undefined,
+          path: readString(node.attrs?.path) || undefined,
+          payload: decodePayload(node.attrs?.payload),
+        },
+      ];
+    }
+
+    if (node.type === "composerFileReference") {
+      const path = readString(node.attrs?.path);
+      if (!path) return [];
+      return [
+        {
+          type: "file-ref",
+          path,
+          name: readString(node.attrs?.name) || path,
+          mime: readString(node.attrs?.mime) || undefined,
+          size: readNumber(node.attrs?.size),
+          url: readString(node.attrs?.url) || undefined,
+          payload: decodePayload(node.attrs?.payload),
+        },
+      ];
+    }
+
+    if (node.type === "codeBlock") {
+      return [
+        {
+          type: "code-block",
+          text: collectText(node),
+        },
+      ];
+    }
+
+    if (node.type === "bulletList" || node.type === "orderedList") {
+      return [
+        {
+          type: "list",
+          ordered: node.type === "orderedList",
+          items: (node.content ?? [])
+            .filter((child) => child.type === "listItem")
+            .map((child) => (child.content ?? []).flatMap(toNodes)),
+        },
+      ];
+    }
+
+    return (node.content ?? []).flatMap(toNodes);
+  }
+
+  function collectText(node: JSONContent): string {
+    if (node.type === "text") return node.text ?? "";
+    return (node.content ?? []).map(collectText).join("");
+  }
+
+  function readString(value: unknown): string {
+    return typeof value === "string" ? value : "";
+  }
+
+  function readNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value)
+      ? value
+      : undefined;
+  }
+
+  function encodePayload(payload: Record<string, unknown> | undefined): string {
+    if (!payload) return "";
+    return JSON.stringify(payload);
+  }
+
+  function decodePayload(value: unknown): Record<string, unknown> | undefined {
+    if (typeof value !== "string" || !value) return undefined;
+    try {
+      const payload = JSON.parse(value);
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        return payload as Record<string, unknown>;
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+}

--- a/editor/kits/composer/composer-tiptap.ts
+++ b/editor/kits/composer/composer-tiptap.ts
@@ -188,6 +188,10 @@ export namespace ComposerTiptap {
     moveTriggerIndex: (delta: number) => void;
     submit: () => void;
   }): boolean {
+    if (isComposing(input.event)) {
+      return false;
+    }
+
     const trigger = input.core.getSnapshot().trigger;
     const triggerItemsCount = trigger?.items.length ?? 0;
 
@@ -219,6 +223,10 @@ export namespace ComposerTiptap {
     }
 
     return false;
+  }
+
+  function isComposing(event: KeyboardEvent): boolean {
+    return event.isComposing || event.keyCode === 229;
   }
 
   export function selectTriggerItem(

--- a/editor/kits/composer/index.ts
+++ b/editor/kits/composer/index.ts
@@ -1,0 +1,25 @@
+export {
+  ComposerContent,
+  ComposerProvider,
+  useComposer,
+  type ComposerController,
+  type ComposerViewSnapshot,
+} from "./composer-react";
+
+export {
+  ComposerAttachmentCards,
+  ComposerTriggerMenu,
+} from "./composer-defaults";
+
+export type {
+  ComposerAttachment,
+  ComposerAttachmentFilter,
+  ComposerAttachmentInput,
+  ComposerCatalog,
+  ComposerCommand,
+  ComposerEditorContext,
+  ComposerFileReference,
+  ComposerMention,
+  ComposerMessage,
+  ComposerPart,
+} from "./composer-core";


### PR DESCRIPTION
## Summary
- add a reusable Tiptap-based composer kit under editor/kits/composer
- add a dev UI demo that consumes the kit through @/kits/composer
- document the kit surface, model, customization contract, and boundaries

## Demo
- https://grida.co/ui/components/composer

## Verification
- pnpm vitest run 'kits/composer/composer-core.test.ts' 'kits/composer/composer-tiptap.test.ts'
- pnpm build:packages
- pnpm turbo build --filter @grida/canvas-wasm
- pnpm typegen
- pnpm exec tsc --noEmit --pretty false --incremental false
- browser smoke: /ui/components/composer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer kit: full prompt/message composer with commands, mentions, attachments, rich-text editing
  * Demo UI: composer page with file sidebar (drag-and-drop, drop-mode selector), message log (formatted/raw views), attachments, and submission flow
  * Added top-level “Composer” navigation item under Components

* **Documentation**
  * Added Composer kit guide and registry entry

* **Tests**
  * Added tests for composition engine and editor integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->