### PR TITLE
docs(skills): add docs + docs-wg skills, unify the docs-* family

### DIFF
--- a/.agents/skills/docs-canvas/SKILL.md
+++ b/.agents/skills/docs-canvas/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: canvas-user-docs
+name: docs-canvas
 description: >
   Author and manage user-facing documentation for the Grida Canvas editor.
   Covers writing style, tone, product screenshots, demo state preparation,
@@ -111,7 +111,7 @@ For workflows, before/after, or relationships a screenshot can't show.
 - Annotations: red (#FF3B30) circles/arrows, 2px stroke, 1-3 callouts max
 
 For SVG figures specifically — gestures, alignment, before/after diagrams that
-recreate canvas UI — use the **`canvas-docs-svg-kit`** skill. It provides a
+recreate canvas UI — use the **`docs-svg-kit`** skill. It provides a
 starter template, a primitives catalog (selection chrome, size badges, anchor
 pins, resize cursors, ripples), and finished examples to crib from. Saves you
 from re-deriving stroke widths, colors, and the half-pixel alignment tricks.

--- a/.agents/skills/docs-svg-kit/SKILL.md
+++ b/.agents/skills/docs-svg-kit/SKILL.md
@@ -1,21 +1,28 @@
 ---
-name: canvas-docs-svg-kit
+name: docs-svg-kit
 description: >
-  Author SVG figures for canvas user docs at docs/editor/. Provides reusable
+  Author SVG figures for Grida docs — diff-able, version-controlled vector
+  diagrams embedded in doc pages instead of screenshots. Provides reusable
   primitives (selection chrome, size badges, anchor pins, resize cursors,
   click ripples), color/typography tokens, a starter template, and finished
-  examples to crib from. Use when drawing diagrams that explain canvas UI
-  behaviour — gestures, alignment, before/after states — that a screenshot
-  alone can't capture. Trigger phrases: "svg diagram", "draw a figure",
-  "visual for docs", "explain this gesture visually", "before/after diagram".
+  examples to crib from. Canvas user docs (docs/editor/) are the first
+  consumer; the kit is meant to generalize to any product's docs. Use when
+  drawing diagrams that explain UI behaviour — gestures, alignment,
+  before/after states — that a screenshot alone can't capture. Trigger
+  phrases: "svg diagram", "draw a figure", "visual for docs", "explain this
+  gesture visually", "before/after diagram".
 ---
 
-# Canvas Docs SVG Kit
+# Docs SVG Kit
 
-A snippet library for drawing SVG figures used in canvas user docs.
+A snippet library for drawing SVG figures embedded in Grida docs. Canvas
+user docs are the kit's first consumer; the same primitives and
+conventions are meant to carry over to any product's docs as they adopt
+SVG figures.
 
-**Companion to:** [`canvas-user-docs`](../canvas-user-docs/SKILL.md).
-Use that skill for prose, this one for the visuals embedded inside it.
+**First consumer / companion:**
+[`docs-canvas`](../docs-canvas/SKILL.md). Use that skill for the prose,
+this one for the visuals embedded inside it.
 
 ## Why SVG, not a screenshot
 
@@ -55,13 +62,13 @@ So we can enumerate, audit, and migrate kit assets later without reading each fi
 1. A top-level XML comment immediately before the root `<svg>` (grep-friendly):
 
    ```xml
-   <!-- @generated-by: canvas-docs-svg-kit v1 -->
+   <!-- @generated-by: docs-svg-kit v1 -->
    ```
 
 2. A `<metadata>` element as the first child of `<svg>` (SVG-spec-native, survives minification and SVGO passes that strip comments):
 
    ```xml
-   <metadata>canvas-docs-svg-kit/v1</metadata>
+   <metadata>docs-svg-kit/v1</metadata>
    ```
 
 Both markers are present in `snippets/template.svg`, so they propagate automatically when you copy from the template. If you start a figure from scratch, paste both before composing anything else.
@@ -71,7 +78,7 @@ Both markers are present in `snippets/template.svg`, so they propagate automatic
 **Enumerate kit assets:**
 
 ```sh
-grep -rl "canvas-docs-svg-kit" docs/editor/
+grep -rl "docs-svg-kit" docs/editor/
 ```
 
 When the kit changes, walk the grep output and update each file.
@@ -241,8 +248,8 @@ We don't have this validator yet — add it the first time you find yourself fix
 
 **Pre-publish checklist:**
 
-- [ ] Watermark comment present (`@generated-by: canvas-docs-svg-kit v1`)
-- [ ] `<metadata>canvas-docs-svg-kit/v1</metadata>` is the first child of `<svg>`
+- [ ] Watermark comment present (`@generated-by: docs-svg-kit v1`)
+- [ ] `<metadata>docs-svg-kit/v1</metadata>` is the first child of `<svg>`
 - [ ] Inline `<style>` only — no external stylesheet references
 - [ ] No `<use href="other.svg#…">` — all referenced ids exist in this file
 - [ ] Viewport is `960 × 960`

--- a/.agents/skills/docs-svg-kit/examples/text-node-auto-size-alignment.svg
+++ b/.agents/skills/docs-svg-kit/examples/text-node-auto-size-alignment.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/examples/text-node-auto-size-edges.svg
+++ b/.agents/skills/docs-svg-kit/examples/text-node-auto-size-edges.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/cursors.svg
+++ b/.agents/skills/docs-svg-kit/snippets/cursors.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  cursors
+  docs-svg-kit  ·  cursors
 
   Focused catalog of every cursor symbol in the kit. Each cell shows the
   cursor at its native size (with shadow), labelled with its `<use>` id and
@@ -16,7 +16,7 @@
      width="960"
      height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/handles.svg
+++ b/.agents/skills/docs-svg-kit/snippets/handles.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  handles
+  docs-svg-kit  ·  handles
 
   The kit's three "point" primitives:
     .handle             → square corner handle (selection chrome)
@@ -19,7 +19,7 @@
      width="960"
      height="480"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/keycap.svg
+++ b/.agents/skills/docs-svg-kit/snippets/keycap.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  keycap
+  docs-svg-kit  ·  keycap
 
   Modifier-key pill (kbd-style). Use in interaction figures to show which
   key the user holds during a gesture (Alt-hover, Shift-resize, etc.).
@@ -20,7 +20,7 @@
      width="960"
      height="360"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg   { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/meters.svg
+++ b/.agents/skills/docs-svg-kit/snippets/meters.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  meters
+  docs-svg-kit  ·  meters
 
   The meter primitive comes in two variants:
     .badge          → size readout, blue (selection variant)
@@ -19,7 +19,7 @@
      width="960"
      height="480"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg      { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/primitives.svg
+++ b/.agents/skills/docs-svg-kit/snippets/primitives.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  primitives catalog
+  docs-svg-kit  ·  primitives catalog
 
   Visual reference of every primitive in the kit. Open this file to see
   what's available before composing a new figure. The CSS classes shown
@@ -11,7 +11,7 @@
      width="960"
      height="1400"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }

--- a/.agents/skills/docs-svg-kit/snippets/template.svg
+++ b/.agents/skills/docs-svg-kit/snippets/template.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <!--
-  canvas-docs-svg-kit  ·  starter template
+  docs-svg-kit  ·  starter template
 
   Copy this file as a starting point for a new docs figure. All tokens,
   filters, markers, and reusable defs are wired up. Compose your figure
@@ -17,7 +17,7 @@
      width="960"
      height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       /* ============================================================

--- a/.agents/skills/docs-wg/SKILL.md
+++ b/.agents/skills/docs-wg/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: docs-wg
+description: >
+  Doctrine for drafting and keeping working-group docs under
+  `docs/wg/**` — RFC/RFD specs and findings/research/glossary. A WG doc
+  is a language-agnostic, code-agnostic study of a domain: it argues
+  *why* and defines *what*, never *how in our code*. Use when writing or
+  editing anything under `docs/wg/`, an RFC/RFD, a spec, a design note, a
+  glossary, or research findings — including "write up the design",
+  "document the spec", or "capture what we learned". Not for plans/TODOs
+  (untracked `*.plan.md`), user docs, or SDK API refs — use `docs` to
+  route those.
+---
+
+# WG docs
+
+Working-group docs are where Grida reasons about a problem **before and
+above** any one implementation. A good WG doc could be handed to someone
+rebuilding the feature in a different language, on a different stack, in a
+different decade, and still be the right starting point. That is the bar.
+
+The reason WG docs are code-agnostic is not stylistic. Code moves; a file
+path or a function name is stale within months, and a doc anchored to it
+rots into a lie. A doc anchored to the _domain_ — the problem, the spec,
+the why — stays true as long as the problem does. You are writing the
+thing that outlives the code.
+
+This skill is the doctrine. Operational mechanics (frontmatter,
+`format: md`, `draft`/`unlisted`/`doc_tasks`, the sync model) live in
+[`docs/AGENTS.md`](../../../docs/AGENTS.md) — read it once. For _reading_
+the WG tree before you edit, use [`grounding`](../grounding/SKILL.md).
+
+## The two genres
+
+A WG doc is almost always one of these. Name which before you draft —
+they have different shapes.
+
+### 1. RFC / RFD — spec
+
+A specification of _what a feature or system is_ and _why it is that
+way_. Spec-rich. It defines vocabulary, states constraints and
+invariants, and argues the design tradeoffs. It reads like a standards
+document, not like a code comment.
+
+- **Covers why and what.** The motivation, the requirements, the model,
+  the chosen design and the alternatives rejected (and why).
+- **No code-level implementation detail.** Describe the behavior and the
+  contract, not the functions that will realize them. If you find
+  yourself naming a struct or a file, you have dropped from spec altitude
+  into implementation — climb back up.
+- **Language- and stack-agnostic.** Express the model in terms a second
+  implementer could honor, not in terms of the current one.
+
+### 2. Findings / research / glossary
+
+Grounded, concise domain knowledge — what is _true_ about the problem
+space. A glossary that pins down vocabulary; findings that record what a
+study established; research that surveys how the domain is understood.
+
+- **Always factual and grounded.** Every claim traceable to a spec, a
+  standard, or a demonstrated result — not to a hunch or a memory.
+- **Concise and managed.** This is reference material; it earns its keep
+  by being correct and findable, not long.
+- **Domain-first.** It studies the _problem_, not Grida's solution to it.
+
+> **The dedicated upstream-survey subtree is `docs/wg/research/**`**, and
+it has its own stricter rules (pure survey, Grida absent from the body).
+When writing there, use [`research`](../research/SKILL.md) — it governs
+> that subtree specifically. This skill governs the broader WG surface.
+
+## What a good WG doc is
+
+- **Clear and well-researched** — the reader trusts it because it shows
+  its grounding.
+- **Always factual; agnostic spec; language-agnostic** — true regardless
+  of who implements it or in what.
+- **A deep study and a starting place** — the canonical entry point for
+  understanding a feature or spec, covering _why_ and _what_.
+- **A manifesto / doctrine when that is what the topic needs** — a WG doc
+  may take a position and argue it. Taking a stance is allowed; the stance
+  must rest on fact.
+
+## What a bad WG doc is
+
+These are not style nits — each one is the doc rotting or pointing the
+reader wrong:
+
+- **References specific parts of the code.** File paths, function names,
+  line numbers. They date the doc and pull it down to implementation
+  altitude. Describe the contract, not the call site.
+- **References an external project as the model.** A WG doc studies the
+  _domain_, not some other project's take on it. Citing "how library X
+  does it" smuggles a foreign implementation in as if it were the spec.
+  - **Exception: domain reference standards.** Citing a de-facto standard
+    or reference implementation of the _domain itself_ is fine and often
+    necessary — Chromium and the W3C/WHATWG specs for web rendering, for
+    example, _are_ the domain. The test: are you citing the standard, or
+    a project's opinion? Dedicated surveys of such sources belong in
+    `docs/wg/research/**` under [`research`](../research/SKILL.md).
+- **Dirty plans / TODO sprawl.** Scattered "TODO: fix this later" and
+  half-formed task lists turn a reference into a scratchpad. Keep the doc
+  a clean statement of what is true and intended.
+
+## What is NOT a WG doc at all
+
+These do not belong under `docs/wg/` in any form. They are a different
+kind of artifact:
+
+- **Plans.** Implementation plans live in `*.plan.md` files, which are
+  **gitignored on purpose** ([.gitignore](../../../.gitignore)) — they are
+  working scratch, not committed knowledge. A plan is about _the work_; a
+  WG doc is about _the thing_.
+- **TODO lists.** Tracked work belongs in issues/PRs, not in a doc.
+- **Conversational logs / history / decision diaries.** "On Tuesday we
+  decided…" is process, not knowledge. Historical snapshots that must be
+  kept go under a `_history/` folder marked `unlisted: true` (see
+  [`docs/AGENTS.md`](../../../docs/AGENTS.md)), never in the live spec.
+
+The throughline: a WG doc states **what is true and what is intended**,
+in domain terms, for a reader who arrives cold. Anything that is _about
+the work_ rather than _about the thing_ is a different artifact.
+
+## Placement and upkeep
+
+- WG docs live in topic clusters: `docs/wg/feat-*/`, `docs/wg/format/`,
+  `docs/wg/platform/`, `docs/wg/ai/`, and surveys in
+  `docs/wg/research/`. Put the doc in the cluster that owns its topic;
+  create a new `feat-<topic>/` cluster when none fits (consult
+  [`naming`](../naming/SKILL.md) for the cluster name).
+- **Most clusters have an `index.md` hub.** When you add a doc, update the
+  hub so the cluster stays navigable — an orphaned doc is an unfindable
+  doc.
+- **Frontmatter** (per [`docs/AGENTS.md`](../../../docs/AGENTS.md)):
+  `title`, a `description`, `tags: [internal, wg, <topic>…]` drawn from
+  the controlled vocabulary in [`docs/tags.yml`](../../../docs/tags.yml),
+  and `format: md` for plain-Markdown pages (the MDX-safety opt-out).
+- **Links** follow the [`links`](../links/SKILL.md) skill: relative within
+  `/docs`, GitHub-absolute for anything outside `/docs`, universal `/_/`
+  routes for "open in the product."
+
+## Before you save — review
+
+- [ ] Could a second implementer in another language honor this doc
+      without reading our code? If not, you have implementation detail to
+      remove.
+- [ ] Search the draft for file paths, function/struct names, `crates/`,
+      `editor/`, `packages/`. Each match must justify itself — usually by
+      being lifted to a domain-level statement.
+- [ ] Any external project cited as _the model_ rather than as a domain
+      standard? Reframe to the domain, or move a genuine survey to
+      `research/`.
+- [ ] Any `TODO`, plan fragment, or "we decided on <date>"? Remove it —
+      it belongs in a plan, an issue, or `_history/`.
+- [ ] Did you update the cluster `index.md`?
+
+## Related skills
+
+[`docs`](../docs/SKILL.md) (the family router — start there if unsure this
+is even a WG doc), [`research`](../research/SKILL.md) (the `research/`
+upstream-survey subtree), [`grounding`](../grounding/SKILL.md) (read and
+reconcile before editing), [`links`](../links/SKILL.md),
+[`naming`](../naming/SKILL.md) (cluster and concept names).
+Operational mechanics: [`docs/AGENTS.md`](../../../docs/AGENTS.md).

--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: docs
+description: >
+  Decide which family a doc belongs to before drafting — SDK/developer,
+  user/product, or working-group (WG) — since family sets the audience,
+  home, and tone. Use when creating, moving, or restructuring docs, when
+  unsure which directory a doc belongs in, or when a request says
+  "document this" / "write docs for X" without naming the kind. Routes to
+  the specialized skill for each family.
+---
+
+# Docs
+
+Documentation in Grida is not one thing. Before drafting, name the
+**family** — because the family decides the audience, the home directory,
+the tone, and which skill governs the rest. Writing the right content in
+the wrong family (a spec dump in a user guide, a marketing tone in an
+RFC) is the most common and most expensive docs mistake, because it is
+invisible until someone reads it for the wrong reason.
+
+`/docs/**` is the source of truth, synced to `/apps/docs/docs/**` at
+build and published at `grida.co/docs`. Edit the root `/docs`, never the
+synced copy. The operational rules that apply to _every_ family —
+taxonomy (`draft` / `unlisted` / `doc_tasks`), frontmatter, MDX safety
+(`format: md`), `_history/`, the structure table — live in
+[`docs/AGENTS.md`](../../../docs/AGENTS.md). Read it once; this skill does
+not repeat it.
+
+## The three families
+
+| Family                      | Audience                                                       | Home                                                                            | Character                                              | Governing skill                                                                                                                                                                                                                                                        |
+| --------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SDK / developer**         | engineers (and, implicitly, agents) consuming a package or API | `packages/<pkg>/docs/` for spec-only; `docs/reference/**` for stable references | technical, example-dense, low-visual, precise          | this skill (below)                                                                                                                                                                                                                                                     |
+| **User / product**          | humans using a Grida product                                   | `docs/editor/**`, `docs/forms/**`, `docs/platform/**`, `docs/with-figma/**`, …  | content-rich, screenshots, SEO-friendly, task-oriented | canvas editor (`docs/editor/`) → [`docs-canvas`](../docs-canvas/SKILL.md); cross-cutting → [`seo`](../seo/SKILL.md) + [`docs-svg-kit`](../docs-svg-kit/SKILL.md); other surfaces have no dedicated skill yet — use [`docs/AGENTS.md`](../../../docs/AGENTS.md) + `seo` |
+| **WG / research / RFC-RFD** | contributors and maintainers reasoning about _why_ and _what_  | `docs/wg/**`                                                                    | spec-rich, language-agnostic, code-agnostic, factual   | [`docs-wg`](../docs-wg/SKILL.md)                                                                                                                                                                                                                                       |
+
+If the request fits one family cleanly, hand off to its governing skill
+and stop reading here. The rest of this page covers the routing edges and
+the SDK family (which has no skill of its own).
+
+## Routing — which family is this?
+
+Ask, in order:
+
+1. **Is it about _why_ a thing is designed the way it is, or _what_ a
+   feature/spec should be — independent of any one implementation?**
+   → WG. Go to [`docs-wg`](../docs-wg/SKILL.md).
+2. **Is the reader a person trying to _use_ a shipped product?**
+   → User docs. Content-rich and SEO-aware. For the canvas editor
+   (`docs/editor/`) use [`docs-canvas`](../docs-canvas/SKILL.md); for
+   other surfaces (forms, platform, with-figma) there is no dedicated
+   skill yet — follow [`docs/AGENTS.md`](../../../docs/AGENTS.md) and
+   [`seo`](../seo/SKILL.md). [`docs-svg-kit`](../docs-svg-kit/SKILL.md)
+   covers SVG figures for any of them.
+3. **Is the reader an engineer (or agent) trying to _consume_ a package
+   or API correctly?** → SDK docs (below).
+
+The boundaries are real, not bureaucratic:
+
+- **Architecture / design rationale never goes in user docs.** It belongs
+  in WG. ([`docs-canvas`](../docs-canvas/SKILL.md) enforces the
+  same boundary from its side.)
+- **A WG doc is not an SDK doc.** WG says "this is what the feature is and
+  why"; SDK says "this is the API and how to call it." A WG doc that
+  drifts into API signatures has become an SDK doc in the wrong place —
+  see [`docs-wg`](../docs-wg/SKILL.md) on staying code-agnostic.
+- **Plans, TODO lists, and conversational logs are not docs of any
+  family.** Plans live in untracked `*.plan.md` files (gitignored); they
+  do not belong under `docs/`.
+
+## SDK / developer docs
+
+SDK docs explain how to consume a package or API. They optimize for an
+engineer (and, without ever saying so, for an agent) who needs to get a
+call right on the first try.
+
+**Where they live:**
+
+- **`packages/<pkg>/docs/`** — when the docs are spec-heavy and not
+  visually rich. Co-locating with the package keeps the contract next to
+  the code it describes and versioned with it. (Precedent:
+  `packages/grida-svg-editor/docs/`.) A package's `README.md` and
+  `AGENTS.md` are the entry points; `docs/` holds the deeper material.
+- **`docs/reference/**`** — for stable, cross-package technical
+references, glossaries, and specs that deserve a place on the published
+site. This tree is actively maintained alongside `docs/wg/\*\*`.
+
+**What good SDK docs look like:**
+
+- **Example-dense.** Every non-trivial API earns a short, runnable
+  example. Examples carry more than prose for a consumer.
+- **Technical and precise** about types, contracts, and edge cases —
+  light on screenshots and marketing.
+- **Good for agents by being good, period.** Do not write "for AI" — a
+  clear, complete, example-backed reference is what an agent needs and
+  what a human needs. The two goals do not diverge.
+- **Honest about stability.** Mark experimental surfaces; an SDK doc that
+  oversells a shaky API costs its readers time.
+
+## Related skills
+
+[`docs-wg`](../docs-wg/SKILL.md) (WG authoring doctrine),
+[`docs-canvas`](../docs-canvas/SKILL.md) (canvas/editor user docs),
+[`seo`](../seo/SKILL.md) (frontmatter + search),
+[`links`](../links/SKILL.md) (how to write any link),
+[`grounding`](../grounding/SKILL.md) (find/reconcile the authoritative
+doc before editing). Operational taxonomy and frontmatter:
+[`docs/AGENTS.md`](../../../docs/AGENTS.md).

--- a/docs/editor/resources/surface-image-editor-overlay.svg
+++ b/docs/editor/resources/surface-image-editor-overlay.svg
@@ -1,10 +1,10 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 960 960"
      width="960"
      height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }

--- a/docs/editor/resources/text-node-auto-size-alignment.svg
+++ b/docs/editor/resources/text-node-auto-size-alignment.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg { fill: #ECECEC; }

--- a/docs/editor/resources/text-node-auto-size-edges.svg
+++ b/docs/editor/resources/text-node-auto-size-edges.svg
@@ -1,6 +1,6 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960" width="960" height="960" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg { fill: #ECECEC; }

--- a/docs/editor/resources/vector-network-editor-midpoint-projection.svg
+++ b/docs/editor/resources/vector-network-editor-midpoint-projection.svg
@@ -1,10 +1,10 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 960 960"
      width="960"
      height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }

--- a/docs/editor/resources/vector-network-measurement-alt-hover.svg
+++ b/docs/editor/resources/vector-network-measurement-alt-hover.svg
@@ -1,10 +1,10 @@
-<!-- @generated-by: canvas-docs-svg-kit v1 -->
+<!-- @generated-by: docs-svg-kit v1 -->
 <svg xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 960 960"
      width="960"
      height="960"
      font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif">
-  <metadata>canvas-docs-svg-kit/v1</metadata>
+  <metadata>docs-svg-kit/v1</metadata>
   <defs>
     <style>
       .canvas-bg     { fill: #ECECEC; }


### PR DESCRIPTION
## What

Adds two documentation-authoring skills and re-clusters the existing canvas doc tooling under a shared `docs-*` prefix so all documentation skills sit together in the skills tree.

### New skills
- **`docs`** — taxonomy router. Names the doc *family* (SDK / user / WG) before drafting, since family sets audience, home, and tone. Carries the SDK family inline (it has no skill of its own) and defers operational mechanics to `docs/AGENTS.md` rather than duplicating them.
- **`docs-wg`** — doctrine for working-group docs under `docs/wg/**` (RFC/RFD specs + findings/research/glossary). Encodes the language-agnostic, code-agnostic discipline (*why*/*what*, never *how-in-our-code*), the good/bad/not-WG distinctions, the external-project rule with the Chromium/standards exception (deferring dedicated project surveys to the existing `research` skill), and a before-you-save review checklist.

### Renames (history preserved via `git mv`)
- `canvas-user-docs` → **`docs-canvas`**
- `canvas-docs-svg-kit` → **`docs-svg-kit`** — generalized from "canvas user docs only" to "SVG figures for any Grida docs"; canvas user docs are named as the first consumer.

The four skills now cluster as `docs`, `docs-canvas`, `docs-svg-kit`, `docs-wg`.

## Why

WG-docs guidance previously lived only in `docs/AGENTS.md` plus scattered fragments across `research`, `grounding`, `links`, and `seo` — there was no skill owning "how to write/keep a WG design doc." The `docs` router fills the "which family / where does this belong" gap; `docs-wg` fills the WG-authoring gap. The `docs-*` prefix makes the family browsable in the tree (domain-first ordering per the `naming` skill).

## Notes for reviewers

- **Provenance stamps**: `docs-svg-kit`'s `@generated-by` / `<metadata>` watermark convention was renamed in lockstep, including the 5 already-generated figures under `docs/editor/resources/`, so the kit's static lint stays self-consistent.
- **Family-table scoping**: `docs-canvas` is honestly scoped to the canvas editor (`docs/editor/`); the router notes that forms/platform/with-figma user docs have no dedicated skill yet and fall back to `docs/AGENTS.md` + `seo`.
- **Intentionally left untouched** (separate artifacts, outside this change): the old skill names still appear as illustrative *examples* in `docs/wg/ai/agent/{skills.md,compositor.md}`, as sample fixture labels in the composer test/demo data, and in the generated `apps/docs/**` build copies (which re-sync from source on the next docs build).
- Markdown tables were reflowed by the repo's `oxfmt` pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation skills for improved structure and clarity
  * Added new working group documentation guidelines and standards
  * Established clearer documentation routing and organization framework
  * Updated skill naming conventions for better consistency and discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->