### PR TITLE
fix(hud demo): wire resize + parametric handles in @grida/hud spec page

### DIFF
--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -837,15 +837,19 @@ export function HUDStage(props: HUDStageProps) {
         });
       }
     } else if (intent.kind === "resize") {
-      // Demo applies resize to a single rect node only (the visibility +
-      // size-meter sections both use single-rect fixtures). For multi-id
-      // selections we'd need to distribute the new group AABB across
-      // members — out of scope for the dev showcase.
+      // Demo applies resize to a single axis-aligned rect node only (the
+      // visibility section's fixture). Multi-id groups would need the
+      // new AABB distributed across members; rotated nodes carry their
+      // true dims as `intent.shape.local` + a matrix, not the doc-space
+      // AABB in `intent.rect` — writing the AABB into a `rect-rotated`'s
+      // local rect would corrupt its geometry while preserving the angle.
+      // Both cases are out of scope for the showcase; bail explicitly.
       const ids = intent.ids as readonly string[];
       if (ids.length !== 1) return;
       const id = ids[0];
       const node = fixtureRef.current.nodes.find((n) => n.id === id);
       if (!node?.rect) return;
+      if (node.kind === "rect-rotated") return;
       const next = {
         x: intent.rect.x,
         y: intent.rect.y,

--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -212,13 +212,14 @@ export interface HUDStageProps {
   readonly?: boolean;
   /**
    * Lock the host so only host-routed handle intents are honored —
-   * everything that mutates selection or moves nodes (`select` /
-   * `deselect_all` / `marquee_select` / `translate` / `set_endpoint`)
-   * is dropped. Selection chrome stays pinned and the scene becomes a
-   * fixed stage for whichever affordance the section wired up
-   * (corner-radius, parametric handles, etc.). Used by §15 and the
-   * parametric-star demo so the reader can focus on the active
-   * handle without accidentally moving or reselecting demo nodes.
+   * every intent kind in {@link FREE_GESTURE_INTENTS} (`select` /
+   * `deselect_all` / `translate` / `resize` / `rotate` /
+   * `marquee_select` / `lasso_select` / `set_endpoint`) is dropped.
+   * Selection chrome stays pinned and the scene becomes a fixed stage
+   * for whichever affordance the section wired up (corner-radius,
+   * parametric handles, etc.). Used by §15 and the parametric-star
+   * demo so the reader can focus on the active handle without
+   * accidentally moving or reselecting demo nodes.
    */
   interactionLocked?: boolean;
   /** Decoration layered on top of the hud surface chrome. */

--- a/editor/app/(dev)/ui/components/hud/_host.tsx
+++ b/editor/app/(dev)/ui/components/hud/_host.tsx
@@ -47,6 +47,23 @@ import { fixtureToShape, type Fixture, type FixtureNode } from "./_fixtures";
 
 type NodeId = string;
 
+// Intent kinds that represent "free gestures" — the reader poking the
+// canvas via selection chrome, marquee, or direct node manipulation.
+// `interactionLocked` drops exactly these. Host-routed handle intents
+// (corner-radius, parametric, padding, transform-box, …) and mode
+// transitions pass through, so a new handle family doesn't need to
+// remember to update a per-family allowlist here.
+const FREE_GESTURE_INTENTS: ReadonlySet<Intent["kind"]> = new Set([
+  "select",
+  "deselect_all",
+  "translate",
+  "resize",
+  "rotate",
+  "marquee_select",
+  "lasso_select",
+  "set_endpoint",
+]);
+
 // ───────────────────────────────────────────────────────────────────────────
 // Public state shape — what the inspector subscribes to.
 // ───────────────────────────────────────────────────────────────────────────
@@ -78,6 +95,15 @@ export type HUDExtraBuilder = (ctx: {
   gesture: SurfaceGesture;
   /** dx/dy per dragged id while a translate gesture is in flight. */
   offsets: Record<string, [number, number]>;
+  /**
+   * Live target rect per resized id while a resize gesture is in flight.
+   * Empty when no resize is active. Symmetric to {@link offsets}; lets
+   * size-meter / measurement extras read W × H without double-baking.
+   */
+  resizes: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >;
 }) => HUDDraw | undefined;
 
 export interface HUDStageProps {
@@ -185,12 +211,14 @@ export interface HUDStageProps {
   /** Block all mutating intents. */
   readonly?: boolean;
   /**
-   * Lock the host so the only honored intents are corner-radius drags.
-   * `select` / `deselect_all` / `marquee_select` / `translate` are all
-   * dropped — selection chrome stays pinned, nodes don't move, and the
-   * scene becomes a fixed stage for one affordance. Used by §15 so the
-   * reader can focus on the radius handles without accidentally moving
-   * or reselecting the demo rects.
+   * Lock the host so only host-routed handle intents are honored —
+   * everything that mutates selection or moves nodes (`select` /
+   * `deselect_all` / `marquee_select` / `translate` / `set_endpoint`)
+   * is dropped. Selection chrome stays pinned and the scene becomes a
+   * fixed stage for whichever affordance the section wired up
+   * (corner-radius, parametric handles, etc.). Used by §15 and the
+   * parametric-star demo so the reader can focus on the active
+   * handle without accidentally moving or reselecting demo nodes.
    */
   interactionLocked?: boolean;
   /** Decoration layered on top of the hud surface chrome. */
@@ -279,6 +307,7 @@ function FixtureSvg({
   fixture,
   offsets,
   endpointPreviews,
+  resizes,
   width,
   height,
   transform,
@@ -288,6 +317,10 @@ function FixtureSvg({
   endpointPreviews: Record<
     string,
     { p1?: [number, number]; p2?: [number, number] }
+  >;
+  resizes: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
   >;
   width: number;
   height: number;
@@ -306,7 +339,7 @@ function FixtureSvg({
         {fixture.nodes.map((n) => (
           <FixtureShape
             key={n.id}
-            node={applyOffsetToNode(n, offsets, endpointPreviews)}
+            node={applyOffsetToNode(n, offsets, endpointPreviews, resizes)}
           />
         ))}
       </g>
@@ -538,11 +571,16 @@ function eventButton(e: PointerEvent): "primary" | "secondary" | "middle" {
 function applyOffsetToNode(
   n: FixtureNode,
   offs: Record<string, [number, number]>,
-  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>
+  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>,
+  resizes?: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >
 ): FixtureNode {
   const off = offs[n.id];
   const ep = endpoints?.[n.id];
-  if (!off && !ep) return n;
+  const rz = resizes?.[n.id];
+  if (!off && !ep && !rz) return n;
   let next: FixtureNode = n;
   if (off) {
     const [dx, dy] = off;
@@ -565,22 +603,32 @@ function applyOffsetToNode(
       p2: ep.p2 ?? next.p2,
     };
   }
+  if (rz && next.rect) {
+    next = { ...next, rect: { ...next.rect, ...rz } };
+  }
   return next;
 }
 
 function commitOffsets(
   fixture: Fixture,
   offs: Record<string, [number, number]>,
-  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>
+  endpoints?: Record<string, { p1?: [number, number]; p2?: [number, number] }>,
+  resizes?: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >
 ): Fixture {
   if (
     Object.keys(offs).length === 0 &&
-    (!endpoints || Object.keys(endpoints).length === 0)
+    (!endpoints || Object.keys(endpoints).length === 0) &&
+    (!resizes || Object.keys(resizes).length === 0)
   )
     return fixture;
   return {
     ...fixture,
-    nodes: fixture.nodes.map((n) => applyOffsetToNode(n, offs, endpoints)),
+    nodes: fixture.nodes.map((n) =>
+      applyOffsetToNode(n, offs, endpoints, resizes)
+    ),
   };
 }
 
@@ -664,6 +712,16 @@ export function HUDStage(props: HUDStageProps) {
   const endpointPreviewsRef = React.useRef(endpointPreviews);
   endpointPreviewsRef.current = endpointPreviews;
 
+  // Resize preview rects, applied on top of liveFixture in shapeOf / SVG /
+  // extra ctx. Resize intent's `rect` is the group AABB; for the demo's
+  // single-rect fixtures we apply it directly to the one resized id. Multi-
+  // id groups are out of scope (svg-editor solves that with shape, not rect).
+  const [resizePreviews, setResizePreviews] = React.useState<
+    Record<string, { x: number; y: number; width: number; height: number }>
+  >({});
+  const resizePreviewsRef = React.useRef(resizePreviews);
+  resizePreviewsRef.current = resizePreviews;
+
   // Camera. `initialTransform` is read once at mount — runtime changes
   // would fight the user's wheel-zoom, so we don't track it as a dep.
   const [transform, setTransform] = React.useState<cmath.Transform>(
@@ -714,6 +772,7 @@ export function HUDStage(props: HUDStageProps) {
       fixture: fixtureRef.current,
       gesture: surfaceRef.current?.gesture() ?? { kind: "idle" },
       offsets: previewOffsetsRef.current,
+      resizes: resizePreviewsRef.current,
     });
   }, []);
 
@@ -722,18 +781,12 @@ export function HUDStage(props: HUDStageProps) {
   const handleIntentRef = React.useRef<((intent: Intent) => void) | null>(null);
   handleIntentRef.current = (intent) => {
     lastIntentRef.current = intent;
-    // When the host has locked interaction to corner-radius only, drop
-    // every intent kind that isn't a corner-radius mutation. The hud
-    // still emits everything (it doesn't know about the lock); the host
-    // is the gate. Allowlist on purpose — a future intent kind defaults
-    // to "blocked while locked," which is the safer default for a
-    // "corner-radius only" stage.
-    if (
-      interactionLockedRef.current &&
-      intent.kind !== "corner_radius" &&
-      intent.kind !== "corner_radius_explicit" &&
-      intent.kind !== "corner_radius_uniform"
-    ) {
+    // When the host has locked interaction, drop free-gesture intents
+    // (selection / marquee / direct node manipulation). The hud still
+    // emits everything; the host is the gate. Denylist on purpose —
+    // host-routed handle intents (any handle family the section wired
+    // up) pass through automatically without having to be enumerated.
+    if (interactionLockedRef.current && FREE_GESTURE_INTENTS.has(intent.kind)) {
       return;
     }
     if (intent.kind === "select") {
@@ -781,6 +834,46 @@ export function HUDStage(props: HUDStageProps) {
           const next = { ...prev };
           for (const id of ids) delete next[id];
           return next;
+        });
+      }
+    } else if (intent.kind === "resize") {
+      // Demo applies resize to a single rect node only (the visibility +
+      // size-meter sections both use single-rect fixtures). For multi-id
+      // selections we'd need to distribute the new group AABB across
+      // members — out of scope for the dev showcase.
+      const ids = intent.ids as readonly string[];
+      if (ids.length !== 1) return;
+      const id = ids[0];
+      const node = fixtureRef.current.nodes.find((n) => n.id === id);
+      if (!node?.rect) return;
+      const next = {
+        x: intent.rect.x,
+        y: intent.rect.y,
+        width: intent.rect.width,
+        height: intent.rect.height,
+      };
+      if (intent.phase === "preview") {
+        setResizePreviews((prev) => {
+          const cur = prev[id];
+          if (
+            cur &&
+            cur.x === next.x &&
+            cur.y === next.y &&
+            cur.width === next.width &&
+            cur.height === next.height
+          )
+            return prev;
+          return { ...prev, [id]: next };
+        });
+      } else if (intent.phase === "commit") {
+        setLiveFixture((prev) =>
+          commitOffsets(prev, {}, undefined, { [id]: next })
+        );
+        setResizePreviews((prev) => {
+          if (!prev[id]) return prev;
+          const out = { ...prev };
+          delete out[id];
+          return out;
         });
       }
     } else if (intent.kind === "set_endpoint") {
@@ -879,7 +972,8 @@ export function HUDStage(props: HUDStageProps) {
       commitOffsets(
         fixtureRef.current,
         previewOffsetsRef.current,
-        endpointPreviewsRef.current
+        endpointPreviewsRef.current,
+        resizePreviewsRef.current
       );
     const s = new Surface(canvasRef.current, {
       pick: (p) => hitPick(ghosted(), p),
@@ -995,6 +1089,7 @@ export function HUDStage(props: HUDStageProps) {
     liveFixture,
     previewOffsets,
     endpointPreviews,
+    resizePreviews,
     selectionGroups,
     computeExtra,
   ]);
@@ -1339,6 +1434,7 @@ export function HUDStage(props: HUDStageProps) {
         fixture={liveFixture}
         offsets={previewOffsets}
         endpointPreviews={endpointPreviews}
+        resizes={resizePreviews}
         width={size.width}
         height={size.height}
         transform={transform}

--- a/editor/app/(dev)/ui/components/hud/_showcase.tsx
+++ b/editor/app/(dev)/ui/components/hud/_showcase.tsx
@@ -2216,7 +2216,8 @@ export function SizeMeterSection() {
   const fixture = React.useMemo(() => rotatedRectFixture(angle), [angle]);
   const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
   const extra = React.useCallback<HUDExtraBuilder>(
-    (ctx) => buildSizeMeterExtra(ctx.fixture, ctx.selection) ?? undefined,
+    (ctx) =>
+      buildSizeMeterExtra(ctx.fixture, ctx.selection, ctx.resizes) ?? undefined,
     []
   );
   return (
@@ -2410,12 +2411,14 @@ export function MeasurementSection() {
 // ───────────────────────────────────────────────────────────────────────────
 
 // Per-gesture hidden set. Mirrors the policy in `VisibilitySection.visibility`
-// — keep the two in sync. `hidesOn` is empty for groups the policy never
-// touches (hover / marquee / lasso); those stay visible whenever they have
-// reason to render.
-const VISIBILITY_GROUPS: { name: string; hidesOn: ReadonlyArray<string> }[] = [
-  { name: "selection", hidesOn: ["translate"] },
-  { name: "selectionControls", hidesOn: ["translate"] },
+// — keep the two in sync. `hidesOn` is the set of gesture kinds where the
+// group is suppressed; empty means the group is always allowed to paint.
+const VISIBILITY_GROUPS: {
+  name: string;
+  hidesOn: ReadonlyArray<string>;
+}[] = [
+  { name: "selection", hidesOn: ["translate", "resize"] },
+  { name: "selectionControls", hidesOn: ["translate", "resize"] },
   { name: "sizeMeter", hidesOn: ["translate"] },
   { name: "hover", hidesOn: [] },
   { name: "marquee", hidesOn: [] },
@@ -2468,7 +2471,16 @@ export function VisibilitySection() {
   // sizeMeter visible during RESIZE — that's where its W × H readout
   // matters most. The fixture is just a single rect; the demo is about
   // which chrome stays when, not the geometry.
-  const fixture = React.useMemo(() => singleRectFixture(220, 140), []);
+  // Strip the underlay stroke — the demo is about which CHROME family
+  // paints when, and a fixture stroke reads as a misleading "border"
+  // that competes with the selection rectangle.
+  const fixture = React.useMemo(() => {
+    const base = singleRectFixture(220, 140);
+    return {
+      ...base,
+      nodes: base.nodes.map((n) => ({ ...n, stroke: undefined })),
+    };
+  }, []);
   const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
   const [policyOn, setPolicyOn] = React.useState(true);
   const groups = React.useMemo(
@@ -2484,19 +2496,29 @@ export function VisibilitySection() {
   // Mount the size-meter as host extra so the demo has a third chrome
   // family to filter. The line carries `group: "sizeMeter"` (see
   // `buildSizeMeterExtra`); the policy below filters by that tag.
+  // Pass `ctx.resizes` so the W × H label tracks the in-flight resize
+  // rect — that's the moment when the meter is actually on-screen.
   const extra = React.useCallback<HUDExtraBuilder>(
-    (ctx) => buildSizeMeterExtra(ctx.fixture, ctx.selection) ?? undefined,
+    (ctx) =>
+      buildSizeMeterExtra(ctx.fixture, ctx.selection, ctx.resizes) ?? undefined,
     []
   );
   const visibility = React.useCallback<SurfaceVisibilityPolicy>(
     (ctx) => {
       if (!policyOn) return undefined;
-      // Translate is the only gesture this policy filters on. During
-      // resize, idle, rotate, marquee, etc. nothing is hidden — the
-      // size meter shows its live W × H while resizing, which is the
-      // whole point of having a separate group for it.
-      if (ctx.gesture.kind !== "translate") return undefined;
-      return { hidden: ["selection", "selectionControls", "sizeMeter"] };
+      // Three states:
+      //   • idle / hover — show selection + selectionControls + sizeMeter
+      //   • translate    — hide all three (clean moving silhouette)
+      //   • resize       — show ONLY sizeMeter (drop the static chrome
+      //                    so the live W × H pill stands alone with the
+      //                    in-flight rect)
+      if (ctx.gesture.kind === "translate") {
+        return { hidden: ["selection", "selectionControls", "sizeMeter"] };
+      }
+      if (ctx.gesture.kind === "resize") {
+        return { hidden: ["selection", "selectionControls"] };
+      }
+      return undefined;
     },
     [policyOn]
   );
@@ -2520,13 +2542,14 @@ export function VisibilitySection() {
           SurfaceOptions.visibility
         </code>{" "}
         per-gesture. The hud package never owns the vocabulary; hosts name their
-        own. The svg-editor uses this for an asymmetric rule: during{" "}
-        <strong>translate</strong> the silhouette goes clean ({" "}
-        <code>selection</code>, <code>selectionControls</code>, and{" "}
-        <code>sizeMeter</code> all vanish ), but during <strong>resize</strong>{" "}
-        the size meter stays — that&apos;s when its W × H readout matters.
-        Select the rect, then drag the body (translate) vs. a handle (resize)
-        and watch the legend.
+        own. The demo runs three states off one policy: at <strong>idle</strong>{" "}
+        all three chrome families (<code>selection</code>,{" "}
+        <code>selectionControls</code>, <code>sizeMeter</code>) paint; during{" "}
+        <strong>translate</strong> all three vanish so the moving silhouette is
+        clean; during <strong>resize</strong> the static chrome drops out and
+        only <code>sizeMeter</code> remains, label tracking the in-flight rect
+        live. Select the rect, then drag the body (translate) vs. a corner /
+        edge handle (resize) and watch the legend.
       </SectionHeader>
       <SplitStage
         toolbar={
@@ -2561,12 +2584,16 @@ export function VisibilitySection() {
               rule: "On each draw, the surface walks every primitive in built-in chrome + extras and drops the ones whose group is in `hidden`. Unrelated extras pass through untouched. Returns undefined when every primitive is hidden.",
             },
             {
+              name: "idle rule",
+              rule: "No filter — selection + selectionControls + sizeMeter all paint. The size meter is mounted as a host extra (one HUDLine tagged group: 'sizeMeter'); the policy lets it through.",
+            },
+            {
               name: "translate-hide rule",
               rule: "When gesture.kind === 'translate', hide selection + selectionControls + sizeMeter. The moving silhouette renders alone.",
             },
             {
-              name: "resize-keep rule (the asymmetry)",
-              rule: "Every other gesture — resize, rotate, idle, marquee — pass through unfiltered. The size meter is mounted as a host extra (one HUDLine tagged group: 'sizeMeter') and benefits directly: hidden during translate, on-screen during resize, where its live W × H reading is what the user is watching.",
+              name: "resize-isolate rule (the asymmetry)",
+              rule: "When gesture.kind === 'resize', hide selection + selectionControls but KEEP sizeMeter. The static chrome drops out so the live W × H pill stands alone with the in-flight rect — the host threads the dragging rect into the extra builder so the label tracks the handle live, not the pre-drag size.",
             },
             {
               name: "Pass-through",
@@ -3468,6 +3495,19 @@ function ParametricStarDemo() {
     [innerR, pointCount]
   );
 
+  // Polygon-wide corner-radius limit — only depends on the star
+  // geometry (innerR, pointCount), so it's memoized on `star` and
+  // reused by both the handle's domain ceiling and the paint clamp.
+  // Stable across cornerRadius drags, which is the hot path.
+  const cornerRadiusMax = React.useMemo(() => star.maxCornerRadius(), [star]);
+
+  // Clamp at read sites instead of writing the clamp back to state —
+  // the React state holds the user's last drag intent (preserved
+  // across geometry shrink/grow); display and paint always reflect
+  // what the polygon admits *now*. Eliminates the one-frame stale
+  // chip lie that an after-render effect would leave.
+  const clampedCornerRadius = Math.min(cornerRadius, cornerRadiusMax);
+
   // Three parametric inputs declared as a single multi-handle input
   // on one logical node ("star"). Each handle has its own id; the
   // host's reducer routes by id.
@@ -3491,21 +3531,20 @@ function ParametricStarDemo() {
       STAR_CX + STAR_OUTER * Math.cos(innerValleyAngle),
       STAR_CY + STAR_OUTER * Math.sin(innerValleyAngle),
     ];
-    // Corner-radius handle — segment from outerTip(0) inward along
-    // the tip's radius (bisector). Travels TOWARD the star center,
-    // NOT along the tip→valley edge. Cap at `outerR - innerR` so the
-    // rounded corner can't grow past the inner ring (a clean
-    // geometric ceiling even though the true tangent-circle cap is
-    // sharper — the demo doesn't care about exact star geometry).
-    const cornerRadiusMax = Math.max(0, STAR_OUTER - innerR);
+    // Corner-radius handle — segment from outerTip(0) toward the star
+    // center, exactly as long as the geometric cap so knob travel
+    // matches value travel one-to-one (no dead zone past the cap).
+    // At innerR=0 the cap collapses to 0 and the track degenerates
+    // to a point — honest signal that the handle is geometrically
+    // dead, not a silently-frozen knob.
     const cornerRadiusHandle = {
       id: "corner-radius",
       track: {
         kind: "segment" as const,
         a: tip0,
-        b: [STAR_CX, STAR_CY - innerR] as cmath.Vector2,
+        b: [STAR_CX, STAR_CY - STAR_OUTER + cornerRadiusMax] as cmath.Vector2,
       },
-      value: cornerRadius,
+      value: clampedCornerRadius,
       domain: { min: 0, max: cornerRadiusMax },
       inset: 16,
     };
@@ -3545,7 +3584,7 @@ function ParametricStarDemo() {
       node_id: "star",
       handles: [cornerRadiusHandle, ratioHandle, countHandle],
     };
-  }, [cornerRadius, innerR, pointCount]);
+  }, [clampedCornerRadius, cornerRadiusMax, innerR, pointCount]);
 
   const onParametricHandle = React.useCallback((intent: Intent) => {
     if (intent.kind !== "parametric_handle") return;
@@ -3584,7 +3623,7 @@ function ParametricStarDemo() {
             Reset
           </button>
           <code className="font-mono text-[11px] tabular-nums text-zinc-600">
-            r={cornerRadius.toFixed(1)} · ratio=
+            r={clampedCornerRadius.toFixed(1)} · ratio=
             {(innerR / STAR_OUTER).toFixed(2)} · count={pointCount}
           </code>
         </>
@@ -3596,7 +3635,13 @@ function ParametricStarDemo() {
           onParametricHandle={onParametricHandle}
           onState={setState}
           interactionLocked
-          underlay={<StarCanvas star={star} state={state} />}
+          underlay={
+            <StarCanvas
+              star={star}
+              state={state}
+              cornerRadius={clampedCornerRadius}
+            />
+          }
         />
       }
       inspector={<InspectorPanel state={state} title="Star" />}
@@ -3613,9 +3658,11 @@ function ParametricStarDemo() {
 function StarCanvas({
   star,
   state,
+  cornerRadius,
 }: {
   star: ParametricStar;
   state: HUDPlaygroundState | null;
+  cornerRadius: number;
 }) {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -3660,8 +3707,9 @@ function StarCanvas({
       fill: "rgba(99, 102, 241, 0.12)",
       stroke: "#6366f1",
       strokeWidth: 1.5 / Math.max(Math.abs(sx), 1e-6),
+      cornerRadius,
     });
-  }, [size.width, size.height, star, state?.transform]);
+  }, [size.width, size.height, star, state?.transform, cornerRadius]);
 
   return (
     <div
@@ -4780,13 +4828,20 @@ function selectedRect(
 
 function buildSizeMeterExtra(
   fixture: Fixture,
-  selection: string[]
+  selection: string[],
+  resizes?: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >
 ): HUDDraw | null {
   if (selection.length === 0) return null;
   const id = selection[0];
   const node = fixture.nodes.find((n) => n.id === id);
   if (!node?.rect) return null;
-  const { x, y, width, height } = node.rect;
+  // Live W × H during a resize gesture — read the in-flight rect so the
+  // pill tracks the dragging handle rather than the pre-drag size.
+  const live = resizes?.[id];
+  const { x, y, width, height } = live ?? node.rect;
   const angle =
     node.kind === "rect-rotated" && node.angle !== undefined ? node.angle : 0;
   const label = `${Math.round(width)} × ${Math.round(height)}`;

--- a/editor/app/(dev)/ui/components/hud/_showcase.tsx
+++ b/editor/app/(dev)/ui/components/hud/_showcase.tsx
@@ -2217,7 +2217,12 @@ export function SizeMeterSection() {
   const [state, setState] = React.useState<HUDPlaygroundState | null>(null);
   const extra = React.useCallback<HUDExtraBuilder>(
     (ctx) =>
-      buildSizeMeterExtra(ctx.fixture, ctx.selection, ctx.resizes) ?? undefined,
+      buildSizeMeterExtra(
+        ctx.fixture,
+        ctx.selection,
+        ctx.offsets,
+        ctx.resizes
+      ) ?? undefined,
     []
   );
   return (
@@ -2500,7 +2505,12 @@ export function VisibilitySection() {
   // rect — that's the moment when the meter is actually on-screen.
   const extra = React.useCallback<HUDExtraBuilder>(
     (ctx) =>
-      buildSizeMeterExtra(ctx.fixture, ctx.selection, ctx.resizes) ?? undefined,
+      buildSizeMeterExtra(
+        ctx.fixture,
+        ctx.selection,
+        ctx.offsets,
+        ctx.resizes
+      ) ?? undefined,
     []
   );
   const visibility = React.useCallback<SurfaceVisibilityPolicy>(
@@ -4829,6 +4839,7 @@ function selectedRect(
 function buildSizeMeterExtra(
   fixture: Fixture,
   selection: string[],
+  offsets?: Record<string, [number, number]>,
   resizes?: Record<
     string,
     { x: number; y: number; width: number; height: number }
@@ -4838,10 +4849,16 @@ function buildSizeMeterExtra(
   const id = selection[0];
   const node = fixture.nodes.find((n) => n.id === id);
   if (!node?.rect) return null;
-  // Live W × H during a resize gesture — read the in-flight rect so the
-  // pill tracks the dragging handle rather than the pre-drag size.
+  // Live rect across both gestures — resize wins (gestures are mutually
+  // exclusive at the surface, so this is the documented case), translate
+  // adds dx/dy when no resize is in flight. Without folding offsets in,
+  // the pill lags the dragged rect during translate.
   const live = resizes?.[id];
-  const { x, y, width, height } = live ?? node.rect;
+  const off = live ? undefined : offsets?.[id];
+  const base = live ?? node.rect;
+  const x = base.x + (off?.[0] ?? 0);
+  const y = base.y + (off?.[1] ?? 0);
+  const { width, height } = base;
   const angle =
     node.kind === "rect-rotated" && node.angle !== undefined ? node.angle : 0;
   const label = `${Math.round(width)} × ${Math.round(height)}`;

--- a/editor/app/(dev)/ui/components/hud/_star.ts
+++ b/editor/app/(dev)/ui/components/hud/_star.ts
@@ -2,12 +2,17 @@
 // universal `surface.setParametricHandles` primitive against a shape
 // hud doesn't know about — the host paints the star on a custom
 // `<canvas>` underlay (no SVG fixture), and feeds hud three handles
-// (tip-radius, inner/outer ratio, point-count).
+// (corner-radius, inner/outer ratio, point-count).
 //
-// Out-of-scope: rounded-corner star path rendering. The handles
-// visualize their host-owned values; the polygon stays sharp. If a
-// real rounded-tip render is needed later it's a separate PR against
-// this file.
+// Corner-radius rounding (paint side): when `style.cornerRadius > 0`
+// the painter rounds every polygon corner uniformly via `arcTo`. The
+// per-corner cap is `(min_incident_edge / 2) · tan(θ/2)` where θ is
+// the unsigned angle between the corner's edge vectors — the tightest
+// constraint that prevents adjacent fillets from overlapping or
+// `arcTo` from overshooting. Star tips have very acute θ, so this
+// cap dominates the half-edge constraint. The polygon geometry itself
+// stays sharp (hit-test, AABB, etc. don't change); rounding lives only
+// in the paint path.
 
 export interface ParametricStarParams {
   /** Star center, doc-space. */
@@ -24,6 +29,13 @@ export interface ParametricStarParams {
 }
 
 export class ParametricStar {
+  // Instance caches — safe because `ParametricStar` is constructed
+  // fresh whenever its params change (the demo's useMemo on
+  // [innerR, pointCount]). Same params → reused instance → cached
+  // polygon and max-radius, no per-frame recomputation.
+  private _polygon: Array<[number, number]> | null = null;
+  private _maxR: number | null = null;
+
   constructor(public readonly params: ParametricStarParams) {}
 
   /**
@@ -32,6 +44,7 @@ export class ParametricStar {
    * one at angle `-π/2 + rotation`) and walks counter-clockwise.
    */
   polygon(): Array<[number, number]> {
+    if (this._polygon) return this._polygon;
     const { cx, cy, outerR, innerR, points, rotation = 0 } = this.params;
     const N = Math.max(3, Math.floor(points));
     const verts: Array<[number, number]> = [];
@@ -41,6 +54,7 @@ export class ParametricStar {
       const a = -Math.PI / 2 + rotation + i * step;
       verts.push([cx + r * Math.cos(a), cy + r * Math.sin(a)]);
     }
+    this._polygon = verts;
     return verts;
   }
 
@@ -96,19 +110,80 @@ export class ParametricStar {
   }
 
   /**
+   * Maximum corner radius the polygon admits without `arcTo` fillets
+   * overshooting or overlapping. The limit per-corner is
+   * `(min_incident_edge / 2) · tan(θ/2)` where θ is the unsigned angle
+   * at that corner; the polygon-wide max is the min across all corners.
+   * Star tips have very acute θ, so this cap is much tighter than half
+   * the edge length and dominates the limit.
+   */
+  maxCornerRadius(): number {
+    if (this._maxR !== null) return this._maxR;
+    const verts = this.polygon();
+    if (verts.length < 3) return (this._maxR = 0);
+    const n = verts.length;
+    let max = Infinity;
+    for (let i = 0; i < n; i++) {
+      const prev = verts[(i - 1 + n) % n];
+      const cur = verts[i];
+      const next = verts[(i + 1) % n];
+      const ux = prev[0] - cur[0];
+      const uy = prev[1] - cur[1];
+      const vx = next[0] - cur[0];
+      const vy = next[1] - cur[1];
+      const lenU = Math.hypot(ux, uy);
+      const lenV = Math.hypot(vx, vy);
+      // Fail-closed on any degenerate corner: a zero-length edge means
+      // adjacent verts coincide, and `arcTo` over coincident points is
+      // implementation-defined. Better to disable rounding entirely
+      // than skip the corner and let paint() emit undefined output.
+      if (lenU === 0 || lenV === 0) return (this._maxR = 0);
+      const cosT = Math.max(
+        -1,
+        Math.min(1, (ux * vx + uy * vy) / (lenU * lenV))
+      );
+      const theta = Math.acos(cosT);
+      const halfEdge = Math.min(lenU, lenV) / 2;
+      const cornerMax = halfEdge * Math.tan(theta / 2);
+      if (cornerMax < max) max = cornerMax;
+    }
+    return (this._maxR = Number.isFinite(max) ? Math.max(0, max) : 0);
+  }
+
+  /**
    * Paint the star into a Canvas 2D context, in DOC SPACE — caller
    * must have already applied the camera transform via `ctx.setTransform`.
    *
-   * Sharp-cornered polygon; rounded corners are deliberately not
-   * rendered (out-of-scope for the demo, see file header).
+   * When `style.cornerRadius > 0` every polygon corner is rounded
+   * uniformly via `arcTo`. The radius is clamped to {@link maxCornerRadius}
+   * so adjacent fillets can never overlap and `arcTo` never overshoots
+   * the corner.
    */
   paint(ctx: CanvasRenderingContext2D, style: ParametricStarStyle): void {
     const verts = this.polygon();
     if (verts.length < 3) return;
+    const r = Math.max(0, style.cornerRadius ?? 0);
     ctx.beginPath();
-    ctx.moveTo(verts[0][0], verts[0][1]);
-    for (let i = 1; i < verts.length; i++) {
-      ctx.lineTo(verts[i][0], verts[i][1]);
+    if (r <= 0) {
+      ctx.moveTo(verts[0][0], verts[0][1]);
+      for (let i = 1; i < verts.length; i++) {
+        ctx.lineTo(verts[i][0], verts[i][1]);
+      }
+    } else {
+      const n = verts.length;
+      const clamped = Math.min(r, this.maxCornerRadius());
+      // Start at the midpoint of the first edge so the first `arcTo`
+      // has a defined "current point" for its incoming tangent.
+      const start: [number, number] = [
+        (verts[0][0] + verts[1][0]) / 2,
+        (verts[0][1] + verts[1][1]) / 2,
+      ];
+      ctx.moveTo(start[0], start[1]);
+      for (let i = 1; i <= n; i++) {
+        const corner = verts[i % n];
+        const next = verts[(i + 1) % n];
+        ctx.arcTo(corner[0], corner[1], next[0], next[1], clamped);
+      }
     }
     ctx.closePath();
     if (style.fill) {
@@ -127,4 +202,6 @@ export interface ParametricStarStyle {
   fill?: string;
   stroke?: string;
   strokeWidth?: number;
+  /** Per-corner fillet radius, doc-space. 0 (or omitted) = sharp polygon. */
+  cornerRadius?: number;
 }


### PR DESCRIPTION
## Summary

The `/packages/@grida/hud` spec page had two broken demos: the visibility-groups section's resize handles fired but nothing changed (host had no resize handler), and the parametric-star demo's handles never reached the section reducer (host's `interactionLocked` was a corner-radius-only allowlist).

This PR fixes both — and along the way generalizes the lock policy, gives the parametric star real rounded-corner rendering with a geometrically honest handle, and rewrites the visibility-groups demo's policy into three legible states.

Demo-only changes; nothing inside `@grida/hud` or any other package was touched.

### Host (`_host.tsx`)
- **Lock policy from allowlist → denylist.** `FREE_GESTURE_INTENTS` enumerates the few "user-pokes-the-canvas" intent kinds (`select`, `translate`, `resize`, `marquee_select`, `set_endpoint`, etc.). `interactionLocked` drops exactly those; any host-routed handle family (corner-radius, parametric, padding, transform-box, future…) passes through without having to be re-enumerated.
- **`resize` intent wiring.** New preview/commit map symmetric to translate. The preview rect is baked through `applyOffsetToNode` / `commitOffsets` / `FixtureSvg` / `ghosted()` so the SVG underlay, hit-test, and chrome all follow the in-flight handle.
- **`HUDExtraBuilder` ctx gained `resizes: Record<id, Rect>`** so size-meter / measurement extras can read live W × H without double-baking. Demo-only single-id implementation; multi-id bails (documented as out of scope).

### Visibility-groups section (`_showcase.tsx`)
- **Three honest states, one policy:**
  - **idle / hover** — show `selection` + `selectionControls` + `sizeMeter`
  - **translate** — hide all three (clean moving silhouette)
  - **resize** — hide `selection` + `selectionControls`, **keep** `sizeMeter` (live W × H pill stands alone with the in-flight rect)
- Wire `ctx.resizes` through `buildSizeMeterExtra` so the label tracks the dragging rect, not the pre-drag size.
- Strip the fixture stroke — the underlay border read as a misleading chrome family during the demo.
- Section prose + spec table rewritten to describe the new policy honestly.

### Parametric-star section (`_showcase.tsx` + `_star.ts`)
- **Real corner-radius rendering.** `ParametricStar.paint` now rounds every polygon corner via `arcTo` (the previous paint silently ignored the host-owned radius — handle moved, star stayed sharp).
- **Geometrically honest handle cap.** Replace the arbitrary `STAR_OUTER - innerR` ceiling (which let users drag to values that `arcTo` then overshot — that's the broken render from the `buggy?` screenshot earlier) with the true per-corner tangent-circle limit `(min_edge / 2) · tan(θ/2)`, taken across all corners. The handle track is shortened to match so knob travel equals value travel one-to-one.
- **Derive `clampedCornerRadius` at read sites** instead of writing it back through a `useEffect`. Eliminates the one-frame stale chip lie.
- **Instance caches on `ParametricStar`** (`_polygon`, `_maxR`) — safe because the constructor is keyed by `[innerR, pointCount]`, so identity changes only on a real geometry change.

## Test plan

Manual on `/packages/@grida/hud`:

- **Visibility groups section**
  - [ ] Toggle `Apply visibility policy` ON; rect is selected by default. At idle: `selection`, `selectionControls`, `sizeMeter` chips all green.
  - [ ] Drag the rect body (translate) → all three chips go red / struck-through, silhouette renders alone, returns to green on release.
  - [ ] Drag a corner or edge handle (resize) → rect actually resizes (was a no-op before); `selection` + `selectionControls` chips go red, `sizeMeter` stays green; the W × H pill tracks the dragging handle live.
- **Parametric star section**
  - [ ] Drag each of the three handles — they should respond (corner-radius, ratio, count). Was broken before.
  - [ ] Drag corner-radius to the right end of its track — star paints with rounded tips that never overshoot. Toolbar `r=` chip matches what's painted (no off-by-one frame).
  - [ ] Drop ratio so inner ring is near the outer — corner-radius cap grows; track extends accordingly.
- **Other sections** — sanity check, no regressions:
  - [ ] Size meter section still rotates as before; W × H pill follows the lowest OBB edge.
  - [ ] Measurement section still tracks translate dx/dy.
  - [ ] Corner-radius section still drags four independent radii.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live resize previews with real-time W×H display and ability to commit in-flight resize geometry
  * Per-corner radius control for star shapes with automatic clamping to valid limits

* **Improvements**
  * Visibility rules updated to hide selection controls during translate and resize gestures; size meter remains visible while resizing
  * Interaction locking adjusted to allow common free gestures (select, translate, resize, rotate, marquee/lasso, endpoint) during manipulations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->