### PR TITLE
chore(release): @grida/svg-editor 1.0.0-alpha.14 + workspace deps

### DIFF
--- a/packages/grida-canvas-hud/package.json
+++ b/packages/grida-canvas-hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/hud",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "description": "Canvas-based heads-up display for the Grida editor viewport",
   "keywords": [

--- a/packages/grida-canvas-vn/package.json
+++ b/packages/grida-canvas-vn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/vn",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": false,
   "description": "Vector Network Spec",
   "files": [

--- a/packages/grida-cmath/package.json
+++ b/packages/grida-cmath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/cmath",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "description": "unopinionated canvas math",
   "keywords": [

--- a/packages/grida-history/package.json
+++ b/packages/grida-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/history",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "dependency-free transaction and undo/redo engine",
   "license": "MIT",
   "author": "softmarshmallow",

--- a/packages/grida-keybinding/package.json
+++ b/packages/grida-keybinding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/keybinding",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Declarative keybinding primitives — types, modifiers, platform resolution, and event matching. Building blocks for hotkey systems; not a hotkey manager.",
   "keywords": [
     "hotkey",

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "Headless SVG editor (experimental).",
   "license": "MIT",
   "author": "Grida",

--- a/packages/grida-svg/package.json
+++ b/packages/grida-svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Grida-owned SVG tooling for parsing, transforming, and authoring SVG data.",
   "keywords": [

--- a/packages/grida-text-editor/package.json
+++ b/packages/grida-text-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/text-editor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Backend-agnostic text editor engine (experimental).",
   "license": "MIT",
   "author": "Grida",


### PR DESCRIPTION
## What

Version bumps for `@grida/svg-editor` and its workspace dependencies. **All versions are already published to npm** — this PR records the bumps in the repo.

| Package | old → new |
|---|---|
| `@grida/svg-editor` | `1.0.0-alpha.13` → `1.0.0-alpha.14` |
| `@grida/cmath` | `0.2.2` → `0.2.3` |
| `@grida/history` | `0.1.0` → `0.1.1` |
| `@grida/hud` | `0.2.0` → `0.2.1` |
| `@grida/keybinding` | `0.2.0` → `0.2.1` |
| `@grida/svg` | `0.1.0` → `0.1.1` |
| `@grida/text-editor` | `0.1.1` → `0.1.2` |
| `@grida/vn` | `0.0.0` → `0.1.0` (first publish) |

## Why not changesets

`pnpm changeset version` currently aborts workspace-wide: `@grida/schema` is private with no `version` field, so Changesets skips it while its dependents (`@grida/io`, `@grida/sdk-render-figma`, `@grida/io-figma`) are not skipped. The bumps were applied directly to keep this release unblocked. The changeset blocker is tracked separately.

## Reviewer notes

- `workspace:*` ranges are unchanged; pnpm resolved them to real versions at publish time.
- A plain changeset `patch` on `1.0.0-alpha.13` would graduate it to `1.0.0`; `alpha.14` was chosen intentionally to stay on the alpha track.
- No CHANGELOG entries were auto-generated this release (consequence of bypassing changesets).
- `@grida/vn` lacks a `prepack` hook and `publishConfig.access`, unlike its siblings — worth normalizing in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package versions across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->