### PR TITLE
feat(svg-editor): click-to-place text tool (T)

### DIFF
--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -52,6 +52,10 @@ preserving the author's source on round-trip.
 - [`feedback-transform.md`](./feedback-transform.md) — internal
   critique of the current transform pipeline. Input to the IR
   redesign; cited from the intent matrix.
+- [`text-tool.md`](./text-tool.md) — why text creation is
+  click-to-place rather than drag-to-size, and why an empty text
+  element is treated as a deletion (the empty-equals-delete
+  invariant, shared with existing-text editing).
 
 ### Glossary
 

--- a/docs/wg/feat-svg-editor/text-tool.md
+++ b/docs/wg/feat-svg-editor/text-tool.md
@@ -1,0 +1,160 @@
+---
+title: "Text creation — design"
+description: "Why creating text in an SVG editor is click-to-place rather than drag-to-size, and why an empty text element is treated as a deletion."
+keywords:
+  - svg
+  - svg-editor
+  - text
+  - insertion
+  - content-edit
+tags:
+  - internal
+  - svg
+  - wg
+format: md
+---
+
+# Text creation — design
+
+An SVG editor that can create rectangles, ellipses, and lines should also
+let the author create text. Text was the one primitive deferred from the
+first insertion pass, because it does not share the interaction model the
+geometric shapes use. This note states what text creation is and why it
+takes the shape it does.
+
+## Why text is not like the other shapes
+
+The geometric primitives have **intrinsic size**: the author presses,
+drags, and the drag distance sets the width and height (or the radii, or
+the endpoints). The shape exists at whatever size the drag describes.
+
+Text has no intrinsic size in SVG. A text element's extent is a
+_consequence_ of its string content, its font, and its font size — not a
+quantity the author sets by dragging a box. There is no "empty text of
+size 200×80". The press-drag-size gesture is therefore meaningless for
+text: there is nothing for the drag distance to set.
+
+## The interaction model: click to place, type immediately
+
+Creating text is a single action. The author indicates **where**, a caret
+appears there, and input begins at once. This matches every text tool the
+author already knows — point, then type. There is no intermediate "empty
+placeholder" the author must then fill; placing and editing are the same
+gesture.
+
+1. The author selects the text tool and clicks a point on the canvas.
+2. A text element is created at that point with the editor's default text
+   appearance, and the inline content editor opens on it immediately with
+   the caret active.
+3. The author types. Editing ends on exit — clicking away or pressing
+   Escape.
+
+### Why there is no drag-to-define-a-box
+
+In other tools, a drag gesture defines a **text box**: a fixed-width
+region into which text wraps. The editor's text model is **single-line
+positioned text** — a text element anchored at a point, sized only by its
+content and font. A single-line element has no width to drag out, so the
+drag-to-box gesture has nothing to set; text creation is therefore
+**click-only**.
+
+Auto-wrapped text is a genuinely different model. SVG 2 does define
+wrapping (the `inline-size` and `shape-inside` properties give a text
+element a wrapping width), so a drag-defined text box is _expressible_ in
+the format — it is simply a separate creation affordance for a separate
+model, with its own caret, selection, and reflow behavior. That model is
+deliberately out of scope here; this note is about creating single-line
+text. If wrapped text is taken up later, it gets its own gesture (a drag
+that sets `inline-size`), orthogonal to this decision.
+
+## Invariant: empty text is not a valid persistent state
+
+A text element with no content renders nothing. It cannot be seen, and it
+is effectively impossible to select on the canvas — there is no painted
+geometry to aim at. An empty text element is indistinguishable from "no
+element" to a viewer, yet it lingers in the file as noise and as an
+unselectable trap.
+
+The editor enforces a single, unconditional rule:
+
+> **On exit from text content-editing, a text element whose content is
+> empty is removed.** "Empty" means zero-length text content — a typed
+> space is authored content and is kept.
+
+This is a general fact about text, not a special case of the creation
+tool. It fires the same way regardless of how the element reached empty:
+
+- a freshly created text element the author placed but never typed into,
+- a pre-existing text element whose content the author cleared before exiting, and
+- a pre-existing element that was already empty when the author entered it and left unchanged.
+
+In every case the empty text is treated as a deletion intent.
+
+The rule is deliberately unconditional rather than firing only on a
+_transition_ to empty. Entering content-editing on an element is itself
+the author's "I am authoring this" signal; an empty text carries no
+visible content for the canvas author to act on, so the editor does not
+preserve one on exit. The accepted consequence: a source element that
+happened to be empty — even one carrying an `id`, an animation target, or
+a script-filled slot — is removed if the author opens it for editing and
+exits. This trades a corner of round-trip fidelity for a simpler, more
+predictable rule; it is a chosen tradeoff, not an oversight. (Loading a
+file never triggers it — the element is removed only if the author
+actually enters and exits content-editing on it.)
+
+### Undo contract
+
+What undo restores depends only on **whether the element existed before
+the gesture** — not on how it became empty:
+
+- **Freshly placed, never filled.** Creation and the empty exit are one
+  abandoned gesture. After exit there is no element and no committed
+  history step — undo does not resurrect an empty element, because from
+  the document's perspective nothing happened. This mirrors how an
+  abandoned drag of any insertion tool leaves no trace.
+- **Pre-existing element removed.** The element existed before the gesture
+  — whether it held content the author cleared, or was already empty on
+  entry. Removing it on exit is a deletion: a single undoable step, and
+  undo restores the element exactly as it was before the gesture (with its
+  original content, empty or not, and all its attributes).
+
+The throughline: undo returns the document to the state before the
+gesture began. For a creation that never produced visible content, that
+state is _nothing_. For the removal of a pre-existing element, that state
+is the _original element_.
+
+## Default appearance
+
+A newly created text element carries the editor's default text appearance
+— a default font family, font size, and fill — so it is visible and
+editable the instant it is placed. These are **editor defaults**, the same
+class of decision as the default fill of a new rectangle, not parameters
+the author supplies through the gesture.
+
+Font _resolution_ — mapping a family name to real metrics and glyphs —
+remains a host-provided capability. The defaults here are only the initial
+attribute values the new element starts with.
+
+## Rejected alternatives
+
+- **Drag-to-define-a-box.** Out of scope, not impossible — a drag box maps
+  to SVG 2 wrapped text (`inline-size` / `shape-inside`), which is a
+  separate model from the single-line text this tool creates. It gets its
+  own gesture if and when that model is taken up.
+- **Placeholder text** (drop the literal word "Text", let the author edit
+  it later). Rejected — it writes content the author did not author,
+  pollutes the document, and forces a select-then-edit second step that
+  click-to-caret avoids.
+- **Keep empty text elements.** Rejected — they are invisible, effectively
+  unselectable, and accumulate as file noise (see the invariant above).
+
+## Relationship to existing content editing
+
+Editing the content of an existing text element is already part of the
+editor. The creation tool does not add a second editing path: it creates
+the element and then enters that same content-editing flow. The
+empty-equals-delete invariant is shared by both entry points — creating
+new text and editing existing text exit through the same rule.
+
+Status: implemented (click-only, single-line). Wrapped/multi-line text and
+the tool-axis cleanup remain deferred (see the package `TODO.md`).

--- a/editor/app/(canvas)/svg/_components/svg-toolbar.tsx
+++ b/editor/app/(canvas)/svg/_components/svg-toolbar.tsx
@@ -5,6 +5,7 @@ import {
   CircleIcon,
   CursorArrowIcon,
   SlashIcon,
+  TextIcon,
 } from "@radix-ui/react-icons";
 import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
@@ -53,6 +54,13 @@ const TOOLS: ReadonlyArray<ToolEntry> = [
     label: "Line",
     shortcut: "L",
   },
