### PR TITLE
docs(grounding): point legacy recovery at the snapshot branch

### DIFF
--- a/.agents/skills/grounding/SKILL.md
+++ b/.agents/skills/grounding/SKILL.md
@@ -54,8 +54,8 @@ they match:** `docs/_history/`,
 Some directories are git-tracked but dead — a bare `rg` from repo root
 returns obsolete hits that look like confirmation: `docs/_history/`,
 `.ref/`, vendored `third_party/`. (The legacy editor trees `.legacy/`
-and `packages/.legacy/` were retired May 2026; recover via the
-`archive/do-not-delete-legacy-retired-pr759` tag.) `rg` already skips gitignored build dirs
+and `packages/.legacy/` were retired May 2026 in #759; recover from the
+`snapshot/legacy-with-2023-grida-code-editor-at-202505` branch.) `rg` already skips gitignored build dirs
 (`node_modules/`, `target/`, `.next/`, …); don't waste flags there.
 Scope positively, or exclude the dead trees:
 


### PR DESCRIPTION
Follow-up to #759.

While reconciling archives we found a pre-existing, fuller snapshot branch — `snapshot/legacy-with-2023-grida-code-editor-at-202505` (1,186 `.legacy` files vs the tag's 702). It supersedes the ad-hoc `archive/...` tag I created during #759, which has since been deleted.

This repoints the grounding skill's recovery note from the (now-deleted) tag to the canonical snapshot branch. The retirement commit is permanently on `main`'s history regardless, so nothing is at risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recovery guidance for legacy editor trees with revised recovery procedures and current references to help users successfully restore systems and recover data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->