### PR TITLE
chore: rust hygiene cleanup (Copy derives, drop needless clones)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,55 @@
 
 ---
 
+## Prerequisites
+
+Grida uses **Git LFS** for binary fixtures and prebuilt artifacts (`*.fig` / `*.deck` test fixtures and the prebuilt canvas WASM in `crates/grida-canvas-wasm/lib/bin/*.wasm`). Install it **before cloning** — otherwise these files come down as text pointer stubs and you'll see `git-lfs: command not found` warnings on every build, plus broken fixtures/WASM.
+
+```bash
+# install git-lfs and register its git filters (once per machine)
+brew install git-lfs
+git lfs install
+```
+
 First, clone the repo with git submodules (required for canvas/WASM builds; GitHub Desktop clones submodules automatically).
 
 ```bash
-# clone the repo
+# clone the repo (LFS files are fetched automatically once git-lfs is installed)
 git clone --recurse-submodules https://github.com/gridaco/grida
 cd grida
 
-# or, if you already cloned without --recurse-submodules
+# or, if you already cloned without --recurse-submodules / before installing git-lfs
 git submodule update --init
+git lfs pull
 
 # setup node & package manager
 nvm use
 corepack enable pnpm
 
-# install just
+# install just (command runner)
 brew install just
 
-# install typos (typo checker)
-brew install typos
+# install typos (typo checker) — note: the formula is `typos-cli`, not `typos`
+brew install typos-cli
 ```
 
 ## Rust / Canvas (Skia) prerequisites