+  {
+    value: "text",
+    tool: { type: "insert-text" },
+    Icon: TextIcon,
+    label: "Text",
+    shortcut: "T",
+  },
 ];
 
 export function SvgToolbar({ className }: { className?: string }) {
@@ -61,7 +69,12 @@ export function SvgToolbar({ className }: { className?: string }) {
   // `lasso` and `bend` are path-edit-only and SvgToolbar is mounted in
   // select mode, so they're never actually visible while either is active
   // — fall back to cursor to keep this toolbar's active value defined.
-  const value = tool.type === "insert" ? tool.tag : "cursor";
+  const value =
+    tool.type === "insert"
+      ? tool.tag
+      : tool.type === "insert-text"
+        ? "text"
+        : "cursor";
 
   return (
     <ToolbarPosition className={className}>

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/README.md
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/README.md
@@ -1,0 +1,145 @@
+# `/packages/@grida/svg-editor` — spec demo + design harness
+
+This directory renders the package landing/spec page for
+[`@grida/svg-editor`](https://github.com/gridaco/grida/tree/main/packages/grida-svg-editor)
+at `/packages/@grida/svg-editor`.
+
+It is **not** the full editor. It is the sibling of the `@grida/hud` and
+`@grida/tree-view` package pages: a set of small, isolated cards, each one
+exercising a **single feature or scenario** of the package's public API.
+
+## Two kinds of demo, on purpose
+
+| Surface                   | Route                                                          | What it is                                                                                                                                               |
+| ------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Full-editor seam          | [`/svg`](/svg), [`/svg/examples/slides`](/svg/examples/slides) | The whole editor wired to a real host — file IO, multi-doc storage, toolbars, path tooling, AI. Proves the package composes into a product.              |
+| **Spec demo (this page)** | `/packages/@grida/svg-editor`                                  | One feature per card. Proves each capability in isolation, the way `@grida/hud`'s showcase does. The reference for "what does this package actually do." |
+
+Keep the `/svg` demos as-is. They answer "can you build an editor with this?"
+This page answers "what is each piece, exactly?"
+
+## Why this page also exists as a harness
+
+The package's design doctrine is **"default is core, not customizable"**
+(README P1–P6, and the anti-goals "Not a plugin host", "Not customizable in
+HUD layout"). That doctrine is about _behavior_ and _extension_: you can't add
+tools, replace the chrome, or swap the serializer.
+
+But a spec demo needs a different axis the package does not yet have:
+**the ability to expose, enable, or lock the editor to a chosen subset of its
+built-in features.** Today it has none. Every card on this page mounts the
+_entire_ editor and then merely _presets_ a tool. Nothing stops the rest of the
+surface from activating:
+
+- The "Insert rectangle" card presets the rect tool — but pressing `V`, `O`,
+  `L`, or `T` switches tools, and `Cmd+Z`, arrow-nudge, group, delete, etc. are
+  all live. The card can _describe_ an isolated feature; it cannot _enforce_
+  one.
+- There is no read-only / view-only mode, so a card that only wants to show
+  selection chrome still accepts mutation.
+- There is no way to mount "just text editing" or "just paint" for a focused
+  teaching example, an embed, or a regression fixture.
+
+This is the design feedback. **A spec demo is the first concrete consumer that
+wants a capability profile, and the absence of one is visible in every card.**
+
+### This is not a request to make the editor "customizable"
+
+To be precise against the package's deciding table — the ask is **not**:
+
+- a plugin registry (P3 / anti-goal "not a plugin host"),
+- behavior overrides or custom gestures,
+- a swappable serializer or HUD slots (anti-goals).
+
+The ask is a new, orthogonal axis: **which of the editor's own, fixed built-in
+capabilities are _enabled_ for this mount.** The behavior of each capability
+stays 100% editor-owned and non-customizable. We only gate whether it is
+reachable. That is closer to a host concern (P2) — "this embedding only wants
+the editor to do X" — than to extension.
+
+### Sketch (not a committed API)
+
+Construction-time, additive, default = everything on (so existing consumers are
+unaffected):
+
+```ts
+const editor = createSvgEditor({
+  svg,
+  // all provisional names — design lives in the WG track, not here
+  capabilities: {
+    tools: ["insert-text"], // allow-list; others are inert (keymap + toolbar)
+    commands: { history: false, structure: false },
+    readonly: false,
+    lock_mode: "edit-content", // pin the mode; set_mode becomes a no-op
+  },
+});
+```
+
+Enforcement would have to land at three layers the package already owns, so the
+gate can't be escaped from the keyboard or a stray command:
+
+1. **Keymap** — disabled capabilities don't bind their shortcuts.
+2. **Command registry** — disabled commands are no-ops (consistent with the
+   existing "can't apply → no-op, not error" rule).
+3. **Tool/mode** — `set_tool` / `set_mode` reject values outside the profile.
+
+Whether the unit of gating is the _command_, the _tool_, the _Policy Class_, or
+a coarser _feature_ is exactly the question this harness should help settle by
+trying to author the cards it can't author today.
+
+## How this should grow
+
+The page opens on a **featured demo** (the whole editor, full toolbar) and then
+isolates one _fixture_ per card. The fixtures are the spine: each one targets a
+single interaction surface, so it can later be paired with a behavior
+constraint. It grows along two tracks:
+
+**Track 1 — more fixtures + cards, as the package ships features.** Shipped
+fixtures (`_fixtures.ts`): every primitive shape, path (vector edit), line (the
+2-point exception), text + tspan, groups + transform, symbol + use (shared
+instances), and a CSS-cascade harness (fill _and_ geometry via a document
+`<style>` block). The backlog, roughly in package-maturity order:
+
+- Clean round-trip / minimal-diff (live `serialize()` next to the canvas — the
+  package's headline guarantee; this is the highest-value card to add next).
+- Paint read/write (`fill` / `stroke`) with provenance.
+- Generic property read/write with the cascade `provenance` badge.
+- Defs / gradients (`editor.defs.gradients`).
+- Alignment, z-order reorder, grouping.
+- Snap-to-geometry and snap-to-pixel-grid (toggleable via `EditorStyle`).
+- History (undo/redo) and dirty tracking.
+
+Each fixture is authored to _pair with a constraint_: the line fixture wants a
+"line only" profile, the text fixture a "text only" embed, the CSS fixture a
+decision on how the editor cooperates with the cascade. Writing them now means
+fixture + behavior-constraint line up when the profile lands.
+
+**Track 2 — the harness drives the capability-profile API.** As soon as the
+profile sketch above (or whatever the WG settles on) exists, every card here
+becomes an _acceptance test_ for it: a card that says "text editing only"
+should actually be locked to text editing. Until then, each card carries an
+honest caption noting what _isn't_ yet enforceable.
+
+When the gating work is picked up, it belongs in the package + its WG track
+(`docs/wg/feat-svg-editor/`) and the package `TODO.md`, not here. This README is
+the **motivation and the consumer**, not the design home.
+
+## Structure / how to add a card
+
+```
+[%40grida]/svg-editor/
+  layout.tsx     SEO metadata + JSON-LD (mirrors hud / tree-view)
+  page.tsx       hero + featured demo + composition of the fixture cards
+  _featured.tsx  the fully-featured hero (toolbar + canvas + status), like hud's live section
+  _examples.tsx  the isolated <SvgStage> scaffold + one component per fixture
+  _fixtures.ts   the authored SVG fixtures — the spine of the page
+  README.md      this file
+```
+
+To add a card: author a fixture SVG in `_fixtures.ts` (with a comment naming the
+interaction it targets), add an exported component in `_examples.tsx` that mounts
+`<SvgStage svg={...} tool={...} selectName={...} />` (each card is its own
+isolated `SvgEditorProvider`), then drop a `<SpecCard>` for it in `page.tsx`.
+Keep one interaction per fixture; if a fixture needs two to make sense, that's a
+signal the feature boundary — or the future capability profile — is drawn at the
+wrong place. Note that observation.

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  SvgEditorCanvas,
+  SvgEditorProvider,
+  useSvgEditor,
+} from "@grida/svg-editor/react";
+import type { Tool } from "@grida/svg-editor";
+import {
+  CSS,
+  GROUP_TRANSFORM,
+  LINE,
+  PATH,
+  SHAPES,
+  SYMBOL_USE,
+  TEXT,
+} from "./_fixtures";
+
+/**
+ * One isolated editor per card.
+ *
+ * Each `SvgStage` owns its own `SvgEditorProvider`, so the cards on this page
+ * are independent editor instances — the spec-demo equivalent of `@grida/hud`'s
+ * per-section playgrounds. `tool` is *preset* and `selectName` *seeds* a
+ * selection, but neither is *locked*: the package has no capability profile yet,
+ * so every other tool and command stays live. The pairing of fixture +
+ * intended interaction is what a future profile would enforce. See the
+ * directory README.
+ */
+function SvgStage({
+  svg,
+  tool,
+  selectName,
+}: {
+  svg: string;
+  tool?: Tool;
+  /** Select the node with this authored `id=` on mount, so the card lands warm. */
+  selectName?: string;
+}) {
+  return (
+    <SvgEditorProvider initialSvg={svg}>
+      <SvgStageBody tool={tool} selectName={selectName} />
+    </SvgEditorProvider>
+  );
+}
+
+function SvgStageBody({
+  tool,
+  selectName,
+}: {
+  tool?: Tool;
+  selectName?: string;
+}) {
+  const editor = useSvgEditor();
+  // Apply preset tool + seed selection exactly once on mount. Identity of the
+  // props is ignored on purpose — re-running would fight the user's own picks.
+  const applied = useRef(false);
+  useEffect(() => {
+    if (applied.current) return;
+    applied.current = true;
+    if (tool) editor.set_tool(tool);
+    if (selectName) {
+      for (const node of editor.tree().nodes.values()) {
+        if (node.name === selectName) {
+          editor.commands.select([node.id]);
+          break;
+        }
+      }
+    }
+  }, [editor, tool, selectName]);
+
+  return (
+    <div className="relative aspect-video w-full overflow-hidden rounded-lg border bg-[radial-gradient(circle,theme(colors.border)_1px,transparent_1px)] [background-size:20px_20px]">
+      <SvgEditorCanvas fit className="absolute inset-0 h-full w-full" />
+    </div>
+  );
+}
+
+// ─── Cards — one fixture each ────────────────────────────────────────────────
+
+/** Every primitive shape, one of each. Cursor tool; click any shape. */
+export function ShapesExample() {
+  return <SvgStage svg={SHAPES} tool={{ type: "cursor" }} />;
+}
+
+/** Path content edit. Path pre-selected; Enter / Q drops into vertex edit. */
+export function PathExample() {
+  return <SvgStage svg={PATH} tool={{ type: "cursor" }} selectName="wave" />;
+}
+
+/** Line's 2-endpoint interaction. Diagonal pre-selected to show endpoint handles. */
+export function LineExample() {
+  return (
+    <SvgStage svg={LINE} tool={{ type: "cursor" }} selectName="diagonal" />
+  );
+}
+
+/** Text + tspan. Headline pre-selected; double-click to edit inline. */
+export function TextExample() {
+  return (
+    <SvgStage svg={TEXT} tool={{ type: "cursor" }} selectName="headline" />
+  );
+}
+
+/** Groups + transform. Rotated group pre-selected; Enter descends scope. */
+export function GroupTransformExample() {
+  return (
+    <SvgStage
+      svg={GROUP_TRANSFORM}
+      tool={{ type: "cursor" }}
+      selectName="card"
+    />
+  );
+}
+
+/** Symbol + use. A scaled instance pre-selected; geometry lives in the symbol. */
+export function SymbolUseExample() {
+  return (
+    <SvgStage svg={SYMBOL_USE} tool={{ type: "cursor" }} selectName="pin-d" />
+  );
+}
+
+/** CSS-driven fill + transform via a document <style> block. */
+export function CssExample() {
+  return <SvgStage svg={CSS} tool={{ type: "cursor" }} selectName="pill" />;
+}

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_featured.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_featured.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import * as React from "react";
+import {
+  SvgEditorCanvas,
+  SvgEditorProvider,
+  useCanRedo,
+  useCanUndo,
+  useCommands,
+  useMode,
+  useSelection,
+  useSvgEditor,
+  useTool,
+} from "@grida/svg-editor/react";
+import type { Tool } from "@grida/svg-editor";
+import { Button } from "@/components/ui/button";
+import {
+  CircleIcon,
+  MinusIcon,
+  MousePointer2Icon,
+  RedoIcon,
+  SquareDashedIcon,
+  SquareIcon,
+  Trash2Icon,
+  TypeIcon,
+  UndoIcon,
+} from "lucide-react";
+import { FEATURED } from "./_fixtures";
+
+/**
+ * The fully-featured demo, mirroring `@grida/hud`'s "live editor" hero: the
+ * real editor with the full tool/history/structure surface and a rich
+ * document, so the page opens on what the editor can do end-to-end. The
+ * isolated spec cards below it each strip back to one feature.
+ */
+export function FeaturedDemo() {
+  return (
+    <SvgEditorProvider initialSvg={FEATURED}>
+      <InitialSelection name="series" />
+      <div className="rounded-2xl bg-zinc-100 p-2 ring-1 ring-zinc-200/70">
+        <Toolbar />
+        <div className="mt-2 aspect-video overflow-hidden rounded-lg border border-zinc-200 bg-white">
+          <SvgEditorCanvas className="h-full w-full" fit />
+        </div>
+        <StatusBar />
+      </div>
+    </SvgEditorProvider>
+  );
+}
+
+/**
+ * Seed a selection so the hero lands warm (chrome visible on first paint).
+ * Look the node up by its authored `id=` (resilient to re-parses), not by the
+ * parser-assigned NodeId. Mount-once — re-running would fight the user's clicks.
+ */
+function InitialSelection({ name }: { name: string }) {
+  const editor = useSvgEditor();
+  React.useEffect(() => {
+    for (const node of editor.tree().nodes.values()) {
+      if (node.name === name) {
+        editor.commands.select([node.id]);
+        break;
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+function Toolbar() {
+  const editor = useSvgEditor();
+  const tool = useTool();
+  const cmd = useCommands();
+  const canUndo = useCanUndo();
+  const canRedo = useCanRedo();
+  const sel = useSelection();
+  const mode = useMode();
+
+  const setTool = (t: Tool) => editor.set_tool(t);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-2 pt-1 pb-2">
+      <ToolButton
+        label="Cursor"
+        shortcut="V"
+        active={tool.type === "cursor"}
+        onClick={() => setTool({ type: "cursor" })}
+        Icon={MousePointer2Icon}
+      />
+      <ToolButton
+        label="Rect"
+        shortcut="R"
+        active={tool.type === "insert" && tool.tag === "rect"}
+        onClick={() => setTool({ type: "insert", tag: "rect" })}
+        Icon={SquareIcon}
+      />
+      <ToolButton
+        label="Ellipse"
+        shortcut="O"
+        active={tool.type === "insert" && tool.tag === "ellipse"}
+        onClick={() => setTool({ type: "insert", tag: "ellipse" })}
+        Icon={CircleIcon}
+      />
+      <ToolButton
+        label="Line"
+        shortcut="L"
+        active={tool.type === "insert" && tool.tag === "line"}
+        onClick={() => setTool({ type: "insert", tag: "line" })}
+        Icon={MinusIcon}
+      />
+      <ToolButton
+        label="Text"
+        shortcut="T"
+        active={tool.type === "insert-text"}
+        onClick={() => setTool({ type: "insert-text" })}
+        Icon={TypeIcon}
+      />
+      <ToolButton
+        label="Lasso"
+        shortcut="Q"
+        active={tool.type === "lasso"}
+        onClick={() => setTool({ type: "lasso" })}
+        disabled={mode !== "edit-content"}
+        Icon={SquareDashedIcon}
+        hint="path edit only"
+      />
+
+      <span className="mx-1 h-5 w-px bg-zinc-300" />
+
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={!canUndo}
+        onClick={() => cmd.undo()}
+        className="h-7 px-2"
+        aria-label="Undo"
+        title="Undo (⌘Z)"
+      >
+        <UndoIcon className="size-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={!canRedo}
+        onClick={() => cmd.redo()}
+        className="h-7 px-2"
+        aria-label="Redo"
+        title="Redo (⌘⇧Z)"
+      >
+        <RedoIcon className="size-3.5" />
+      </Button>
+
+      <span className="mx-1 h-5 w-px bg-zinc-300" />
+
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={sel.length === 0}
+        onClick={() => cmd.remove()}
+        className="h-7 px-2"
+        aria-label="Delete selection"
+        title="Delete (⌫)"
+      >
+        <Trash2Icon className="size-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => cmd.select_all()}
+        className="h-7 px-2 text-[11px]"
+      >
+        Select all
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={sel.length === 0}
+        onClick={() => cmd.deselect()}
+        className="h-7 px-2 text-[11px]"
+      >
+        Deselect
+      </Button>
+
+      <span className="ml-auto text-[11px] text-zinc-500">
+        ⌘/ctrl + wheel = zoom · space-drag = pan · ⌫ = delete
+      </span>
+    </div>
+  );
+}
+
+function ToolButton({
+  label,
+  shortcut,
+  active,
+  onClick,
+  disabled,
+  Icon,
+  hint,
+}: {
+  label: string;
+  shortcut?: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  Icon: typeof MousePointer2Icon;
+  hint?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={`${label}${shortcut ? ` (${shortcut})` : ""}${hint ? ` — ${hint}` : ""}`}
+      className={[
+        "inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-[11px] font-medium shadow-sm transition-colors",
+        active
+          ? "border-zinc-900 bg-zinc-900 text-white"
+          : "border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50",
+        disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer",
+      ].join(" ")}
+    >
+      <Icon className="size-3.5" />
+      {label}
+      {shortcut ? (
+        <kbd className="ml-0.5 rounded bg-black/10 px-1 text-[10px] tabular-nums">
+          {shortcut}
+        </kbd>
+      ) : null}
+    </button>
+  );
+}
+
+function StatusBar() {
+  const sel = useSelection();
+  const tool = useTool();
+  const mode = useMode();
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-3 px-2 pb-1 font-mono text-[11px] text-zinc-500">
+      <span>
+        mode: <code className="text-zinc-800">{mode}</code>
+      </span>
+      <span>
+        tool:{" "}
+        <code className="text-zinc-800">
+          {tool.type}
+          {"tag" in tool ? `:${tool.tag}` : ""}
+        </code>
+      </span>
+      <span>
+        selection:{" "}
+        <code className="text-zinc-800">
+          {sel.length === 0
+            ? "—"
+            : sel.length === 1
+              ? sel[0]
+              : `${sel.length} ids`}
+        </code>
+      </span>
+    </div>
+  );
+}

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
@@ -1,0 +1,173 @@
+// Fixtures for the @grida/svg-editor spec demo.
+//
+// Each fixture targets a *specific interaction surface* of the editor, so a
+// card can mount it in isolation. They are authored, not exported from a real
+// document — small, legible, and pixel-aligned where it helps.
+//
+// The harness intent: each fixture is paired (in `_examples.tsx`) with the
+// interaction it is meant to exercise. Today the editor cannot be *locked* to
+// that interaction — every tool and command stays live. When a capability
+// profile lands (see README), each fixture becomes the canvas for a constrained
+// profile: "line only", "text only", "no structural edits", etc. The fixtures
+// are written now so that fixture + behavior-constraint line up later.
+
+// ─── Featured — the showcase artifact ────────────────────────────────────────
+// A refined analytics card, not a cartoon. Same breadth on purpose — a gradient
+// paint server (the area fill), cubic-bezier paths (the series + its fill),
+// grouped + transformed elements (the icon, the delta badge), shapes (card,
+// gridlines, data dots), and type — but composed like a real design deliverable.
+// Mounted in the hero with the full toolbar so the page opens on something that
+// looks shipped, while still touching everything the editor edits.
+export const FEATURED = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" width="640" height="400">
+  <defs>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6366f1" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#6366f1" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect id="bg" width="640" height="400" fill="#f8fafc"/>
+
+  <g id="card">
+    <rect x="56" y="48" width="528" height="304" rx="16" fill="#ffffff" stroke="#e5e7eb"/>
+
+    <g id="icon" transform="translate(88 80)">
+      <rect width="28" height="28" rx="8" fill="#6366f1"/>
+      <rect x="7" y="14" width="4" height="7" rx="1.5" fill="#ffffff"/>
+      <rect x="12" y="9" width="4" height="12" rx="1.5" fill="#ffffff"/>
+      <rect x="17" y="6" width="4" height="15" rx="1.5" fill="#ffffff"/>
+    </g>
+    <text x="128" y="92" font-family="ui-sans-serif, system-ui, sans-serif" font-size="15" font-weight="600" fill="#0f172a">Monthly revenue</text>
+    <text x="128" y="110" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b">Last 30 days</text>
+
+    <g id="delta" transform="translate(486 76)">
+      <rect width="70" height="24" rx="12" fill="#ecfdf5"/>
+      <path d="M11 16 L15 9 L19 16 Z" fill="#059669"/>
+      <text x="40" y="16" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#059669" text-anchor="middle">12.4%</text>
+    </g>
+
+    <text x="88" y="150" font-family="ui-sans-serif, system-ui, sans-serif" font-size="30" font-weight="700" fill="#0f172a" letter-spacing="-0.5">$48,250</text>
+
+    <g id="grid" stroke="#f1f5f9" stroke-width="1">
+      <line x1="88" y1="208" x2="552" y2="208"/>
+      <line x1="88" y1="244" x2="552" y2="244"/>
+      <line x1="88" y1="280" x2="552" y2="280"/>
+    </g>
+    <line x1="88" y1="312" x2="552" y2="312" stroke="#e2e8f0" stroke-width="1"/>
+
+    <path id="area-fill" d="M88 312 L88 286 C134 286 133 262 180 262 C226 262 225 272 272 272 C318 272 318 234 364 234 C410 234 409 222 456 222 C502 222 506 200 552 198 L552 312 Z" fill="url(#area)"/>
+    <path id="series" d="M88 286 C134 286 133 262 180 262 C226 262 225 272 272 272 C318 272 318 234 364 234 C410 234 409 222 456 222 C502 222 506 200 552 198" fill="none" stroke="#6366f1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <g id="dots" fill="#ffffff" stroke="#6366f1" stroke-width="2">
+      <circle cx="180" cy="262" r="3.5"/>
+      <circle cx="272" cy="272" r="3.5"/>
+      <circle cx="364" cy="234" r="3.5"/>
+      <circle cx="456" cy="222" r="3.5"/>
+    </g>
+    <circle id="cursor-point" cx="552" cy="198" r="5" fill="#6366f1" stroke="#ffffff" stroke-width="2"/>
+
+    <g id="xlabels" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#94a3b8" text-anchor="middle">
+      <text x="88" y="332">Jan</text>
+      <text x="180" y="332">Feb</text>
+      <text x="272" y="332">Mar</text>
+      <text x="364" y="332">Apr</text>
+      <text x="456" y="332">May</text>
+      <text x="552" y="332">Jun</text>
+    </g>
+  </g>
+</svg>`;
+
+// ─── Shapes — every primitive ────────────────────────────────────────────────
+// rect, rounded rect, circle, ellipse, line, polyline, polygon, path — one of
+// each. Each is its own Policy Class with distinct resize semantics; this is the
+// fixture for "what shapes does the editor understand".
+export const SHAPES = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 320" width="560" height="320">
+  <rect id="rect" x="40" y="50" width="80" height="80" fill="#ef4444"/>
+  <rect id="rounded-rect" x="180" y="50" width="80" height="80" rx="16" fill="#f97316"/>
+  <circle id="circle" cx="360" cy="90" r="42" fill="#eab308"/>
+  <ellipse id="ellipse" cx="500" cy="90" rx="52" ry="36" fill="#22c55e"/>
+
+  <line id="line" x1="40" y1="270" x2="120" y2="190" stroke="#06b6d4" stroke-width="7" stroke-linecap="round"/>
+  <polyline id="polyline" points="160,270 190,190 220,250 250,200 280,270" fill="none" stroke="#3b82f6" stroke-width="7" stroke-linejoin="round"/>
+  <polygon id="polygon" points="360,188 394,270 326,270" fill="#8b5cf6"/>
+  <path id="path" d="M444 230 C 468 188, 488 272, 512 230 S 552 188, 552 230" fill="none" stroke="#ec4899" stroke-width="7" stroke-linecap="round"/>
+</svg>`;
+
+// ─── Path — vector content edit ──────────────────────────────────────────────
+// A single expressive path (cubic + smooth-cubic segments). The card selects it
+// so Enter / lasso (Q) drops into content-edit and the vertex/tangent chrome
+// shows. The fixture for path-node interaction.
+export const PATH = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240">
+  <path id="wave" d="M40 170 C 104 50, 184 50, 240 130 S 392 210, 440 90" fill="none" stroke="#6366f1" stroke-width="6" stroke-linecap="round"/>
+</svg>`;
+
+// ─── Line — the 2-point exception ────────────────────────────────────────────
+// <line> doesn't resize against a bbox; it has exactly two endpoints. Selecting
+// it shows endpoint handles, not 8 corner/edge handles. The fixture for the
+// unique line interaction mode.
+export const LINE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 240" width="480" height="240">
+  <line id="diagonal" x1="80" y1="180" x2="400" y2="70" stroke="#0ea5e9" stroke-width="8" stroke-linecap="round"/>
+  <line id="baseline" x1="80" y1="210" x2="400" y2="210" stroke="#94a3b8" stroke-width="4" stroke-dasharray="2 8"/>
+</svg>`;
+
+// ─── Text & tspan — runs and lines ───────────────────────────────────────────
+// One <text> with multiple <tspan> runs (different fills) and a second baseline
+// via dy. Inline edit is single-flat-run today; tspan / multi-line is exactly
+// the open behavior this fixture is a harness for.
+export const TEXT = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 220" width="520" height="220">
+  <text id="headline" x="40" y="104" font-family="ui-sans-serif, system-ui, sans-serif" font-size="52" font-weight="700"><tspan fill="#111827">Hello </tspan><tspan fill="#e11d48">SVG</tspan><tspan x="40" dy="58" font-size="24" font-weight="400" fill="#6b7280">multi-run · multi-line via tspan</tspan></text>
+</svg>`;
+
+// ─── Groups & transform ──────────────────────────────────────────────────────
+// A rotated <g> with children, nesting a second translated <g>. Selecting the
+// group shows a rotation-aware bbox; Enter descends scope into the children.
+// The fixture for group selection, scope, and transform handling.
+export const GROUP_TRANSFORM = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300" width="480" height="300">
+  <g id="card" transform="translate(96 64) rotate(-10)">
+    <rect x="0" y="0" width="220" height="140" rx="14" fill="#1e293b"/>
+    <circle cx="40" cy="40" r="18" fill="#f59e0b"/>
+    <g id="stripes" transform="translate(20 92)">
+      <rect x="0" y="0" width="180" height="10" rx="5" fill="#64748b"/>
+      <rect x="0" y="22" width="120" height="10" rx="5" fill="#64748b"/>
+    </g>
+  </g>
+</svg>`;
+
+// ─── Symbol & use — one source, many instances ───────────────────────────────
+// A <symbol> defines the geometry once; each <use> instantiates it. The `color`
+// attribute on each instance flows into `fill="currentColor"` inside the symbol,
+// so the shared shape recolors per instance. Editing a <use> is its own Policy
+// Class — you move / scale the instance, not the symbol — and `editor.defs.symbols`
+// is the registry. The fixture for instance-vs-source interaction.
+export const SYMBOL_USE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 240" width="520" height="240">
+  <defs>
+    <symbol id="pin" viewBox="0 0 24 24">
+      <path d="M12 2 C 7.6 2 4 5.6 4 10 C 4 16 12 22 12 22 C 12 22 20 16 20 10 C 20 5.6 16.4 2 12 2 Z" fill="currentColor"/>
+      <circle cx="12" cy="9.5" r="3" fill="#ffffff"/>
+    </symbol>
+  </defs>
+
+  <use id="pin-a" href="#pin" x="40" y="70" width="64" height="64" color="#ef4444"/>
+  <use id="pin-b" href="#pin" x="150" y="70" width="64" height="64" color="#3b82f6"/>
+  <use id="pin-c" href="#pin" x="260" y="70" width="64" height="64" color="#22c55e"/>
+  <use id="pin-d" href="#pin" x="372" y="48" width="96" height="96" color="#a855f7"/>
+</svg>`;
+
+// ─── CSS — cascade beyond color ──────────────────────────────────────────────
+// A document <style> block that drives fill AND geometry (transform / translate)
+// — not just paint. Selection chrome reads world geometry, so CSS transforms are
+// the open question. The harness for deciding how the editor cooperates with the
+// cascade. (Truly external/linked stylesheets stay out of scope; this is the
+// in-document <style> subset the editor supports.)
+export const CSS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 240" width="520" height="240">
+  <style>
+    .brand { fill: #6366f1; }
+    .ghost { fill: none; stroke: #6366f1; stroke-width: 4; }
+    .tilt  { transform: rotate(-8deg); transform-origin: 120px 160px; }
+    #pill  { fill: #ec4899; transform: translateX(40px); }
+  </style>
+  <rect id="pill" x="40" y="40" width="160" height="60" rx="30"/>
+  <rect class="brand tilt" x="60" y="120" width="120" height="80"/>
+  <circle class="ghost" cx="380" cy="130" r="64"/>
+  <text class="brand" x="280" y="220" font-family="ui-monospace, monospace" font-size="18">fill + transform via style</text>
+</svg>`;

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/layout.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/layout.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+const canonical = "https://grida.co/packages/@grida/svg-editor";
+const title = "@grida/svg-editor — Headless, clean SVG editor for the web";
+// 157 chars — under Google's 160-char snippet cap.
+const description =
+  "Headless SVG editor that round-trips by default: open, edit, save, and the diff is exactly your change. Spec demo for each feature. Experimental, MIT.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://grida.co"),
+  title,
+  description,
+  keywords: [
+    // primary
+    "svg editor",
+    "svg editor react",
+    "headless svg editor",
+    "react svg editor",
+    "edit svg",
+    "svg editing library",
+    // pattern / value
+    "headless",
+    "headless ui",
+    "clean svg",
+    "round-trip svg",
+    "minimal diff svg",
+    "svg round trip",
+    // capabilities
+    "svg selection",
+    "svg transform",
+    "svg text editing",
+    "svg insert shape",
+    "svg paint",
+    "svg gradients",
+    // ecosystem
+    "react",
+    "typescript",
+    "tailwind",
+    "canvas editor",
+    "design tool",
+    "ai editing",
+    // brand
+    "Grida",
+    "@grida/svg-editor",
+  ],
+  alternates: { canonical },
+  openGraph: {
+    title,
+    description:
+      "A clean SVG editor — open a file, edit it, save it, and the diff is exactly the change you made. Headless, backend-agnostic, round-trips by default.",
+    url: canonical,
+    siteName: "Grida",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    site: "@grida_co",
+    creator: "@grida_co",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+// JSON-LD: declared as a SoftwareSourceCode so search engines link the
+// package landing to its npm + GitHub coordinates.
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  name: "@grida/svg-editor",
+  description,
+  url: canonical,
+  codeRepository:
+    "https://github.com/gridaco/grida/tree/main/packages/grida-svg-editor",
+  programmingLanguage: ["TypeScript", "JavaScript"],
+  runtimePlatform: ["Browser", "Node.js"],
+  license: "https://opensource.org/licenses/MIT",
+  keywords:
+    "svg editor, headless, react, clean svg, round-trip, typescript, design tool",
+  author: { "@type": "Organization", name: "Grida", url: "https://grida.co" },
+  isPartOf: {
+    "@type": "SoftwareApplication",
+    name: "Grida",
+    url: "https://grida.co",
+  },
+};
+
+export default function SvgEditorPackageLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import {
+  CssExample,
+  GroupTransformExample,
+  LineExample,
+  PathExample,
+  ShapesExample,
+  SymbolUseExample,
+  TextExample,
+} from "./_examples";
+import { FeaturedDemo } from "./_featured";
+import { NpmLogoIcon } from "@/components/logos/npm";
+import { Button } from "@/components/ui/button";
+import { CopyToClipboardInput } from "@/components/copy-to-clipboard-input";
+import { cn } from "@/components/lib/utils";
+import { useScrollSpy } from "@/hooks/use-scroll-spy";
+import Footer from "@/www/footer";
+import Header from "@/www/header";
+import { ArrowRightIcon, GithubIcon } from "lucide-react";
+import Link from "next/link";
+import { useMemo } from "react";
+import type * as React from "react";
+
+const NPM_URL = "https://www.npmjs.com/package/@grida/svg-editor";
+const GITHUB_URL =
+  "https://github.com/gridaco/grida/tree/main/packages/grida-svg-editor";
+
+// Related demos — the full-editor seams and the sibling package page.
+const RELATED: { href: string; label: string }[] = [
+  { href: "/svg", label: "Full editor" },
+  { href: "/svg/examples/slides", label: "Slides example" },
+  { href: "/packages/@grida/hud", label: "@grida/hud" },
+];
+
+// On-this-page nav — keep ids in sync with the section/card ids below.
+const SECTIONS: { id: string; label: string }[] = [
+  { id: "featured", label: "Featured demo" },
+  { id: "shapes", label: "Shapes" },
+  { id: "path", label: "Path" },
+  { id: "line", label: "Line" },
+  { id: "text", label: "Text & tspan" },
+  { id: "groups", label: "Groups & transform" },
+  { id: "symbol-use", label: "Symbol & use" },
+  { id: "css", label: "CSS cascade" },
+];
+
+export default function SvgEditorPackagePage() {
+  return (
+    <main className="min-h-screen">
+      <Header className="relative" />
+
+      {/* Hero + sections share one layout grid. On xl+ the right column is the
+          sticky on-this-page nav; below xl the layout collapses and the inline
+          TOC card in the hero handles navigation. (Same shape as @grida/hud.) */}
+      <div className="mx-auto max-w-7xl xl:flex xl:gap-24 xl:px-4">
+        <div className="min-w-0 xl:flex-1">
+          {/* Hero — left-aligned within the grid column, mirroring @grida/hud */}
+          <section className="px-4 pt-32 pb-10">
+            <div className="max-w-5xl space-y-6">
+              <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-zinc-200 bg-zinc-50 text-xs font-medium text-zinc-600">
+                <span className="size-1.5 rounded-full bg-amber-500" />
+                Experimental · alpha · MIT
+              </div>
+              <h1 className="text-4xl md:text-5xl font-bold tracking-tight font-mono">
+                @grida/svg-editor
+              </h1>
+              <p className="max-w-3xl text-lg text-muted-foreground leading-relaxed">
+                A <strong>clean</strong> SVG editor — open a file, edit it, save
+                it, and the diff is exactly the change you made. The demo below
+                is the whole editor; the cards under it isolate one feature
+                each. For the editor wired into a full product, see the{" "}
+                <Link href="/svg" className="underline underline-offset-4">
+                  editor seam demo
+                </Link>
+                .
+              </p>
+              <div className="flex flex-wrap items-center gap-3">
+                <Link href={NPM_URL} target="_blank" rel="noopener noreferrer">
+                  <Button size="lg" variant="outline">
+                    <NpmLogoIcon className="size-8 mr-1" />
+                    npm
+                  </Button>
+                </Link>
+                <Link
+                  href={GITHUB_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button size="lg" variant="outline">
+                    <GithubIcon className="size-4 mr-2" />
+                    GitHub
+                  </Button>
+                </Link>
+              </div>
+              <div className="w-full max-w-sm">
+                <CopyToClipboardInput value="npm install @grida/svg-editor" />
+              </div>
+              <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+                {RELATED.map(({ href, label }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                  >
+                    {label}
+                    <ArrowRightIcon className="size-3" />
+                  </Link>
+                ))}
+              </div>
+
+              {/* Inline TOC — small screens only; the sticky aside takes over on xl+ */}
+              <nav className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 xl:hidden">
+                <div className="mb-3 text-[11px] font-semibold tracking-wider text-zinc-500">
+                  On this page
+                </div>
+                <ul className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm sm:grid-cols-3">
+                  {SECTIONS.map((s) => (
+                    <li key={s.id}>
+                      <a
+                        href={`#${s.id}`}
+                        className="block py-0.5 text-zinc-700 hover:text-foreground"
+                      >
+                        {s.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </div>
+          </section>
+
+          {/* Featured demo — the whole editor, end-to-end. */}
+          <section id="featured" className="px-4 pb-6 scroll-mt-24">
+            <div className="max-w-5xl mx-auto">
+              <FeaturedDemo />
+            </div>
+          </section>
+
+          {/* Harness note — this page is also design feedback to the package. */}
+          <section className="px-4 py-6">
+            <div className="max-w-5xl mx-auto rounded-lg border border-amber-200 bg-amber-50/60 px-5 py-4 text-sm text-amber-900">
+              <p className="font-medium">
+                This page is a harness, not just a gallery.
+              </p>
+              <p className="mt-1 leading-relaxed text-amber-800">
+                Each fixture below is paired with the interaction it is meant to
+                exercise — line endpoints, path vertices, text runs, group
+                scope, the CSS cascade. But the editor cannot yet be{" "}
+                <em>locked</em> to that interaction: there is no capability
+                profile, so every tool and command stays live in every card. The
+                fixtures are written now so that fixture + behavior-constraint
+                line up once that profile lands. See the directory{" "}
+                <code className="rounded bg-amber-100 px-1 py-0.5">
+                  README.md
+                </code>{" "}
+                for the proposal and roadmap.
+              </p>
+            </div>
+          </section>
+
+          {/* Spec cards — one fixture each. */}
+          <section className="px-4 py-8">
+            <div className="max-w-5xl mx-auto space-y-12">
+              <div className="max-w-3xl space-y-1">
+                <h2 className="text-3xl font-bold tracking-tight">Fixtures</h2>
+                <p className="text-sm text-muted-foreground">
+                  Each card mounts an isolated editor on a fixture that targets
+                  one interaction surface. Click an element to see its chrome;
+                  the relevant element is pre-selected where it helps.
+                </p>
+              </div>
+
+              <SpecCard
+                id="shapes"
+                title="Shapes — every primitive"
+                description={
+                  <>
+                    <code>rect</code>, rounded <code>rect</code>,{" "}
+                    <code>circle</code>, <code>ellipse</code>, <code>line</code>
+                    , <code>polyline</code>, <code>polygon</code>,{" "}
+                    <code>path</code> — one of each. Every shape is its own
+                    Policy Class with distinct resize semantics.
+                  </>
+                }
+                caption="A future 'shapes only' profile would gate which primitives the insert tools can author and select."
+              >
+                <ShapesExample />
+              </SpecCard>
+
+              <SpecCard
+                id="path"
+                title="Path — vector content edit"
+                description={
+                  <>
+                    A single path (cubic + smooth-cubic segments), pre-selected.
+                    Press <kbd>Enter</kbd> or the lasso (<kbd>Q</kbd>) to drop
+                    into content-edit and reveal the vertex / tangent chrome.
+                  </>
+                }
+                caption="A 'path editing' profile would lock to content-edit on this node and suppress select-mode transforms."
+              >
+                <PathExample />
+              </SpecCard>
+
+              <SpecCard
+                id="line"
+                title="Line — the 2-point exception"
+                description={
+                  <>
+                    <code>&lt;line&gt;</code> has no bbox resize — it has
+                    exactly two endpoints. The pre-selected diagonal shows
+                    endpoint handles, not eight corner/edge handles.
+                  </>
+                }
+                caption="A 'line only' profile would constrain interaction to the two endpoints — the canonical fixture + constraint pairing."
+              >
+                <LineExample />
+              </SpecCard>
+
+              <SpecCard
+                id="text"
+                title="Text & tspan"
+                description={
+                  <>
+                    One <code>&lt;text&gt;</code> with multiple{" "}
+                    <code>&lt;tspan&gt;</code> runs and a second baseline via{" "}
+                    <code>dy</code>. Double-click to edit inline. Inline edit is
+                    single-flat-run today; tspan / multi-line is the open
+                    behavior this fixture probes.
+                  </>
+                }
+                caption="A 'text only' embed is exactly the kind of locked profile this harness wants and the package can't yet express."
+              >
+                <TextExample />
+              </SpecCard>
+
+              <SpecCard
+                id="groups"
+                title="Groups & transform"
+                description={
+                  <>
+                    A rotated <code>&lt;g&gt;</code> nesting a translated one.
+                    The pre-selected group shows a rotation-aware bbox;{" "}
+                    <kbd>Enter</kbd> descends scope into the children.
+                  </>
+                }
+                caption="Profiles intersect with structure here: 'no structural edits' would keep selection + transform but disable group / ungroup / reorder."
+              >
+                <GroupTransformExample />
+              </SpecCard>
+
+              <SpecCard
+                id="symbol-use"
+                title="Symbol & use — one source, many instances"
+                description={
+                  <>
+                    A <code>&lt;symbol&gt;</code> defines the geometry once;
+                    each <code>&lt;use&gt;</code> instantiates it. The{" "}
+                    <code>color</code> on each instance flows into{" "}
+                    <code>currentColor</code> inside the symbol, so the shared
+                    pin recolors per instance. The big one is pre-selected — its
+                    chrome is the instance box, not the symbol.
+                  </>
+                }
+                caption="Editing a <use> is its own Policy Class: move / scale the instance vs. edit the shared symbol. How the editor surfaces that split — and per-instance paint overrides — is the open question. editor.defs.symbols is the registry."
+              >
+                <SymbolUseExample />
+              </SpecCard>
+
+              <SpecCard
+                id="css"
+                title="CSS — cascade beyond color"
+                description={
+                  <>
+                    A document <code>&lt;style&gt;</code> block drives{" "}
+                    <em>fill</em> and <em>geometry</em> (rotate, translate) —
+                    not just paint. Selection chrome reads world geometry, so
+                    CSS transforms are the open question this harness exists to
+                    settle.
+                  </>
+                }
+                caption="Not yet decided: how the editor cooperates with the cascade. This card is the surface for choosing the behavior, not a finished feature."
+              >
+                <CssExample />
+              </SpecCard>
+            </div>
+          </section>
+        </div>
+
+        <aside
+          aria-label="On this page"
+          className="hidden w-56 shrink-0 pt-32 xl:block"
+        >
+          <SidebarToc sections={SECTIONS} />
+        </aside>
+      </div>
+
+      <Footer />
+    </main>
+  );
+}
+
+function SidebarToc({
+  sections,
+}: {
+  sections: { id: string; label: string }[];
+}) {
+  // Memoize the id array so the hook's effect doesn't refire on every render —
+  // useScrollSpy depends on referential stability of the input list.
+  const ids = useMemo(() => sections.map((s) => s.id), [sections]);
+  const active = useScrollSpy(ids);
+
+  return (
+    <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-auto pb-8">
+      <div className="mb-3 text-[11px] font-semibold tracking-wider text-zinc-500">
+        On this page
+      </div>
+      <ul className="border-l border-zinc-200 text-sm">
+        {sections.map((s) => (
+          <li key={s.id}>
+            <a
+              href={`#${s.id}`}
+              className={cn(
+                "-ml-px block border-l py-1 pl-3 transition-colors hover:border-zinc-400 hover:text-foreground",
+                active === s.id
+                  ? "border-foreground font-medium text-foreground"
+                  : "border-transparent text-muted-foreground"
+              )}
+            >
+              {s.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SpecCard({
+  id,
+  title,
+  description,
+  caption,
+  children,
+}: {
+  id?: string;
+  title: React.ReactNode;
+  description: React.ReactNode;
+  caption?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-24 space-y-3">
+      <div>
+        <h3 className="text-xl font-semibold mb-1">{title}</h3>
+        <p className="text-sm text-muted-foreground max-w-2xl">{description}</p>
+      </div>
+      {children}
+      {caption && (
+        <p className="text-xs text-muted-foreground/80 max-w-2xl">
+          <span className="font-medium text-amber-600">Harness note — </span>
+          {caption}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/editor/app/(tools)/(packages)/packages/data.ts
+++ b/editor/app/(tools)/(packages)/packages/data.ts
@@ -1,5 +1,20 @@
 export const packages = [
   {
+    name: "@grida/svg-editor",
+    description:
+      "Headless, clean SVG editor. Open a file, edit it, save it — the diff is exactly the change you made. Round-trips by default, adds no proprietary noise, backend-agnostic. Experimental.",
+    demoPath: "/packages/@grida/svg-editor",
+    npm: true,
+    features: [
+      "Round-trips by default (byte-equal open + save)",
+      "Minimal-diff mutations, no proprietary noise",
+      "Headless core, DOM surface + React layer",
+      "Selection, transform, insert, inline text edit",
+      "Typed paint, properties, and defs/gradients",
+      "Core, not customizable — narrow public surface",
+    ],
+  },
+  {
     name: "@grida/refig",
     description:
       "Headless Figma renderer — render Figma documents to PNG, JPEG, WebP, PDF, or SVG in Node.js (no browser) or in the browser. Deterministic exports, offline rendering from .fig, CLI and library API.",

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -530,18 +530,23 @@ editor.tree(): {
 
 Returns a shallow snapshot. Cheap to call after a `version` bump.
 
-### Modes
+### Modes and tools
 
-Modes are the editor's internal state machine for "what does a click do." Consumers observe `state.mode`, flip it via commands, but cannot define new modes.
+"What does a click do" is governed by **two orthogonal axes**, both editor-internal — consumers observe them and flip them via commands, but cannot define new values for either.
+
+- **`Mode`** — what the editor is _doing_. Two values: `select` (normal interaction — pick / marquee / drag) and `edit-content` (inline text edit, or vector content edit on a path).
+- **`Tool`** — what pointer-down _means_ within the current mode. `cursor` (the default — select / marquee / drag), `insert` (a tag — pointer-down draws a new element of that tag, drag-to-size), `insert-text` (click-only — places a single-line `<text>` and enters content-edit immediately; `<text>` has no intrinsic size so it doesn't drag-to-size), and the content-edit-only `lasso` / `bend` (valid only while `mode === "edit-content"` on a path).
 
 ```ts
-editor.modes: ReadonlyArray<Mode>; // discoverable, frozen after construction
-// e.g. ["select", "insert-rect", "insert-ellipse", "insert-line", "insert-text", "edit-content"]
+editor.modes: ReadonlyArray<Mode>; // discoverable, frozen after construction — ["select", "edit-content"]
+editor.state.mode: Mode;
+editor.state.tool: Tool;
 
 editor.commands.set_mode(mode: Mode): void;
+editor.set_tool(tool: Tool): void; // also dispatchable as the `tool.set` command (keymap V/R/O/L/T)
 ```
 
-When a mode-driven gesture completes (rect drawn, text inserted), the editor returns to `select` automatically. Modifier keys can override this (Shift to stay in insert mode); that behavior is bundled, not customizable.
+When a tool-driven gesture completes (a shape is drawn, a text element placed), the tool reverts to `cursor` automatically. Modifier keys can override this (e.g. hold to stay in the insert tool); that behavior is bundled, not customizable.
 
 ### Commands
 
@@ -590,9 +595,11 @@ editor.commands.{
   group(): void;                      // wrap selection in a new <g>
   remove(): void;
 
-  // insertion
-  insert(tag: InsertableTag, attrs?: Readonly<Record<string, string>>): NodeId;
-  insert_preview(tag: InsertableTag, initial?: Readonly<Record<string, string>>): InsertPreviewSession;
+  // insertion — `tag` is an open string (so paste / RPC can create any element,
+  // e.g. "path"); only the closed `InsertableTag` set gets a pointer-driven
+  // draw gesture and default paint.
+  insert(tag: string, attrs?: Readonly<Record<string, string>>): NodeId;
+  insert_preview(tag: string, initial?: Readonly<Record<string, string>>): InsertPreviewSession;
 
   // content
   set_text(value: string): void;
@@ -853,9 +860,10 @@ If a consumer needs any of the above, the right answer is "this is the wrong too
 
 ## Status
 
-- `v0.0.0` — selection only, no mutation.
+- `v0.x` — selection, transform, insert (rect / ellipse / line), inline text
+  edit, and the click-to-place text tool. Experimental.
 
-The shape of the API, the mental model, the file-format guarantees, and the scope are all unsettled. Nothing here is stable. Do not depend on it from production code.
+The shape of the API, the mental model, the file-format guarantees, and the scope are all unsettled. Nothing here is stable — public types still in flux include the `Tool` union (a planned axis split, see `TODO.md` F2). Do not depend on it from production code.
 
 ## Contributing
 

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -740,25 +740,27 @@ Everything else is consumer-built against the editor's API. The two patterns:
 
 ```tsx
 function Toolbar() {
-  const mode = useEditorState((s) => s.mode);
-  const cmd = useCommands();
+  // Insertion is the `Tool` axis, not `Mode` — `Mode` is only
+  // "select" / "edit-content". Flip tools via `editor.set_tool(...)`.
+  const tool = useEditorState((s) => s.tool);
+  const editor = useSvgEditor();
   return (
     <>
       <ToolButton
-        active={mode === "select"}
-        onClick={() => cmd.set_mode("select")}
+        active={tool.type === "cursor"}
+        onClick={() => editor.set_tool({ type: "cursor" })}
       >
         ↖
       </ToolButton>
       <ToolButton
-        active={mode === "insert-rect"}
-        onClick={() => cmd.set_mode("insert-rect")}
+        active={tool.type === "insert" && tool.tag === "rect"}
+        onClick={() => editor.set_tool({ type: "insert", tag: "rect" })}
       >
         ▭
       </ToolButton>
       <ToolButton
-        active={mode === "insert-text"}
-        onClick={() => cmd.set_mode("insert-text")}
+        active={tool.type === "insert-text"}
+        onClick={() => editor.set_tool({ type: "insert-text" })}
       >
         T
       </ToolButton>

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -31,12 +31,6 @@ alpha.10. Open items:
   / stroke / stroke-width / font on inserted nodes, promote them to
   `EditorStyle.insertion_*` fields (values, not slots; P2). Similarly
   for `DEFAULT_SIZE = 100` and the `CLICK_THRESHOLD_PX = 2` in `dom.ts`.
-- **Tunable defaults via `EditorStyle`.** `default_paint_attrs` (in
-  `src/core/insertions.ts`) returns `#D9D9D9` for rect/ellipse and
-  `#000000` 1px for line, hard-coded. If hosts ask for brand-default fill
-  / stroke / stroke-width on inserted shapes, promote them to
-  `EditorStyle.insertion_*` fields (values, not slots; P2). Similarly
-  for `DEFAULT_SIZE = 100` and the `CLICK_THRESHOLD_PX = 2` in `dom.ts`.
 - **Scope-respecting insertion.** v1 always inserts at root. Wire `parent`
   to `state.scope` in `start_insert_gesture` once "enter group → draw
   inside group" UX is requested. No API change needed.

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -8,14 +8,29 @@ calls, some need both. Listed by area; order is not priority.
 The `Tool` axis + `commands.insert` / `commands.insert_preview` shipped in
 alpha.10. Open items:
 
-- **Text tool (`T`).** Deferred. SVG `<text>` has no intrinsic size, so
-  drag-to-size doesn't apply naively (font-size scaling is a different
-  mental model). A usable text-insert UX must immediately mount the inline
-  content-editor on the new node (matching Figma's "click → caret appears")
-  rather than dropping literal "Text" placeholder characters. The wiring
-  exists (`editor.enter_content_edit(id)`); gesture, default attrs
-  (font-family, font-size, fill), and commit-vs-cancel semantics for an
-  empty text node all need design. Reserve `T`.
+- **Text tool (`T`).** _Shipped (click-only)._ Pointer-down places a
+  single-line `<text>` (`insertions.default_text_attrs`) and enters
+  content-edit immediately; create + first edit are bracketed in one
+  history step via `insert_text_preview`, and the empty-equals-delete rule
+  removes a node left empty on exit (fresh placement discards with no undo
+  entry; an existing node cleared empty is removed as one undoable step).
+  Design: [`docs/wg/feat-svg-editor/text-tool.md`](../../docs/wg/feat-svg-editor/text-tool.md).
+  Still open:
+  - **Tool-axis cleanup (F2).** `insert-text` was added as a sibling
+    `Tool` variant gated to `select` mode. The `Tool` union still conflates
+    select-mode tools (`cursor` / `insert` / `insert-text`) with
+    content-edit-only tools (`lasso` / `bend`) on one axis; splitting them
+    into honest mode-gated categories is deferred.
+  - **Wrapped / multi-line text.** Out of scope. A drag-to-define-box maps
+    to SVG 2 wrapped text (`inline-size` / `shape-inside`) — a separate
+    model with its own gesture; this tool only creates single-line text.
+- **Tunable defaults via `EditorStyle`.** `default_paint_attrs` (in
+  `src/core/insertions.ts`) returns `#D9D9D9` for rect/ellipse and
+  `#000000` 1px for line, hard-coded; `default_text_attrs` likewise
+  hard-codes 16px sans-serif black. If hosts ask for brand-default fill
+  / stroke / stroke-width / font on inserted nodes, promote them to
+  `EditorStyle.insertion_*` fields (values, not slots; P2). Similarly
+  for `DEFAULT_SIZE = 100` and the `CLICK_THRESHOLD_PX = 2` in `dom.ts`.
 - **Tunable defaults via `EditorStyle`.** `default_paint_attrs` (in
   `src/core/insertions.ts`) returns `#D9D9D9` for rect/ellipse and
   `#000000` 1px for line, hard-coded. If hosts ask for brand-default fill

--- a/packages/grida-svg-editor/__tests__/enter-content-edit.test.ts
+++ b/packages/grida-svg-editor/__tests__/enter-content-edit.test.ts
@@ -1,0 +1,107 @@
+// `Enter` is a second trigger for content-edit, on par with double-click.
+//
+// dblclick enters content-edit via the HUD's `enter_content_edit` intent
+// (dom.ts:commit_intent → editor.enter_content_edit). This pins the KEYBOARD
+// half: `Enter` is a chained keymap binding (`content.enter`) that calls the
+// same `editor.enter_content_edit()`, registered AHEAD of `hierarchy.enter`
+// so it preempts on an editable node and falls through to hierarchy descent
+// on a container.
+//
+// Tests dispatch against the real `editor.keymap` (wired by createSvgEditor
+// with the default commands + DEFAULT_BINDINGS), so they also lock the
+// binding-registration ORDER that gives `content.enter` precedence. The
+// content-edit driver is a host/surface concern (null in headless), so we
+// stub it via `_internal.set_content_edit_driver` to observe what node the
+// editor would route into edit.
+
+import { describe, expect, it } from "vitest";
+import type { Keymap } from "../src/keymap/keymap";
+import { createSvgEditor } from "../src/index";
+
+// `<line>` is deliberately omitted: is_vector_edit_target rejects it in v1
+// (document.ts), so the vector node MUST be a <path>/<polyline>/<polygon>.
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text id="t" x="10" y="20">hi</text>
+  <path id="p" d="M0 0 L10 10"/>
+  <g id="g"><rect id="c" x="0" y="0" width="10" height="10"/></g>
+</svg>`;
+
+function mkEnter(): KeyboardEvent {
+  return {
+    code: "Enter",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent;
+}
+
+type Internal = { set_content_edit_driver: (fn: unknown) => void };
+
+// The document re-ids nodes on load (author `id=""` is a plain attribute,
+// not the internal NodeId), so resolve the nodes we select by tag.
+function idsByTag(editor: ReturnType<typeof createSvgEditor>) {
+  const tree = editor.tree();
+  const byTag: Record<string, string> = {};
+  for (const [id, node] of tree.nodes) {
+    byTag[node.tag] = id;
+  }
+  return byTag;
+}
+
+function setup() {
+  const editor = createSvgEditor({ svg: SVG });
+  let driven: string | null = null;
+  (
+    editor as unknown as { _internal: Internal }
+  )._internal.set_content_edit_driver((id: string) => {
+    driven = id;
+    return true;
+  });
+  const keymap = (editor as unknown as { keymap: Keymap }).keymap;
+  return { editor, keymap, ids: idsByTag(editor), driven: () => driven };
+}
+
+describe("Enter → content-edit (parity with double-click)", () => {
+  it("Enter enters content-edit on a selected text node", () => {
+    const { editor, keymap, ids, driven } = setup();
+    editor.commands.select(ids.text);
+    expect(keymap.dispatch(mkEnter())).toBe(true);
+    expect(driven()).toBe(ids.text);
+  });
+
+  it("Enter enters content-edit on a selected path node", () => {
+    const { editor, keymap, ids, driven } = setup();
+    editor.commands.select(ids.path);
+    expect(keymap.dispatch(mkEnter())).toBe(true);
+    expect(driven()).toBe(ids.path);
+  });
+
+  it("Enter on a container descends the hierarchy instead of editing", () => {
+    // `content.enter` declines (a <g> is neither text nor vector target), so
+    // the chain falls through to `hierarchy.enter`, which selects the first
+    // child. Locks chain precedence AND the no-regression of the old binding.
+    const { editor, keymap, ids, driven } = setup();
+    editor.commands.select(ids.g);
+    expect(keymap.dispatch(mkEnter())).toBe(true);
+    expect(driven()).toBe(null);
+    expect(editor.state.selection).toEqual([ids.rect]);
+  });
+
+  it("Enter is a no-op with zero selection", () => {
+    const { editor, keymap, driven } = setup();
+    editor.commands.deselect();
+    expect(keymap.dispatch(mkEnter())).toBe(false);
+    expect(driven()).toBe(null);
+    expect(editor.state.selection).toEqual([]);
+  });
+
+  it("Enter is a no-op with multiple selection", () => {
+    const { editor, keymap, ids, driven } = setup();
+    editor.commands.select([ids.text, ids.path]);
+    expect(keymap.dispatch(mkEnter())).toBe(false);
+    expect(driven()).toBe(null);
+    expect(editor.state.selection).toEqual([ids.text, ids.path]);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -17,8 +17,16 @@ const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
 </svg>`;
 
 type Internal = {
-  doc: unknown;
+  doc: {
+    text_of: (id: string) => string;
+    set_text: (id: string, text: string) => void;
+    all_elements: () => string[];
+  };
   history: { preview: (label: string) => unknown };
+  insert_text_preview: (
+    initial: Readonly<Record<string, string>>,
+    opts?: { parent?: string }
+  ) => { id: string; commit: () => void; discard: () => void };
   emit: () => void;
   subscribe_translate_commit: (cb: () => void) => () => void;
   notify_translate_commit: () => void;
@@ -42,6 +50,7 @@ describe("editor._internal contract", () => {
         "doc",
         "emit",
         "history",
+        "insert_text_preview",
         "notify_translate_commit",
         "push_surface_hover",
         "set_computed_resolver",

--- a/packages/grida-svg-editor/__tests__/text-edit-exit.test.ts
+++ b/packages/grida-svg-editor/__tests__/text-edit-exit.test.ts
@@ -1,0 +1,82 @@
+// Empty-equals-delete decision (pure policy) + text-insert default attrs.
+// The DOM surface only dispatches `resolve_text_exit`'s action, so these
+// headless tests are the spec for the rule itself.
+// Design: docs/wg/feat-svg-editor/text-tool.md.
+
+import { describe, expect, it } from "vitest";
+import { resolve_text_exit } from "../src/core/text-edit";
+import { insertions } from "../src/core/insertions";
+
+describe("resolve_text_exit — empty-equals-delete policy", () => {
+  it("fresh + empty discards the insert (no node, no history entry)", () => {
+    expect(
+      resolve_text_exit({ origin: "fresh", result: "", original: "" })
+    ).toEqual({ kind: "discard_insert" });
+  });
+
+  it("fresh + content commits the insert as one step", () => {
+    expect(
+      resolve_text_exit({ origin: "fresh", result: "hello", original: "" })
+    ).toEqual({ kind: "commit_insert" });
+  });
+
+  it("a typed space is content — fresh + space commits, not discards", () => {
+    expect(
+      resolve_text_exit({ origin: "fresh", result: " ", original: "" })
+    ).toEqual({ kind: "commit_insert" });
+  });
+
+  it("existing + emptied is removed (undo restores original content)", () => {
+    expect(
+      resolve_text_exit({ origin: "existing", result: "", original: "hello" })
+    ).toEqual({ kind: "remove" });
+  });
+
+  it("existing + already-empty-and-unchanged is still removed (unconditional rule)", () => {
+    expect(
+      resolve_text_exit({ origin: "existing", result: "", original: "" })
+    ).toEqual({ kind: "remove" });
+  });
+
+  it("existing + changed content writes the new text", () => {
+    expect(
+      resolve_text_exit({ origin: "existing", result: "new", original: "old" })
+    ).toEqual({ kind: "set_text", value: "new" });
+  });
+
+  it("existing + unchanged content is a no-op", () => {
+    expect(
+      resolve_text_exit({
+        origin: "existing",
+        result: "same",
+        original: "same",
+      })
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("whitespace is content — existing edited from empty to a space writes it", () => {
+    expect(
+      resolve_text_exit({ origin: "existing", result: " ", original: "" })
+    ).toEqual({ kind: "set_text", value: " " });
+  });
+});
+
+describe("insertions.default_text_attrs", () => {
+  it("anchors at the world point and carries the default font appearance", () => {
+    expect(insertions.default_text_attrs({ x: 12, y: 34 })).toEqual({
+      x: "12",
+      y: "34",
+      "font-size": "16",
+      "font-family": "sans-serif",
+      fill: "#000000",
+    });
+  });
+
+  it("rounds fractional world coordinates (IEEE-754 noise suppression)", () => {
+    const attrs = insertions.default_text_attrs({
+      x: 0.30000000000000004,
+      y: 1,
+    });
+    expect(attrs.x).toBe("0.3");
+  });
+});

--- a/packages/grida-svg-editor/__tests__/text-insert.test.ts
+++ b/packages/grida-svg-editor/__tests__/text-insert.test.ts
@@ -1,0 +1,109 @@
+// Empty-equals-delete + history bracketing for the click-to-place text tool.
+//
+// These pin the CORE half of the rule — `insert_text_preview` — which the DOM
+// shell's `finalize_text_exit` drives on content-edit exit. The shell
+// orchestration (Enter -> onCommit -> finalize) needs a DOM and is verified
+// manually; the undo/redo semantics that actually matter live here and run
+// headlessly. Design: docs/wg/feat-svg-editor/text-tool.md.
+
+import { describe, expect, it } from "vitest";
+import { createSvgEditor } from "../src/index";
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect id="r" x="0" y="0" width="10" height="10" fill="red"/>
+</svg>`;
+
+type TextSession = { id: string; commit: () => void; discard: () => void };
+type Internal = {
+  doc: {
+    text_of: (id: string) => string;
+    set_text: (id: string, text: string) => void;
+    all_elements: () => string[];
+  };
+  insert_text_preview: (
+    initial: Readonly<Record<string, string>>,
+    opts?: { parent?: string }
+  ) => TextSession;
+};
+
+function internalOf(editor: ReturnType<typeof createSvgEditor>): Internal {
+  return (editor as unknown as { _internal: Internal })._internal;
+}
+
+const ATTRS = {
+  x: "10",
+  y: "20",
+  "font-size": "16",
+  "font-family": "sans-serif",
+  fill: "#000000",
+} as const;
+
+describe("text insert — history bracketing (empty == delete)", () => {
+  it("text insert with content is a single undo step", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const internal = internalOf(editor);
+    expect(editor.state.can_undo).toBe(false);
+
+    const session = internal.insert_text_preview(ATTRS);
+    // Simulate inline editing: content-edit mutates the node text in place.
+    internal.doc.set_text(session.id, "hello");
+    session.commit();
+
+    expect(editor.state.can_undo).toBe(true);
+    expect(editor.serialize()).toContain("hello");
+
+    // ONE undo removes the whole inserted node (not just the text).
+    editor.commands.undo();
+    expect(editor.state.can_undo).toBe(false);
+    expect(internal.doc.all_elements()).not.toContain(session.id);
+    expect(editor.serialize()).not.toContain("hello");
+  });
+
+  it("text insert with no content leaves no node and no undo entry", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const internal = internalOf(editor);
+    expect(editor.state.can_undo).toBe(false);
+
+    const session = internal.insert_text_preview(ATTRS);
+    // Node exists during editing (the caret needs somewhere to live)...
+    expect(internal.doc.all_elements()).toContain(session.id);
+
+    // ...but typing nothing and exiting discards it entirely.
+    session.discard();
+    expect(internal.doc.all_elements()).not.toContain(session.id);
+    // No history entry — an abandoned placement leaves no trace.
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("redo after a committed text insert restores the node WITH its content", () => {
+    // Regression guard: a plain insert_preview would re-create an EMPTY node
+    // on redo (text is not an attribute). insert_text_preview captures the
+    // final text into the delta so redo replays it.
+    const editor = createSvgEditor({ svg: SVG });
+    const internal = internalOf(editor);
+
+    const session = internal.insert_text_preview(ATTRS);
+    internal.doc.set_text(session.id, "world");
+    session.commit();
+
+    editor.commands.undo();
+    expect(editor.serialize()).not.toContain("world");
+
+    editor.commands.redo();
+    expect(internal.doc.all_elements()).toContain(session.id);
+    expect(internal.doc.text_of(session.id)).toBe("world");
+    expect(editor.serialize()).toContain("world");
+  });
+
+  it("discard restores the prior selection (an abandoned placement is invisible to state)", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const internal = internalOf(editor);
+    const before = editor.state.selection;
+
+    const session = internal.insert_text_preview(ATTRS);
+    expect(editor.state.selection).toEqual([session.id]);
+
+    session.discard();
+    expect(editor.state.selection).toEqual(before);
+  });
+});

--- a/packages/grida-svg-editor/src/commands/defaults.ts
+++ b/packages/grida-svg-editor/src/commands/defaults.ts
@@ -148,6 +148,15 @@ export function registerDefaultCommands(
     return editor.commands.align(args as AlignDirection);
   });
 
+  // ─── content edit ─────────────────────────────────────────────────────────
+  // Enter — enter content-edit (text edit / vector edit) on the single
+  // selected node. Mirrors the double-click → `enter_content_edit` intent
+  // path (dom.ts:commit_intent). `enter_content_edit()` self-guards on a
+  // single selection and returns false for non-editable nodes (or when no
+  // surface is attached to drive the edit), so the chained `hierarchy.enter`
+  // binding can preempt and descend into a container instead.
+  reg.register("content.enter", () => editor.enter_content_edit());
+
   // ─── hierarchy ────────────────────────────────────────────────────────────
   // Enter — select the first child of the selected node. Lets the user drill
   // into a group from the keyboard. Returns false when the selection isn't a
@@ -209,7 +218,7 @@ export function registerDefaultCommands(
     const required_mode: "select" | "edit-content" | null =
       next.type === "lasso" || next.type === "bend"
         ? "edit-content"
-        : next.type === "insert"
+        : next.type === "insert" || next.type === "insert-text"
           ? "select"
           : null; // cursor — any mode
     if (required_mode !== null && editor.state.mode !== required_mode)

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -505,7 +505,13 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
 
   function tools_equal(a: Tool, b: Tool): boolean {
     if (a.type !== b.type) return false;
-    if (a.type === "cursor" || a.type === "lasso" || a.type === "bend")
+    // Payload-free tool variants are equal once their types match.
+    if (
+      a.type === "cursor" ||
+      a.type === "lasso" ||
+      a.type === "bend" ||
+      a.type === "insert-text"
+    )
       return true;
     return b.type === "insert" && a.tag === b.tag;
   }
@@ -1451,6 +1457,67 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     };
   }
 
+  /**
+   * Text-creation bracket for the click-to-place text tool. Creates an
+   * empty `<text>` with `initial` attrs, opens a single history preview,
+   * and selects it — the DOM surface then mounts inline content-edit on
+   * it. The surface finalizes the returned session when content-edit
+   * exits:
+   *
+   *  - `commit()` — snapshots the live text content into the delta and
+   *    commits ONE undo step (create + text together). Redo replays both,
+   *    so a redone text insert keeps its content (a plain `insert_preview`
+   *    would lose it — text is not an attribute).
+   *  - `discard()` — rolls the creation back entirely: no node, no
+   *    committed history entry. This is the empty-equals-delete rule for a
+   *    freshly-placed node (design:
+   *    `docs/wg/feat-svg-editor/text-tool.md`).
+   *
+   * The node is inserted empty on open (so the caret has somewhere to
+   * live); live edits mutate its text in place, and `commit()` reads the
+   * final text back off the document.
+   */
+  function insert_text_preview(
+    initial: Readonly<Record<string, string>>,
+    opts?: { parent?: NodeId }
+  ): { id: NodeId; commit(): void; discard(): void } {
+    const parent = opts?.parent ?? doc.root;
+    const id = doc.create_element("text");
+    const previous_selection = selection;
+    const attrs = { ...initial };
+    // Read back at commit() so redo replays the final authored text.
+    let committed_text = "";
+    const apply = () => {
+      for (const name in attrs) doc.set_attr(id, name, attrs[name]);
+      if (doc.parent_of(id) === null) doc.insert(id, parent, null);
+      doc.set_text(id, committed_text);
+      set_selection([id]);
+    };
+    const revert = () => {
+      doc.remove(id);
+      set_selection(previous_selection);
+    };
+    const preview = history.preview("insert text");
+    let active = true;
+    // First apply: empty node, selected. Content-edit mutates the node's
+    // text in place from here (the node is already in the tree).
+    preview.set({ providerId: PROVIDER_ID, apply, revert });
+    return {
+      id,
+      commit() {
+        if (!active) return;
+        active = false;
+        committed_text = doc.text_of(id);
+        preview.commit();
+      },
+      discard() {
+        if (!active) return;
+        active = false;
+        preview.discard();
+      },
+    };
+  }
+
   /** Per-tag default paint attrs. Wrapped so callers don't need to depend
    *  on the InsertableTag type — `insert()` accepts arbitrary string tags
    *  (so `commands.insert("path", ...)` works for paste / RPC) but only
@@ -1811,6 +1878,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       history: {
         preview: (label: string) => history.preview(label),
       },
+      insert_text_preview,
       emit,
       subscribe_translate_commit(cb: () => void): () => void {
         translate_commit_listeners.add(cb);

--- a/packages/grida-svg-editor/src/core/insertions.ts
+++ b/packages/grida-svg-editor/src/core/insertions.ts
@@ -154,6 +154,32 @@ export namespace insertions {
     }
   }
 
+  /** v1 default font appearance for a freshly-placed `<text>`: 16px
+   *  sans-serif, black fill — visible and editable the instant it's
+   *  placed. Hard-coded for v1, exactly like the shape paint defaults
+   *  above; promote to `EditorStyle.insertion_*` only when a host asks
+   *  for brand defaults (see TODO.md "Tunable defaults via EditorStyle").
+   *
+   *  `<text>` is intentionally NOT an `InsertableTag` — its creation is a
+   *  click-only gesture, not drag-to-size — so it lives outside the
+   *  per-tag switches above rather than forcing a `size` it has no use
+   *  for. */
+  export const DEFAULT_TEXT_FONT_SIZE = 16;
+  export const DEFAULT_TEXT_FONT_FAMILY = "sans-serif";
+  export const DEFAULT_TEXT_FILL = "#000000";
+
+  /** Attrs for a click-to-place text insert: anchor at the click point
+   *  plus the default font appearance. `point` is in world space. */
+  export function default_text_attrs(point: Vec2): Record<string, string> {
+    return {
+      x: fmt(point.x),
+      y: fmt(point.y),
+      "font-size": String(DEFAULT_TEXT_FONT_SIZE),
+      "font-family": DEFAULT_TEXT_FONT_FAMILY,
+      fill: DEFAULT_TEXT_FILL,
+    };
+  }
+
   // ─── Per-tag drag math ───────────────────────────────────────────────
 
   function rect_attrs(

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -30,6 +30,18 @@ export interface SurfaceBridge {
     preview(label: string): Preview;
   };
 
+  /** Text-creation bracket for the click-to-place text tool. Creates an
+   *  empty `<text>` with `initial` attrs under `opts.parent` (root by
+   *  default), selects it, and opens one history preview. The surface
+   *  mounts inline content-edit on the returned `id`, then calls
+   *  `commit()` (one undo step, content captured for redo) or `discard()`
+   *  (no node, no history entry — the empty-equals-delete rule for a
+   *  freshly-placed node). See `core/editor.ts`. */
+  insert_text_preview(
+    initial: Readonly<Record<string, string>>,
+    opts?: { parent?: NodeId }
+  ): { id: NodeId; commit(): void; discard(): void };
+
   /** surface → editor: bump the version counter and notify subscribers.
    *  Used inside preview-session apply/revert closures so a per-frame
    *  geometry write reaches `subscribe()` listeners. */

--- a/packages/grida-svg-editor/src/core/text-edit.ts
+++ b/packages/grida-svg-editor/src/core/text-edit.ts
@@ -1,0 +1,58 @@
+// Text content-edit exit policy — pure, DOM-free.
+//
+// The empty-equals-delete rule (docs/wg/feat-svg-editor/text-tool.md) is a
+// decision, not a mechanism: given how text-edit exited, what should happen
+// to the node? Keeping that decision here — separate from the DOM surface
+// that realizes it — makes the rule unit-testable without mounting a surface
+// (the surface can't run under the headless test env). The surface only
+// dispatches the returned action to the relevant primitive.
+
+/** Whether the node being edited was created by this same gesture (the
+ *  click-to-place text tool) or pre-existed it. The two differ only in undo
+ *  treatment: a fresh node's creation+edit are one bracket (commit = one
+ *  step, discard = no trace); a pre-existing node is mutated/removed as its
+ *  own step. */
+export type TextEditOrigin = "fresh" | "existing";
+
+/**
+ * What the surface should do when inline text content-editing exits.
+ *
+ *  - `commit_insert` / `discard_insert` — finalize the fresh-insert history
+ *    bracket (keep as one undo step / roll back with no entry).
+ *  - `remove` — delete a pre-existing node (one undo step; undo restores it).
+ *  - `set_text` — write changed content to a pre-existing node.
+ *  - `noop` — pre-existing node, content unchanged.
+ */
+export type TextExitAction =
+  | { kind: "commit_insert" }
+  | { kind: "discard_insert" }
+  | { kind: "remove" }
+  | { kind: "set_text"; value: string }
+  | { kind: "noop" };
+
+/**
+ * Decide what happens when inline text content-editing exits.
+ *
+ * `result` is the text that should remain — the typed text on commit, the
+ * original on cancel. "Empty" means zero-length: a space is authored
+ * content and is kept. The rule is unconditional — an empty result deletes
+ * the node however it got there (freshly placed and never typed, cleared by
+ * the author, or already empty on entry).
+ *
+ * See docs/wg/feat-svg-editor/text-tool.md.
+ */
+export function resolve_text_exit(input: {
+  origin: TextEditOrigin;
+  result: string;
+  original: string;
+}): TextExitAction {
+  const is_empty = input.result.length === 0;
+  if (input.origin === "fresh") {
+    return is_empty ? { kind: "discard_insert" } : { kind: "commit_insert" };
+  }
+  if (is_empty) return { kind: "remove" };
+  if (input.result !== input.original) {
+    return { kind: "set_text", value: input.result };
+  }
+  return { kind: "noop" };
+}

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -73,6 +73,7 @@ import { resize_pipeline } from "./core/resize-pipeline";
 import type { RotatableVerdict } from "./core/rotate-pipeline";
 import { transform } from "./core/transform";
 import { insertions, type DragModifiers } from "./core/insertions";
+import { resolve_text_exit } from "./core/text-edit";
 import { paint } from "./core/paint";
 import { Gestures } from "./gestures/gestures";
 import { applyDefaultGestures } from "./gestures/defaults";
@@ -401,6 +402,16 @@ class DomSurface implements Surface {
   private text_edit: TextEditor | null = null;
   private text_edit_target: NodeId | null = null;
   private text_edit_original: string = "";
+
+  /** Open insertion bracket for the text tool — set while the inline
+   *  content-edit that follows a click-to-place is in flight. When set,
+   *  the text-edit exit finalizes through this session (commit = one undo
+   *  step; discard = no node) instead of the existing-node path. Null for
+   *  double-click edits of pre-existing text. */
+  private pending_text_insert: {
+    id: NodeId;
+    session: { commit(): void; discard(): void };
+  } | null = null;
 
   /** Active vector-edit session (null when not in vector content-edit mode).
    *  Mutually exclusive with `text_edit` — content-edit mode owns exactly
@@ -2073,6 +2084,23 @@ class DomSurface implements Surface {
       // the HUD process it (hover during tool mode is fine).
     }
 
+    // Text tool intercept — click-only (no drag-to-size; see
+    // types.ts `insert-text`). Primary pointer-down creates a single-line
+    // <text> at the world point with default appearance and immediately
+    // enters content-edit so the caret is live. Reverts to cursor.
+    // Create + first edit are bracketed in one history step that discards
+    // cleanly if the author types nothing (empty-equals-delete; design:
+    // docs/wg/feat-svg-editor/text-tool.md).
+    if (tool.type === "insert-text") {
+      if (kind === "pointer_down" && e.button === 0) {
+        const world = this.camera.screen_to_world({ x, y });
+        this.editor.set_tool({ type: "cursor" });
+        this.begin_text_insert(world);
+        return;
+      }
+      // Non-primary or non-down events fall through to the HUD.
+    }
+
     const button: PointerButton =
       e.button === 0 ? "primary" : e.button === 2 ? "secondary" : "middle";
 
@@ -2275,6 +2303,13 @@ class DomSurface implements Surface {
     // trying to draw a new shape.
     if (this.current_tool.type === "insert") {
       this.container.style.cursor = "crosshair";
+      return;
+    }
+    // Text tool — same reasoning as `insert` above: without this the cursor
+    // would flip to "move" / "resize-*" while hovering existing nodes,
+    // contradicting the "click to place text" intent. An I-beam signals it.
+    if (this.current_tool.type === "insert-text") {
+      this.container.style.cursor = "text";
       return;
     }
     // Delegate icon → CSS to the HUD's installed renderer. The
@@ -2980,6 +3015,34 @@ class DomSurface implements Surface {
     return false;
   }
 
+  // ─── Text creation (click-to-place tool) ───────────────────────────────────
+
+  /**
+   * Place a new single-line `<text>` at `world` and immediately enter
+   * content-edit on it. Creation + first edit are bracketed in one history
+   * preview (via `insert_text_preview`): committing with content is one
+   * undo step, exiting empty discards the node entirely (empty-equals-
+   * delete). The bracket is finalized in {@link enter_text_edit}'s
+   * commit/cancel callbacks via `this.pending_text_insert`.
+   *
+   * Default font appearance lives in `core/insertions.ts`
+   * (`default_text_attrs`), alongside the shape insertion defaults — not
+   * hard-coded here — so the per-element insert semantics stay in core (P3).
+   */
+  private begin_text_insert(world: Vec2): void {
+    if (this.text_edit || this.vector_edit) return;
+    const session = this.editor_internal().insert_text_preview(
+      insertions.default_text_attrs(world)
+    );
+    this.pending_text_insert = { id: session.id, session };
+    this.editor.enter_content_edit(session.id);
+    // If content-edit failed to mount, don't leak the empty node.
+    if (this.text_edit_target !== session.id) {
+      this.pending_text_insert = null;
+      session.discard();
+    }
+  }
+
   // ─── Content edit (text) ──────────────────────────────────────────────────
 
   private enter_text_edit(id: NodeId): boolean {
@@ -3008,19 +3071,6 @@ class DomSurface implements Surface {
       /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 
     let settled = false;
-    const cleanup_after_commit_or_cancel = () => {
-      // P4 — observers should see a consistent post-edit state. Do all
-      // observable mutations + surface syncs first; clear the
-      // text-edit handles last so anything that polls "is text-edit
-      // active?" still says yes until the rest of the world is settled.
-      this.editor.commands.set_mode("select");
-      this.render();
-      this.sync_surface_selection();
-      this.sync_cursor();
-      this.redraw();
-      this.text_edit = null;
-      this.text_edit_target = null;
-    };
 
     this.text_edit = createTextEditor({
       container: this.container,
@@ -3037,18 +3087,14 @@ class DomSurface implements Surface {
         onCommit: (final_text) => {
           if (settled) return;
           settled = true;
-          doc.doc.set_text(id, this.text_edit_original);
-          cleanup_after_commit_or_cancel();
-          if (final_text !== this.text_edit_original) {
-            this.editor.commands.set_text(final_text);
-          }
+          // Commit keeps what the author typed (`final_text`).
+          this.finalize_text_exit(id, final_text);
         },
         onCancel: () => {
           if (settled) return;
           settled = true;
-          doc.doc.set_text(id, this.text_edit_original);
-          cleanup_after_commit_or_cancel();
-          doc.emit();
+          // Cancel abandons edits — the result is the original text.
+          this.finalize_text_exit(id, this.text_edit_original);
         },
         onUndoFallthrough: () => {
           this.text_edit?.commit();
@@ -3061,6 +3107,86 @@ class DomSurface implements Surface {
       },
     });
     return true;
+  }
+
+  /**
+   * Exit inline text-edit back to select mode. P4 — observers should see a
+   * consistent post-edit state, so do all observable mutations + surface
+   * syncs first, then clear the text-edit handles last (so anything polling
+   * "is text-edit active?" still says yes until the world is settled).
+   */
+  private cleanup_text_edit(): void {
+    this.editor.commands.set_mode("select");
+    this.render();
+    this.sync_surface_selection();
+    this.sync_cursor();
+    this.redraw();
+    this.text_edit = null;
+    this.text_edit_target = null;
+  }
+
+  /**
+   * Realize the result of a text content-edit session and exit. `result`
+   * is the text that should remain — the typed text on commit, the original
+   * on cancel. Implements the empty-equals-delete rule (design:
+   * docs/wg/feat-svg-editor/text-tool.md): an empty result removes the node.
+   * (see test/svg-editor-text-empty-delete.md)
+   *
+   * The empty-equals-delete decision is pure and lives in
+   * {@link resolve_text_exit} (`core/text-edit.ts`) — tested headlessly.
+   * This method is the thin dispatcher that realizes each action against
+   * the surface + editor.
+   */
+  private finalize_text_exit(id: NodeId, result: string): void {
+    const internal = this.editor_internal();
+    const insert = this.pending_text_insert;
+    this.pending_text_insert = null;
+    const action = resolve_text_exit({
+      origin: insert && insert.id === id ? "fresh" : "existing",
+      result,
+      original: this.text_edit_original,
+    });
+
+    // Fresh-insert bracket: the live doc already holds `result`.
+    if (action.kind === "commit_insert" || action.kind === "discard_insert") {
+      if (!insert) return;
+      if (action.kind === "discard_insert") {
+        // Discard before cleanup so the final render rebuilds without the
+        // node; nothing is committed to history.
+        insert.session.discard();
+        this.cleanup_text_edit();
+      } else {
+        // Cleanup renders the live `result`, then the bracket commits as a
+        // single undo step.
+        this.cleanup_text_edit();
+        insert.session.commit();
+      }
+      return;
+    }
+
+    // Pre-existing node. Restore the original first so the delete/edit step
+    // below captures a clean revert baseline.
+    internal.doc.set_text(id, this.text_edit_original);
+    this.cleanup_text_edit();
+    switch (action.kind) {
+      case "remove":
+        this.editor.commands.select(id);
+        this.editor.commands.remove();
+        break;
+      case "set_text":
+        this.editor.commands.set_text(action.value);
+        break;
+      case "noop":
+        internal.emit();
+        break;
+      default: {
+        // Exhaustiveness guard — a new `TextExitAction` kind from the pure
+        // `resolve_text_exit` core must be handled here, not silently dropped
+        // by the shell (the core's tests can't catch a missing shell case).
+        const _exhaustive: never = action;
+        void _exhaustive;
+      }
+    }
   }
 
   // ─── Content edit (path) ─────────────────────────────────────────────────

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -3151,10 +3151,13 @@ class DomSurface implements Surface {
     if (action.kind === "commit_insert" || action.kind === "discard_insert") {
       if (!insert) return;
       if (action.kind === "discard_insert") {
-        // Discard before cleanup so the final render rebuilds without the
-        // node; nothing is committed to history.
-        insert.session.discard();
+        // Clear the text-edit guard (cleanup) BEFORE discard: `render()`
+        // early-returns while a text-edit is active, so the rebuild that drops
+        // the node must come from discard()'s emit *after* the guard is
+        // cleared — otherwise the discarded node lingers in the DOM until the
+        // next unrelated render. Nothing is committed to history.
         this.cleanup_text_edit();
+        insert.session.discard();
       } else {
         // Cleanup renders the live `result`, then the bracket commits as a
         // single undo step.

--- a/packages/grida-svg-editor/src/keymap/defaults.ts
+++ b/packages/grida-svg-editor/src/keymap/defaults.ts
@@ -89,7 +89,12 @@ export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
     args: "vertical_centers",
   },
 
-  // ─── hierarchy ────────────────────────────────────────────────────────────
+  // ─── content edit / hierarchy ─────────────────────────────────────────────
+  // Enter is overloaded; chain order matters. First try entering content
+  // edit on an editable (text/vector) node; `content.enter` returns false
+  // for everything else, so the chain falls through to hierarchy descent.
+  // This gives `Enter` parity with double-click.
+  { keybinding: kb(KeyCode.Enter), command: "content.enter" },
   { keybinding: kb(KeyCode.Enter), command: "hierarchy.enter" },
   { keybinding: kb(KeyCode.Enter, M.Shift), command: "hierarchy.exit" },
 
@@ -138,12 +143,12 @@ export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
     args: { dx: 0, dy: 10 },
   },
 
-  // ─── tools — V (cursor) / R (rect) / O (ellipse) / L (line) ─────────────
+  // ─── tools — V (cursor) / R (rect) / O (ellipse) / L (line) / T (text) ──
   // Bare letter keys. All default bindings are suppressed while a text
   // input is focused (the form-element focus guard in keymap/keymap.ts);
   // the dom.ts on_keydown early-return additionally suppresses them
-  // during inline SVG text edit. `T` is deliberately omitted — text
-  // insertion needs its own UX design pass (see TODO.md).
+  // during inline SVG text edit. `T` selects the click-only text tool
+  // (design: docs/wg/feat-svg-editor/text-tool.md).
   { keybinding: kb(KeyCode.KeyV), command: TOOL_SET, args: { type: "cursor" } },
   {
     keybinding: kb(KeyCode.KeyR),
@@ -159,6 +164,11 @@ export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
     keybinding: kb(KeyCode.KeyL),
     command: TOOL_SET,
     args: { type: "insert", tag: "line" },
+  },
+  {
+    keybinding: kb(KeyCode.KeyT),
+    command: TOOL_SET,
+    args: { type: "insert-text" },
   },
   // Q — vector lasso. The TOOL_SET handler gates on `mode === "edit-content"`,
   // so this fires only during path content-edit; outside that, the

--- a/packages/grida-svg-editor/src/types.ts
+++ b/packages/grida-svg-editor/src/types.ts
@@ -15,12 +15,14 @@ export type Mode = "select" | "edit-content";
 // ─── Tool (orthogonal to Mode — what does pointer-down do in select mode?) ─
 
 /**
- * SVG element tags supported by the insertion subsystem. Closed set; adding
- * a new insertable tag requires a PR.
+ * SVG element tags inserted by the **drag-to-size** subsystem. Closed set;
+ * adding a new insertable tag requires a PR.
  *
- * `text` is deliberately out of v1: `<text>` has no intrinsic size and any
- * usable text-insert UX must immediately mount the inline content-editor on
- * the new node rather than dropping a placeholder. Reserved for a future PR.
+ * `text` is intentionally NOT here. It is creatable (the `insert-text`
+ * tool — see {@link Tool}), but via a **click-only** gesture, not
+ * drag-to-size: `<text>` has no intrinsic size, so there is nothing for a
+ * drag to set. Its creation path mounts the inline content-editor
+ * immediately. Design: `docs/wg/feat-svg-editor/text-tool.md`.
  */
 export type InsertableTag = "rect" | "ellipse" | "line";
 
@@ -38,6 +40,17 @@ export type InsertableTag = "rect" | "ellipse" | "line";
 export type Tool =
   | { type: "cursor" }
   | { type: "insert"; tag: InsertableTag }
+  /**
+   * Text creation tool. A select-mode tool like `insert`, but **click-only**
+   * rather than drag-to-size: pointer-down creates a single-line `<text>` at
+   * the click point with default appearance and immediately enters
+   * content-edit (caret active). `<text>` has no intrinsic size, so the
+   * drag-to-size model doesn't apply; a drag box would mean SVG 2 wrapped
+   * text, which is a separate (out-of-scope) model. Reverts to `cursor`
+   * after the node is placed. Design:
+   * `docs/wg/feat-svg-editor/text-tool.md`.
+   */
+  | { type: "insert-text" }
   /**
    * Vector content-edit lasso (Q). Empty-space drag draws a freeform
    * polygon that picks vertices + tangents inside it (segments are NOT

--- a/test/svg-editor-text-empty-delete.md
+++ b/test/svg-editor-text-empty-delete.md
@@ -1,0 +1,76 @@
+---
+id: TC-SVGEDITOR-TEXT-001
+title: Empty text is deleted on content-edit exit
+module: svg-editor
+area: text
+tags: [text, content-edit, history, undo]
+status: tested
+severity: medium
+date: 2026-06-03
+updated: 2026-06-03
+automatable: false
+covered_by:
+  - packages/grida-svg-editor/__tests__/text-insert.test.ts
+---
+
+## Behavior
+
+A `<text>` element with no content renders nothing and is effectively
+impossible to select on the canvas (no painted geometry to hit). It is a
+dead document state — invisible, unselectable, and noise in the file. So
+the editor treats it as a deletion: **on exit from text content-editing, a
+text element whose content is empty is removed.** "Empty" means zero-length
+content — a typed space is authored content and is kept.
+
+The rule is unconditional (it fires however the node became empty), but the
+undo treatment depends on whether the node existed before the gesture:
+
+- **Freshly placed** (text tool → click → no typing → exit): creation and
+  the empty exit are one abandoned gesture. The node is gone and there is
+  **no committed history entry** — undo does not resurrect an empty node.
+- **Pre-existing, cleared empty** (double-click an existing text → delete
+  all chars → exit): a deletion of that element, as **one undoable step**.
+  Undo restores the element with its original content intact.
+
+Committing with content is one undo step (create + text together); redo
+restores the node _with_ its text.
+
+Design: `docs/wg/feat-svg-editor/text-tool.md`. The core history bracketing
+is unit-tested (`covered_by`); the full pointer→type→exit flow needs real
+interaction and is verified here.
+
+## Steps
+
+Open the SVG editor demo at `http://localhost:3000/svg/`.
+
+1. **Fresh, empty → vanishes.** Press `T` (or pick the Text tool), click an
+   empty area. A caret appears. Type nothing. Press `Enter` (or click away).
+   - Expected: no `<text>` remains, no 0×0 selection chrome lingers.
+   - Press `Cmd/Ctrl+Z`. Expected: nothing is resurrected (the placement
+     left no history entry).
+
+2. **Fresh, with content → one undo / redo keeps text.** Press `T`, click,
+   type `hello`, press `Enter`.
+   - Expected: the text shows and is selected.
+   - `Cmd/Ctrl+Z` once. Expected: the whole text node is gone (not just the
+     characters).
+   - `Cmd/Ctrl+Shift+Z` (redo). Expected: the text node returns showing
+     `hello` (not an empty node).
+
+3. **Existing, cleared → removed and restorable.** With a text node that has
+   content, double-click it to edit, select all (`Cmd/Ctrl+A`), delete,
+   press `Enter`.
+   - Expected: the node is removed.
+   - `Cmd/Ctrl+Z`. Expected: the node returns with its original content.
+
+4. **Whitespace is content.** Press `T`, click, type a single space, press
+   `Enter`.
+   - Expected: the node is kept (a space is authored content, not empty).
+
+## Notes
+
+Implemented via `insert_text_preview` (core history bracket) +
+`finalize_text_exit` (DOM shell) in `packages/grida-svg-editor`. The
+"redo keeps text" assertion (step 2) guards against a regression to a plain
+`insert_preview`, which would redo to an empty node since text is not an
+attribute.

--- a/test/svg-editor-text-empty-delete.md
+++ b/test/svg-editor-text-empty-delete.md
@@ -4,7 +4,7 @@ title: Empty text is deleted on content-edit exit
 module: svg-editor
 area: text
 tags: [text, content-edit, history, undo]
-status: tested
+status: untested
 severity: medium
 date: 2026-06-03
 updated: 2026-06-03


### PR DESCRIPTION
## What

Adds the **text creation tool** to `@grida/svg-editor`. With the tool active (`T`), pointer-down places a single-line `<text>` at the click point with the editor's default appearance and immediately enters inline content-edit — point, then type. No placeholder characters, no select-then-edit second step.

Design note: [`docs/wg/feat-svg-editor/text-tool.md`](docs/wg/feat-svg-editor/text-tool.md).

## Demo

New packages demo page (to-be-hosted): **`/packages/@grida/svg-editor`** — https://grida.co/packages/@grida/svg-editor

Added under `editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/` and registered in `editor/app/(tools)/(packages)/packages/data.ts`.

## Why text isn't like the other shapes

Rect/ellipse/line have intrinsic size — drag sets width/height. SVG `<text>` has no intrinsic size; its extent is a consequence of content + font. So there's nothing for a drag to set, and creation is **click-only**. (A drag-to-define-a-box would mean SVG 2 wrapped text — a separate model, deliberately out of scope.)

## How

**Core (headless, tested):**
- `insert-text` `Tool` variant; bound to `T`, reverts to `cursor` after placement.
- `insert_text_preview` (internal `SurfaceBridge` seam) brackets *create + first edit* into **one** history step — commit captures the final text into the delta so redo replays content; discard rolls creation back with no history entry.
- `resolve_text_exit` (`core/text-edit.ts`) — pure, DOM-free **empty-equals-delete** policy: an empty result removes the node however it got there (fresh-and-never-typed discards with no undo entry; an existing node cleared empty is removed as one undoable step).
- `Enter` now enters content-edit (text/vector) on the selected node, on par with double-click; chained ahead of hierarchy descent.

**Shell (`dom.ts`):** `begin_text_insert` / `finalize_text_exit` orchestrate the bracket; the *decision* lives in the pure core, the shell only dispatches it.

## Cleanups (from in-session review)

- **Exhaustiveness guard** on `finalize_text_exit`'s action switch — a future `TextExitAction` kind can't be silently dropped by the untestable shell (D2).
- **Cursor affordance** — the text tool now shows an I-beam (mirrors the insert-tool override) so hovering existing nodes no longer flips to move/resize.
- **README Status** corrected to the actual shipped surface; instability disclaimer kept, and the `Tool`-union axis split (TODO F2) named as a planned breaking change.

## Reviewer notes

- The package is explicitly **pre-stable** (`v0.x`, "do not depend on it from production code"); the `Tool` union deliberately still conflates select-mode and content-edit-only tools (F2 cleanup deferred).
- **Known tradeoff, by design:** the empty-equals-delete rule is *unconditional* — entering and exiting content-edit on an already-empty `<text>` removes it even if it carried an `id`/animation target. This trades a corner of round-trip fidelity for a predictable rule; documented in the design note. Loading a file never triggers it.

## Testing

- New: `text-edit-exit`, `text-insert`, `enter-content-edit` (+ internal-surface contract). Manual TC: [`test/svg-editor-text-empty-delete.md`](test/svg-editor-text-empty-delete.md).
- **1000 package tests green; `tsc --noEmit` clean.**
- The I-beam cursor is DOM-only (not headlessly testable); it's a verbatim mirror of the existing, verified insert-tool cursor override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added text tool to SVG editor with click-to-place creation (shortcut: T).
  * Empty text elements are automatically deleted upon exit.
  * Enter key now triggers content-editing mode for text and path elements.

* **Documentation**
  * Added text tool design specification and behavior documentation.
  * Added SVG editor package landing page with interactive demos and fixture examples.
  * Updated API reference with new tool modes and insertion capabilities.

* **Tests**
  * Added coverage for text editing workflows, undo/redo behavior, and exit handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gridaco/grida/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->