### PR TITLE
feat(tree-view): add /async subpath for lazy children

### DIFF
--- a/editor/app/(dev)/ui/components/tree-view/_async-fixture.ts
+++ b/editor/app/(dev)/ui/components/tree-view/_async-fixture.ts
@@ -240,9 +240,15 @@ export function createFakeFsProvider(init?: {
       ]);
     },
     emitDeleted(parent, child) {
+      const prune = (id: NodeId) => {
+        const node = nodes.get(id);
+        if (!node) return;
+        for (const cid of node.children) prune(cid);
+        nodes.delete(id);
+      };
       const p = nodes.get(parent);
       if (p) p.children = p.children.filter((c) => c !== child);
-      nodes.delete(child);
+      prune(child);
       changeHandler?.([{ type: "deleted", parent, child }]);
     },
     emitInvalidated(id) {

--- a/editor/app/(dev)/ui/components/tree-view/_async-fixture.ts
+++ b/editor/app/(dev)/ui/components/tree-view/_async-fixture.ts
@@ -1,0 +1,261 @@
+import type {
+  AsyncChangeEvent,
+  AsyncTreeEntry,
+  AsyncTreeProvider,
+} from "@grida/tree-view/async";
+import type { NodeId } from "@grida/tree-view";
+import type { DemoMeta } from "./_fixtures";
+
+/**
+ * The shape of the in-memory FS the fake provider serves. Mirrors a
+ * trimmed VS Code project tree so the existing `VSCodeRow` renderer
+ * has the right `meta.kind` ("folder" | "file") to switch on.
+ */
+interface FakeNode {
+  id: NodeId;
+  parent: NodeId | null;
+  children: NodeId[];
+  meta: DemoMeta;
+}
+
+const SEED: FakeNode[] = [
+  // Root is auto-loaded; everything below it is lazy.
+  {
+    id: "/",
+    parent: null,
+    children: ["/src", "/public", "/package.json", "/README.md"],
+    meta: { kind: "folder", label: "my-app" },
+  },
+  {
+    id: "/src",
+    parent: "/",
+    children: ["/src/components", "/src/app", "/src/lib", "/src/index.ts"],
+    meta: { kind: "folder", label: "src" },
+  },
+  {
+    id: "/src/components",
+    parent: "/src",
+    children: ["/src/components/Button.tsx", "/src/components/Card.tsx"],
+    meta: { kind: "folder", label: "components" },
+  },
+  {
+    id: "/src/components/Button.tsx",
+    parent: "/src/components",
+    children: [],
+    meta: { kind: "file", label: "Button.tsx", ext: "tsx" },
+  },
+  {
+    id: "/src/components/Card.tsx",
+    parent: "/src/components",
+    children: [],
+    meta: { kind: "file", label: "Card.tsx", ext: "tsx", dirty: true },
+  },
+  {
+    id: "/src/app",
+    parent: "/src",
+    children: [
+      "/src/app/page.tsx",
+      "/src/app/layout.tsx",
+      "/src/app/globals.css",
+    ],
+    meta: { kind: "folder", label: "app" },
+  },
+  {
+    id: "/src/app/page.tsx",
+    parent: "/src/app",
+    children: [],
+    meta: { kind: "file", label: "page.tsx", ext: "tsx" },
+  },
+  {
+    id: "/src/app/layout.tsx",
+    parent: "/src/app",
+    children: [],
+    meta: { kind: "file", label: "layout.tsx", ext: "tsx" },
+  },
+  {
+    id: "/src/app/globals.css",
+    parent: "/src/app",
+    children: [],
+    meta: { kind: "file", label: "globals.css", ext: "css" },
+  },
+  {
+    id: "/src/lib",
+    parent: "/src",
+    children: ["/src/lib/utils.ts", "/src/lib/api.ts"],
+    meta: { kind: "folder", label: "lib" },
+  },
+  {
+    id: "/src/lib/utils.ts",
+    parent: "/src/lib",
+    children: [],
+    meta: { kind: "file", label: "utils.ts", ext: "ts" },
+  },
+  {
+    id: "/src/lib/api.ts",
+    parent: "/src/lib",
+    children: [],
+    meta: { kind: "file", label: "api.ts", ext: "ts", dirty: true },
+  },
+  {
+    id: "/src/index.ts",
+    parent: "/src",
+    children: [],
+    meta: { kind: "file", label: "index.ts", ext: "ts" },
+  },
+  {
+    id: "/public",
+    parent: "/",
+    children: ["/public/favicon.ico", "/public/vercel.svg"],
+    meta: { kind: "folder", label: "public" },
+  },
+  {
+    id: "/public/favicon.ico",
+    parent: "/public",
+    children: [],
+    meta: { kind: "file", label: "favicon.ico", ext: "ico" },
+  },
+  {
+    id: "/public/vercel.svg",
+    parent: "/public",
+    children: [],
+    meta: { kind: "file", label: "vercel.svg", ext: "svg" },
+  },
+  {
+    id: "/package.json",
+    parent: "/",
+    children: [],
+    meta: { kind: "file", label: "package.json", ext: "json" },
+  },
+  {
+    id: "/README.md",
+    parent: "/",
+    children: [],
+    meta: { kind: "file", label: "README.md", ext: "md" },
+  },
+];
+
+/**
+ * External controls the demo panel uses to drive the fake FS — change
+ * latency on the fly, force the next listing to fail, push a watcher
+ * event.
+ */
+export interface FakeFsControls {
+  setLatency(ms: number): void;
+  setFailNext(fail: boolean): void;
+  emitCreated(parent: NodeId, child: FakeNode): void;
+  emitDeleted(parent: NodeId, child: NodeId): void;
+  emitInvalidated(id: NodeId): void;
+  /** A stable, browser-visible snapshot of the underlying FS state for
+   *  the demo's "Create file" button to pick parent ids from. */
+  listKnownFolders(): NodeId[];
+}
+
+export interface FakeFsProvider {
+  provider: AsyncTreeProvider<DemoMeta>;
+  controls: FakeFsControls;
+}
+
+export function createFakeFsProvider(init?: {
+  latencyMs?: number;
+}): FakeFsProvider {
+  let latencyMs = init?.latencyMs ?? 600;
+  let failNext = false;
+  const nodes = new Map<NodeId, FakeNode>();
+  for (const n of SEED) nodes.set(n.id, { ...n, children: [...n.children] });
+
+  let changeHandler:
+    | ((events: ReadonlyArray<AsyncChangeEvent<DemoMeta>>) => void)
+    | null = null;
+
+  const provider: AsyncTreeProvider<DemoMeta> = {
+    rootId: "/",
+    hasChildren(id) {
+      return nodes.get(id)?.meta.kind === "folder";
+    },
+    listChildren(id, signal) {
+      return new Promise((resolve, reject) => {
+        const fail = failNext;
+        if (failNext) failNext = false;
+        const t = setTimeout(() => {
+          if (signal.aborted) return;
+          if (fail) {
+            reject(new Error(`EPERM: simulated permission denied for ${id}`));
+            return;
+          }
+          const node = nodes.get(id);
+          if (!node) {
+            reject(new Error(`ENOENT: ${id}`));
+            return;
+          }
+          const entries: AsyncTreeEntry<DemoMeta>[] = node.children.map(
+            (cid) => {
+              const c = nodes.get(cid)!;
+              return {
+                id: cid,
+                hasChildren: c.meta.kind === "folder",
+                meta: c.meta,
+              };
+            }
+          );
+          resolve(entries);
+        }, latencyMs);
+        signal.addEventListener("abort", () => {
+          clearTimeout(t);
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    },
+    subscribeChanges(handler) {
+      changeHandler = handler;
+      return () => {
+        if (changeHandler === handler) changeHandler = null;
+      };
+    },
+    getRootMeta() {
+      return nodes.get("/")?.meta;
+    },
+  };
+
+  const controls: FakeFsControls = {
+    setLatency(ms) {
+      latencyMs = Math.max(0, ms);
+    },
+    setFailNext(fail) {
+      failNext = fail;
+    },
+    emitCreated(parent, child) {
+      nodes.set(child.id, child);
+      const p = nodes.get(parent);
+      if (p && !p.children.includes(child.id)) p.children.push(child.id);
+      changeHandler?.([
+        {
+          type: "created",
+          parent,
+          entry: {
+            id: child.id,
+            hasChildren: child.meta.kind === "folder",
+            meta: child.meta,
+          },
+        },
+      ]);
+    },
+    emitDeleted(parent, child) {
+      const p = nodes.get(parent);
+      if (p) p.children = p.children.filter((c) => c !== child);
+      nodes.delete(child);
+      changeHandler?.([{ type: "deleted", parent, child }]);
+    },
+    emitInvalidated(id) {
+      changeHandler?.([{ type: "invalidated", id }]);
+    },
+    listKnownFolders() {
+      const out: NodeId[] = [];
+      for (const [id, n] of nodes) {
+        if (n.meta.kind === "folder") out.push(id);
+      }
+      return out;
+    },
+  };
+
+  return { provider, controls };
+}

--- a/editor/app/(dev)/ui/components/tree-view/_showcase.tsx
+++ b/editor/app/(dev)/ui/components/tree-view/_showcase.tsx
@@ -10,6 +10,11 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 import { modeFromEvent, TreeController, type NodeId } from "@grida/tree-view";
+import {
+  bindAsyncTreeController,
+  createAsyncTreeSource,
+  type AsyncTreeSourceHandle,
+} from "@grida/tree-view/async";
 import { TreeProvider, useTree, useTreeSnapshot } from "@grida/tree-view/react";
 import {
   SvgEditorCanvas,
@@ -26,10 +31,15 @@ import {
 import { Resources } from "@/resources";
 import Image from "next/image";
 import {
+  AlertCircleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   CommandIcon,
   FileCode2Icon,
+  FileIcon,
+  FolderIcon,
+  Loader2Icon,
+  RefreshCwIcon,
   SearchIcon,
   SettingsIcon,
   TerminalIcon,
@@ -41,6 +51,7 @@ import {
   buildVSCodeFixture,
   type DemoMeta,
 } from "./_fixtures";
+import { createFakeFsProvider, type FakeFsControls } from "./_async-fixture";
 import { DemoPanel, type RenderRowArgs } from "./_panel";
 import {
   applyIntent,
@@ -865,6 +876,344 @@ export function FinderShowcase() {
             />
           </MacOSDesktop>
         </div>
+      </div>
+    </section>
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// VS Code (async) — the SAME explorer chrome, but the children of each
+// folder are listed asynchronously through `@grida/tree-view/async`.
+// Proof-of-recipe for the README; mirrors what an Electron file explorer
+// or a REST resource panel would wire up.
+// ───────────────────────────────────────────────────────────────────────────
+
+interface AsyncRowProps {
+  args: RenderRowArgs;
+  handle: AsyncTreeSourceHandle<DemoMeta>;
+}
+
+function AsyncVSCodeRow({ args, handle }: AsyncRowProps) {
+  const { row } = args;
+  const ctrl = useTree<DemoMeta>();
+  // Subscribe to source version so load-state transitions repaint. The
+  // load-state itself lives off-meta; the version is the change signal.
+  useTreeSnapshot<DemoMeta, number>((c) => c.source.getVersion());
+  const meta = (() => {
+    try {
+      return ctrl.source.getNode(row.id).meta;
+    } catch {
+      return undefined;
+    }
+  })();
+  const selected = useTreeSnapshot<DemoMeta, boolean>((c) =>
+    c.getSelection().includes(row.id)
+  );
+  // Guard: a watcher event can prune a row id between the rows
+  // snapshot and this render. Use hasNode to avoid throwing.
+  const known = handle.hasNode(row.id);
+  const loadState = known ? handle.getLoadState(row.id) : "loaded";
+  const error = known ? handle.getError(row.id) : null;
+  const isFolder = meta?.kind === "folder";
+  const label = meta?.label ?? row.id;
+  return (
+    <div
+      data-tree-row-id={row.id}
+      data-row-depth={row.depth}
+      data-state={
+        selected ? "selected" : loadState === "error" ? "error" : "idle"
+      }
+      role="treeitem"
+      aria-selected={selected}
+      aria-busy={loadState === "loading" || undefined}
+      tabIndex={-1}
+      onClick={(e) => {
+        ctrl.focus(row.id);
+        ctrl.select([row.id], modeFromEvent(e));
+        if (isFolder) ctrl.toggle(row.id);
+      }}
+      className="relative flex h-[22px] items-center gap-1.5 px-2 text-[13px] leading-none select-none cursor-pointer font-normal text-[#CCCCCC] data-[state=selected]:bg-[#04395E] data-[state=selected]:text-white data-[state=error]:text-[#F48771] data-[state=idle]:hover:bg-[#2A2D2E]"
+      style={{ paddingLeft: 8 + row.depth * 14 }}
+    >
+      {/* indent guides */}
+      {Array.from({ length: row.depth }).map((_, i) => (
+        <span
+          key={i}
+          className="absolute top-0 bottom-0 w-px bg-[#404040]"
+          style={{ left: 8 + i * 14 + 6 }}
+        />
+      ))}
+      <span className="inline-flex size-3 items-center justify-center text-[#CCCCCC]">
+        {isFolder ? (
+          row.isExpanded ? (
+            <ChevronDownIcon className="size-3" />
+          ) : (
+            <ChevronRightIcon className="size-3" />
+          )
+        ) : null}
+      </span>
+      {isFolder ? (
+        <FolderIcon className="size-3.5 text-[#DCB67A]" />
+      ) : (
+        <FileIcon className="size-3.5 text-[#75BEFF]" />
+      )}
+      <span className="truncate flex-1" title={String(row.id)}>
+        {label}
+      </span>
+      {loadState === "loading" && (
+        <Loader2Icon
+          className="size-3 animate-spin text-[#9DA5B4]"
+          aria-label="Loading"
+        />
+      )}
+      {loadState === "error" && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            handle.invalidate(row.id);
+            handle.load(row.id);
+          }}
+          title={error instanceof Error ? error.message : "Error"}
+          className="inline-flex size-4 items-center justify-center text-[#F48771] hover:text-white"
+          aria-label="Retry"
+        >
+          <AlertCircleIcon className="size-3" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function AsyncControls({
+  controls,
+  handle,
+  controller,
+}: {
+  controls: FakeFsControls;
+  handle: AsyncTreeSourceHandle<DemoMeta>;
+  controller: TreeController<DemoMeta>;
+}) {
+  const [latency, setLatencyState] = React.useState(600);
+  const [createCounter, setCreateCounter] = React.useState(1);
+  const setLatency = (v: number) => {
+    setLatencyState(v);
+    controls.setLatency(v);
+  };
+  return (
+    <div
+      className={`flex ${STAGE_H} flex-col gap-4 overflow-auto rounded-lg border border-[#3C3C3C] bg-[#1E1E1E] p-4 text-[12px] text-[#CCCCCC]`}
+    >
+      <div>
+        <div className="mb-1 text-[11px] uppercase tracking-wider text-[#9DA5B4]">
+          What this is
+        </div>
+        <p className="text-[#CCCCCC]/85 leading-relaxed">
+          Same <code>TreeController</code> as the static VS Code section above.
+          Children are listed async via
+          <code className="mx-1 rounded bg-[#252526] px-1 py-0.5">
+            @grida/tree-view/async
+          </code>
+          . Expand a folder → spinner; collapse mid-load → abort; toggle{" "}
+          <em>Fail next</em> → error row with retry; press{" "}
+          <em>Emit watcher event</em> → tree mutates without re-listing.
+        </p>
+      </div>
+
+      <div>
+        <div className="mb-2 text-[11px] uppercase tracking-wider text-[#9DA5B4]">
+          Latency · {latency} ms
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={2000}
+          step={50}
+          value={latency}
+          onChange={(e) => setLatency(Number(e.target.value))}
+          className="w-full accent-[#007ACC]"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => controls.setFailNext(true)}
+          className="rounded border border-[#3C3C3C] bg-[#252526] px-2.5 py-1 text-[11px] text-[#CCCCCC] hover:bg-[#2A2D2E]"
+        >
+          Fail next listing
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            const focused = controller.getFocused();
+            const target = focused ?? "/";
+            handle.invalidate(target);
+            // Re-load only if currently expanded; otherwise wait for the
+            // next expansion.
+            if (controller.isExpanded(target) || target === "/") {
+              handle.load(target);
+            }
+          }}
+          className="rounded border border-[#3C3C3C] bg-[#252526] px-2.5 py-1 text-[11px] text-[#CCCCCC] hover:bg-[#2A2D2E]"
+        >
+          <RefreshCwIcon className="mr-1 inline size-3" />
+          Refresh focused
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            const id = `/src/lib/note-${createCounter}.md`;
+            setCreateCounter((c) => c + 1);
+            controls.emitCreated("/src/lib", {
+              id,
+              parent: "/src/lib",
+              children: [],
+              meta: {
+                kind: "file",
+                label: `note-${createCounter}.md`,
+                ext: "md",
+              },
+            });
+          }}
+          className="rounded border border-[#3C3C3C] bg-[#252526] px-2.5 py-1 text-[11px] text-[#CCCCCC] hover:bg-[#2A2D2E]"
+        >
+          Emit watcher event (create)
+        </button>
+        <button
+          type="button"
+          onClick={() => controls.emitInvalidated("/src/app")}
+          className="rounded border border-[#3C3C3C] bg-[#252526] px-2.5 py-1 text-[11px] text-[#CCCCCC] hover:bg-[#2A2D2E]"
+        >
+          Emit invalidate (/src/app)
+        </button>
+      </div>
+
+      <div className="rounded border border-[#3C3C3C] bg-[#252526] p-3 leading-relaxed">
+        <div className="mb-1 font-mono text-[11px] text-[#9DA5B4]">
+          handle.getLoadState(focused)
+        </div>
+        <FocusedLoadState handle={handle} />
+      </div>
+
+      <div className="mt-auto text-[11px] text-[#9DA5B4]">
+        Producer interface: <code>hasChildren</code> +{" "}
+        <code>listChildren(id, signal)</code> + <code>subscribeChanges?</code>.
+        The same shape works for <code>fs.promises.readdir</code>, an HTTP
+        endpoint, or OPFS.
+      </div>
+    </div>
+  );
+}
+
+function FocusedLoadState({
+  handle,
+}: {
+  handle: AsyncTreeSourceHandle<DemoMeta>;
+}) {
+  const focused = useTreeSnapshot<DemoMeta, NodeId | null>((c) =>
+    c.getFocused()
+  );
+  // Re-render on source-version bumps so load-state stays fresh.
+  useTreeSnapshot<DemoMeta, number>((c) => c.source.getVersion());
+  if (!focused) {
+    return <span className="text-[#CCCCCC]/60">(focus a row)</span>;
+  }
+  // Guard: focused may briefly reference an id pruned by a watcher
+  // event before the controller's focus catches up.
+  if (!handle.hasNode(focused)) {
+    return (
+      <span className="text-[#CCCCCC]/60 font-mono text-[11px]">
+        (unknown · {String(focused)})
+      </span>
+    );
+  }
+  const state = handle.getLoadState(focused);
+  const err = handle.getError(focused);
+  const color =
+    state === "loading"
+      ? "text-[#75BEFF]"
+      : state === "error"
+        ? "text-[#F48771]"
+        : state === "loaded"
+          ? "text-[#89D185]"
+          : "text-[#CCCCCC]";
+  return (
+    <div className="font-mono text-[11px]">
+      <span className={color}>{state}</span>
+      <span className="text-[#CCCCCC]/60"> · {String(focused)}</span>
+      {err instanceof Error && (
+        <div className="mt-1 text-[#F48771]/80">{err.message}</div>
+      )}
+    </div>
+  );
+}
+
+export function VSCodeAsyncShowcase() {
+  // Source + controller + binding are constructed once per mount. The
+  // useMemo dependency list is empty because all state lives inside
+  // the handle / controller.
+  const { controller, handle, controls } = React.useMemo(() => {
+    const { provider, controls } = createFakeFsProvider({ latencyMs: 600 });
+    const handle = createAsyncTreeSource(provider);
+    const controller = new TreeController<DemoMeta>({
+      source: handle.source,
+    });
+    return { controller, handle, controls };
+  }, []);
+  React.useEffect(() => {
+    const unbind = bindAsyncTreeController(controller, handle);
+    return () => {
+      unbind();
+      handle.dispose();
+      controller.dispose();
+    };
+  }, [controller, handle]);
+  return (
+    <section className="border-t border-zinc-200 py-16">
+      <div className="mx-auto max-w-6xl px-4">
+        <SectionHeader
+          eyebrow="VS Code (async)"
+          icon={Resources.assets.macos.icons.vscode}
+          iconAlt="VS Code"
+        >
+          Same controller, lazy children. Expand a folder to fire{" "}
+          <code>listChildren</code>; collapse mid-load aborts via the{" "}
+          <code>AbortSignal</code> the provider receives. Errors land on a
+          side-channel <code>getLoadState</code> — your <code>meta</code> stays
+          clean.
+        </SectionHeader>
+        <TreeProvider controller={controller}>
+          <SplitStage
+            frame="bg-[#141416] ring-1 ring-white/5"
+            tree={
+              <div
+                className={`flex ${STAGE_H} flex-col overflow-hidden rounded-lg border border-[#3C3C3C] bg-[#252526] font-mono shadow-lg`}
+              >
+                <div className="flex items-center gap-2 border-b border-[#3C3C3C] bg-[#333333] px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-[#CCCCCC]">
+                  <TerminalIcon className="size-3" />
+                  <span>Explorer · async</span>
+                </div>
+                <DemoPanel
+                  controller={controller}
+                  indentBase={8}
+                  indentStep={14}
+                  className="min-h-0 flex-1 !border-0 !bg-[#252526]"
+                  renderRow={(args) => (
+                    <AsyncVSCodeRow args={args} handle={handle} />
+                  )}
+                />
+              </div>
+            }
+            editor={
+              <AsyncControls
+                controls={controls}
+                handle={handle}
+                controller={controller}
+              />
+            }
+          />
+        </TreeProvider>
       </div>
     </section>
   );

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/tree-view/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/tree-view/page.tsx
@@ -5,6 +5,7 @@ import {
   FinderShowcase,
   GridaShowcase,
   NotionShowcase,
+  VSCodeAsyncShowcase,
   VSCodeShowcase,
 } from "@/app/(dev)/ui/components/tree-view/_showcase";
 import { CustomSourcePanel } from "@/app/(dev)/ui/components/tree-view/_custom-source";
@@ -94,6 +95,7 @@ export default function TreeViewLandingPage() {
       <GridaShowcase />
       <FigmaShowcase />
       <VSCodeShowcase />
+      <VSCodeAsyncShowcase />
       <NotionShowcase />
       <FinderShowcase />
 

--- a/packages/grida-tree-view/README.md
+++ b/packages/grida-tree-view/README.md
@@ -168,7 +168,7 @@ That's the entire surface a basic layer panel needs. Drag, keymap,
 constraints, virtualization, and grouping highlights are opt-in
 additions documented below.
 
-## Two entry points
+## Three entry points
 
 ```ts
 // Core: state, math, intents — pure TypeScript, no React, no DOM.
@@ -181,12 +181,24 @@ import {
 
 // React bindings: <TreeProvider> + useTree + useTreeSnapshot.
 import { TreeProvider, useTree, useTreeSnapshot } from "@grida/tree-view/react";
+
+// Async children: turn an async listing (fs, REST, OPFS, …) into a
+// synchronous TreeSource the existing controller consumes.
+import {
+  createAsyncTreeSource,
+  bindAsyncTreeController,
+  type AsyncTreeProvider,
+} from "@grida/tree-view/async";
 ```
 
 `react` is an optional peer (`>=18`). The `/react` subpath is the **only**
 React surface — there are no per-row hooks shipped. The intended pattern
 is `useEditorState`-style: one provider, one subscription hook,
 consumers select whatever slice they want.
+
+`/async` is the adapter for lazy / remote / filesystem-shaped sources.
+See [Wrapping an async store](#wrapping-an-async-store-fs-rest-opfs)
+for the recipe.
 
 ### Typed React context (recommended for typed apps)
 
@@ -397,6 +409,95 @@ version bumps, key the cache on the underlying node — the adapter object
 stays stable as long as the source does. The WeakMap also collects
 entries automatically as the host drops its nodes, so there's no
 explicit invalidation step on the consumer side.
+
+### Wrapping an async store (FS, REST, OPFS)
+
+Sometimes the children of a container aren't in memory yet — a folder
+on disk, a paginated REST collection, an OPFS directory, an S3 prefix.
+The package's optional `/async` subpath ships a tiny adapter that
+turns an async listing into a synchronous `TreeSource` the existing
+`TreeController` consumes unchanged. Load state stays on a side
+channel so your `meta` type doesn't grow a `loadState` field.
+
+```ts
+import {
+  createAsyncTreeSource,
+  bindAsyncTreeController,
+  type AsyncTreeProvider,
+} from "@grida/tree-view/async";
+
+interface FsMeta {
+  name: string;
+}
+
+const provider: AsyncTreeProvider<FsMeta> = {
+  rootId: "/",
+  // Sync chevron hint. Return `true` for "probably a container, I'll
+  // confirm on the first listing" — never return a third state.
+  hasChildren: (id) => isLikelyDir(id),
+
+  // The sole async point. Throw / reject to enter `error`.
+  async listChildren(id, signal) {
+    const entries = await window.fs.readdir(id, { signal });
+    return entries.map((e) => ({
+      id: e.path,
+      hasChildren: e.isDirectory,
+      meta: { name: e.name },
+    }));
+  },
+
+  // Optional. Wire your watcher (chokidar, FileSystemObserver, SSE…).
+  subscribeChanges(handler) {
+    return window.fs.watch("/", (events) => handler(events));
+  },
+
+  getRootMeta: () => ({ name: "/" }),
+};
+
+const handle = createAsyncTreeSource(provider);
+const controller = new TreeController({ source: handle.source });
+// Wire expand → load, collapse → abort.
+const unbind = bindAsyncTreeController(controller, handle);
+
+// In your row renderer, paint a spinner / error per row:
+//   const state = handle.getLoadState(row.id);
+//   const err = handle.getError(row.id);
+//   <span aria-busy={state === "loading"}>{meta.name}</span>
+```
+
+**Load state lives on the handle, not in `meta`.** The handle exposes
+`getLoadState(id)` returning `"unloaded" | "loading" | "loaded" | "error"`
+and `getError(id)` for the rejection reason. Load-state transitions
+bump `source.getVersion()`, so any `useTreeSnapshot` selector re-runs
+naturally; in the selector, read the handle.
+
+**Change events.** If your watcher emits granular events (created /
+changed / deleted), pass them through. If it can only tell you
+"something under X changed", emit `{ type: "invalidated", id: X }`
+and the adapter drops the cache so the next expand re-lists.
+Currently-visible children stay until the re-listing commits a
+replacement (VS Code semantics).
+
+**Abort semantics.** Collapsing a node with an in-flight `listChildren`
+aborts via the `AbortSignal` you receive in the producer. The node
+returns to `unloaded`; a subsequent expand re-issues the listing. The
+adapter dedupes in-flight calls — calling `load(id)` twice while one
+is in flight is a no-op.
+
+**What `/async` deliberately does NOT do:**
+
+- No URI / path parsing. `NodeId` stays opaque.
+- No `stat`-equivalent or `readFile`. The producer is yours.
+- No retry / backoff. After `error`, call `handle.load(id)` to retry.
+- No synthetic placeholder rows. The row renderer paints inline
+  spinners using `handle.getLoadState(row.id)`. Keyboard focus on
+  unfilled rows + `aria-busy` are one-liners on the consumer side.
+- No pagination cursor model. A future extension if a real consumer
+  needs it.
+- No `FsMeta<T>` wrapper. Your `meta` stays clean.
+
+The live demo for this recipe is the "VS Code (async)" panel at
+[`grida.co/packages/@grida/tree-view`](https://grida.co/packages/@grida/tree-view).
 
 ### External selection adapter
 

--- a/packages/grida-tree-view/__tests__/async/_helpers.ts
+++ b/packages/grida-tree-view/__tests__/async/_helpers.ts
@@ -1,0 +1,141 @@
+import type {
+  AsyncChangeEvent,
+  AsyncTreeEntry,
+  AsyncTreeProvider,
+} from "../../src/async";
+import type { NodeId } from "../..";
+
+interface FakeNode {
+  id: NodeId;
+  hasChildren: boolean;
+  children: NodeId[];
+  meta: { label: string };
+}
+
+export interface FakeProviderControls<TMeta = { label: string }> {
+  provider: AsyncTreeProvider<TMeta>;
+  /** Resolve the next in-flight listChildren for `id` (FIFO). */
+  resolve(id: NodeId): Promise<void>;
+  /** Reject the next in-flight listChildren for `id`. */
+  reject(id: NodeId, err: unknown): Promise<void>;
+  /** Number of unresolved listChildren calls for `id`. */
+  pending(id: NodeId): number;
+  /** Emit watcher events to the subscriber, if any. */
+  emit(events: ReadonlyArray<AsyncChangeEvent<TMeta>>): void;
+  /** Whether the most-recent listChildren for `id` aborted. */
+  wasAborted(id: NodeId): boolean;
+}
+
+/**
+ * Build a controllable fake `AsyncTreeProvider` backed by an in-memory
+ * tree. `listChildren` returns a Promise the test resolves manually so
+ * ordering of state transitions is observable. Mirrors the discipline
+ * of the package's other unit tests — deterministic, no real I/O.
+ */
+export function createFakeFsProvider(init: {
+  rootId?: NodeId;
+  tree: ReadonlyArray<FakeNode>;
+}): FakeProviderControls {
+  const rootId = init.rootId ?? "<root>";
+  const map = new Map<NodeId, FakeNode>();
+  for (const n of init.tree) map.set(n.id, n);
+
+  type Pending = {
+    resolve: (
+      entries: ReadonlyArray<AsyncTreeEntry<{ label: string }>>
+    ) => void;
+    reject: (err: unknown) => void;
+    aborted: boolean;
+  };
+  const pending = new Map<NodeId, Pending[]>();
+  const abortedSnapshot = new Map<NodeId, boolean>();
+  let changeHandler:
+    | ((events: ReadonlyArray<AsyncChangeEvent<{ label: string }>>) => void)
+    | null = null;
+
+  const provider: AsyncTreeProvider<{ label: string }> = {
+    rootId,
+    hasChildren(id) {
+      return map.get(id)?.hasChildren ?? false;
+    },
+    listChildren(id, signal) {
+      return new Promise((resolve, reject) => {
+        const slot: Pending = {
+          resolve: (entries) => resolve(entries),
+          reject,
+          aborted: false,
+        };
+        const queue = pending.get(id) ?? [];
+        queue.push(slot);
+        pending.set(id, queue);
+        signal.addEventListener("abort", () => {
+          slot.aborted = true;
+          abortedSnapshot.set(id, true);
+          // Remove this slot from the queue — `pending(id)` must reflect
+          // outstanding requests, not historical ones.
+          const q = pending.get(id);
+          if (q) {
+            const idx = q.indexOf(slot);
+            if (idx >= 0) q.splice(idx, 1);
+          }
+          // Reject so the source's signal-aware error branch resets to
+          // `unloaded`.
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    },
+    subscribeChanges(handler) {
+      changeHandler = handler;
+      return () => {
+        changeHandler = null;
+      };
+    },
+    getRootMeta() {
+      return map.get(rootId)?.meta;
+    },
+  };
+
+  function flush(): Promise<void> {
+    // Two microtask flushes: one for the resolver, one for the source's
+    // .then chain.
+    return Promise.resolve().then(() => Promise.resolve());
+  }
+
+  return {
+    provider,
+    async resolve(id) {
+      const queue = pending.get(id);
+      if (!queue || queue.length === 0) {
+        throw new Error(`no pending listChildren for ${id}`);
+      }
+      const slot = queue.shift()!;
+      const node = map.get(id);
+      const entries: AsyncTreeEntry<{ label: string }>[] = (
+        node?.children ?? []
+      ).map((cid) => {
+        const c = map.get(cid)!;
+        return { id: cid, hasChildren: c.hasChildren, meta: c.meta };
+      });
+      slot.resolve(entries);
+      await flush();
+    },
+    async reject(id, err) {
+      const queue = pending.get(id);
+      if (!queue || queue.length === 0) {
+        throw new Error(`no pending listChildren for ${id}`);
+      }
+      const slot = queue.shift()!;
+      slot.reject(err);
+      await flush();
+    },
+    pending(id) {
+      return pending.get(id)?.length ?? 0;
+    },
+    emit(events) {
+      changeHandler?.(events);
+    },
+    wasAborted(id) {
+      return abortedSnapshot.get(id) ?? false;
+    },
+  };
+}

--- a/packages/grida-tree-view/__tests__/async/abort.test.ts
+++ b/packages/grida-tree-view/__tests__/async/abort.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createAsyncTreeSource } from "../../src/async";
+import {
+  createAsyncTreeSource,
+  type AsyncTreeEntry,
+  type AsyncTreeProvider,
+} from "../../src/async";
 import { createFakeFsProvider } from "./_helpers";
 
 describe("createAsyncTreeSource: abort semantics", () => {
@@ -84,6 +88,38 @@ describe("createAsyncTreeSource: abort semantics", () => {
     handle.dispose();
     expect(fp.wasAborted("a")).toBe(true);
     expect(fp.wasAborted("b")).toBe(true);
+  });
+
+  it("provider that resolves after abort still cleans up — load(id) can retry", async () => {
+    // Regression for Codex P2: if a custom IPC/REST wrapper ignores
+    // the AbortSignal and resolves anyway, the source must still
+    // reset loadState/inflight so a subsequent load() fires.
+    let captured: {
+      resolve: (entries: readonly AsyncTreeEntry<{ label: string }>[]) => void;
+    } | null = null;
+    const ignoresAbort: AsyncTreeProvider<{ label: string }> = {
+      rootId: "<root>",
+      hasChildren: () => true,
+      listChildren: (_id, _signal) =>
+        new Promise((resolve) => {
+          captured = { resolve };
+          // Deliberately ignore _signal — simulate a misbehaved producer.
+        }),
+    };
+    const handle = createAsyncTreeSource(ignoresAbort, { autoLoadRoot: false });
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
+    handle.abort("<root>");
+    // No reject ever fires from the provider — instead it resolves
+    // late as if the abort never happened.
+    captured!.resolve([{ id: "a", hasChildren: false, meta: { label: "a" } }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+    expect(handle.hasNode("a")).toBe(false);
+    // A subsequent load must fire — would no-op if loadState was stuck.
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
   });
 
   it("abort on a non-loading id is a no-op", () => {

--- a/packages/grida-tree-view/__tests__/async/abort.test.ts
+++ b/packages/grida-tree-view/__tests__/async/abort.test.ts
@@ -39,31 +39,40 @@ describe("createAsyncTreeSource: abort semantics", () => {
     expect(handle.getLoadState("<root>")).toBe("loaded");
   });
 
-  it("abort then load before microtask flush is safe", async () => {
-    // Rapid abort+load sequence: the rejection handler from the first
-    // call lands after the second load has started. The source must
-    // not stomp the second load's "loading" state on the first's
-    // signal-aware reset.
+  it("abort then immediate load — the second load is not stomped by the first's late rejection", async () => {
+    // The race: load1 → abort → load2 all in one synchronous tick.
+    // The first call's rejection lands as a microtask AFTER load2
+    // has started. The source must:
+    //   1. let load2 actually fire (loadState reset synchronously by
+    //      abort, so load2's "if loading return" guard doesn't trip),
+    //   2. NOT stomp load2's "loading" state when the first's
+    //      rejection later sees signal.aborted.
     const fp = createFakeFsProvider({
       tree: [
         {
           id: "<root>",
           hasChildren: true,
-          children: [],
+          children: ["a"],
           meta: { label: "root" },
         },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
       ],
     });
     const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
     handle.load("<root>");
     handle.abort("<root>");
-    // Pending count: 1 (first call still queued). The store cleared
-    // its inflight entry before the rejection lands.
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
+
     await Promise.resolve();
     await Promise.resolve();
-    // After abort settles, state is unloaded; pending fake queue still
-    // has the resolver but it's been rejected so it's no-op for the test.
-    expect(handle.getLoadState("<root>")).toBe("unloaded");
+    // The first rejection has now landed; it must NOT have stomped
+    // the second load's "loading" state.
+    expect(handle.getLoadState("<root>")).toBe("loading");
+
+    await fp.resolve("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+    expect(handle.source.getNode("<root>").children).toEqual(["a"]);
   });
 
   it("dispose aborts every in-flight listChildren", async () => {

--- a/packages/grida-tree-view/__tests__/async/abort.test.ts
+++ b/packages/grida-tree-view/__tests__/async/abort.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { createAsyncTreeSource } from "../../src/async";
+import { createFakeFsProvider } from "./_helpers";
+
+describe("createAsyncTreeSource: abort semantics", () => {
+  it("abort(id) reverts loadState to unloaded; later load() re-fires", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
+
+    handle.abort("<root>");
+    // The Promise rejection runs on a microtask; wait for it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+    expect(fp.wasAborted("<root>")).toBe(true);
+
+    // Now retry — a fresh listChildren must run.
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
+    expect(fp.pending("<root>")).toBe(1);
+    await fp.resolve("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+  });
+
+  it("abort then load before microtask flush is safe", async () => {
+    // Rapid abort+load sequence: the rejection handler from the first
+    // call lands after the second load has started. The source must
+    // not stomp the second load's "loading" state on the first's
+    // signal-aware reset.
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+    handle.load("<root>");
+    handle.abort("<root>");
+    // Pending count: 1 (first call still queued). The store cleared
+    // its inflight entry before the rejection lands.
+    await Promise.resolve();
+    await Promise.resolve();
+    // After abort settles, state is unloaded; pending fake queue still
+    // has the resolver but it's been rejected so it's no-op for the test.
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+  });
+
+  it("dispose aborts every in-flight listChildren", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: [], meta: { label: "a" } },
+        { id: "b", hasChildren: true, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.load("a");
+    handle.load("b");
+    expect(fp.pending("a")).toBe(1);
+    expect(fp.pending("b")).toBe(1);
+    handle.dispose();
+    expect(fp.wasAborted("a")).toBe(true);
+    expect(fp.wasAborted("b")).toBe(true);
+  });
+
+  it("abort on a non-loading id is a no-op", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: false,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    expect(() => handle.abort("<root>")).not.toThrow();
+    expect(() => handle.abort("nonexistent")).not.toThrow();
+  });
+});

--- a/packages/grida-tree-view/__tests__/async/change-events.test.ts
+++ b/packages/grida-tree-view/__tests__/async/change-events.test.ts
@@ -262,6 +262,52 @@ describe("createAsyncTreeSource: change events", () => {
     expect(handle.source.getNode("b").children).toEqual(["x"]);
   });
 
+  it("commitListing pruning: container → leaf transition discards cached descendants", async () => {
+    // Regression for Codex P2: when a re-list returns an existing
+    // child with hasChildren=false after it was previously cached
+    // as a container, the cached children + descendant records must
+    // be pruned (not just the hint flipped).
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        {
+          id: "a",
+          hasChildren: true,
+          children: ["a/x", "a/y"],
+          meta: { label: "a" },
+        },
+        { id: "a/x", hasChildren: false, children: [], meta: { label: "x" } },
+        { id: "a/y", hasChildren: false, children: [], meta: { label: "y" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.load("a");
+    await fp.resolve("a");
+    expect(handle.source.getNode("a").children).toEqual(["a/x", "a/y"]);
+    expect(handle.hasNode("a/x")).toBe(true);
+    expect(handle.hasNode("a/y")).toBe(true);
+
+    // Re-list root: 'a' is now a leaf in the producer's view.
+    fp.emit([
+      {
+        type: "created",
+        parent: "<root>",
+        entry: { id: "a", hasChildren: false, meta: { label: "a" } },
+      },
+    ]);
+
+    expect(handle.source.getNode("a").children).toEqual([]);
+    expect(handle.source.isContainer!("a")).toBe(false);
+    expect(handle.hasNode("a/x")).toBe(false);
+    expect(handle.hasNode("a/y")).toBe(false);
+  });
+
   it("re-listing prunes children no longer present", async () => {
     const fp = createFakeFsProvider({
       tree: [

--- a/packages/grida-tree-view/__tests__/async/change-events.test.ts
+++ b/packages/grida-tree-view/__tests__/async/change-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createAsyncTreeSource } from "../../src/async";
+import { createAsyncTreeSource, type AsyncTreeProvider } from "../../src/async";
 import { createFakeFsProvider } from "./_helpers";
 
 describe("createAsyncTreeSource: change events", () => {
@@ -216,92 +216,114 @@ describe("createAsyncTreeSource: change events", () => {
   });
 
   it("commitListing re-listing the same id under a new parent detaches from old parent", async () => {
-    // Cross-parent re-list — adapter must remove the child from the
-    // previous parent's children list, not leave it dual-membered.
-    const fp = createFakeFsProvider({
-      tree: [
-        {
-          id: "<root>",
-          hasChildren: true,
-          children: ["a", "b"],
-          meta: { label: "root" },
-        },
-        { id: "a", hasChildren: true, children: ["x"], meta: { label: "a" } },
-        { id: "x", hasChildren: false, children: [], meta: { label: "x" } },
-        { id: "b", hasChildren: true, children: [], meta: { label: "b" } },
-      ],
-    });
-    const handle = createAsyncTreeSource(fp.provider);
-    await fp.resolve("<root>");
+    // Cross-parent re-list via the actual commitListing path (not a
+    // watcher event). Mutate the underlying tree between
+    // listChildren calls so 'x' appears under 'b' on b's re-list.
+    type FsTree = {
+      [id: string]: {
+        children: string[];
+        hasChildren: boolean;
+        meta: { label: string };
+      };
+    };
+    const tree: FsTree = {
+      "<root>": {
+        children: ["a", "b"],
+        hasChildren: true,
+        meta: { label: "root" },
+      },
+      a: { children: ["x"], hasChildren: true, meta: { label: "a" } },
+      x: { children: [], hasChildren: false, meta: { label: "x" } },
+      b: { children: [], hasChildren: true, meta: { label: "b" } },
+    };
+    const provider: AsyncTreeProvider<{ label: string }> = {
+      rootId: "<root>",
+      hasChildren: (id) => tree[id]?.hasChildren ?? false,
+      listChildren: async (id) =>
+        (tree[id]?.children ?? []).map((cid) => ({
+          id: cid,
+          hasChildren: tree[cid].hasChildren,
+          meta: tree[cid].meta,
+        })),
+      getRootMeta: () => tree["<root>"].meta,
+    };
+    const handle = createAsyncTreeSource(provider);
+    // Microtask flush so the auto-load of root settles.
+    await new Promise((r) => setTimeout(r, 0));
     handle.load("a");
-    await fp.resolve("a");
+    await new Promise((r) => setTimeout(r, 0));
     expect(handle.source.getNode("a").children).toEqual(["x"]);
     expect(handle.source.getNode("x").parent).toBe("a");
 
-    // Provider's view changes: 'x' moves to 'b'. Re-list 'b'.
+    // Mutate the producer's view of the world: x moves from a to b.
+    tree.a.children = [];
+    tree.b.children = ["x"];
+
+    // Re-list b through listChildren. commitListing must detach x
+    // from a's children list and rebind under b.
+    handle.invalidate("b");
     handle.load("b");
-    // Mutate the fake's underlying tree by emitting deleted-then-created
-    // is one path; here we exercise commitListing's cross-parent path
-    // by resolving 'b' with an entry whose id already lives under 'a'.
-    const queue = (fp as unknown as { provider: typeof fp.provider }).provider;
-    void queue;
-    // Resolve 'b' with x as a member; the adapter must reparent x.
-    // Use a manual resolution path: just resolve b normally with its
-    // current children (none), then emit a `created` event for x
-    // under b — same effect, using existing test surface.
-    await fp.resolve("b");
-    fp.emit([
-      {
-        type: "created",
-        parent: "b",
-        entry: { id: "x", hasChildren: false, meta: { label: "x" } },
-      },
-    ]);
+    await new Promise((r) => setTimeout(r, 0));
     expect(handle.source.getNode("x").parent).toBe("b");
     expect(handle.source.getNode("a").children).toEqual([]);
     expect(handle.source.getNode("b").children).toEqual(["x"]);
   });
 
   it("commitListing pruning: container → leaf transition discards cached descendants", async () => {
-    // Regression for Codex P2: when a re-list returns an existing
-    // child with hasChildren=false after it was previously cached
-    // as a container, the cached children + descendant records must
-    // be pruned (not just the hint flipped).
-    const fp = createFakeFsProvider({
-      tree: [
-        {
-          id: "<root>",
-          hasChildren: true,
-          children: ["a"],
-          meta: { label: "root" },
-        },
-        {
-          id: "a",
-          hasChildren: true,
-          children: ["a/x", "a/y"],
-          meta: { label: "a" },
-        },
-        { id: "a/x", hasChildren: false, children: [], meta: { label: "x" } },
-        { id: "a/y", hasChildren: false, children: [], meta: { label: "y" } },
-      ],
-    });
-    const handle = createAsyncTreeSource(fp.provider);
-    await fp.resolve("<root>");
+    // Regression: when a re-list returns an existing child with
+    // hasChildren=false after it was previously cached as a
+    // container, the cached children + descendant records must be
+    // pruned via the real commitListing path (not via a watcher
+    // event).
+    type FsTree = {
+      [id: string]: {
+        children: string[];
+        hasChildren: boolean;
+        meta: { label: string };
+      };
+    };
+    const tree: FsTree = {
+      "<root>": {
+        children: ["a"],
+        hasChildren: true,
+        meta: { label: "root" },
+      },
+      a: {
+        children: ["a/x", "a/y"],
+        hasChildren: true,
+        meta: { label: "a" },
+      },
+      "a/x": { children: [], hasChildren: false, meta: { label: "x" } },
+      "a/y": { children: [], hasChildren: false, meta: { label: "y" } },
+    };
+    const provider: AsyncTreeProvider<{ label: string }> = {
+      rootId: "<root>",
+      hasChildren: (id) => tree[id]?.hasChildren ?? false,
+      listChildren: async (id) =>
+        (tree[id]?.children ?? []).map((cid) => ({
+          id: cid,
+          hasChildren: tree[cid].hasChildren,
+          meta: tree[cid].meta,
+        })),
+      getRootMeta: () => tree["<root>"].meta,
+    };
+    const handle = createAsyncTreeSource(provider);
+    await new Promise((r) => setTimeout(r, 0));
     handle.load("a");
-    await fp.resolve("a");
+    await new Promise((r) => setTimeout(r, 0));
     expect(handle.source.getNode("a").children).toEqual(["a/x", "a/y"]);
     expect(handle.hasNode("a/x")).toBe(true);
     expect(handle.hasNode("a/y")).toBe(true);
 
-    // Re-list root: 'a' is now a leaf in the producer's view.
-    fp.emit([
-      {
-        type: "created",
-        parent: "<root>",
-        entry: { id: "a", hasChildren: false, meta: { label: "a" } },
-      },
-    ]);
+    // Mutate: 'a' is now a leaf in the producer's view.
+    tree.a.hasChildren = false;
+    tree.a.children = [];
 
+    // Re-list root through listChildren — commitListing must prune
+    // a's cached descendants because the new entry says hasChildren=false.
+    handle.invalidate("<root>");
+    handle.load("<root>");
+    await new Promise((r) => setTimeout(r, 0));
     expect(handle.source.getNode("a").children).toEqual([]);
     expect(handle.source.isContainer!("a")).toBe(false);
     expect(handle.hasNode("a/x")).toBe(false);

--- a/packages/grida-tree-view/__tests__/async/change-events.test.ts
+++ b/packages/grida-tree-view/__tests__/async/change-events.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import { createAsyncTreeSource } from "../../src/async";
+import { createFakeFsProvider } from "./_helpers";
+
+describe("createAsyncTreeSource: change events", () => {
+  it("invalidated resets a loaded subtree to unloaded; children stay visible", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+
+    fp.emit([{ type: "invalidated", id: "<root>" }]);
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+    // Children still visible — VS Code semantics.
+    expect(handle.source.getNode("<root>").children).toEqual(["a"]);
+  });
+
+  it("invalidate(id) handle method is sugar for the invalidated event", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.invalidate("<root>");
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+  });
+
+  it("created appends a child to parent's listing", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    fp.emit([
+      {
+        type: "created",
+        parent: "<root>",
+        entry: { id: "b", hasChildren: false, meta: { label: "b" } },
+      },
+    ]);
+    expect(handle.source.getNode("<root>").children).toEqual(["a", "b"]);
+    expect(handle.source.getNode("b").meta).toEqual({ label: "b" });
+    expect(handle.source.getNode("b").parent).toBe("<root>");
+  });
+
+  it("deleted removes a child and prunes the subtree from cache", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+        { id: "b", hasChildren: false, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    fp.emit([{ type: "deleted", parent: "<root>", child: "a" }]);
+    expect(handle.source.getNode("<root>").children).toEqual(["b"]);
+    expect(() => handle.source.getNode("a")).toThrow(/unknown node/);
+  });
+
+  it("changed updates meta without touching topology", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    fp.emit([{ type: "changed", id: "a", meta: { label: "A renamed" } }]);
+    expect(handle.source.getNode("a").meta).toEqual({ label: "A renamed" });
+    expect(handle.source.getNode("<root>").children).toEqual(["a"]);
+  });
+
+  it("a batch of events causes one version bump", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const versionBefore = handle.source.getVersion();
+    fp.emit([
+      {
+        type: "created",
+        parent: "<root>",
+        entry: { id: "b", hasChildren: false, meta: { label: "b" } },
+      },
+      {
+        type: "created",
+        parent: "<root>",
+        entry: { id: "c", hasChildren: false, meta: { label: "c" } },
+      },
+      { type: "changed", id: "a", meta: { label: "A!" } },
+    ]);
+    expect(handle.source.getVersion()).toBe(versionBefore + 1);
+  });
+
+  it("re-listing after invalidate merges: surviving children keep their subtree", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: ["a1"], meta: { label: "a" } },
+        { id: "a1", hasChildren: false, children: [], meta: { label: "a1" } },
+        { id: "b", hasChildren: false, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.load("a");
+    await fp.resolve("a");
+    expect(handle.source.getNode("a").children).toEqual(["a1"]);
+    expect(handle.getLoadState("a")).toBe("loaded");
+
+    // Invalidate root and re-list. Re-listing yields the same kids; the
+    // loaded subtree under "a" must survive.
+    handle.invalidate("<root>");
+    handle.load("<root>");
+    await fp.resolve("<root>");
+    expect(handle.source.getNode("a").children).toEqual(["a1"]);
+    expect(handle.getLoadState("a")).toBe("loaded");
+  });
+
+  it("created event for an existing id under a new parent re-parents cleanly", async () => {
+    // Producer reparents 'a' from /src to /dst via a single `created`
+    // event under the new parent — historically a silent corruption
+    // (stale parent pointer, dual membership). Adapter must detach
+    // from the old parent's children list and rebind.
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["src", "dst"],
+          meta: { label: "root" },
+        },
+        {
+          id: "src",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "src" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+        { id: "dst", hasChildren: true, children: [], meta: { label: "dst" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.load("src");
+    await fp.resolve("src");
+    handle.load("dst");
+    await fp.resolve("dst");
+
+    expect(handle.source.getNode("src").children).toEqual(["a"]);
+    expect(handle.source.getNode("a").parent).toBe("src");
+
+    fp.emit([
+      {
+        type: "created",
+        parent: "dst",
+        entry: { id: "a", hasChildren: false, meta: { label: "a" } },
+      },
+    ]);
+
+    expect(handle.source.getNode("a").parent).toBe("dst");
+    expect(handle.source.getNode("src").children).toEqual([]);
+    expect(handle.source.getNode("dst").children).toEqual(["a"]);
+  });
+
+  it("commitListing re-listing the same id under a new parent detaches from old parent", async () => {
+    // Cross-parent re-list — adapter must remove the child from the
+    // previous parent's children list, not leave it dual-membered.
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: ["x"], meta: { label: "a" } },
+        { id: "x", hasChildren: false, children: [], meta: { label: "x" } },
+        { id: "b", hasChildren: true, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    handle.load("a");
+    await fp.resolve("a");
+    expect(handle.source.getNode("a").children).toEqual(["x"]);
+    expect(handle.source.getNode("x").parent).toBe("a");
+
+    // Provider's view changes: 'x' moves to 'b'. Re-list 'b'.
+    handle.load("b");
+    // Mutate the fake's underlying tree by emitting deleted-then-created
+    // is one path; here we exercise commitListing's cross-parent path
+    // by resolving 'b' with an entry whose id already lives under 'a'.
+    const queue = (fp as unknown as { provider: typeof fp.provider }).provider;
+    void queue;
+    // Resolve 'b' with x as a member; the adapter must reparent x.
+    // Use a manual resolution path: just resolve b normally with its
+    // current children (none), then emit a `created` event for x
+    // under b — same effect, using existing test surface.
+    await fp.resolve("b");
+    fp.emit([
+      {
+        type: "created",
+        parent: "b",
+        entry: { id: "x", hasChildren: false, meta: { label: "x" } },
+      },
+    ]);
+    expect(handle.source.getNode("x").parent).toBe("b");
+    expect(handle.source.getNode("a").children).toEqual([]);
+    expect(handle.source.getNode("b").children).toEqual(["x"]);
+  });
+
+  it("re-listing prunes children no longer present", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+        { id: "b", hasChildren: false, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    // Simulate file system: delete "b" out-of-band, then invalidate.
+    // The fake provider's tree mutates so re-listing yields ["a"] only.
+    // (We patch the fake by emitting a delete instead, which prunes
+    // first; then invalidate+relist of ["a","b"] from the snapshot
+    // would resurrect "b" — so use the deletion of "b" by patching the
+    // provider's view directly.)
+    // For this test, model the "second listing yields only a" case by
+    // emitting a delete event.
+    fp.emit([{ type: "deleted", parent: "<root>", child: "b" }]);
+    expect(() => handle.source.getNode("b")).toThrow(/unknown node/);
+    expect(handle.source.getNode("<root>").children).toEqual(["a"]);
+  });
+});

--- a/packages/grida-tree-view/__tests__/async/controller-binding.test.ts
+++ b/packages/grida-tree-view/__tests__/async/controller-binding.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { TreeController } from "../../src/controller";
+import {
+  bindAsyncTreeController,
+  createAsyncTreeSource,
+} from "../../src/async";
+import { createFakeFsProvider } from "./_helpers";
+
+describe("bindAsyncTreeController", () => {
+  it("triggers load when a node is expanded with unloaded children", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: ["a1"], meta: { label: "a" } },
+        { id: "a1", hasChildren: false, children: [], meta: { label: "a1" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const controller = new TreeController({ source: handle.source });
+    const unbind = bindAsyncTreeController(controller, handle);
+
+    expect(handle.getLoadState("a")).toBe("unloaded");
+    controller.expand("a");
+    expect(handle.getLoadState("a")).toBe("loading");
+    expect(fp.pending("a")).toBe(1);
+    await fp.resolve("a");
+    expect(handle.getLoadState("a")).toBe("loaded");
+    expect(handle.source.getNode("a").children).toEqual(["a1"]);
+
+    unbind();
+  });
+
+  it("aborts the in-flight listChildren when the node is collapsed mid-load", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const controller = new TreeController({ source: handle.source });
+    bindAsyncTreeController(controller, handle);
+
+    controller.expand("a");
+    expect(handle.getLoadState("a")).toBe("loading");
+    controller.collapse("a");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handle.getLoadState("a")).toBe("unloaded");
+    expect(fp.wasAborted("a")).toBe(true);
+  });
+
+  it("expanding a leaf does not fire listChildren", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const controller = new TreeController({ source: handle.source });
+    bindAsyncTreeController(controller, handle);
+
+    controller.expand("a");
+    // "a" has hasChildren=false → controller's expanded set still adds it,
+    // but the binding's load() check sees loadState already "loaded"
+    // (leaves are auto-loaded at construction) → no call.
+    // Actually: the load() check skips already-loaded ids. Verify no
+    // listChildren fired.
+    expect(fp.pending("a")).toBe(0);
+  });
+
+  it("expanded ids at bind time are loaded immediately", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: true, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const controller = new TreeController({
+      source: handle.source,
+      expanded: ["a"],
+    });
+    bindAsyncTreeController(controller, handle);
+    expect(handle.getLoadState("a")).toBe("loading");
+    expect(fp.pending("a")).toBe(1);
+  });
+});

--- a/packages/grida-tree-view/__tests__/async/reference-stability.test.ts
+++ b/packages/grida-tree-view/__tests__/async/reference-stability.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { createAsyncTreeSource } from "../../src/async";
+import { createFakeFsProvider } from "./_helpers";
+
+describe("createAsyncTreeSource: reference stability (FEEDBACKS F1)", () => {
+  it("getNode returns the same reference across unrelated version bumps", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+        { id: "b", hasChildren: false, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const aBefore = handle.source.getNode("a");
+    // Change b's meta — a's adapted node should not be rebuilt.
+    fp.emit([{ type: "changed", id: "b", meta: { label: "B!" } }]);
+    const aAfter = handle.source.getNode("a");
+    expect(aAfter).toBe(aBefore);
+  });
+
+  it("rebuilds the adapted node when its own meta changes", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const aBefore = handle.source.getNode("a");
+    fp.emit([{ type: "changed", id: "a", meta: { label: "A!" } }]);
+    const aAfter = handle.source.getNode("a");
+    expect(aAfter).not.toBe(aBefore);
+    expect(aAfter.meta).toEqual({ label: "A!" });
+  });
+
+  it("rebuilds the parent's adapted node when children list changes", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const rootBefore = handle.source.getNode("<root>");
+    fp.emit([
+      {
+        type: "created",
+        parent: "<root>",
+        entry: { id: "b", hasChildren: false, meta: { label: "b" } },
+      },
+    ]);
+    const rootAfter = handle.source.getNode("<root>");
+    expect(rootAfter).not.toBe(rootBefore);
+    expect(rootAfter.children).toEqual(["a", "b"]);
+  });
+
+  it("a no-op change event does not bump version", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    const aMeta = handle.source.getNode("a").meta;
+    const versionBefore = handle.source.getVersion();
+    // Same reference — store should detect and skip the rebuild.
+    fp.emit([{ type: "changed", id: "a", meta: aMeta! }]);
+    expect(handle.source.getVersion()).toBe(versionBefore);
+  });
+});

--- a/packages/grida-tree-view/__tests__/async/source.test.ts
+++ b/packages/grida-tree-view/__tests__/async/source.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAsyncTreeSource } from "../../src/async";
+import { createFakeFsProvider } from "./_helpers";
+
+describe("createAsyncTreeSource: load lifecycle", () => {
+  it("auto-loads root on construction and transitions unloaded → loading → loaded", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a", "b"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+        { id: "b", hasChildren: false, children: [], meta: { label: "b" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    expect(handle.getLoadState("<root>")).toBe("loading");
+    expect(fp.pending("<root>")).toBe(1);
+
+    await fp.resolve("<root>");
+
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+    expect(handle.source.getNode("<root>").children).toEqual(["a", "b"]);
+    expect(handle.source.getNode("a").parent).toBe("<root>");
+    expect(handle.source.getNode("a").meta).toEqual({ label: "a" });
+  });
+
+  it("skips root auto-load when autoLoadRoot: false", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+    expect(handle.getLoadState("<root>")).toBe("unloaded");
+    expect(fp.pending("<root>")).toBe(0);
+  });
+
+  it("treats leaves (hasChildren=false) at construction as fully loaded, no listing fires", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: false,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    expect(fp.pending("<root>")).toBe(0);
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+  });
+
+  it("transitions to error on rejection and surfaces the error", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    const err = new Error("EPERM");
+    await fp.reject("<root>", err);
+    expect(handle.getLoadState("<root>")).toBe("error");
+    expect(handle.getError("<root>")).toBe(err);
+  });
+
+  it("retry-after-error via load() re-fires listChildren", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.reject("<root>", new Error("first attempt"));
+    expect(handle.getLoadState("<root>")).toBe("error");
+
+    handle.load("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loading");
+    await fp.resolve("<root>");
+    expect(handle.getLoadState("<root>")).toBe("loaded");
+    expect(handle.getError("<root>")).toBeNull();
+  });
+
+  it("load() is idempotent during loading and loaded states", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    // root already loading from auto-kick
+    handle.load("<root>");
+    handle.load("<root>");
+    expect(fp.pending("<root>")).toBe(1); // no extra request
+
+    await fp.resolve("<root>");
+    handle.load("<root>"); // already loaded → no-op
+    expect(fp.pending("<root>")).toBe(0);
+  });
+
+  it("getRootMeta seeds the root's adapted meta before the first listing", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: [],
+          meta: { label: "root-label" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+    expect(handle.source.getNode("<root>").meta).toEqual({
+      label: "root-label",
+    });
+  });
+
+  it("isContainer reports the hasChildren hint, not children.length", async () => {
+    // A folder with no children yet (hasChildren=true) should still show
+    // the chevron — testing the chevron-before-loading promise.
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        {
+          id: "a",
+          hasChildren: true, // claims to be a container...
+          children: [], // ...but empty for now
+          meta: { label: "a" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    await fp.resolve("<root>");
+    expect(handle.source.isContainer!("a")).toBe(true);
+    expect(handle.source.getNode("a").children).toEqual([]);
+  });
+
+  it("load success fires exactly one notification (folded mutate)", async () => {
+    // Regression: previously commitListing's mutate notified once,
+    // then a follow-up mutate to flip loadState notified again — 2x
+    // re-runs per expand.
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+    const versionBefore = handle.source.getVersion();
+    const listener = vi.fn<() => void>();
+    handle.source.subscribe(listener);
+    handle.load("<root>");
+    // The "loading" transition is one bump.
+    const versionAfterLoadingFlip = handle.source.getVersion();
+    expect(versionAfterLoadingFlip).toBe(versionBefore + 1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    await fp.resolve("<root>");
+    // The resolution should be exactly ONE more bump + notify.
+    expect(handle.source.getVersion()).toBe(versionAfterLoadingFlip + 1);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("getLoadState / getError / isContainer throw on unknown ids; hasNode probes safely", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    expect(handle.hasNode("<root>")).toBe(true);
+    expect(handle.hasNode("not-a-thing")).toBe(false);
+    expect(() => handle.getLoadState("not-a-thing")).toThrow(/unknown node/);
+    expect(() => handle.getError("not-a-thing")).toThrow(/unknown node/);
+    expect(() => handle.source.isContainer!("not-a-thing")).toThrow(
+      /unknown node/
+    );
+    expect(() => handle.source.getNode("not-a-thing")).toThrow(/unknown node/);
+  });
+
+  it("showRoot option forwards to the produced TreeSource", () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: [],
+          meta: { label: "root" },
+        },
+      ],
+    });
+    const withRoot = createAsyncTreeSource(fp.provider, { showRoot: true });
+    expect(withRoot.source.showRoot!()).toBe(true);
+    withRoot.dispose();
+
+    const withoutRoot = createAsyncTreeSource(fp.provider);
+    expect(withoutRoot.source.showRoot!()).toBe(false);
+  });
+
+  it("subscriber exceptions are isolated; later subscribers still fire", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider, { autoLoadRoot: false });
+
+    const order: string[] = [];
+    handle.source.subscribe(() => {
+      order.push("first");
+      throw new Error("first subscriber threw");
+    });
+    handle.source.subscribe(() => {
+      order.push("second");
+    });
+
+    // Silence the expected console.error from the isolation handler.
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    handle.load("<root>");
+    await fp.resolve("<root>");
+
+    expect(order).toContain("first");
+    expect(order).toContain("second");
+    // Multiple notifications (loading flip + resolve) — each must
+    // invoke BOTH subscribers despite the first throwing.
+    expect(order.filter((s) => s === "first").length).toBeGreaterThanOrEqual(2);
+    expect(order.filter((s) => s === "second").length).toBeGreaterThanOrEqual(
+      2
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("dispose aborts in-flight loads and clears records", async () => {
+    const fp = createFakeFsProvider({
+      tree: [
+        {
+          id: "<root>",
+          hasChildren: true,
+          children: ["a"],
+          meta: { label: "root" },
+        },
+        { id: "a", hasChildren: false, children: [], meta: { label: "a" } },
+      ],
+    });
+    const handle = createAsyncTreeSource(fp.provider);
+    expect(fp.pending("<root>")).toBe(1);
+    handle.dispose();
+    expect(fp.wasAborted("<root>")).toBe(true);
+  });
+});

--- a/packages/grida-tree-view/async.ts
+++ b/packages/grida-tree-view/async.ts
@@ -1,0 +1,1 @@
+export * from "./src/async";

--- a/packages/grida-tree-view/package.json
+++ b/packages/grida-tree-view/package.json
@@ -4,12 +4,14 @@
   "private": false,
   "description": "Headless, agnostic tree-view controller for the Grida editor.",
   "keywords": [
+    "async",
     "dnd",
     "drag-and-drop",
     "file-explorer",
     "headless",
     "keyboard-navigation",
     "layers-panel",
+    "lazy-loading",
     "outliner",
     "react",
     "selection",
@@ -41,6 +43,11 @@
       "types": "./dist/react.d.ts",
       "import": "./dist/react.mjs",
       "require": "./dist/react.js"
+    },
+    "./async": {
+      "types": "./dist/async.d.ts",
+      "import": "./dist/async.mjs",
+      "require": "./dist/async.js"
     }
   },
   "publishConfig": {

--- a/packages/grida-tree-view/src/async/change-events.ts
+++ b/packages/grida-tree-view/src/async/change-events.ts
@@ -59,6 +59,36 @@ function applyInvalidated<TMeta>(store: AsyncStore<TMeta>, id: NodeId): void {
   }
 }
 
+/**
+ * Apply a `hasChildren` transition on an existing record. The
+ * container → leaf direction is destructive: the cached children
+ * list and every descendant record are pruned, because they no
+ * longer exist in the producer's view. `syncAdapted(rec)` should
+ * still be called by the caller after — this helper only mutates
+ * the record's fields + descendant cache.
+ */
+function applyHasChildrenTransition<TMeta>(
+  store: AsyncStore<TMeta>,
+  rec: NodeRecord<TMeta>,
+  hasChildren: boolean
+): void {
+  if (rec.hasChildren === hasChildren) return;
+  if (rec.hasChildren && !hasChildren && rec.children.length > 0) {
+    // Container → leaf: prune the entire cached subtree. Producers
+    // documented `listChildren` as the canonical replace; a re-list
+    // (or re-create) that flips the hint to leaf implies the
+    // descendants are gone.
+    for (const childId of rec.children) store.pruneSubtree(childId);
+    rec.children = [];
+    // A leaf is implicitly "loaded" — no listing to fire. If the
+    // node was previously "unloaded" (rare), keep that state honest.
+    if (rec.loadState === "loaded" || rec.loadState === "error") {
+      rec.error = null;
+    }
+  }
+  rec.hasChildren = hasChildren;
+}
+
 function applyCreated<TMeta>(
   store: AsyncStore<TMeta>,
   parentId: NodeId,
@@ -77,7 +107,8 @@ function applyCreated<TMeta>(
         store.markDirty();
       }
       if (existing.hasChildren !== entry.hasChildren) {
-        existing.hasChildren = entry.hasChildren;
+        applyHasChildrenTransition(store, existing, entry.hasChildren);
+        syncAdapted(existing);
         store.markDirty();
       }
       if (!parent.children.includes(entry.id)) {
@@ -102,7 +133,7 @@ function applyCreated<TMeta>(
     existing.parent = parentId;
     if (existing.meta !== entry.meta) existing.meta = entry.meta;
     if (existing.hasChildren !== entry.hasChildren) {
-      existing.hasChildren = entry.hasChildren;
+      applyHasChildrenTransition(store, existing, entry.hasChildren);
     }
     syncAdapted(existing);
     if (!parent.children.includes(entry.id)) {
@@ -195,7 +226,7 @@ export function commitListing<TMeta>(
           changed = true;
         }
         if (existing.hasChildren !== entry.hasChildren) {
-          existing.hasChildren = entry.hasChildren;
+          applyHasChildrenTransition(store, existing, entry.hasChildren);
           changed = true;
         }
         if (changed) syncAdapted(existing);

--- a/packages/grida-tree-view/src/async/change-events.ts
+++ b/packages/grida-tree-view/src/async/change-events.ts
@@ -1,0 +1,220 @@
+import type { NodeId } from "../types";
+import type { AsyncChangeEvent, AsyncTreeEntry } from "./types";
+import {
+  type AsyncStore,
+  type NodeRecord,
+  createRecord,
+  syncAdapted,
+} from "./state";
+
+/**
+ * Apply one batch of change events to the store. Wraps the writes in
+ * `store.mutate` so the version bumps once and listeners see the
+ * batch atomically.
+ *
+ * Unknown ids in events are silently ignored — the producer's watcher
+ * may emit events for ids the adapter never observed (because their
+ * parent was never expanded). That's correct behavior, not an error.
+ */
+export function applyChangeEvents<TMeta>(
+  store: AsyncStore<TMeta>,
+  events: ReadonlyArray<AsyncChangeEvent<TMeta>>
+): void {
+  if (events.length === 0) return;
+  store.mutate(() => {
+    for (const ev of events) applyOne(store, ev);
+  });
+}
+
+function applyOne<TMeta>(
+  store: AsyncStore<TMeta>,
+  ev: AsyncChangeEvent<TMeta>
+): void {
+  switch (ev.type) {
+    case "invalidated":
+      applyInvalidated(store, ev.id);
+      return;
+    case "created":
+      applyCreated(store, ev.parent, ev.entry);
+      return;
+    case "deleted":
+      applyDeleted(store, ev.parent, ev.child);
+      return;
+    case "changed":
+      applyChanged(store, ev.id, ev.meta);
+      return;
+  }
+}
+
+function applyInvalidated<TMeta>(store: AsyncStore<TMeta>, id: NodeId): void {
+  const rec = store.records.get(id);
+  if (!rec) return;
+  // Cached listing is stale; next expand re-lists. Children stay
+  // visible — the producer can chain `deleted` events if it wants a
+  // wipe.
+  if (rec.loadState === "loaded" || rec.loadState === "error") {
+    rec.loadState = "unloaded";
+    rec.error = null;
+    store.markDirty();
+  }
+}
+
+function applyCreated<TMeta>(
+  store: AsyncStore<TMeta>,
+  parentId: NodeId,
+  entry: AsyncTreeEntry<TMeta>
+): void {
+  const parent = store.records.get(parentId);
+  if (!parent) return;
+  const existing = store.records.get(entry.id);
+  if (existing) {
+    // Same parent → meta-only idempotent replay. Children list is
+    // untouched.
+    if (existing.parent === parentId) {
+      if (existing.meta !== entry.meta) {
+        existing.meta = entry.meta;
+        syncAdapted(existing);
+        store.markDirty();
+      }
+      if (existing.hasChildren !== entry.hasChildren) {
+        existing.hasChildren = entry.hasChildren;
+        store.markDirty();
+      }
+      if (!parent.children.includes(entry.id)) {
+        // Pointer was right but the listing somehow lost it — restore.
+        parent.children = [...parent.children, entry.id];
+        syncAdapted(parent);
+        store.markDirty();
+      }
+      return;
+    }
+    // Cross-parent → producer is reparenting. Detach from the old
+    // parent's children list (if still cached) and rebind under the
+    // new parent. Preserves the cached subtree (loadState + children)
+    // under `existing`.
+    if (existing.parent != null) {
+      const oldParent = store.records.get(existing.parent);
+      if (oldParent && oldParent.children.includes(entry.id)) {
+        oldParent.children = oldParent.children.filter((c) => c !== entry.id);
+        syncAdapted(oldParent);
+      }
+    }
+    existing.parent = parentId;
+    if (existing.meta !== entry.meta) existing.meta = entry.meta;
+    if (existing.hasChildren !== entry.hasChildren) {
+      existing.hasChildren = entry.hasChildren;
+    }
+    syncAdapted(existing);
+    if (!parent.children.includes(entry.id)) {
+      parent.children = [...parent.children, entry.id];
+      syncAdapted(parent);
+    }
+    store.markDirty();
+    return;
+  }
+  const rec = createRecord<TMeta>(
+    entry.id,
+    parentId,
+    entry.hasChildren,
+    entry.meta
+  );
+  store.records.set(entry.id, rec);
+  // Append to parent's children list.
+  parent.children = [...parent.children, entry.id];
+  syncAdapted(parent);
+  store.markDirty();
+}
+
+function applyDeleted<TMeta>(
+  store: AsyncStore<TMeta>,
+  parentId: NodeId,
+  childId: NodeId
+): void {
+  const parent = store.records.get(parentId);
+  if (!parent) return;
+  if (!parent.children.includes(childId)) return;
+  parent.children = parent.children.filter((c) => c !== childId);
+  syncAdapted(parent);
+  store.pruneSubtree(childId);
+  store.markDirty();
+}
+
+function applyChanged<TMeta>(
+  store: AsyncStore<TMeta>,
+  id: NodeId,
+  meta: TMeta
+): void {
+  const rec = store.records.get(id);
+  if (!rec) return;
+  if (rec.meta === meta) return;
+  rec.meta = meta;
+  syncAdapted(rec);
+  store.markDirty();
+}
+
+/**
+ * Replace the children list of `parent` with the result of a
+ * `listChildren` resolution. Survives invalidate-then-relist by
+ * merging — existing child records whose ids are still present in the
+ * new listing retain their subtree (children + loadState); ids no
+ * longer present are pruned.
+ */
+export function commitListing<TMeta>(
+  store: AsyncStore<TMeta>,
+  parentId: NodeId,
+  entries: ReadonlyArray<AsyncTreeEntry<TMeta>>
+): void {
+  const parent = store.records.get(parentId);
+  if (!parent) return;
+  store.mutate(() => {
+    const nextIds: NodeId[] = [];
+    const seen = new Set<NodeId>();
+    for (const entry of entries) {
+      nextIds.push(entry.id);
+      seen.add(entry.id);
+      const existing = store.records.get(entry.id);
+      if (existing) {
+        let changed = false;
+        if (existing.parent !== parentId) {
+          // Cross-parent re-list: this child was previously cached
+          // under a different parent. Detach from the old parent's
+          // children list to avoid the same id appearing in two
+          // parents' children at once.
+          if (existing.parent != null) {
+            const old = store.records.get(existing.parent);
+            if (old && old.children.includes(entry.id)) {
+              old.children = old.children.filter((c) => c !== entry.id);
+              syncAdapted(old);
+            }
+          }
+          existing.parent = parentId;
+          changed = true;
+        }
+        if (existing.meta !== entry.meta) {
+          existing.meta = entry.meta;
+          changed = true;
+        }
+        if (existing.hasChildren !== entry.hasChildren) {
+          existing.hasChildren = entry.hasChildren;
+          changed = true;
+        }
+        if (changed) syncAdapted(existing);
+      } else {
+        const rec: NodeRecord<TMeta> = createRecord(
+          entry.id,
+          parentId,
+          entry.hasChildren,
+          entry.meta
+        );
+        store.records.set(entry.id, rec);
+      }
+    }
+    // Prune anything in the previous list that's not in the new one.
+    for (const oldId of parent.children) {
+      if (!seen.has(oldId)) store.pruneSubtree(oldId);
+    }
+    parent.children = nextIds;
+    syncAdapted(parent);
+    store.markDirty();
+  });
+}

--- a/packages/grida-tree-view/src/async/index.ts
+++ b/packages/grida-tree-view/src/async/index.ts
@@ -1,0 +1,10 @@
+export type {
+  AsyncChangeEvent,
+  AsyncSourceOptions,
+  AsyncTreeEntry,
+  AsyncTreeProvider,
+  AsyncTreeSourceHandle,
+  LoadState,
+} from "./types";
+
+export { createAsyncTreeSource, bindAsyncTreeController } from "./source";

--- a/packages/grida-tree-view/src/async/source.ts
+++ b/packages/grida-tree-view/src/async/source.ts
@@ -73,24 +73,11 @@ export function createAsyncTreeSource<TMeta>(
 
     provider.listChildren(id, ac.signal).then(
       (entries) => {
-        if (ac.signal.aborted) {
-          // Provider resolved after abort. Defensive: a well-behaved
-          // producer rejects on signal-abort (the rejection branch
-          // handles cleanup), but custom IPC/REST wrappers may swallow
-          // the signal and resolve anyway. Apply the same cleanup the
-          // rejection branch would — drop the inflight controller and
-          // reset to "unloaded" so a re-expand re-issues the load.
-          store.inflight.delete(id);
-          const live = store.records.get(id);
-          if (live && live.loadState === "loading") {
-            store.mutate(() => {
-              live.loadState = "unloaded";
-              live.error = null;
-              store.markDirty();
-            });
-          }
-          return;
-        }
+        // signal.aborted ⇒ abort() already cleared inflight + reset
+        // loadState synchronously. A second load may have started in
+        // the same tick with its own AbortController; do NOT touch
+        // shared state here or we'd stomp on it.
+        if (ac.signal.aborted) return;
         // Defensive: the record may have been pruned mid-flight (e.g.
         // a deleted parent up the chain). Bail in that case.
         const live = store.records.get(id);
@@ -110,20 +97,11 @@ export function createAsyncTreeSource<TMeta>(
         });
       },
       (err) => {
-        if (ac.signal.aborted) {
-          // The consumer aborted — reset to unloaded so a re-expand
-          // re-issues the load. Do NOT surface the error.
-          const live = store.records.get(id);
-          if (live) {
-            store.mutate(() => {
-              live.loadState = "unloaded";
-              live.error = null;
-              store.markDirty();
-            });
-          }
-          store.inflight.delete(id);
-          return;
-        }
+        // Same as the success branch: if we were aborted, abort()
+        // already cleaned up. The producer's rejection (typically an
+        // AbortError) is the expected echo — do not surface it as an
+        // error and do not stomp on a fresh second load's state.
+        if (ac.signal.aborted) return;
         store.inflight.delete(id);
         const live = store.records.get(id);
         if (!live) return;
@@ -140,9 +118,22 @@ export function createAsyncTreeSource<TMeta>(
   function abort(id: NodeId): void {
     const ac = store.inflight.get(id);
     if (!ac) return;
+    // Cleanup must be synchronous: an immediate `load(id)` after
+    // `abort(id)` would otherwise short-circuit because loadState is
+    // still "loading" — the producer's rejection runs on a microtask.
+    // Drop the inflight pointer and reset loadState now; the late
+    // settlement sees `signal.aborted` and bails without touching
+    // state.
+    store.inflight.delete(id);
+    const rec = store.records.get(id);
+    if (rec && rec.loadState === "loading") {
+      store.mutate(() => {
+        rec.loadState = "unloaded";
+        rec.error = null;
+        store.markDirty();
+      });
+    }
     ac.abort();
-    // The Promise's rejection handler resets loadState; nothing more
-    // to do here.
   }
 
   function invalidate(id: NodeId): void {
@@ -193,7 +184,12 @@ export function createAsyncTreeSource<TMeta>(
       if (!rec) {
         throw new Error(`[grida/tree-view] async: unknown node: ${id}`);
       }
-      return rec.hasChildren;
+      // `hasChildren` is the producer's last-known hint; it can lag
+      // behind change events that grow / shrink the actual children
+      // list. Treat either signal as authoritative — VS Code's mental
+      // model: a node is a container if it has any children OR the
+      // producer claims it can have some.
+      return rec.hasChildren || rec.children.length > 0;
     },
   };
 

--- a/packages/grida-tree-view/src/async/source.ts
+++ b/packages/grida-tree-view/src/async/source.ts
@@ -1,0 +1,260 @@
+import type { Listener, NodeId, TreeNode } from "../types";
+import type { TreeSource } from "../source";
+import type { TreeController } from "../controller";
+import type {
+  AsyncSourceOptions,
+  AsyncTreeProvider,
+  AsyncTreeSourceHandle,
+  LoadState,
+} from "./types";
+import { AsyncStore, createRecord } from "./state";
+import { applyChangeEvents, commitListing } from "./change-events";
+
+/**
+ * Adapt an `AsyncTreeProvider` into a synchronous `TreeSource` plus a
+ * load-state side channel. The returned `source` plugs into
+ * `TreeController` unchanged.
+ *
+ * The adapter owns: per-node `LoadState`, in-flight `AbortController`
+ * dedupe, reference-stable adapted `TreeNode` cache, change-event
+ * coalescing into version bumps.
+ *
+ * What it does NOT own: transport (the provider's responsibility),
+ * retry policy (re-call `load(id)` after an error to retry), URI
+ * parsing, synthetic placeholder rows.
+ */
+export function createAsyncTreeSource<TMeta>(
+  provider: AsyncTreeProvider<TMeta>,
+  options: AsyncSourceOptions = {}
+): AsyncTreeSourceHandle<TMeta> {
+  const store = new AsyncStore<TMeta>();
+
+  // Seed the root record. Root has no parent and its hasChildren is
+  // queried directly from the provider — children come from
+  // listChildren on the first load.
+  const rootHasChildren = provider.hasChildren(provider.rootId);
+  const rootMeta = provider.getRootMeta?.();
+  const rootRec = createRecord<TMeta>(
+    provider.rootId,
+    null,
+    rootHasChildren,
+    rootMeta
+  );
+  // A leaf root is already "loaded" — there's nothing to list. Save
+  // the controller a no-op transition by setting the state up front.
+  if (!rootHasChildren) rootRec.loadState = "loaded";
+  store.records.set(provider.rootId, rootRec);
+
+  const onError = options.onError;
+
+  function load(id: NodeId): void {
+    const rec = store.records.get(id);
+    if (!rec) return;
+    if (rec.loadState === "loading" || rec.loadState === "loaded") return;
+    // Leaves have no listing to fire. Transition directly to "loaded"
+    // — equivalent to a successful empty listChildren without burning
+    // a provider call.
+    if (!rec.hasChildren) {
+      store.mutate(() => {
+        rec.loadState = "loaded";
+        rec.error = null;
+        store.markDirty();
+      });
+      return;
+    }
+
+    const ac = new AbortController();
+    store.inflight.set(id, ac);
+    store.mutate(() => {
+      rec.loadState = "loading";
+      rec.error = null;
+      store.markDirty();
+    });
+
+    provider.listChildren(id, ac.signal).then(
+      (entries) => {
+        if (ac.signal.aborted) return;
+        // Defensive: the record may have been pruned mid-flight (e.g.
+        // a deleted parent up the chain). Bail in that case.
+        const live = store.records.get(id);
+        if (!live) {
+          store.inflight.delete(id);
+          return;
+        }
+        store.inflight.delete(id);
+        // Wrap commitListing + the loadState flip in one outer mutate
+        // so the version bumps once and listeners notify once for the
+        // resolution. commitListing's inner mutate collapses into this
+        // batch via AsyncStore._batchDepth.
+        store.mutate(() => {
+          commitListing(store, id, entries);
+          live.loadState = "loaded";
+          store.markDirty();
+        });
+      },
+      (err) => {
+        if (ac.signal.aborted) {
+          // The consumer aborted — reset to unloaded so a re-expand
+          // re-issues the load. Do NOT surface the error.
+          const live = store.records.get(id);
+          if (live) {
+            store.mutate(() => {
+              live.loadState = "unloaded";
+              live.error = null;
+              store.markDirty();
+            });
+          }
+          store.inflight.delete(id);
+          return;
+        }
+        store.inflight.delete(id);
+        const live = store.records.get(id);
+        if (!live) return;
+        store.mutate(() => {
+          live.loadState = "error";
+          live.error = err;
+          store.markDirty();
+        });
+        onError?.(id, err);
+      }
+    );
+  }
+
+  function abort(id: NodeId): void {
+    const ac = store.inflight.get(id);
+    if (!ac) return;
+    ac.abort();
+    // The Promise's rejection handler resets loadState; nothing more
+    // to do here.
+  }
+
+  function invalidate(id: NodeId): void {
+    applyChangeEvents(store, [{ type: "invalidated", id }]);
+  }
+
+  // Wire the optional change-event subscription. The handler is
+  // captured by reference so dispose() can release the producer's
+  // resources too.
+  let unsubscribeChanges: (() => void) | null = null;
+  if (provider.subscribeChanges) {
+    try {
+      unsubscribeChanges = provider.subscribeChanges((events) => {
+        applyChangeEvents(store, events);
+      });
+    } catch (err) {
+      onError?.(provider.rootId, err);
+    }
+  }
+
+  const showRoot = options.showRoot ?? false;
+
+  // Build the synchronous TreeSource facade.
+  const source: TreeSource<TMeta> = {
+    getRoot() {
+      return provider.rootId;
+    },
+    showRoot() {
+      return showRoot;
+    },
+    getNode(id: NodeId): TreeNode<TMeta> {
+      const rec = store.records.get(id);
+      if (!rec) {
+        throw new Error(`[grida/tree-view] async: unknown node: ${id}`);
+      }
+      return rec.adapted;
+    },
+    getVersion() {
+      return store.getVersion();
+    },
+    subscribe(listener: Listener) {
+      return store.subscribe(listener);
+    },
+    isContainer(id: NodeId): boolean {
+      const rec = store.records.get(id);
+      // Unknown ids throw — consistent with getNode. Callers that need
+      // a defensive read should guard with a try/catch or `hasNode`.
+      if (!rec) {
+        throw new Error(`[grida/tree-view] async: unknown node: ${id}`);
+      }
+      return rec.hasChildren;
+    },
+  };
+
+  const autoLoadRoot = options.autoLoadRoot ?? true;
+  if (autoLoadRoot && rootHasChildren) {
+    load(provider.rootId);
+  }
+
+  return {
+    source,
+    getLoadState(id: NodeId): LoadState {
+      const rec = store.records.get(id);
+      // Unknown ids throw — consistent with getNode + isContainer.
+      // Use `hasNode(id)` to probe without throwing.
+      if (!rec) {
+        throw new Error(`[grida/tree-view] async: unknown node: ${id}`);
+      }
+      return rec.loadState;
+    },
+    getError(id: NodeId): unknown | null {
+      const rec = store.records.get(id);
+      if (!rec) {
+        throw new Error(`[grida/tree-view] async: unknown node: ${id}`);
+      }
+      return rec.error;
+    },
+    hasNode(id: NodeId): boolean {
+      return store.records.has(id);
+    },
+    load,
+    abort,
+    invalidate,
+    dispose() {
+      unsubscribeChanges?.();
+      store.dispose();
+    },
+  };
+}
+
+/**
+ * Wire a handle's auto-load behavior to a controller's `expanded`
+ * channel. Expanding a node with `loadState === "unloaded"` triggers
+ * `handle.load(id)`; collapsing a node with `loadState === "loading"`
+ * triggers `handle.abort(id)`.
+ *
+ * Keep the binding optional so consumers who want manual load control
+ * (preloaded prefixes, eager children of selected ancestors, …) can
+ * leave it off.
+ */
+export function bindAsyncTreeController<TMeta>(
+  controller: TreeController<TMeta>,
+  handle: AsyncTreeSourceHandle<TMeta>
+): () => void {
+  let prev = new Set<NodeId>(controller.getExpanded());
+  // Kick off loads for anything already expanded at bind time (e.g. an
+  // initial-expanded set passed via `TreeController` options).
+  for (const id of prev) {
+    if (handle.hasNode(id) && handle.getLoadState(id) === "unloaded") {
+      handle.load(id);
+    }
+  }
+  return controller.subscribe("expanded", () => {
+    const now = controller.getExpanded();
+    for (const id of now) {
+      if (prev.has(id)) continue;
+      // `expandTo` may add ancestors whose subtree the source has not
+      // observed yet (their parent was never listed). The load skips
+      // them quietly — a deeper "reveal-through-unloaded-ancestors"
+      // mechanism is a separate design (would need a reveal-path the
+      // adapter walks from root). See review finding #6.
+      if (!handle.hasNode(id)) continue;
+      if (handle.getLoadState(id) === "unloaded") handle.load(id);
+    }
+    for (const id of prev) {
+      if (now.has(id)) continue;
+      if (!handle.hasNode(id)) continue;
+      if (handle.getLoadState(id) === "loading") handle.abort(id);
+    }
+    prev = new Set(now);
+  });
+}

--- a/packages/grida-tree-view/src/async/source.ts
+++ b/packages/grida-tree-view/src/async/source.ts
@@ -73,7 +73,24 @@ export function createAsyncTreeSource<TMeta>(
 
     provider.listChildren(id, ac.signal).then(
       (entries) => {
-        if (ac.signal.aborted) return;
+        if (ac.signal.aborted) {
+          // Provider resolved after abort. Defensive: a well-behaved
+          // producer rejects on signal-abort (the rejection branch
+          // handles cleanup), but custom IPC/REST wrappers may swallow
+          // the signal and resolve anyway. Apply the same cleanup the
+          // rejection branch would — drop the inflight controller and
+          // reset to "unloaded" so a re-expand re-issues the load.
+          store.inflight.delete(id);
+          const live = store.records.get(id);
+          if (live && live.loadState === "loading") {
+            store.mutate(() => {
+              live.loadState = "unloaded";
+              live.error = null;
+              store.markDirty();
+            });
+          }
+          return;
+        }
         // Defensive: the record may have been pruned mid-flight (e.g.
         // a deleted parent up the chain). Bail in that case.
         const live = store.records.get(id);

--- a/packages/grida-tree-view/src/async/state.ts
+++ b/packages/grida-tree-view/src/async/state.ts
@@ -1,0 +1,175 @@
+import type { NodeId, TreeNode } from "../types";
+import type { LoadState } from "./types";
+
+/**
+ * The internal per-node record kept by `createAsyncTreeSource`.
+ *
+ * Distinct from the public `TreeNode<TMeta>` because we hold lifecycle
+ * fields (`loadState`, `error`) that the source surfaces side-channel,
+ * not via `TreeNode.meta`. The cached `adapted` field is the
+ * reference-stable `TreeNode` returned to the controller — it is only
+ * rebuilt when one of (`parent`, `children`, `meta`) changes.
+ */
+export interface NodeRecord<TMeta> {
+  id: NodeId;
+  parent: NodeId | null;
+  hasChildren: boolean;
+  children: readonly NodeId[];
+  meta: TMeta | undefined;
+  loadState: LoadState;
+  error: unknown | null;
+  adapted: TreeNode<TMeta>;
+}
+
+/**
+ * Build a fresh `NodeRecord` for `id`. Initial `loadState` is
+ * `"unloaded"`; the consumer of this helper bumps it.
+ */
+export function createRecord<TMeta>(
+  id: NodeId,
+  parent: NodeId | null,
+  hasChildren: boolean,
+  meta: TMeta | undefined
+): NodeRecord<TMeta> {
+  const adapted = {
+    id,
+    parent,
+    children: [] as readonly NodeId[],
+    meta,
+  } as TreeNode<TMeta>;
+  return {
+    id,
+    parent,
+    hasChildren,
+    children: adapted.children,
+    meta,
+    loadState: "unloaded",
+    error: null,
+    adapted,
+  };
+}
+
+/**
+ * Rebuild the cached `adapted` `TreeNode` for `rec` if any of the
+ * fields the renderer observes changed. Reference-stable when nothing
+ * changed (FEEDBACKS F1 discipline — `useSyncExternalStore` selectors
+ * keyed on `getNode()` see no change).
+ */
+export function syncAdapted<TMeta>(rec: NodeRecord<TMeta>): void {
+  const prev = rec.adapted;
+  if (
+    prev.parent === rec.parent &&
+    prev.children === rec.children &&
+    prev.meta === rec.meta &&
+    prev.id === rec.id
+  ) {
+    return;
+  }
+  rec.adapted = {
+    id: rec.id,
+    parent: rec.parent,
+    children: rec.children,
+    meta: rec.meta,
+  } as TreeNode<TMeta>;
+}
+
+/**
+ * The store the async source maintains internally. Keeps records keyed
+ * by id, a monotonically-increasing version, listener set, and the
+ * map of in-flight `AbortController`s for cancellation.
+ *
+ * The store itself is pure data + emit — it never reaches out to the
+ * provider. The source layer above wires the provider calls.
+ */
+export class AsyncStore<TMeta> {
+  readonly records = new Map<NodeId, NodeRecord<TMeta>>();
+  readonly inflight = new Map<NodeId, AbortController>();
+  private _version = 0;
+  private _listeners = new Set<() => void>();
+  /**
+   * `notify()` is debounced inside one mutation batch via `_dirty`.
+   * Callers wrap a mutation in `mutate(fn)` and only one `bump()`
+   * fires regardless of how many records changed.
+   */
+  private _dirty = false;
+  private _batchDepth = 0;
+
+  getVersion(): number {
+    return this._version;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Batch a set of record mutations into one version bump and one
+   * notification. Nested calls collapse to a single notify at the
+   * outer exit.
+   */
+  mutate(fn: () => void): void {
+    this._batchDepth++;
+    try {
+      fn();
+    } finally {
+      this._batchDepth--;
+      if (this._batchDepth === 0 && this._dirty) {
+        this._dirty = false;
+        this._version++;
+        // Isolate listener exceptions: one buggy subscriber must not
+        // silently drop notifications to the rest of the chain.
+        // Errors are reported via console.error so they remain visible
+        // in dev without taking down the store.
+        for (const l of this._listeners) {
+          try {
+            l();
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error(
+              "[grida/tree-view] async store subscriber threw",
+              err
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /** Mark the store dirty — call after any record write inside `mutate`. */
+  markDirty(): void {
+    this._dirty = true;
+  }
+
+  /**
+   * Delete `id` and every descendant of `id` reachable through the
+   * cached `children` lists. Mirrors `InMemoryTreeSource.remove` — a
+   * leak otherwise (orphans pile up in `records`).
+   */
+  pruneSubtree(id: NodeId): void {
+    const stack: NodeId[] = [id];
+    while (stack.length) {
+      const cur = stack.pop()!;
+      const rec = this.records.get(cur);
+      if (!rec) continue;
+      stack.push(...rec.children);
+      this.records.delete(cur);
+      // Defensive: if a load was in-flight against this id, abort it.
+      const ac = this.inflight.get(cur);
+      if (ac) {
+        ac.abort();
+        this.inflight.delete(cur);
+      }
+    }
+  }
+
+  /** Abort every in-flight controller and clear listeners. */
+  dispose(): void {
+    for (const ac of this.inflight.values()) ac.abort();
+    this.inflight.clear();
+    this._listeners.clear();
+    this.records.clear();
+  }
+}

--- a/packages/grida-tree-view/src/async/state.ts
+++ b/packages/grida-tree-view/src/async/state.ts
@@ -127,7 +127,6 @@ export class AsyncStore<TMeta> {
           try {
             l();
           } catch (err) {
-            // eslint-disable-next-line no-console
             console.error(
               "[grida/tree-view] async store subscriber threw",
               err

--- a/packages/grida-tree-view/src/async/types.ts
+++ b/packages/grida-tree-view/src/async/types.ts
@@ -1,0 +1,193 @@
+import type { NodeId } from "../types";
+import type { TreeSource } from "../source";
+
+/**
+ * Per-node load lifecycle exposed by `AsyncTreeSourceHandle.getLoadState`.
+ *
+ * - `unloaded` — children have not been requested yet.
+ * - `loading` — `listChildren` is in flight.
+ * - `loaded` — children resolved and committed.
+ * - `error` — `listChildren` rejected; the error is available via
+ *   `getError(id)`. The node stays in this state until `invalidate(id)`
+ *   or a subsequent `load(id)` retries.
+ */
+export type LoadState = "unloaded" | "loading" | "loaded" | "error";
+
+/**
+ * One entry in a `listChildren` result.
+ *
+ * `hasChildren` is the chevron hint for THIS child — the producer knows
+ * whether it is a container at listing time (a file vs a folder, a
+ * collection vs a leaf record). If you genuinely don't know cheaply,
+ * return `true` and let the next `listChildren(id)` return `[]` to
+ * correct the chevron post-load.
+ */
+export interface AsyncTreeEntry<TMeta = unknown> {
+  readonly id: NodeId;
+  readonly hasChildren: boolean;
+  readonly meta?: TMeta;
+}
+
+/**
+ * Watcher / SSE / poll event from the producer. The adapter applies
+ * these against its internal cache and bumps the source's version.
+ *
+ * Four shapes by design:
+ *
+ * - `invalidated` — coarse. "Something under `id` changed; drop my
+ *   cached listing so the next expand re-lists." Children that are
+ *   currently visible stay visible until the re-listing commits a
+ *   replacement.
+ * - `created` — granular. Append `entry` to `parent`'s children.
+ * - `deleted` — granular. Remove `child` from `parent`'s children and
+ *   prune its subtree from the cache.
+ * - `changed` — granular. Replace the meta for `id`.
+ *
+ * Watchers vary in fidelity; emit what you have. Coarse-only is fine.
+ */
+export type AsyncChangeEvent<TMeta = unknown> =
+  | { readonly type: "invalidated"; readonly id: NodeId }
+  | {
+      readonly type: "created";
+      readonly parent: NodeId;
+      readonly entry: AsyncTreeEntry<TMeta>;
+    }
+  | {
+      readonly type: "deleted";
+      readonly parent: NodeId;
+      readonly child: NodeId;
+    }
+  | {
+      readonly type: "changed";
+      readonly id: NodeId;
+      readonly meta: TMeta;
+    };
+
+/**
+ * The contract the consumer implements. Transport-agnostic — wrap
+ * `fs.promises.readdir`, an HTTP endpoint, an IPC bridge, OPFS, S3
+ * `listObjects`, whatever.
+ *
+ * Reference stability rule: the adapter caches the adapted `TreeNode`
+ * objects keyed on (children, meta) of THIS node — if your
+ * `listChildren` returns fresh `meta` references on every call for a
+ * conceptually-unchanged child, the adapter will rebuild its
+ * `TreeNode` and downstream `useTreeSnapshot` selectors keyed on
+ * `meta` will thrash. Memoize on your side, or accept the cost.
+ */
+export interface AsyncTreeProvider<TMeta = unknown> {
+  readonly rootId: NodeId;
+
+  /**
+   * Synchronous chevron hint. Called once per id; the result is cached
+   * by the adapter. For unknown-cost cases (a remote URL where you
+   * don't know if it's a folder without listing), return `true` and
+   * let the listing self-correct.
+   */
+  hasChildren(id: NodeId): boolean;
+
+  /**
+   * The sole async point. Resolve with the new entries — throw / reject
+   * to enter the `error` state. `signal` aborts when the consumer
+   * collapses the node mid-load (or calls `handle.abort(id)`).
+   *
+   * Re-list semantics: subsequent `listChildren` calls REPLACE the
+   * cached children. Children present in both the old and new listing
+   * keep their cached subtree (load state, descendants); children
+   * absent from the new listing are pruned.
+   */
+  listChildren(
+    id: NodeId,
+    signal: AbortSignal
+  ): Promise<ReadonlyArray<AsyncTreeEntry<TMeta>>>;
+
+  /**
+   * Optional. Subscribe to mutation events from the underlying store
+   * (fs watcher, SSE, websocket, poll). The handler receives batches —
+   * pass change events as they arrive; the adapter applies them and
+   * bumps the source's version once per batch.
+   */
+  subscribeChanges?(
+    handler: (events: ReadonlyArray<AsyncChangeEvent<TMeta>>) => void
+  ): () => void;
+
+  /** Optional. Meta to attach to the root node. */
+  getRootMeta?(): TMeta | undefined;
+}
+
+/**
+ * Options accepted by `createAsyncTreeSource`.
+ */
+export interface AsyncSourceOptions {
+  /**
+   * If `true`, the root's `listChildren` is invoked once during source
+   * construction. Defaults to `true` — without it the tree starts
+   * empty and the consumer must call `handle.load(rootId)` manually.
+   */
+  readonly autoLoadRoot?: boolean;
+
+  /**
+   * Controls whether the produced `TreeSource` reports the root node
+   * as a visible row. Mirrors `TreeSource.showRoot?()`; defaults to
+   * `false` (layer-panel convention — only the root's subtree renders).
+   */
+  readonly showRoot?: boolean;
+
+  /**
+   * Optional sink for errors that escape the per-node `error` state
+   * (programmer mistakes, unexpected `subscribeChanges` errors). Errors
+   * surfaced via `listChildren` already land on `getError(id)` — this
+   * callback is for debugging, not user-facing handling.
+   */
+  readonly onError?: (id: NodeId, err: unknown) => void;
+}
+
+/**
+ * The object returned by `createAsyncTreeSource`. The `source` plugs
+ * into `new TreeController({ source })` exactly like any other
+ * `TreeSource`. Load state is queried side-channel via `getLoadState`.
+ */
+export interface AsyncTreeSourceHandle<TMeta = unknown> {
+  /** The synchronous `TreeSource` the controller consumes. */
+  readonly source: TreeSource<TMeta>;
+
+  /** Current load state for `id`. Throws on unknown ids — consistent
+   *  with `source.getNode` and `source.isContainer`. Use `hasNode(id)`
+   *  to probe membership without throwing. */
+  getLoadState(id: NodeId): LoadState;
+
+  /** The error stored for `id` if `getLoadState(id) === "error"`.
+   *  Throws on unknown ids; returns `null` when the node has no
+   *  recorded error. */
+  getError(id: NodeId): unknown | null;
+
+  /** `true` if the source has observed `id` (root + anything reached
+   *  through a previous `listChildren` resolution). Use to guard
+   *  `getLoadState` / `getError` / `getNode` calls on potentially-
+   *  stale ids (drag held across a deletion, focused id from a
+   *  different source). */
+  hasNode(id: NodeId): boolean;
+
+  /**
+   * Manually request a load for `id`. Idempotent — a no-op if `id` is
+   * already `loading` or `loaded`. Use to pre-warm, retry after error,
+   * or load without expanding.
+   */
+  load(id: NodeId): void;
+
+  /**
+   * Abort the in-flight `listChildren` for `id`, if any. The node
+   * returns to `unloaded` so a subsequent `load` re-runs the listing.
+   */
+  abort(id: NodeId): void;
+
+  /**
+   * Drop the cached listing for `id` — its `loadState` returns to
+   * `unloaded` so the next `load(id)` re-lists. Currently visible
+   * children stay until the re-listing commits a replacement.
+   */
+  invalidate(id: NodeId): void;
+
+  /** Aborts all in-flight loads and clears subscriptions. */
+  dispose(): void;
+}

--- a/packages/grida-tree-view/tsdown.config.ts
+++ b/packages/grida-tree-view/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["index.ts", "react.tsx"],
+  entry: ["index.ts", "react.tsx", "async.ts"],
   format: ["cjs", "esm"],
   platform: "neutral",
   dts: true,


### PR DESCRIPTION
## Summary

- New `@grida/tree-view/async` subpath: adapts an `AsyncTreeProvider` into a synchronous `TreeSource` so the existing `TreeController` consumes lazy / remote / filesystem-shaped sources unchanged.
- Producer surface: `hasChildren(id)` + `listChildren(id, signal)` + optional `subscribeChanges?` (watcher-driven invalidation) + optional `getRootMeta?`.
- Consumer surface: `meta` stays clean; load state lives on the handle (`getLoadState`, `getError`, `hasNode`). All unknown-id accessors throw consistently with `getNode`; `hasNode(id)` is the safe probe.
- \"VS Code (async)\" showcase on the package landing page exercises every path end-to-end: load, abort-on-collapse, error+retry, watcher event injection, live load-state readout.

## Design context

A short design tournament (pattern-only vs. sibling package vs. core extension) is captured in [the plan file](https://github.com/gridaco/grida/blob/feature/tree-view-async/.claude/plans/explore-all-options-pedantic-flickering-treasure.md) — TL;DR: subpath chosen for in-package versioning + tree-shake, no core changes, no synthetic placeholder rows, no FsMeta wrapper, no path/URI/stat surface (transport-agnostic).

Producer interface mirrors VS Code's internal `IAsyncDataSource<T>` (battle-tested) plus an `AbortSignal` (peer art's #1 complaint) and a 4-shape change-event taxonomy (`invalidated` coarse, `created`/`deleted`/`changed` granular).

## Self-review fixes folded into the PR

A `/code-review high` pass surfaced 10 findings; the high-leverage ones were addressed in the same diff:

- **#1 + #5** Cross-parent re-parenting via `created` event or re-list no longer leaves the record pointing at the old parent (was silent dual-membership) — now detaches from the old parent's children list and rebinds.
- **#2** `AsyncStore.mutate` listener loop now isolates exceptions per subscriber so one bad listener can't drop notifications to the rest of the chain.
- **#3** Load success now folds `commitListing` + the `loadState` flip into one outer `mutate` — single version bump + single listener notify per expand (was 2x).
- **#4** Unknown-id behavior unified: `getLoadState` / `getError` / `isContainer` all throw (was: returned defensive defaults, inconsistent with `getNode`). Added `handle.hasNode(id)` as the safe probe; binding + demo updated to guard.
- **#8** Added `showRoot` to `AsyncSourceOptions` (was: permanently root-hidden).

## Test plan

- [x] Vitest: **157/157** pass, including 6 regression tests for the review fixes (`source.test.ts`: single-notify, unknown-id throws, showRoot, listener isolation; `change-events.test.ts`: cross-parent via `created`, cross-parent via re-list)
- [x] `turbo typecheck --filter=editor`: clean
- [x] `tsdown` build: emits `dist/async.{js,mjs,d.ts,d.mts}` (12.76 kB / 3.71 kB gzip ESM)
- [x] `pnpm lint`: zero errors from this diff
- [x] Manual verification in the live preview (grida.co/packages/@grida/tree-view showcase): root auto-load, expand-triggered load, error+retry, abort-on-collapse, watcher event injection — all verified end-to-end via the new showcase controls

## Reviewer notes

- **Acceptance gate before tagging stable**: lockstep wiring with the desktop branch's `fs.promises.readdir` adapter — until both sides converge without forking the contract, the subpath stays unstable.
- **Deferred (tracked, not gated):**
  - #6 `expandTo` through unobserved-ancestor ids silently no-ops (needs a separate reveal-path design).
  - #7 `NodeRecord.children` field redundant with `adapted.children` (cleanup is non-trivial; would require also flattening `parent`/`meta` mirrors).
  - #9 SEED + nodes Map duplication in `_async-fixture.ts` (demo-only).
- **Scoped watching à la VS Code's `FileSystemProvider.watch(uri)`**: explicitly NOT added — global `subscribeChanges` matches the named use cases (Electron + chokidar, single SSE channel per remote graph). The `watch?(id, handler): Disposable` shape can be added later as a non-breaking alternative if a producer surfaces a per-subscription cost model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async tree-view adapter: load-state & error tracking, cancelable loads, change-event handling, controller binding for expand/collapse-driven fetching.
  * Demo: new async showcase with loading spinners, error/retry UI, and runtime controls for latency, forced failures, refresh, and watcher events.

* **Documentation**
  * README updated to document the async integration as a first-class entry point.

* **Packaging**
  * New async entry export and barrel export added.

* **Tests**
  * Comprehensive async test suites for aborts, change events, controller binding, lifecycle, and reference stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->