+
+> Only needed if you work on the Rust crates (`crates/**`) or build the canvas WASM. The Node/TypeScript workflow (`pnpm install`, `pnpm dev:editor`, `pnpm typecheck`, `pnpm test`) does **not** require Rust — the editor consumes the prebuilt WASM pulled via Git LFS.
+
+### Rust toolchain
+
+Install Rust via [rustup](https://rustup.rs). The repo pins the exact toolchain in `rust-toolchain.toml` (currently `1.92.0` with `rustfmt` + `clippy`), so rustup auto-installs and selects the right version the first time you run a `cargo` command inside the repo — no manual version pick needed.
+
+```bash
+# install rustup (official installer — avoids Homebrew's keg-only PATH caveats)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# verify (run inside the repo so rust-toolchain.toml is honored)
+cargo --version   # -> cargo 1.92.0
+```
+
+### Skia build (ninja)
 
 Some Rust crates (e.g. the canvas backend) build Skia via `skia-bindings`, which requires `ninja` to be available on your system.
 
@@ -64,6 +91,16 @@ pnpm turbo build
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+> **Running `pnpm typecheck` from a clean checkout?** It depends on compiled package artifacts, so build the shared packages first:
+>
+> ```bash
+> pnpm build:packages
+> pnpm turbo build --filter @grida/canvas-wasm
+> pnpm typecheck
+> ```
+>
+> See [`AGENTS.md`](./AGENTS.md) ("Running `pnpm typecheck` from a clean checkout") for the full sequence.
 
 ## Packaging canvas wasm
 

--- a/crates/grida/src/cache/paragraph.rs
+++ b/crates/grida/src/cache/paragraph.rs
@@ -100,7 +100,7 @@ pub enum ParagraphIdentifier {
 ///
 /// This struct contains the geometric information needed to draw baseline paths
 /// for text overlay features like hit testing and stroke visualization.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct BaselineInfo {
     /// Left edge of the line in text coordinates
     pub left: f32,
@@ -114,7 +114,7 @@ pub struct BaselineInfo {
 ///
 /// This struct contains all available measurement results from the Skia Paragraph API,
 /// providing complete geometric information for layout calculations and rendering.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct LayoutMeasurements {
     // Basic dimensions
     /// Total height of the paragraph
@@ -160,7 +160,7 @@ pub struct ParagraphCacheEntry {
 
 /// Accumulated statistics from `measure()` calls — for benchmarking only.
 /// All fields are simple integer counters (zero-cost increments).
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct ParagraphMeasureStats {
     pub calls: u64,
     pub cache_hits: u64,
@@ -282,13 +282,13 @@ impl ParagraphCache {
                     // Fast path: return cached measurements if width matches
                     if let Some((cached_w, ref measurements)) = entry.cached_measurements {
                         if cached_w == width {
-                            return measurements.clone();
+                            return *measurements;
                         }
                     }
                     // Width changed: re-layout and cache
                     let paragraph_rc = entry.paragraph.clone();
                     let m = Self::compute_measurements(paragraph_rc, width);
-                    entry.cached_measurements = Some((width, m.clone()));
+                    entry.cached_measurements = Some((width, m));
                     return m;
                 }
             }
@@ -299,12 +299,12 @@ impl ParagraphCache {
                     self.stats.cache_hits += 1;
                     if let Some((cached_w, ref measurements)) = entry.cached_measurements {
                         if cached_w == width {
-                            return measurements.clone();
+                            return *measurements;
                         }
                     }
                     let paragraph_rc = entry.paragraph.clone();
                     let m = Self::compute_measurements(paragraph_rc, width);
-                    entry.cached_measurements = Some((width, m.clone()));
+                    entry.cached_measurements = Some((width, m));
                     return m;
                 }
             }
@@ -322,7 +322,7 @@ impl ParagraphCache {
             hash: shape_key.unwrap_or(0),
             font_generation: fonts_gen,
             paragraph: paragraph_rc,
-            cached_measurements: Some((width, measurements.clone())),
+            cached_measurements: Some((width, measurements)),
         };
 
         // Store in the appropriate cache

--- a/crates/grida/src/cg/rect.rs
+++ b/crates/grida/src/cg/rect.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// # Constraints
 ///
 /// - `width` and `height` must be non-negative (can be zero, but not negative)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct CGRect {
     /// The x-coordinate of the rectangle's origin (left edge).
     pub x: f32,

--- a/crates/grida/src/cg/svg.rs
+++ b/crates/grida/src/cg/svg.rs
@@ -184,7 +184,7 @@ fn svg_linear_gradient_to_paint(
 ) -> Paint {
     let xy1 = Alignment::from_uv(Uv(linear.x1, linear.y1));
     let xy2 = Alignment::from_uv(Uv(linear.x2, linear.y2));
-    let mut transform = AffineTransform::from(&linear.transform);
+    let mut transform = AffineTransform::from(linear.transform);
     normalize_gradient_transform(&mut transform, bounds);
 
     Paint::LinearGradient(LinearGradientPaint {
@@ -209,7 +209,7 @@ fn svg_radial_gradient_to_paint(
         return unsupported_svg_gradient("radial focal point (fx/fy)");
     }
 
-    let mut gradient_transform = AffineTransform::from(&radial.transform);
+    let mut gradient_transform = AffineTransform::from(radial.transform);
     normalize_gradient_transform(&mut gradient_transform, bounds);
     let alignment = radial_gradient_alignment_transform((radial.cx, radial.cy), radial.r);
 

--- a/crates/grida/src/cg/transform.rs
+++ b/crates/grida/src/cg/transform.rs
@@ -81,22 +81,10 @@ impl From<CGTransform2D> for AffineTransform {
     }
 }
 
-impl From<&CGTransform2D> for AffineTransform {
-    fn from(transform: &CGTransform2D) -> Self {
-        (*transform).into()
-    }
-}
-
 impl From<AffineTransform> for CGTransform2D {
     fn from(transform: AffineTransform) -> Self {
         let [[m00, m01, m02], [m10, m11, m12]] = transform.matrix;
         CGTransform2D::new(m00, m01, m02, m10, m11, m12)
-    }
-}
-
-impl From<&AffineTransform> for CGTransform2D {
-    fn from(transform: &AffineTransform) -> Self {
-        (*transform).into()
     }
 }
 

--- a/crates/grida/src/htmlcss/collect.rs
+++ b/crates/grida/src/htmlcss/collect.rs
@@ -926,7 +926,7 @@ fn detect_select_widget(node_data: &DemoNode, dom: &DemoDom, el: &mut StyledElem
         }
     }
 
-    let display_text = selected_text.clone().or(first_option_text);
+    let display_text = selected_text.or(first_option_text);
     if let Some(ref text) = display_text {
         inject_synthetic_text(el, text, el.color);
     }

--- a/crates/grida/src/htmlcss/svg/paint/svg_text_painter/mod.rs
+++ b/crates/grida/src/htmlcss/svg/paint/svg_text_painter/mod.rs
@@ -3244,11 +3244,11 @@ fn read_local_font(node: &DemoNode, prop: &str) -> Option<String> {
     let parts = parse_font_shorthand(&raw)?;
     if parsed_in_shorthand {
         let from_shorthand = match prop {
-            "font-style" => parts.style.clone(),
-            "font-weight" => parts.weight.clone(),
-            "font-stretch" => parts.stretch.clone(),
-            "font-size" => parts.size.clone(),
-            "font-family" => parts.family.clone(),
+            "font-style" => parts.style,
+            "font-weight" => parts.weight,
+            "font-stretch" => parts.stretch,
+            "font-size" => parts.size,
+            "font-family" => parts.family,
             _ => None,
         };
         if from_shorthand.is_some() {

--- a/crates/grida/src/painter/image_filters.rs
+++ b/crates/grida/src/painter/image_filters.rs
@@ -294,7 +294,7 @@ pub fn create_tint_filter(green_multiplier: f32) -> sk::ColorFilter {
 }
 
 /// Parameters for the shadows/highlights filter
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ShadowsHighlightsParams {
     /// Shadow adjustment [-1.0, +1.0] (>0 lift shadows, <0 crush)
     pub shadows: f32,

--- a/crates/grida/src/painter/painter_debug_node.rs
+++ b/crates/grida/src/painter/painter_debug_node.rs
@@ -273,7 +273,7 @@ impl<'a> NodePainter<'a> {
     pub fn draw_polygon_node(&self, node: &PolygonNodeRec) {
         self.painter.with_transform(&node.transform.matrix, || {
             let path = node.to_path();
-            let shape = PainterShape::from_path(path.clone());
+            let shape = PainterShape::from_path(path);
             // In debug rendering, transform is already applied, so bounds should be in local space (identity transform)
             let identity_transform = math2::transform::AffineTransform::identity().matrix;
             self.painter

--- a/crates/grida_dev/src/bench/load_bench.rs
+++ b/crates/grida_dev/src/bench/load_bench.rs
@@ -123,7 +123,7 @@ fn measure_load_scene(
         );
     }
     let layout_us = t1.elapsed().as_micros() as u64;
-    let para_stats = paragraph_cache.stats.clone();
+    let para_stats = paragraph_cache.stats;
 
     // Stage 2: Geometry
     let t2 = Instant::now();


### PR DESCRIPTION
Low-risk, behavior-preserving Rust hygiene cleanup across the grida crates. No public API redesigns, no serialized-output changes.

## Commits
1. **`refactor(grida/cg): drop redundant ref-From impls, make CGRect Copy`** — removed two boilerplate `impl From<&T> for U { (*x).into() }` impls between `CGTransform2D` and `AffineTransform` (both `Copy`); the live caller in `cg/svg.rs` now passes by value. `CGRect` derives `Copy`.
2. **`refactor(grida): derive Copy on POD measurement structs`** — `Copy` on four all-scalar, non-serde PODs (`BaselineInfo`, `LayoutMeasurements`, `ParagraphMeasureStats`, `ShadowsHighlightsParams`); fixed the 6 `clone_on_copy` warnings the new derives surfaced (5 in the paragraph cache hot path, 1 in a `grida_dev` bench).
3. **`refactor(grida): drop redundant clones (move instead of clone)`** — removed 7 `clippy::redundant_clone` clones where the value is consumed once and not reused (`collect.rs`, 5 font-shorthand reads in `svg_text_painter`, `painter_debug_node.rs`).

## Fix categories
- **2** redundant ref-`From` impls removed
- **5** POD structs given `Copy` (`CGRect` + 4 measurement structs)
- **13** needless clones dropped (6 `clone_on_copy` + 7 `redundant_clone`)

## Verification (local, fresh run)
- `cargo check`: grida, grida_dev, grida-canvas-wasm — clean
- `cargo fmt --all --check` — clean
- CI-exact clippy (`cargo clippy --no-deps --workspace --exclude grida-canvas-wasm -- -D warnings`) — clean
- Tests: grida lib **822 passed / 0 failed**, integration **28 binaries / 0 failures**, grida_dev tests pass

Behavior-preserving; the `[[f32;3];2]` transform serde round-trip guards pass unchanged.

## Deliberately skipped (wire-format / schema constraint)
- **`io_grida_fbs.rs:2260`** — a genuine `redundant_clone` (`AttributedString::from_runs(text.clone(), runs)`), but it lives in the FlatBuffers `.grida` bridge; left untouched to stay clear of the binary-format boundary.
- **`FeBlur` / `FeLayerBlur` / `FeBackdropBlur`** — POD-shaped but `FeBlur` carries `serde::Deserialize` (part of the deserialized cg model); making the chain `Copy` would reach into model/serde territory, so it was left alone (no wire-format risk, but outside "clearly low-risk").
- `CGTransform2D` itself is a FlatBuffers schema struct and was **not** collapsed into `AffineTransform` (would change the binary format).

> Note: a stricter `clippy --all-targets` run surfaces **pre-existing** lint debt in `fonts` tests and `csscascade` examples — these fail identically on `main`, are untouched by this PR, and are outside the lefthook/CI clippy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contributor setup instructions with clarified Git LFS workflow and Rust toolchain guidance
  * Clarified that Rust/Skia (canvas WASM) dependencies are only required for canvas-related development
  * Expanded build and typecheck workflow documentation with recommended command sequences and references to detailed setup guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->