### PR TITLE
docs(contributing): fix setup gaps found on a fresh clone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,55 @@
 
 ---
 
+## Prerequisites
+
+Grida uses **Git LFS** for binary fixtures and prebuilt artifacts (`*.fig` / `*.deck` test fixtures and the prebuilt canvas WASM in `crates/grida-canvas-wasm/lib/bin/*.wasm`). Install it **before cloning** — otherwise these files come down as text pointer stubs and you'll see `git-lfs: command not found` warnings on every build, plus broken fixtures/WASM.
+
+```bash
+# install git-lfs and register its git filters (once per machine)
+brew install git-lfs
+git lfs install
+```
+
 First, clone the repo with git submodules (required for canvas/WASM builds; GitHub Desktop clones submodules automatically).
 
 ```bash
-# clone the repo
+# clone the repo (LFS files are fetched automatically once git-lfs is installed)
 git clone --recurse-submodules https://github.com/gridaco/grida
 cd grida
 
-# or, if you already cloned without --recurse-submodules
+# or, if you already cloned without --recurse-submodules / before installing git-lfs
 git submodule update --init
+git lfs pull
 
 # setup node & package manager
 nvm use
 corepack enable pnpm
 
-# install just
+# install just (command runner)
 brew install just
 
-# install typos (typo checker)
-brew install typos
+# install typos (typo checker) — note: the formula is `typos-cli`, not `typos`
+brew install typos-cli
 ```
 
 ## Rust / Canvas (Skia) prerequisites
+
+> Only needed if you work on the Rust crates (`crates/**`) or build the canvas WASM. The Node/TypeScript workflow (`pnpm install`, `pnpm dev:editor`, `pnpm typecheck`, `pnpm test`) does **not** require Rust — the editor consumes the prebuilt WASM pulled via Git LFS.
+
+### Rust toolchain
+
+Install Rust via [rustup](https://rustup.rs). The repo pins the exact toolchain in `rust-toolchain.toml` (currently `1.92.0` with `rustfmt` + `clippy`), so rustup auto-installs and selects the right version the first time you run a `cargo` command inside the repo — no manual version pick needed.
+
+```bash
+# install rustup (official installer — avoids Homebrew's keg-only PATH caveats)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# verify (run inside the repo so rust-toolchain.toml is honored)
+cargo --version   # -> cargo 1.92.0
+```
+
+### Skia build (ninja)
 
 Some Rust crates (e.g. the canvas backend) build Skia via `skia-bindings`, which requires `ninja` to be available on your system.
 
@@ -64,6 +91,16 @@ pnpm turbo build
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+> **Running `pnpm typecheck` from a clean checkout?** It depends on compiled package artifacts, so build the shared packages first:
+>
+> ```bash
+> pnpm build:packages
+> pnpm turbo build --filter @grida/canvas-wasm
+> pnpm typecheck
+> ```
+>
+> See [`AGENTS.md`](./AGENTS.md) ("Running `pnpm typecheck` from a clean checkout") for the full sequence.
 
 ## Packaging canvas wasm
 


### PR DESCRIPTION
## What

Fixes three setup steps in `CONTRIBUTING.md` that fail or are missing entirely. Found by working through the guide on a freshly cloned repo.

## Why / changes

- **`brew install typos` → `typos-cli`.** The documented command errors with `No available formula with the name "typos"`. The Homebrew formula is `typos-cli`.

- **Git LFS documented as a hard prerequisite.** The repo LFS-tracks the `*.fig`/`*.deck` test fixtures and the prebuilt canvas WASM (`crates/grida-canvas-wasm/lib/bin/*.wasm`). Without git-lfs installed, a fresh clone gets pointer stubs instead of real binaries, every `turbo` build prints `git-lfs: command not found`, and even `git status`/`git diff` fail (exit 128). Added a **Prerequisites** section: install + `git lfs install` before cloning, with `git lfs pull` for existing clones.

- **Rust toolchain install added.** The "Rust / Canvas (Skia) prerequisites" section only covered `ninja` and never told you to install Rust, despite `rust-toolchain.toml` pinning `1.92.0`. Added a rustup step (official installer to avoid Homebrew's keg-only PATH caveats), noting the pin auto-selects the version.

- **Clean-checkout typecheck note.** `pnpm typecheck` depends on compiled package artifacts. Added a callout with the `build:packages` → `canvas-wasm` → `typecheck` sequence, cross-linking AGENTS.md. (`build:packages` filters `./packages/*` and does **not** cover canvas-wasm, which lives in `crates/` — hence the separate build step.)

## Reviewer notes

Every command in the diff was actually run on a fresh clone during this pass: full JS/TS pipeline (install → build → typecheck 45/45 → 569 tests → lint), the canvas-wasm TS bundle, and the Rust toolchain (`cargo fmt --check`). Docs-only change; passes the repo's `typos` checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with clearer Git LFS setup instructions.
  * Improved Rust toolchain and build prerequisites documentation.
  * Added clarification on required build sequence for type checking from clean checkout.
  * Updated tooling recommendations for development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->