### PR TITLE
feat(svg-editor): vector-edit non-path shapes via re-type-to-path

### DIFF
--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -56,6 +56,15 @@ preserving the author's source on round-trip.
   click-to-place rather than drag-to-size, and why an empty text
   element is treated as a deletion (the empty-equals-delete
   invariant, shared with existing-text editing).
+- [`promote-to-path.md`](./promote-to-path.md) — editing the non-path
+  shapes (`<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`,
+  `<polygon>`) as vector geometry. One rule, decided per edit: write back
+  to the native tag while it can express the result, promote to `<path>`
+  when it cannot (a curve, or topology that escapes the tag). Fills the
+  `promote` cell the Policy Class glossary leaves open: lazy timing
+  (byte-equal until the first re-typing edit), a single `<path>` target,
+  and a cubic-Bézier conic representation, with the round-trip invariants
+  that keep the conversion honest.
 
 ### Glossary
 

--- a/docs/wg/feat-svg-editor/promote-to-path.md
+++ b/docs/wg/feat-svg-editor/promote-to-path.md
@@ -12,6 +12,8 @@ tags:
   - internal
   - svg
   - wg
+doc_tasks:
+  - enhance
 format: md
 ---
 
@@ -154,7 +156,7 @@ When a `<circle>` or `<ellipse>` is promoted, its outline is written as
 
 The control-handle length for a unit circle is the standard constant
 
-```
+```text
 k = (4/3) · tan(π/8) ≈ 0.5522847498
 ```
 

--- a/docs/wg/feat-svg-editor/promote-to-path.md
+++ b/docs/wg/feat-svg-editor/promote-to-path.md
@@ -1,0 +1,374 @@
+---
+title: "Promote-to-Path — vector editing of non-path shapes"
+description: "RFD for editing the non-path SVG shapes (rect, circle, ellipse, line, polyline, polygon) as vector geometry: native writeback while the tag can express the edit, promotion to <path> when it cannot — the timing, target, conic representation, and round-trip invariants that keep the conversion honest."
+keywords:
+  - svg
+  - svg-editor
+  - vector-edit
+  - promotion
+  - policy-class
+  - round-trip
+tags:
+  - internal
+  - svg
+  - wg
+format: md
+---
+
+# Promote-to-Path — vector editing of non-path shapes
+
+## Summary
+
+The editor lets a user open a `<path>`, `<polyline>`, or `<polygon>` in
+vector-edit mode and manipulate its vertices, segments, and tangents. The
+primitive shapes — `<rect>`, `<circle>`, `<ellipse>` — are excluded,
+because their parameterisations have no addressable interior vertices to
+edit (a circle is two numbers and a centre; a rect is a box). To edit one
+as free vector geometry, the shape must first be re-typed into a form that
+_has_ editable vertices. This is **promotion**.
+
+This RFD specifies promotion of primitive shapes to `<path>` for the
+purpose of vector editing: **when** the document is actually re-typed,
+**what** it is re-typed to, **how** a curved primitive's geometry is
+represented as path data, and the **round-trip invariants** that keep the
+conversion from becoming the kind of silent damage this editor exists to
+avoid.
+
+The same discipline generalises to the **vertex tags** — `<line>`,
+`<polyline>`, `<polygon>`. They already _have_ editable vertices, so a
+straight vertex move stays in the native tag; but an edit that the tag
+cannot express (a curve, or a topology change that escapes its canonical
+form) promotes to `<path>` by the same rule. See
+[Generalisation to the vertex tags](#generalisation-to-the-vertex-tags).
+
+Promotion is not new vocabulary. It is one of the four legal solutions a
+[Policy Class](./glossary/policy-class.md) may declare for an intent
+(`refuse` / `native` / `promote` / `via-transform`). This document fills
+in the `promote` cell for the vector-edit intent on the primitive-shape
+classes, which the Policy Class glossary names as an open question and
+defers.
+
+## Motivation
+
+Two forces meet here.
+
+**The editor is honest about scope.** A `<circle>` that the user merely
+selects, nudges, or recolours stays a `<circle>` — one attribute of diff,
+no proprietary noise, byte-equal round trip. That guarantee (P1, file
+sovereignty) is the product. Editors that silently turn circles into
+four-cubic-Bézier paths on save are exactly what this editor is a reaction
+to.
+
+**But vector editing is a real, requested capability.** A user who
+explicitly enters vertex-edit mode on a circle and drags an anchor is
+asking for something a `<circle>` cannot express. The shape _must_ change
+type to honor the gesture. The question is never "should the bytes change"
+— editing geometry that the native form cannot hold always changes the
+bytes. The question is whether the change is **explicit, user-initiated,
+minimal, and reversible**, or **silent, ambient, and lossy**.
+
+Promotion is the discipline that keeps it the former. The destructive
+conversion the editor refuses to do _on save_ is exactly the conversion it
+will do _on an explicit edit gesture_ — and only then.
+
+## Grounding: why these shapes cannot be edited natively
+
+Apply the [fork test](./glossary/policy-class.md#the-fork-test) for the
+vector-edit intent:
+
+- **`<circle>`, `<ellipse>`** — reject. Their parameterisation
+  (centre + radii) exposes no interior vertices. There is nothing to
+  select, move, or bend within the native attribute space. The only legal
+  vector-edit solution is `promote`.
+- **`<rect>`** — a rect _does_ have four corner points, but they are not
+  addressable as interior vertices; they are reached through the resize
+  gesture, and they carry the `axis_aligned` invariant. Making a single
+  corner independently movable, or a single edge curved, violates that
+  invariant. The legal vector-edit solution is `promote`.
+
+In every case the native form is a constraint surface, and vector editing
+is a gesture that leaves it. The only way to honor the gesture is to drop
+the constraint by re-typing the element to its unconstrained sibling. The
+universal unconstrained sibling — the form that can express any planar
+vector geometry — is `<path>`.
+
+## Decisions
+
+### D1 — Promotion is lazy: the document re-types on first edit, not on mode entry
+
+Entering vector-edit mode on a primitive shape **does not mutate the
+document**. The editor projects a path-equivalent view of the shape and
+presents the vertex/segment/tangent overlay over the still-native element.
+The element is re-typed to `<path>` only at the **first geometry-committing
+gesture**.
+
+Consequences:
+
+- **Enter-and-exit without editing is byte-equal.** A user who
+  double-clicks a circle to inspect its anchors, then presses escape,
+  leaves a document identical to the one they opened. The "open without
+  edits → byte-equal" invariant holds even for shapes whose vector overlay
+  was displayed. This is the decisive reason lazy is chosen over eager.
+- **The promotion and the first edit are one history step.** The type swap
+  is not independently undoable; undoing the first edit reverts the element
+  to its original native form. There is never a document state that is
+  "promoted but unedited" — such a state would be a gratuitous, lossy diff
+  with no user intent behind it.
+- **The overlay is computed, not stored.** While the shape is still native,
+  the vector view is a derived projection. Nothing persists until a gesture
+  commits.
+
+The rejected alternative — **eager** promotion on mode entry — is simpler
+(the session always operates on a real `<path>`), but it converts the
+element the instant the user expresses _interest_ rather than _intent_,
+breaking the byte-equal guarantee for the inspect-and-leave case. The
+guarantee is worth the added care of running a path-form session over a
+node that is still natively typed until the first commit.
+
+### D2 — All three primitives promote to `<path>`
+
+`<rect>`, `<circle>`, and `<ellipse>` all promote to `<path>`. There is a
+single promotion target and a single downstream editing model.
+
+The rejected alternative is a **split target**: promote `<rect>` to
+`<polygon>` (its declared natural target — corners stay real vertices, no
+curves are introduced, and the diff is arguably smaller for a plain
+rectangle) while conics go to `<path>`. This honors the Policy Class fork
+more precisely, but it buys two promotion targets, two downstream editing
+capability sets, and a user-visible inconsistency (editing a rect yields a
+different element type than editing a circle) in exchange for a marginally
+cleaner diff on one shape. Vector editing is fundamentally about reaching
+the full freedom of path geometry; routing one shape through a more
+constrained type that the user will frequently promote _again_ on the next
+curve gesture is a false economy. One target, one model.
+
+> The `<rect> → <polygon>` route remains a legal Policy Class solution and
+> may return as a separate, non-vector-edit "convert to polygon" intent if
+> a product need appears. It is out of scope here.
+
+### D3 — Conic geometry is represented as cubic Béziers, not arcs
+
+When a `<circle>` or `<ellipse>` is promoted, its outline is written as
+**four cubic-Bézier segments** with anchors at the four cardinal points
+(the ends of the major and minor axes), not as elliptical-arc commands.
+
+The control-handle length for a unit circle is the standard constant
+
+```
+k = (4/3) · tan(π/8) ≈ 0.5522847498
+```
+
+scaled by the respective radius on each axis; for an ellipse the same
+construction is applied independently per axis. This is the well-known
+four-segment cubic approximation of an ellipse.
+
+Rationale — this is chosen _for the editing representation_, not merely for
+ease of conversion:
+
+- **Cardinal anchors are the natural grab points.** Four cubic segments
+  give the user four anchor points at the cardinal extremes plus eight
+  tangent handles — the representation a person expects to manipulate when
+  they "edit a circle as a path." A two-arc representation exposes only two
+  anchors and no tangent handles, which is a worse editing surface.
+- **Arcs collapse on the first edit anyway.** The moment a user drags a
+  tangent or bends a segment, an `A` command can no longer describe the
+  result and must fall back to cubics. Promoting to arcs would produce a
+  representation that survives exactly until the first gesture — the very
+  gesture the user entered the mode to perform.
+- **The approximation error is bounded and below perceptual threshold.**
+  The four-segment cubic approximation deviates from a true ellipse by a
+  fraction of a pixel at typical sizes. The user has chosen to convert the
+  shape into editable geometry; an exact analytic ellipse is no longer the
+  thing being edited.
+
+The rejected alternative — **two elliptical-arc (`A`) commands** — yields
+the smallest, most "circle-like" path data and is what a pure
+shape-to-path _converter_ (as opposed to an _editor_) should emit. It is
+the right choice for a non-editing "flatten to path" operation and the
+wrong choice for entering an interactive vector-edit session, for the
+reasons above.
+
+> This is a deliberate, scoped acceptance of the four-cubic conic
+> representation that the editor refuses to emit _silently on save_. The
+> distinction is intent: here the cubics are the product of an explicit,
+> reversible, user-initiated edit, not an ambient rewrite of an untouched
+> shape.
+
+### Rectangle geometry
+
+A `<rect>` promotes to a closed four-segment path tracing its corners in
+local space. A rect with corner rounding (`rx` / `ry`) promotes to a path
+whose four corners are the corresponding rounded joins — the rounding is
+**baked into the path geometry**, not dropped. A rect with no rounding
+promotes to four straight segments and a close.
+
+## Generalisation to the vertex tags
+
+`<line>`, `<polyline>`, and `<polygon>` differ from the geometry primitives
+in one way that matters: they already _have_ addressable vertices. A
+polyline is a list of points; a line is two of them. Many vector edits on
+them — moving a vertex, inserting one along a straight run — stay
+expressible in the native tag. So promotion must not be all-or-nothing.
+
+The rule is decided **per edit, not per tag**:
+
+> Write the edit back to the source tag if the tag can still express the
+> result; otherwise promote the element to `<path>`.
+
+Concretely, for a vertex tag an edit stays native when the result is still
+the tag's canonical form — a straight open chain for `<polyline>`, a
+straight closed chain for `<polygon>`, two straight endpoints for `<line>`
+— and promotes otherwise. The two ways to leave the canonical form:
+
+- **Curvature.** A tangent drag or segment bend introduces a control
+  handle. No vertex tag can carry a curve, so the element promotes to
+  `<path>`. This is the headline case: _drag a point → stays a polyline;
+  curve a segment → becomes a path._
+- **Topology that escapes the tag.** Adding a vertex to a `<line>` (a line
+  is exactly two points) escapes it; opening a `<polygon>` or closing a
+  `<polyline>` escapes its canonical chain. Inserting a vertex _into_ a
+  `<polyline>` does **not** escape — the result is still a straight open
+  chain, so it stays a `<polyline>`.
+
+This subsumes the geometry primitives under a single rule: `<rect>` /
+`<circle>` / `<ellipse>` have **no** native vector form, so _every_ vector
+edit fails the "can the tag still express it?" test and promotes. The
+primitives are the degenerate case where the native-writeback branch is
+never taken.
+
+All the invariants below apply unchanged: native-writeback edits keep the
+tag and its trivia; a promoting edit re-types to `<path>` as one reversible
+step, restoring the original tag byte-for-byte on undo.
+
+**Targets, deliberately uniform.** A vertex tag that escapes its form
+always promotes to `<path>`, never to an intermediate vertex tag — a
+`<line>` that gains a vertex becomes a `<path>`, not a `<polyline>`. The
+intra-vertex promotions (`line → polyline`, `polyline ↔ polygon`) are legal
+Policy Class solutions but are out of scope here; `<path>` is the single
+target, matching the primitive case. A future "convert to polyline/polygon"
+intent could add them without disturbing this rule.
+
+### Fill fidelity: the `<line>` exception
+
+Promotion must preserve the element's **rendered appearance**, not only its
+attributes. For most shapes this is automatic: a shape that paints a fill in
+its native form (`<polyline>`, `<polygon>`, `<rect>`, `<circle>`,
+`<ellipse>`) paints the same fill as a `<path>`, because an open path closes
+implicitly for the purpose of fill. So the default and any inherited fill
+carry across the re-type unchanged.
+
+`<line>` is the one exception. A line has no fill region, so its fill —
+default `black`, or any value it inherits — **never paints**. A `<path>`
+does paint it. A naive re-type would therefore make a curved line suddenly
+show a fill it never had. To keep the re-typed path stroke-only like the
+line, promotion pins the fill to `none` **when the line declares no fill of
+its own**. A line that explicitly declares a fill keeps that authored value
+(an explicit fill on a line is meaningless but is the author's, so it is
+respected, not overridden). The pinned `none` is part of the re-type and is
+removed on revert, so the round-trip stays byte-equal.
+
+This is an instance of the general invariant — _re-type preserves rendered
+appearance_ — surfacing on the only tag where a shape's default rendering
+differs from a path's.
+
+## Invariants
+
+These hold for every promotion regardless of source shape.
+
+1. **Round-trip until first edit (P1).** Displaying the vector overlay on a
+   native primitive mutates nothing. Only a committed geometry gesture
+   re-types the element.
+
+2. **Minimal, intentional diff.** The diff of a promotion is: the element's
+   tag changes to `path`; its native geometry attributes are consumed and
+   replaced by a single `d` carrying the equivalent (D3) geometry; and the
+   first edit's delta is folded in. Nothing else in the element changes,
+   and nothing else in the document moves.
+
+3. **Non-geometry content carries over verbatim.** Every attribute that is
+   not part of the source shape's geometry parameterisation survives the
+   re-type unchanged — identity, class, inline style, paint, stroke,
+   `transform`, data attributes, and any unknown- or legacy-namespace
+   attributes. The element's surrounding source trivia (comments,
+   whitespace, attribute ordering of the carried attributes) is preserved.
+   Promotion changes the shape's _type and geometry_, never its identity,
+   styling, or position in the tree.
+
+4. **Geometry attributes are fully consumed.** The source geometry —
+   `cx`/`cy`/`r` for a circle, `cx`/`cy`/`rx`/`ry` for an ellipse,
+   `x`/`y`/`width`/`height`/`rx`/`ry` for a rect — is entirely expressed by
+   the resulting `d`. No orphaned geometry attribute is left on the
+   promoted `<path>` (a leftover `cx` on a `<path>` would be dead noise).
+
+5. **Reversible as one step.** The promotion is bracketed with the first
+   edit into a single undoable unit. Undo restores the original native
+   element, byte-for-byte, including its consumed geometry attributes and
+   trivia.
+
+6. **No automatic demotion.** Promotion is one-directional within the edit
+   flow. The editor does not attempt to recognise that an edited path is
+   "still circle-shaped" and re-type it back. Pattern recognition that
+   re-derives a primitive from path data is the province of the separate,
+   explicit structural-cleanup intent, never an ambient side effect of
+   editing.
+
+## The promotion operation (contract)
+
+Stated at the level a second implementation must honor, independent of how
+it is realised:
+
+- **Input.** A node that is one of the promotable primitive shapes, and the
+  first geometry edit to apply.
+- **Effect.** Re-type the node to `<path>`; set its `d` to the geometry
+  equivalent of the source shape (per D3 and the rectangle rule) with the
+  edit applied; consume the source geometry attributes; carry all other
+  attributes and surrounding trivia unchanged; record the whole thing as a
+  single reversible unit.
+- **Guarantee.** A consumer observing the document sees the node's type
+  change from the source tag to `path` exactly once, accompanied by the
+  edit it requested — never a bare type change with no edit, and never a
+  type change that disturbs styling, identity, or unrelated nodes.
+
+The downstream vector-edit session that drives subsequent vertex, segment,
+and tangent gestures is the same one that already serves native `<path>`
+content; promotion's job is solely to deliver a `<path>` for it to act on,
+at the right moment, without collateral damage.
+
+## Refusal taxonomy interaction
+
+Promotion converts a former refusal into a success: the vector-edit intent,
+previously refused on these shapes because no native solution existed, now
+resolves via `promote`. Refusals that are _not_ about the missing target —
+for example, a shape carrying an animation or an inline transform that the
+editor declines to edit through — are orthogonal and continue to apply.
+Promotion does not override a refusal grounded in a different invariant; it
+only fills the gap that was "this shape has no editable vertices."
+
+## Open questions
+
+- **Promotion under a structural-safety refusal.** If a primitive carries a
+  construct the editor refuses to edit through (e.g. a time-varying
+  transform), entering vector edit should refuse _before_ any promotion is
+  considered, so the user is never left with a promoted-but-unhonored
+  shape. The precedence between "would refuse anyway" and "would promote"
+  needs to be stated as a single ordering rule.
+- **Multi-shape promotion.** When a vector-edit gesture applies to a
+  selection containing more than one promotable primitive, is each promoted
+  independently, or is the gesture refused for heterogeneous selections?
+  Deferred until multi-selection editing is designed.
+- **Rounded-rect fidelity.** The exact join construction for `rx`/`ry`
+  rounded corners (cubic approximation vs. arc) follows the same
+  editing-representation logic as D3 and should be pinned with the same
+  rationale when the rectangle path builder is specified in detail.
+
+## See also
+
+- [`glossary/policy-class.md`](./glossary/policy-class.md) — the `promote`
+  solution and why `<circle>`, `<ellipse>`, and `<rect>` admit it for the
+  vector-edit intent. This RFD fills the `promote` cell that document
+  leaves open.
+- [`element-ir.md`](./element-ir.md) — the typed element model and refusal
+  taxonomy that promotion plugs into.
+- [`svg-editor-intent-matrix.md`](./svg-editor-intent-matrix.md) — the
+  intent × element inventory; the vector-edit row for primitive shapes
+  moves from "refuse" to "promote" with this work.

--- a/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
+++ b/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
@@ -1,10 +1,11 @@
 // SvgDocument.is_vector_edit_target — eligibility gate for vector
-// (vertex) editing on <path> / <polyline> / <polygon>.
+// (vertex) editing on <path> / <polyline> / <polygon> and the promotable
+// primitives <rect> / <circle> / <ellipse> (which re-type to <path> on the
+// first edit; see docs/wg/feat-svg-editor/promote-to-path.md).
 //
-// Sibling test file to document-structural-predicates.test.ts; covers
-// the v1 vector-edit eligibility surface and the rejection of every
-// non-eligible tag (so the "line/rect/circle/ellipse/image/use are
-// deferred" stance is locked in code).
+// Sibling test file to document-structural-predicates.test.ts; covers the
+// eligibility surface and the rejection of every non-eligible tag (so the
+// "line/image/use are deferred" stance is locked in code).
 
 import { describe, expect, it } from "vitest";
 import { SvgDocument } from "../src/core/document";
@@ -44,6 +45,19 @@ describe("SvgDocument.is_vector_edit_target — accepts", () => {
     });
   });
 
+  it("accepts <line> and carries its two endpoints", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><line x1="1" y1="2" x2="3" y2="4"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "line"))).toEqual({
+      kind: "line",
+      x1: 1,
+      y1: 2,
+      x2: 3,
+      y2: 4,
+    });
+  });
+
   it("accepts <polygon> with ≥ 2 points", () => {
     const d = doc(
       `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,0 5,8"/></svg>`
@@ -72,6 +86,95 @@ describe("SvgDocument.is_vector_edit_target — accepts", () => {
         [10, 10],
       ],
     });
+  });
+
+  // Promotable primitives — eligible from the promote-to-path slice. They
+  // enter vector-edit and re-type to <path> on the first committed gesture
+  // (see docs/wg/feat-svg-editor/promote-to-path.md). The source carries
+  // native geometry in local space.
+  it("accepts <circle> and carries cx/cy/r", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="6" r="3"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "circle"))).toEqual({
+      kind: "circle",
+      cx: 5,
+      cy: 6,
+      r: 3,
+    });
+  });
+
+  it("accepts <ellipse> and carries cx/cy/rx/ry", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><ellipse cx="5" cy="6" rx="3" ry="2"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "ellipse"))).toEqual({
+      kind: "ellipse",
+      cx: 5,
+      cy: 6,
+      rx: 3,
+      ry: 2,
+    });
+  });
+
+  it("accepts <rect> with square corners (rx/ry default to 0)", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect x="1" y="2" width="10" height="8"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "rect"))).toEqual({
+      kind: "rect",
+      x: 1,
+      y: 2,
+      width: 10,
+      height: 8,
+      rx: 0,
+      ry: 0,
+    });
+  });
+
+  it("accepts plain-number geometry in exponent, leading-dot, and signed forms", () => {
+    // `1e2` = 100, `.5`, and `+3` are valid SVG user-unit numbers.
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="+3" cy=".5" r="1e2"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "circle"))).toEqual({
+      kind: "circle",
+      cx: 3,
+      cy: 0.5,
+      r: 100,
+    });
+  });
+
+  it("accepts a rounded <rect>, mirroring a single rx onto ry and clamping to half-extent", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="10" height="8" rx="3"/></svg>`
+    );
+    // rx given, ry absent → ry mirrors rx. Both within half-extent here.
+    expect(d.is_vector_edit_target(id_of_first(d, "rect"))).toEqual({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 8,
+      rx: 3,
+      ry: 3,
+    });
+
+    const clamped = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="10" height="8" rx="999" ry="999"/></svg>`
+    );
+    // Over-large radii clamp to width/2 (5) and height/2 (4) respectively.
+    expect(clamped.is_vector_edit_target(id_of_first(clamped, "rect"))).toEqual(
+      {
+        kind: "rect",
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 8,
+        rx: 5,
+        ry: 4,
+      }
+    );
   });
 });
 
@@ -114,39 +217,68 @@ describe("SvgDocument.is_vector_edit_target — rejects", () => {
     expect(d.is_vector_edit_target(id_of_first(d, "polygon"))).toBeNull();
   });
 
-  // Deferred-tags lock — every tag the v1 plan documents as out of scope.
-  // If any of these flip to non-null, the plan's scope has drifted and
-  // the doctrine docs (Policy Class Table 2/3) need to land first.
-  //
-  // `<line>` lives here too: a line has no in-tag vertex-edit gestures
-  // (insert-vertex would promote to <polyline>, tangent would promote to
-  // <path>), and v1 does not implement promotion — so opening it in
-  // vector-edit would advertise capabilities that don't work.
-  for (const tag of [
-    "line",
-    "rect",
-    "circle",
-    "ellipse",
-    "image",
-    "use",
-  ] as const) {
+  // Deferred-tags lock — tags still out of scope. `<image>` / `<use>` are
+  // raster / reference boxes with no editable outline. If either flips to
+  // non-null, scope has drifted and the doctrine docs need to land first.
+  for (const tag of ["image", "use"] as const) {
     it(`rejects <${tag}>`, () => {
       const markup =
-        tag === "line"
-          ? `<line x1="0" y1="0" x2="10" y2="0"/>`
-          : tag === "rect"
-            ? `<rect x="0" y="0" width="10" height="10"/>`
-            : tag === "circle"
-              ? `<circle cx="5" cy="5" r="3"/>`
-              : tag === "ellipse"
-                ? `<ellipse cx="5" cy="5" rx="3" ry="2"/>`
-                : tag === "image"
-                  ? `<image x="0" y="0" width="10" height="10"/>`
-                  : `<use href="#x" x="0" y="0" width="10" height="10"/>`;
+        tag === "image"
+          ? `<image x="0" y="0" width="10" height="10"/>`
+          : `<use href="#x" x="0" y="0" width="10" height="10"/>`;
       const d = doc(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`);
       expect(d.is_vector_edit_target(id_of_first(d, tag))).toBeNull();
     });
   }
+
+  it("rejects a degenerate (zero-length) <line>", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><line x1="5" y1="5" x2="5" y2="5"/></svg>`
+    );
+    expect(d.is_vector_edit_target(id_of_first(d, "line"))).toBeNull();
+  });
+
+  // Degenerate / non-promotable primitive geometry.
+  it("rejects <circle> with non-positive or missing r", () => {
+    for (const markup of [
+      `<circle cx="5" cy="5" r="0"/>`,
+      `<circle cx="5" cy="5" r="-3"/>`,
+      `<circle cx="5" cy="5"/>`,
+    ]) {
+      const d = doc(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`);
+      expect(d.is_vector_edit_target(id_of_first(d, "circle"))).toBeNull();
+    }
+  });
+
+  it("rejects <rect> with zero/missing width or height", () => {
+    for (const markup of [
+      `<rect x="0" y="0" width="0" height="8"/>`,
+      `<rect x="0" y="0" height="8"/>`,
+      `<rect x="0" y="0" width="10"/>`,
+    ]) {
+      const d = doc(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`);
+      expect(d.is_vector_edit_target(id_of_first(d, "rect"))).toBeNull();
+    }
+  });
+
+  // Unit / percentage geometry is an out-of-scope gap — the editor refuses
+  // a promotion it cannot perform faithfully rather than mis-converting.
+  it("rejects primitives whose geometry is not a plain user-unit number", () => {
+    const pct = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="50%"/></svg>`
+    );
+    expect(pct.is_vector_edit_target(id_of_first(pct, "circle"))).toBeNull();
+
+    const px = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="10px" height="8"/></svg>`
+    );
+    expect(px.is_vector_edit_target(id_of_first(px, "rect"))).toBeNull();
+
+    const em = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><ellipse cx="5" cy="5" rx="3em" ry="2"/></svg>`
+    );
+    expect(em.is_vector_edit_target(id_of_first(em, "ellipse"))).toBeNull();
+  });
 
   it("rejects containers and non-geometric tags", () => {
     const d = doc(

--- a/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
+++ b/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
@@ -1,11 +1,12 @@
 // SvgDocument.is_vector_edit_target — eligibility gate for vector
-// (vertex) editing on <path> / <polyline> / <polygon> and the promotable
-// primitives <rect> / <circle> / <ellipse> (which re-type to <path> on the
-// first edit; see docs/wg/feat-svg-editor/promote-to-path.md).
+// (vertex) editing on the native vector tags <path> / <line> / <polyline> /
+// <polygon> and the promotable primitives <rect> / <circle> / <ellipse>
+// (which re-type to <path> on the first edit; see
+// docs/wg/feat-svg-editor/promote-to-path.md).
 //
 // Sibling test file to document-structural-predicates.test.ts; covers the
 // eligibility surface and the rejection of every non-eligible tag (so the
-// "line/image/use are deferred" stance is locked in code).
+// "image/use are deferred" stance is locked in code).
 
 import { describe, expect, it } from "vitest";
 import { SvgDocument } from "../src/core/document";

--- a/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
+++ b/packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
@@ -280,6 +280,50 @@ describe("SvgDocument.is_vector_edit_target — rejects", () => {
     expect(em.is_vector_edit_target(id_of_first(em, "ellipse"))).toBeNull();
   });
 
+  // The *optional* position coords (line x1/y1/x2/y2, rect x/y, circle /
+  // ellipse cx/cy) default to 0 when absent, but a present-but-unparseable
+  // value (unit / percent) must still disqualify — otherwise `?? 0` would
+  // silently coerce an authored `x1="5px"` to 0 and overwrite it on the
+  // first native writeback.
+  it("rejects shapes whose present optional coord is unit-bearing", () => {
+    for (const markup of [
+      `<line x1="5px" y1="0" x2="10" y2="0"/>`,
+      `<line x1="0" y1="0" x2="10" y2="5%"/>`,
+      `<rect x="2em" y="0" width="10" height="8"/>`,
+      `<rect x="0" y="3px" width="10" height="8"/>`,
+      `<circle cx="50%" cy="5" r="3"/>`,
+      `<ellipse cx="5" cy="2em" rx="3" ry="2"/>`,
+      `<rect x="0" y="0" width="10" height="8" rx="2px"/>`,
+    ]) {
+      const d = doc(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`);
+      const tag = markup.slice(1, markup.indexOf(" "));
+      expect(d.is_vector_edit_target(id_of_first(d, tag))).toBeNull();
+    }
+  });
+
+  // Absent optional coords legitimately default to 0 — the shape stays
+  // eligible (this is the case the unit guard must NOT over-reject).
+  it("accepts shapes that omit optional coords (SVG-default 0)", () => {
+    const c = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle r="3"/></svg>`
+    );
+    const cs = c.is_vector_edit_target(id_of_first(c, "circle"));
+    expect(cs).toEqual({ kind: "circle", cx: 0, cy: 0, r: 3 });
+
+    const r = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="8"/></svg>`
+    );
+    expect(r.is_vector_edit_target(id_of_first(r, "rect"))).toEqual({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 8,
+      rx: 0,
+      ry: 0,
+    });
+  });
+
   it("rejects containers and non-geometric tags", () => {
     const d = doc(
       `<svg xmlns="http://www.w3.org/2000/svg"><g><text>hi</text></g></svg>`

--- a/packages/grida-svg-editor/__tests__/promote-to-path.test.ts
+++ b/packages/grida-svg-editor/__tests__/promote-to-path.test.ts
@@ -1,0 +1,369 @@
+// promote-to-path — the lazy primitive→<path> conversion that powers vector
+// editing of <rect> / <circle> / <ellipse>.
+//
+// Core, DOM-free coverage of three contracts from
+// docs/wg/feat-svg-editor/promote-to-path.md:
+//   - source_to_session_d builds the path-form geometry (cubic conics, a
+//     closed rect outline) the overlay/session run on.
+//   - retype_to_path re-types the element, consuming its geometry attrs.
+//   - revert_retype restores the original primitive byte-for-byte.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import { source_to_session_d, PathModel } from "../src/core/vector-edit";
+
+function doc(svg: string): SvgDocument {
+  return new SvgDocument(svg);
+}
+
+function id_of_first(d: SvgDocument, tag: string): string {
+  for (const id of d.all_elements()) {
+    if (d.tag_of(id) === tag) return id;
+  }
+  throw new Error(`no <${tag}> in document`);
+}
+
+function approx(a: number, b: number, eps = 1e-6): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+describe("source_to_session_d — promotable primitives", () => {
+  it("circle → four cubic segments forming a closed loop matching the bbox", () => {
+    const d = source_to_session_d({ kind: "circle", cx: 10, cy: 10, r: 5 });
+    const m = PathModel.fromSvgPathD(d);
+    expect(m.vertexCount()).toBe(4);
+    expect(m.segmentCount()).toBe(4);
+    // Every segment carries a non-zero tangent → genuine cubic (not lines).
+    for (const s of m.snapshot().segments) {
+      const curved =
+        s.ta[0] !== 0 || s.ta[1] !== 0 || s.tb[0] !== 0 || s.tb[1] !== 0;
+      expect(curved).toBe(true);
+    }
+    const bb = m.bbox();
+    expect(approx(bb.x, 5)).toBe(true);
+    expect(approx(bb.y, 5)).toBe(true);
+    expect(approx(bb.width, 10)).toBe(true);
+    expect(approx(bb.height, 10)).toBe(true);
+  });
+
+  it("ellipse → four cubic segments matching the bbox", () => {
+    const d = source_to_session_d({
+      kind: "ellipse",
+      cx: 10,
+      cy: 20,
+      rx: 6,
+      ry: 4,
+    });
+    const m = PathModel.fromSvgPathD(d);
+    expect(m.segmentCount()).toBe(4);
+    const bb = m.bbox();
+    expect(approx(bb.width, 12)).toBe(true);
+    expect(approx(bb.height, 8)).toBe(true);
+  });
+
+  it("square-cornered rect → four straight segments (no tangents)", () => {
+    const d = source_to_session_d({
+      kind: "rect",
+      x: 1,
+      y: 2,
+      width: 10,
+      height: 8,
+      rx: 0,
+      ry: 0,
+    });
+    const m = PathModel.fromSvgPathD(d);
+    expect(m.segmentCount()).toBe(4);
+    for (const s of m.snapshot().segments) {
+      expect(s.ta).toEqual([0, 0]);
+      expect(s.tb).toEqual([0, 0]);
+    }
+    const bb = m.bbox();
+    expect(approx(bb.x, 1)).toBe(true);
+    expect(approx(bb.y, 2)).toBe(true);
+    expect(approx(bb.width, 10)).toBe(true);
+    expect(approx(bb.height, 8)).toBe(true);
+  });
+});
+
+describe("SvgDocument.retype_to_path", () => {
+  it("re-types <circle> to <path>, consuming geometry and setting d", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3" fill="red"/></svg>`
+    );
+    const id = id_of_first(d, "circle");
+    const session_d = source_to_session_d({
+      kind: "circle",
+      cx: 5,
+      cy: 5,
+      r: 3,
+    });
+    const token = d.retype_to_path(id, session_d);
+    expect(token).not.toBeNull();
+
+    expect(d.tag_of(id)).toBe("path");
+    const out = d.serialize();
+    expect(out).toContain("<path");
+    expect(out).not.toContain("<circle");
+    expect(out).toContain('d="');
+    // Geometry attrs consumed; non-geometry attr preserved.
+    expect(out).not.toMatch(/\bcx=/);
+    expect(out).not.toMatch(/\br=/);
+    expect(out).toContain('fill="red"');
+  });
+
+  it("is idempotent — a second promote on the now-<path> returns null", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>`
+    );
+    const id = id_of_first(d, "circle");
+    expect(d.retype_to_path(id, "M0 0")).not.toBeNull();
+    const before = d.serialize();
+    expect(d.retype_to_path(id, "M9 9")).toBeNull();
+    // No mutation on the no-op call.
+    expect(d.serialize()).toBe(before);
+  });
+
+  it("returns null for an already-<path> node (nothing to re-type)", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0 L1 1"/></svg>`
+    );
+    expect(d.retype_to_path(id_of_first(d, "path"), "M0 0")).toBeNull();
+  });
+
+  it("re-types a vertex tag (<polygon>) — its `points` is consumed for `d`", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 1,0 1,1"/></svg>`
+    );
+    const id = id_of_first(d, "polygon");
+    const token = d.retype_to_path(id, "M0 0 C0 0 1 0 1 1 Z");
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+    const out = d.serialize();
+    expect(out).toContain("<path");
+    expect(out).not.toMatch(/\bpoints=/);
+    d.revert_retype(id, token!);
+    expect(d.tag_of(id)).toBe("polygon");
+    expect(d.serialize()).toContain('points="0,0 1,0 1,1"');
+  });
+});
+
+describe("revert_retype — byte-equal round-trip", () => {
+  // The headline P1 invariant: promote then revert leaves the document
+  // identical to its input — trivia, attribute order, quote styles, comments,
+  // and unknown-namespace attributes all intact.
+  it("restores the original primitive verbatim, including trivia", () => {
+    const svg = [
+      `<svg xmlns="http://www.w3.org/2000/svg">`,
+      `  <!-- a circle -->`,
+      `  <circle fill='red' cx="5"  cy='6'   r="3" inkscape:label="dot" class="brand"/>`,
+      `</svg>`,
+    ].join("\n");
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+
+    const token = d.retype_to_path(id, "M8 5 C8 6 6 8 5 8 C4 8 2 6 2 5 Z");
+    expect(token).not.toBeNull();
+    expect(d.serialize()).not.toBe(original); // really mutated
+    expect(d.tag_of(id)).toBe("path");
+
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+    expect(d.tag_of(id)).toBe("circle");
+  });
+
+  it("round-trips a rect with mixed geometry-attr ordering", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" x="1" height="8" y="2" rx="2" data-id="r1"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "rect");
+    const token = d.retype_to_path(id, "M3 2 L11 2 L11 10 L1 10 Z");
+    expect(token).not.toBeNull();
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("round-trips an <ellipse> (directional rx/ry geometry)", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><ellipse cx="5" cy="6" rx="3" ry="2" stroke="blue"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "ellipse");
+    const token = d.retype_to_path(id, "M8 6 C8 7 6 8 5 8 Z");
+    expect(token).not.toBeNull();
+    expect(d.serialize()).not.toBe(original);
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("preserves a namespace prefix (<svg:circle> ↔ <svg:path>) and round-trips", () => {
+    const svg = `<svg:svg xmlns:svg="http://www.w3.org/2000/svg"><svg:circle cx="5" cy="5" r="3"/></svg:svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+    const token = d.retype_to_path(id, "M8 5 C8 6 6 8 5 8 Z");
+    expect(token).not.toBeNull();
+    // Re-types to the prefixed path, not a bare <path>.
+    expect(d.serialize()).toContain("<svg:path");
+    expect(d.serialize()).not.toContain("<svg:circle");
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("round-trips a non-self-closing primitive (<circle></circle>)", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"></circle></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+    const token = d.retype_to_path(id, "M8 5 C8 6 6 8 5 8 Z");
+    expect(token).not.toBeNull();
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("carries transform / style / unknown-namespace attrs across promotion", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3" transform="rotate(10 5 5)" style="fill:blue" sketch:type="oval"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+    const token = d.retype_to_path(id, "M8 5 C8 6 6 8 5 8 Z");
+    expect(token).not.toBeNull();
+    const out = d.serialize();
+    expect(out).toContain('transform="rotate(10 5 5)"');
+    expect(out).toContain('style="fill:blue"');
+    expect(out).toContain('sketch:type="oval"');
+    expect(out).not.toMatch(/\bcx=/);
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("rounded-rect session-d uses arcs that round-trip through PathModel", () => {
+    const session_d = source_to_session_d({
+      kind: "rect",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 8,
+      rx: 3,
+      ry: 2,
+    });
+    // PathModel parses the arc-based d without throwing and the outline's
+    // bbox matches the rect bounds.
+    const m = PathModel.fromSvgPathD(session_d);
+    expect(m.segmentCount()).toBeGreaterThan(0);
+    const bb = m.bbox();
+    expect(Math.abs(bb.x - 0)).toBeLessThan(1e-6);
+    expect(Math.abs(bb.y - 0)).toBeLessThan(1e-6);
+    expect(Math.abs(bb.width - 10)).toBeLessThan(1e-6);
+    expect(Math.abs(bb.height - 8)).toBeLessThan(1e-6);
+  });
+});
+
+describe("retype_to_path — <line> fill fidelity", () => {
+  // A <line> has no fill region, so its fill never paints. A <path> fills
+  // (open paths close implicitly for fill), so a naive re-type would make a
+  // curved line suddenly show the default black fill. The re-type pins
+  // fill="none" to preserve the line's stroke-only appearance.
+  it('adds fill="none" when the line declares no fill, and revert removes it', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><line x1="40" y1="270" x2="120" y2="190" stroke="#06b6d4" stroke-width="7"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "line");
+
+    const token = d.retype_to_path(id, "M40 270 C60 240 100 220 120 190");
+    expect(token).not.toBeNull();
+    const out = d.serialize();
+    expect(out).toContain("<path");
+    expect(out).toContain('fill="none"');
+    expect(out).toContain('stroke="#06b6d4"'); // stroke carried over
+
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original); // fill="none" removed → byte-equal
+    expect(d.tag_of(id)).toBe("line");
+  });
+
+  it("respects an explicit fill on the line (does not add a second fill)", () => {
+    // Explicit fill on a line is meaningless (invisible) but authored; keep it.
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="10" y2="10" fill="red" stroke="blue"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "line");
+
+    const token = d.retype_to_path(id, "M0 0 C1 1 2 2 10 10");
+    expect(token).not.toBeNull();
+    const out = d.serialize();
+    expect(out).toContain('fill="red"');
+    expect(out).not.toContain('fill="none"');
+
+    d.revert_retype(id, token!);
+    expect(d.serialize()).toBe(original);
+  });
+
+  it('respects a fill declared via inline style (no synthetic fill="none")', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="10" y2="10" style="fill:red" stroke="blue"/></svg>`;
+    const d = doc(svg);
+    const id = id_of_first(d, "line");
+    const token = d.retype_to_path(id, "M0 0 C1 1 2 2 10 10");
+    expect(token).not.toBeNull();
+    expect(d.serialize()).not.toContain('fill="none"');
+  });
+
+  it("only <line> gets the fill guard — a <polyline> never does", () => {
+    // Polyline fills consistently with path (open, implicit close), so no
+    // synthetic fill is needed; its appearance is preserved by default.
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,0 10,10"/></svg>`;
+    const d = doc(svg);
+    const id = id_of_first(d, "polyline");
+    const token = d.retype_to_path(id, "M0 0 C2 2 8 0 10 0 L10 10");
+    expect(token).not.toBeNull();
+    expect(d.serialize()).not.toContain('fill="none"');
+  });
+});
+
+describe("is_vector_edit_target — malformed primitive carrying a d", () => {
+  // A primitive with a pre-authored unprefixed `d` is malformed SVG; promoting
+  // it would append a second `d`. Refuse at the gate so the edit session never
+  // operates on a duplicate-`d` element.
+  it("refuses <circle>/<rect>/<ellipse> that already carry an unprefixed d", () => {
+    const c = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3" d="M0 0"/></svg>`
+    );
+    expect(c.is_vector_edit_target(id_of_first(c, "circle"))).toBeNull();
+    const r = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="10" height="8" d="M0 0"/></svg>`
+    );
+    expect(r.is_vector_edit_target(id_of_first(r, "rect"))).toBeNull();
+    const e = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><ellipse cx="5" cy="5" rx="3" ry="2" d="M0 0"/></svg>`
+    );
+    expect(e.is_vector_edit_target(id_of_first(e, "ellipse"))).toBeNull();
+  });
+
+  // The vertex tags re-type to <path> on a curve edit, and the re-type only
+  // strips the tag's own geometry attrs (`points` / `x1,y1,…`) — not a stray
+  // `d`. A pre-authored `d` would therefore survive into a duplicate-`d`
+  // <path>, so they must be refused at the gate too (same hazard as the
+  // promotable primitives above).
+  it("refuses <line>/<polyline>/<polygon> that already carry an unprefixed d", () => {
+    const l = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="10" y2="10" d="M0 0"/></svg>`
+    );
+    expect(l.is_vector_edit_target(id_of_first(l, "line"))).toBeNull();
+    const pl = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" d="M0 0"/></svg>`
+    );
+    expect(pl.is_vector_edit_target(id_of_first(pl, "polyline"))).toBeNull();
+    const pg = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,10 5,15" d="M0 0"/></svg>`
+    );
+    expect(pg.is_vector_edit_target(id_of_first(pg, "polygon"))).toBeNull();
+  });
+
+  // A prefixed `d` (e.g. `custom:d`) is NOT the path geometry attr — the
+  // gate keys on unprefixed `d` only, so such an element stays eligible.
+  it("still accepts a primitive whose only d is namespace-prefixed", () => {
+    const c = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:x="urn:x"><circle cx="5" cy="5" r="3" x:d="M0 0"/></svg>`
+    );
+    expect(c.is_vector_edit_target(id_of_first(c, "circle"))).not.toBeNull();
+  });
+});

--- a/packages/grida-svg-editor/__tests__/vector-edit-promote.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-promote.test.ts
@@ -1,0 +1,257 @@
+// vector_apply / vector_revert — the session-aware commit chokepoint that
+// promotes a primitive source to <path> on the first edit and demotes it on
+// undo. Exercised here at the core (session + document) level, exactly as
+// the DOM gesture handlers call it, with no DOM — proving the shell is thin.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import {
+  VectorEditSession,
+  source_to_session_d,
+  vector_apply,
+  vector_revert,
+} from "../src/core/vector-edit";
+
+function doc(svg: string): SvgDocument {
+  return new SvgDocument(svg);
+}
+
+function id_of_first(d: SvgDocument, tag: string): string {
+  for (const id of d.all_elements()) {
+    if (d.tag_of(id) === tag) return id;
+  }
+  throw new Error(`no <${tag}> in document`);
+}
+
+function session_for(d: SvgDocument, id: string): VectorEditSession {
+  const source = d.is_vector_edit_target(id);
+  if (!source) throw new Error("not a vector-edit target");
+  return new VectorEditSession(id, source, source_to_session_d(source));
+}
+
+describe("first vector edit promotes a primitive to <path>", () => {
+  it("circle: vector_apply re-types the doc and flips the session source", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3" fill="red"/></svg>`
+    );
+    const id = id_of_first(d, "circle");
+    const session = session_for(d, id);
+    expect(session.source.kind).toBe("circle");
+
+    const edited_d = "M8 5 C8 7 6 8 5 8 C4 8 2 7 2 5 Z";
+    const token = vector_apply(d, session, edited_d);
+
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+    expect(session.source.kind).toBe("path");
+    expect(d.serialize()).toContain('d="M8 5');
+    expect(d.serialize()).toContain('fill="red"');
+  });
+
+  it("vector_revert demotes the doc and restores the session source", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3" fill="red"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+    const session = session_for(d, id);
+    const baseline_d = session.current_d;
+
+    const token = vector_apply(d, session, "M8 5 C8 7 6 8 5 8 Z");
+    expect(d.tag_of(id)).toBe("path");
+
+    vector_revert(d, session, baseline_d, token);
+
+    expect(d.tag_of(id)).toBe("circle");
+    expect(session.source.kind).toBe("circle");
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("a second edit after promotion writes d without re-promoting", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>`
+    );
+    const id = id_of_first(d, "circle");
+    const session = session_for(d, id);
+
+    const first = vector_apply(d, session, "M8 5 C8 7 6 8 5 8 Z");
+    expect(first).not.toBeNull();
+    const second = vector_apply(d, session, "M9 5 C9 7 6 9 5 9 Z");
+    expect(second).toBeNull(); // already a <path>; no new promotion
+    expect(d.tag_of(id)).toBe("path");
+    expect(d.serialize()).toContain('d="M9 5');
+  });
+
+  it("a polygon source is unaffected — it writes native points, never promotes", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,0 10,10"/></svg>`
+    );
+    const id = id_of_first(d, "polygon");
+    const session = session_for(d, id);
+    // A vertex move keeps the canonical closed chain → writes back to points.
+    const token = vector_apply(d, session, "M0 0 L12 0 L10 10 Z");
+    expect(token).toBeNull();
+    expect(d.tag_of(id)).toBe("polygon");
+    expect(d.serialize()).toContain("points=");
+  });
+
+  it("rect and ellipse promote + revert through vector_apply/vector_revert", () => {
+    for (const markup of [
+      `<rect x="0" y="0" width="10" height="8" rx="2" fill="green"/>`,
+      `<ellipse cx="5" cy="6" rx="3" ry="2" fill="green"/>`,
+    ]) {
+      const d = doc(`<svg xmlns="http://www.w3.org/2000/svg">${markup}</svg>`);
+      const original = d.serialize();
+      const id = d.all_elements().find((n) => d.tag_of(n) !== "svg")!;
+      const session = session_for(d, id);
+      const baseline_d = session.current_d;
+
+      const token = vector_apply(d, session, "M1 1 C2 2 3 3 4 4 Z");
+      expect(token).not.toBeNull();
+      expect(d.tag_of(id)).toBe("path");
+      expect(session.source.kind).toBe("path");
+
+      vector_revert(d, session, baseline_d, token);
+      expect(d.tag_of(id)).not.toBe("path");
+      expect(session.source.kind).not.toBe("path");
+      expect(d.serialize()).toBe(original);
+    }
+  });
+
+  it("vector_revert with a null token on an unpromoted primitive is a no-op", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "circle");
+    const session = session_for(d, id);
+    // No vector_apply ran (the user entered edit but never committed a gesture).
+    vector_revert(d, session, session.current_d, null);
+    expect(d.serialize()).toBe(original);
+    expect(session.source.kind).toBe("circle");
+  });
+});
+
+describe("vertex tags: native edits stay native, curves re-type to <path>", () => {
+  it("polyline: a straight vertex move stays a <polyline> (writes points, no re-type)", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,0 10,10"/></svg>`
+    );
+    const id = id_of_first(d, "polyline");
+    const session = session_for(d, id);
+    // Straight, canonical open chain with one vertex moved.
+    const token = vector_apply(d, session, "M0 0 L12 0 L10 10");
+    expect(token).toBeNull();
+    expect(d.tag_of(id)).toBe("polyline");
+    expect(session.source.kind).toBe("polyline");
+    expect(d.get_attr(id, "points")).toBe("0,0 12,0 10,10");
+    expect(d.get_attr(id, "d")).toBeNull();
+  });
+
+  it("polyline: introducing a curve re-types to <path>, and revert restores the polyline", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,0 10,10" stroke="red"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "polyline");
+    const session = session_for(d, id);
+    const baseline_d = session.current_d;
+
+    // A non-zero tangent on the first segment → not expressible as polyline.
+    const token = vector_apply(d, session, "M0 0 C2 2 8 0 10 0 L10 10");
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+    expect(session.source.kind).toBe("path");
+    expect(d.get_attr(id, "points")).toBeNull();
+    expect(d.serialize()).toContain('stroke="red"');
+
+    vector_revert(d, session, baseline_d, token);
+    expect(d.tag_of(id)).toBe("polyline");
+    expect(session.source.kind).toBe("polyline");
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("polygon: a curve re-types to <path>; revert restores the polygon", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,0 5,8"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "polygon");
+    const session = session_for(d, id);
+    const baseline_d = session.current_d;
+
+    const token = vector_apply(d, session, "M0 0 C2 2 8 0 10 0 L5 8 Z");
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+
+    vector_revert(d, session, baseline_d, token);
+    expect(d.tag_of(id)).toBe("polygon");
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("line: dragging an endpoint stays a <line> (writes x1/y1/x2/y2, no re-type)", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><line x1="1" y1="2" x2="3" y2="4"/></svg>`
+    );
+    const id = id_of_first(d, "line");
+    const session = session_for(d, id);
+    const token = vector_apply(d, session, "M1 2 L9 8");
+    expect(token).toBeNull();
+    expect(d.tag_of(id)).toBe("line");
+    expect(d.get_attr(id, "x2")).toBe("9");
+    expect(d.get_attr(id, "y2")).toBe("8");
+    expect(d.get_attr(id, "d")).toBeNull();
+  });
+
+  it("line: curving re-types to <path>; revert restores the line", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><line x1="1" y1="2" x2="3" y2="4"/></svg>`;
+    const d = doc(svg);
+    const original = d.serialize();
+    const id = id_of_first(d, "line");
+    const session = session_for(d, id);
+    const baseline_d = session.current_d;
+
+    const token = vector_apply(d, session, "M1 2 C2 2 3 3 3 4");
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+
+    vector_revert(d, session, baseline_d, token);
+    expect(d.tag_of(id)).toBe("line");
+    expect(d.serialize()).toBe(original);
+  });
+
+  it("line: adding a vertex (3 points) escapes the native form → <path>", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="10" y2="0"/></svg>`
+    );
+    const id = id_of_first(d, "line");
+    const session = session_for(d, id);
+    // A third vertex → no longer a 2-point line → re-type to path.
+    const token = vector_apply(d, session, "M0 0 L5 0 L10 0");
+    expect(token).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+  });
+});
+
+describe("VectorEditSession source flip (promote_source_to_path / restore_source)", () => {
+  function circle_session(): VectorEditSession {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>`
+    );
+    return session_for(d, id_of_first(d, "circle"));
+  }
+
+  it("flips primitive→path once, and is idempotent on a second flip", () => {
+    const s = circle_session();
+    expect(s.source.kind).toBe("circle");
+    s.promote_source_to_path();
+    expect(s.source.kind).toBe("path");
+    // Second flip must not clobber the captured pre-promotion source.
+    s.promote_source_to_path();
+    expect(s.source.kind).toBe("path");
+    s.restore_source();
+    expect(s.source).toEqual({ kind: "circle", cx: 5, cy: 5, r: 3 });
+  });
+
+  it("restore_source is a no-op when never promoted", () => {
+    const s = circle_session();
+    s.restore_source();
+    expect(s.source.kind).toBe("circle");
+  });
+});

--- a/packages/grida-svg-editor/__tests__/vector-edit-promote.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-promote.test.ts
@@ -128,6 +128,58 @@ describe("first vector edit promotes a primitive to <path>", () => {
     expect(d.serialize()).toBe(original);
     expect(session.source.kind).toBe("circle");
   });
+
+  // Regression: exit + undo-exit + undo-geometry. After a promote, the undo
+  // that demotes the document runs against the *captured* session, but the
+  // live session may be a fresh object (re-created when undo-exit re-enters
+  // edit mode while the node was still a <path>). Its `restore_source` is
+  // never called, so it keeps `source.kind === "path"` while the node is back
+  // to a primitive — and the next gesture would write a stray `d`. The host
+  // re-syncs the live session from the current document tag; `sync_source`
+  // is that primitive.
+  it("sync_source re-derives a stale live session's source after an undo-demote", () => {
+    const d = doc(
+      `<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="3"/></svg>`
+    );
+    const id = id_of_first(d, "circle");
+    const original = d.serialize();
+
+    // Gesture that promotes (the captured session that performed the flip).
+    const captured = session_for(d, id);
+    const baseline_d = captured.current_d;
+    const token = vector_apply(d, captured, "M8 5 C8 7 6 8 5 8 Z");
+    expect(d.tag_of(id)).toBe("path");
+
+    // exit + undo-exit re-enters edit mode while the node is a <path>, so the
+    // fresh live session reads a path source.
+    const live = session_for(d, id);
+    expect(live.source.kind).toBe("path");
+
+    // undo-geometry demotes the DOM via the captured session; the live one is
+    // untouched and now disagrees with the document.
+    vector_revert(d, captured, baseline_d, token);
+    expect(d.tag_of(id)).toBe("circle");
+    expect(live.source.kind).toBe("path"); // stale
+
+    // The host's replay step re-syncs the live session from the document.
+    const live_source = d.is_vector_edit_target(id);
+    expect(live_source).not.toBeNull();
+    live.sync_source(live_source!);
+    expect(live.source.kind).toBe("circle");
+
+    // And a subsequent curve gesture on the live session now re-promotes
+    // cleanly (native tag, single appended `d`) rather than writing a stray
+    // `d` onto the <circle>.
+    const reapply = vector_apply(d, live, "M9 5 C9 7 6 9 5 9 Z");
+    expect(reapply).not.toBeNull();
+    expect(d.tag_of(id)).toBe("path");
+    expect(d.serialize().match(/\bd="/g)?.length).toBe(1);
+
+    // Undo the re-promotion → byte-equal to the original circle.
+    vector_revert(d, live, baseline_d, reapply);
+    expect(d.tag_of(id)).toBe("circle");
+    expect(d.serialize()).toBe(original);
+  });
 });
 
 describe("vertex tags: native edits stay native, curves re-type to <path>", () => {

--- a/packages/grida-svg-editor/__tests__/vector-edit-vertex-chain.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-vertex-chain.test.ts
@@ -209,14 +209,16 @@ describe("apply_session_d writes native attrs for vertex-chain sources", () => {
     expect(d.get_attr(id, "d")).toBeNull();
   });
 
-  it("polyline + tangent edit → returns false (v1 refuses, no promotion)", () => {
+  it("polyline + tangent edit → apply_session_d returns false (native writeback only; vector_apply re-types)", () => {
     const d = doc(
       `<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,0 10,10"/></svg>`
     );
     const id = id_of_first(d, "polyline");
     const source = d.is_vector_edit_target(id);
 
-    // A non-zero tangent makes the model un-expressible in <polyline>.
+    // A non-zero tangent makes the model un-expressible in <polyline>, so
+    // the native-writeback primitive refuses (returns false). The re-type to
+    // <path> is `vector_apply`'s job, layered on top of this false return.
     // setTangent takes a TangentRef `[vertex_idx, 0|1]` where 0 = ta on
     // the segment whose `a === vertex_idx` (i.e. the outgoing tangent
     // from this vertex). abs_pos is the new control-point world position.
@@ -264,8 +266,8 @@ describe("round-trip-if-no-change at the document level", () => {
     `<svg xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,0 5,8"/></svg>`,
     // Preserved trivia: attribute order, mixed separators, comments.
     `<svg xmlns="http://www.w3.org/2000/svg"><!-- keep --><polyline class="a" points="0 0, 10 10"/></svg>`,
-    // <line> is not a vector-edit target in v1, but the byte-equal
-    // invariant still holds — the enter pass simply skips it.
+    // <line> is now a vector-edit target; the byte-equal invariant still
+    // holds because the enter pass (predicate + session-d) is non-mutating.
     `<svg xmlns="http://www.w3.org/2000/svg"><line x1="1" y1="2" x2="3" y2="4"/></svg>`,
   ]) {
     it(`byte-equal: ${fixture.slice(0, 60)}…`, () => {

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -568,6 +568,24 @@ export class SvgDocument implements DocumentEvents {
    * Rejects `<image>` / `<use>` (raster / reference bounding boxes, no
    * editable outline).
    */
+  /**
+   * Parse an optional SVG geometry coordinate (`x`/`y`, `cx`/`cy`, the line
+   * endpoints). An **absent** attribute takes the SVG default (`0`); a
+   * **present** attribute that is not a plain user-unit number (`%`, `px`,
+   * `em`, …) is out of scope and yields `null` so the caller refuses the
+   * element — the same gate required attrs (width / radius) already apply.
+   *
+   * The absent-vs-present distinction is the point: a bare `?? 0` would
+   * silently coerce an authored `x1="5px"` to `0`, then the first native
+   * writeback would overwrite that authored value. Refusing keeps the
+   * editor from misrepresenting geometry it cannot read faithfully.
+   */
+  private optional_user_unit_coord(id: NodeId, name: string): number | null {
+    const raw = this.get_attr(id, name);
+    if (raw === null) return 0;
+    return parse_user_unit(raw);
+  }
+
   is_vector_edit_target(id: NodeId): VectorEditSource | null {
     const n = this.nodes.get(id);
     if (!n || n.kind !== "element") return null;
@@ -591,10 +609,13 @@ export class SvgDocument implements DocumentEvents {
         return { kind: "path", d };
       }
       case "line": {
-        const x1 = parse_user_unit(this.get_attr(id, "x1")) ?? 0;
-        const y1 = parse_user_unit(this.get_attr(id, "y1")) ?? 0;
-        const x2 = parse_user_unit(this.get_attr(id, "x2")) ?? 0;
-        const y2 = parse_user_unit(this.get_attr(id, "y2")) ?? 0;
+        const x1 = this.optional_user_unit_coord(id, "x1");
+        const y1 = this.optional_user_unit_coord(id, "y1");
+        const x2 = this.optional_user_unit_coord(id, "x2");
+        const y2 = this.optional_user_unit_coord(id, "y2");
+        // A present-but-unparseable endpoint (unit / percent) is out of scope.
+        if (x1 === null || y1 === null || x2 === null || y2 === null)
+          return null;
         // Degenerate (zero-length) line has nothing to vector-edit.
         if (x1 === x2 && y1 === y2) return null;
         return { kind: "line", x1, y1, x2, y2 };
@@ -610,32 +631,40 @@ export class SvgDocument implements DocumentEvents {
           : { kind: "polygon", points };
       }
       case "rect": {
-        const x = parse_user_unit(this.get_attr(id, "x")) ?? 0;
-        const y = parse_user_unit(this.get_attr(id, "y")) ?? 0;
+        const x = this.optional_user_unit_coord(id, "x");
+        const y = this.optional_user_unit_coord(id, "y");
+        if (x === null || y === null) return null;
         const width = parse_user_unit(this.get_attr(id, "width"));
         const height = parse_user_unit(this.get_attr(id, "height"));
         if (width === null || height === null) return null;
         if (width <= 0 || height <= 0) return null;
         // SVG corner-radii defaulting: a missing rx/ry mirrors the other;
-        // both missing → square corners. Negatives are treated as 0.
-        const rx_raw = parse_user_unit(this.get_attr(id, "rx"));
-        const ry_raw = parse_user_unit(this.get_attr(id, "ry"));
-        let rx = rx_raw ?? ry_raw ?? 0;
-        let ry = ry_raw ?? rx_raw ?? 0;
+        // both missing → square corners. Negatives are treated as 0. A
+        // present-but-unparseable rx/ry (unit / percent) is out of scope.
+        const rx_attr = this.get_attr(id, "rx");
+        const ry_attr = this.get_attr(id, "ry");
+        const rx_parsed = rx_attr === null ? null : parse_user_unit(rx_attr);
+        const ry_parsed = ry_attr === null ? null : parse_user_unit(ry_attr);
+        if (rx_attr !== null && rx_parsed === null) return null;
+        if (ry_attr !== null && ry_parsed === null) return null;
+        let rx = rx_parsed ?? ry_parsed ?? 0;
+        let ry = ry_parsed ?? rx_parsed ?? 0;
         rx = Math.max(0, Math.min(rx, width / 2));
         ry = Math.max(0, Math.min(ry, height / 2));
         return { kind: "rect", x, y, width, height, rx, ry };
       }
       case "circle": {
-        const cx = parse_user_unit(this.get_attr(id, "cx")) ?? 0;
-        const cy = parse_user_unit(this.get_attr(id, "cy")) ?? 0;
+        const cx = this.optional_user_unit_coord(id, "cx");
+        const cy = this.optional_user_unit_coord(id, "cy");
+        if (cx === null || cy === null) return null;
         const r = parse_user_unit(this.get_attr(id, "r"));
         if (r === null || r <= 0) return null;
         return { kind: "circle", cx, cy, r };
       }
       case "ellipse": {
-        const cx = parse_user_unit(this.get_attr(id, "cx")) ?? 0;
-        const cy = parse_user_unit(this.get_attr(id, "cy")) ?? 0;
+        const cx = this.optional_user_unit_coord(id, "cx");
+        const cy = this.optional_user_unit_coord(id, "cy");
+        if (cx === null || cy === null) return null;
         const rx = parse_user_unit(this.get_attr(id, "rx"));
         const ry = parse_user_unit(this.get_attr(id, "ry"));
         if (rx === null || ry === null) return null;

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -40,11 +40,25 @@ import type { NodeId } from "../types";
  *   - All coordinates are in the element's own local space, exactly as
  *     authored. No `transform=` resolution, no parent CTM, no viewport
  *     remap.
- *   - `polyline` / `polygon` points are `[x, y]` tuples so the consumer
- *     can hand them straight to `vn.fromPolyline` / `vn.fromPolygon`.
+ *   - `line` carries its two endpoints; `polyline` / `polygon` points are
+ *     `[x, y]` tuples so the consumer can hand them straight to
+ *     `vn.fromPolyline` / `vn.fromPolygon`.
+ *   - `rect` / `circle` / `ellipse` carry their native geometry numbers.
+ *     These geometry primitives have no addressable interior vertices in
+ *     their native form, so editing one as vector geometry re-types the
+ *     element to `<path>` (see `retype_to_path`). The document holds the
+ *     native tag until that re-type is committed. Design:
+ *     `docs/wg/feat-svg-editor/promote-to-path.md`.
+ *
+ * Re-type vs. native writeback is decided per edit, not per tag: an edit
+ * that the source tag can still express (a straight vertex move on
+ * `line` / `polyline` / `polygon`) writes back natively; one it cannot (a
+ * curve, or a topology change that leaves the tag's canonical form)
+ * re-types the element to `<path>`.
  */
 export type VectorEditSource =
   | { kind: "path"; d: string }
+  | { kind: "line"; x1: number; y1: number; x2: number; y2: number }
   | {
       kind: "polyline";
       points: ReadonlyArray<readonly [number, number]>;
@@ -52,7 +66,69 @@ export type VectorEditSource =
   | {
       kind: "polygon";
       points: ReadonlyArray<readonly [number, number]>;
-    };
+    }
+  | {
+      kind: "rect";
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      /** Corner radii; `0` when the rect has square corners. */
+      rx: number;
+      ry: number;
+    }
+  | { kind: "circle"; cx: number; cy: number; r: number }
+  | { kind: "ellipse"; cx: number; cy: number; rx: number; ry: number };
+
+/** The native vector tags `retype_to_path` can re-type, keyed by tag → the
+ *  native geometry attributes it consumes (so no orphaned geometry attr
+ *  survives on the resulting `<path>`). Covers the geometry primitives
+ *  (rect / circle / ellipse — always re-typed) and the vertex tags (line /
+ *  polyline / polygon — re-typed only when an edit escapes their native
+ *  form). */
+const RETYPABLE_GEOMETRY_ATTRS: Readonly<Record<string, ReadonlySet<string>>> =
+  {
+    line: new Set(["x1", "y1", "x2", "y2"]),
+    polyline: new Set(["points"]),
+    polygon: new Set(["points"]),
+    rect: new Set(["x", "y", "width", "height", "rx", "ry"]),
+    circle: new Set(["cx", "cy", "r"]),
+    ellipse: new Set(["cx", "cy", "rx", "ry"]),
+  };
+
+/**
+ * Opaque reversal token returned by `retype_to_path`. Callers hold it and
+ * hand it back to `revert_retype` to restore the original primitive
+ * byte-for-byte; they do not inspect it. All trivia / attribute-token
+ * knowledge stays inside `SvgDocument`.
+ */
+export type RetypeRecord = {
+  readonly prev_local: string;
+  readonly prev_raw_tag: string;
+  /** Geometry attribute tokens removed on re-type, with their original
+   *  index in the element's `attrs` array. Ascending by index so they can
+   *  be spliced back in order. Typed as the document's internal attr token. */
+  readonly removed: ReadonlyArray<{ index: number; token: AttrToken }>;
+  /** True iff the re-type added a synthetic `fill="none"` (the `<line>`
+   *  fidelity guard — see `retype_to_path`). `revert_retype` removes it. */
+  readonly added_fill_none?: boolean;
+};
+
+/**
+ * Parse a single SVG length attribute as a plain user-unit number. Returns
+ * `null` for absent, non-finite, or unit/percentage values (`50%`, `5px`,
+ * `5em`) — those are an out-of-scope geometry gap, and refusing them here
+ * means the editor never offers a promotion it cannot perform faithfully.
+ */
+function parse_user_unit(raw: string | null): number | null {
+  if (raw === null) return null;
+  const s = raw.trim();
+  if (s === "") return null;
+  // Bare number only: optional sign, digits, optional fraction/exponent.
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
 
 export interface DocumentEvents {
   /** Fires after any structural mutation. */
@@ -466,31 +542,62 @@ export class SvgDocument implements DocumentEvents {
    * Returns a tag-discriminated snapshot of the authored geometry attrs
    * if this node is eligible for vector (vertex) editing — else `null`.
    *
-   * v1 eligibility:
+   * Eligibility:
    *   - `<path>`     — requires non-empty `d`.
+   *   - `<line>`     — requires two distinct finite user-unit endpoints.
    *   - `<polyline>` — requires `points` parseable to ≥ 2 vertices.
    *   - `<polygon>`  — same as polyline.
+   *   - `<rect>`     — requires finite user-unit `width`/`height` > 0.
+   *   - `<circle>`   — requires finite user-unit `r` > 0.
+   *   - `<ellipse>`  — requires finite user-unit `rx`/`ry` > 0.
    *
-   * Deliberately rejects `<line>` in v1: the only useful vertex-edit
-   * gestures on a `<line>` are (a) introducing a new vertex (which would
-   * have to promote it to `<polyline>`) and (b) bending it with a tangent
-   * (which would have to promote it to `<path>`). Both promotions are
-   * out of scope for v1, so opening a `<line>` in vector-edit mode would
-   * advertise capabilities that don't work.
+   * The vertex tags (`line` / `polyline` / `polygon`) write edits back to
+   * their native attributes while the geometry stays expressible there; an
+   * edit that escapes the native form (a curve, or a topology change that
+   * leaves the canonical chain) re-types the element to `<path>`. The
+   * geometry primitives (`rect` / `circle` / `ellipse`) have no native
+   * vector form, so any vector edit re-types them. In all cases the native
+   * tag is preserved byte-for-byte until the first re-typing edit commits
+   * (see `retype_to_path`). Design:
+   * `docs/wg/feat-svg-editor/promote-to-path.md`.
    *
-   * Also rejects `<rect>`, `<circle>`, `<ellipse>`, `<image>`, `<use>` —
-   * those would force the same promotion-to-`<path>` machinery (trivia
-   * transfer, cross-cutting attr carry, DOM-element swap, history-bracket
-   * changes) that v1 keeps out of scope.
+   * Geometry that is not a plain user-unit number (`%`, `px`, `em`, …) is
+   * an out-of-scope gap, so such an element returns `null` rather than
+   * advertising an edit the editor cannot perform faithfully.
+   *
+   * Rejects `<image>` / `<use>` (raster / reference bounding boxes, no
+   * editable outline).
    */
   is_vector_edit_target(id: NodeId): VectorEditSource | null {
     const n = this.nodes.get(id);
     if (!n || n.kind !== "element") return null;
+    // A retypable native shape (line / polyline / polygon / rect / circle /
+    // ellipse) must not already carry an unprefixed `d`: re-typing appends
+    // one, and a pre-authored (malformed) `d` would collide into an invalid
+    // double-`d` `<path>`. A namespaced `foo:d` is a foreign attr that
+    // survives verbatim (re-type only touches unprefixed `d`), so it is not a
+    // collision and does not disqualify. `<path>` is exempt — `d` is its own
+    // geometry, and it is absent from RETYPABLE_GEOMETRY_ATTRS.
+    if (
+      RETYPABLE_GEOMETRY_ATTRS[n.local] &&
+      n.attrs.some((a) => a.prefix === null && a.ns === null && a.local === "d")
+    ) {
+      return null;
+    }
     switch (n.local) {
       case "path": {
         const d = this.get_attr(id, "d");
         if (d === null || d.trim().length === 0) return null;
         return { kind: "path", d };
+      }
+      case "line": {
+        const x1 = parse_user_unit(this.get_attr(id, "x1")) ?? 0;
+        const y1 = parse_user_unit(this.get_attr(id, "y1")) ?? 0;
+        const x2 = parse_user_unit(this.get_attr(id, "x2")) ?? 0;
+        const y2 = parse_user_unit(this.get_attr(id, "y2")) ?? 0;
+        // Degenerate (zero-length) line has nothing to vector-edit.
+        if (x1 === x2 && y1 === y2) return null;
+        return { kind: "line", x1, y1, x2, y2 };
       }
       case "polyline":
       case "polygon": {
@@ -502,9 +609,179 @@ export class SvgDocument implements DocumentEvents {
           ? { kind: "polyline", points }
           : { kind: "polygon", points };
       }
+      case "rect": {
+        const x = parse_user_unit(this.get_attr(id, "x")) ?? 0;
+        const y = parse_user_unit(this.get_attr(id, "y")) ?? 0;
+        const width = parse_user_unit(this.get_attr(id, "width"));
+        const height = parse_user_unit(this.get_attr(id, "height"));
+        if (width === null || height === null) return null;
+        if (width <= 0 || height <= 0) return null;
+        // SVG corner-radii defaulting: a missing rx/ry mirrors the other;
+        // both missing → square corners. Negatives are treated as 0.
+        const rx_raw = parse_user_unit(this.get_attr(id, "rx"));
+        const ry_raw = parse_user_unit(this.get_attr(id, "ry"));
+        let rx = rx_raw ?? ry_raw ?? 0;
+        let ry = ry_raw ?? rx_raw ?? 0;
+        rx = Math.max(0, Math.min(rx, width / 2));
+        ry = Math.max(0, Math.min(ry, height / 2));
+        return { kind: "rect", x, y, width, height, rx, ry };
+      }
+      case "circle": {
+        const cx = parse_user_unit(this.get_attr(id, "cx")) ?? 0;
+        const cy = parse_user_unit(this.get_attr(id, "cy")) ?? 0;
+        const r = parse_user_unit(this.get_attr(id, "r"));
+        if (r === null || r <= 0) return null;
+        return { kind: "circle", cx, cy, r };
+      }
+      case "ellipse": {
+        const cx = parse_user_unit(this.get_attr(id, "cx")) ?? 0;
+        const cy = parse_user_unit(this.get_attr(id, "cy")) ?? 0;
+        const rx = parse_user_unit(this.get_attr(id, "rx"));
+        const ry = parse_user_unit(this.get_attr(id, "ry"));
+        if (rx === null || ry === null) return null;
+        if (rx <= 0 || ry <= 0) return null;
+        return { kind: "ellipse", cx, cy, rx, ry };
+      }
       default:
         return null;
     }
+  }
+
+  /**
+   * Re-type a native vector element (`<line>` / `<polyline>` / `<polygon>` /
+   * `<rect>` / `<circle>` / `<ellipse>`) into a `<path>` in place, consuming
+   * its native geometry attributes and setting `d`. A structural mutation:
+   * this layer executes the re-type; it does not decide when one is
+   * warranted.
+   *
+   * Idempotent: returns `null` if `id` is not currently one of those tags
+   * (so it is safe to call repeatedly — once re-typed, e.g. already a
+   * `<path>`, further calls are no-ops). Otherwise mutates the node and
+   * returns an opaque {@link RetypeRecord} reversal token.
+   *
+   * Identity, children, `self_closing`, non-geometry attributes, and all
+   * source trivia are preserved unchanged — only the tag and the geometry
+   * attributes move. Pass the token to {@link revert_retype} to restore
+   * the original primitive byte-for-byte.
+   *
+   * (see test/svg-editor-vector-promote-to-path.md)
+   */
+  retype_to_path(id: NodeId, d: string): RetypeRecord | null {
+    const n = this.nodes.get(id);
+    if (!n || n.kind !== "element") return null;
+    const geom = RETYPABLE_GEOMETRY_ATTRS[n.local];
+    if (!geom) return null;
+
+    const prev_local = n.local;
+    const prev_raw_tag = n.raw_tag;
+
+    // Capture + remove the native geometry attrs (unprefixed only). Walk
+    // back-to-front so splices don't shift the indices we still need, then
+    // reverse to ascending order for faithful restoration.
+    const removed: { index: number; token: AttrToken }[] = [];
+    for (let i = n.attrs.length - 1; i >= 0; i--) {
+      const a = n.attrs[i];
+      // Unprefixed geometry attrs only — a prefixed `foo:cx` is not the
+      // shape's geometry and must survive verbatim.
+      if (a.prefix === null && a.ns === null && geom.has(a.local)) {
+        removed.push({ index: i, token: a });
+        n.attrs.splice(i, 1);
+      }
+    }
+    removed.reverse();
+
+    // Re-type. Keep any namespace prefix (e.g. `svg:circle` → `svg:path`).
+    n.local = "path";
+    n.raw_tag = n.prefix ? `${n.prefix}:path` : "path";
+
+    // Append the `d` attribute (mirrors set_attr's append shape).
+    n.attrs.push({
+      raw_name: "d",
+      prefix: null,
+      local: "d",
+      ns: null,
+      value: d,
+      pre: " ",
+      eq_trivia: "",
+      quote: '"',
+    });
+
+    // Fidelity guard for `<line>`: a line has no fill region, so its fill
+    // (default `black`, or any inherited/authored value) never paints. A
+    // `<path>` DOES fill — an open path closes implicitly for fill — so the
+    // re-typed element would suddenly show a fill the line never had. When
+    // the element declares no fill of its own (presentation attr or inline
+    // style), pin `fill="none"` so the path renders stroke-only like the
+    // line did. (An element that explicitly declares a fill keeps it — that
+    // authored value is respected as-is.)
+    let added_fill_none = false;
+    if (
+      prev_local === "line" &&
+      this.get_attr(id, "fill") === null &&
+      this.get_style(id, "fill") === null
+    ) {
+      n.attrs.push({
+        raw_name: "fill",
+        prefix: null,
+        local: "fill",
+        ns: null,
+        value: "none",
+        pre: " ",
+        eq_trivia: "",
+        quote: '"',
+      });
+      added_fill_none = true;
+    }
+
+    this._structure_version++;
+    this._geometry_version++;
+    this.emit();
+    return { prev_local, prev_raw_tag, removed, added_fill_none };
+  }
+
+  /**
+   * Reverse a {@link retype_to_path}: restore the original tag, remove the
+   * `d` attribute the promotion added, and splice the captured geometry
+   * attribute tokens back at their original positions (preserving their
+   * trivia, so a later `serialize()` is byte-equal to the pre-promotion
+   * source).
+   */
+  revert_retype(id: NodeId, token: RetypeRecord): void {
+    const n = this.nodes.get(id);
+    if (!n || n.kind !== "element") return;
+
+    // Remove the appended `d` (unprefixed). Only one exists — the re-type
+    // added it and the source tags carry none.
+    for (let i = n.attrs.length - 1; i >= 0; i--) {
+      const a = n.attrs[i];
+      if (a.prefix === null && a.ns === null && a.local === "d") {
+        n.attrs.splice(i, 1);
+        break;
+      }
+    }
+
+    // Remove the synthetic `fill="none"` if the re-type added one.
+    if (token.added_fill_none) {
+      for (let i = n.attrs.length - 1; i >= 0; i--) {
+        const a = n.attrs[i];
+        if (a.prefix === null && a.ns === null && a.local === "fill") {
+          n.attrs.splice(i, 1);
+          break;
+        }
+      }
+    }
+
+    n.local = token.prev_local;
+    n.raw_tag = token.prev_raw_tag;
+
+    // Re-insert removed tokens at ascending original indices.
+    for (const { index, token: t } of token.removed) {
+      n.attrs.splice(index, 0, t);
+    }
+
+    this._structure_version++;
+    this._geometry_version++;
+    this.emit();
   }
 
   // Structural-fact predicates — atomic yes/no queries about authored

--- a/packages/grida-svg-editor/src/core/vector-edit/apply.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/apply.ts
@@ -25,7 +25,9 @@
 // the geometry traffic concentrates here.
 
 import vn from "@grida/vn";
-import type { SvgDocument, VectorEditSource } from "../document";
+import { SVGShapes } from "@grida/svg/pathdata";
+import type { RetypeRecord, SvgDocument, VectorEditSource } from "../document";
+import type { VectorEditSession } from "./session";
 import { PathModel } from "./model";
 
 /**
@@ -45,6 +47,13 @@ export function source_to_session_d(source: VectorEditSource): string {
   switch (source.kind) {
     case "path":
       return source.d;
+    case "line":
+      return vn.toSVGPathData(
+        vn.fromPolyline([
+          [source.x1, source.y1],
+          [source.x2, source.y2],
+        ])
+      );
     case "polyline":
       return vn.toSVGPathData(
         vn.fromPolyline(
@@ -57,25 +66,56 @@ export function source_to_session_d(source: VectorEditSource): string {
           source.points.map((p) => [p[0], p[1]] as [number, number])
         )
       );
+    case "circle":
+      // Cubic-Bézier conic: a four-segment ellipse with cardinal anchors
+      // (the chosen editing representation — see promote-to-path RFD D3).
+      return vn.toSVGPathData(
+        vn.fromEllipse({
+          x: source.cx - source.r,
+          y: source.cy - source.r,
+          width: source.r * 2,
+          height: source.r * 2,
+        })
+      );
+    case "ellipse":
+      return vn.toSVGPathData(
+        vn.fromEllipse({
+          x: source.cx - source.rx,
+          y: source.cy - source.ry,
+          width: source.rx * 2,
+          height: source.ry * 2,
+        })
+      );
+    case "rect":
+      // Square corners → four lines; rounded corners (rx/ry) → exact
+      // arc joins (reuses the tested shape builder; arcs round-trip
+      // through PathModel). rx/ry of 0 falls to the line-only path.
+      return SVGShapes.createRect(
+        source.x,
+        source.y,
+        source.width,
+        source.height,
+        source.rx,
+        source.ry
+      ).encode();
   }
 }
 
 /**
- * Tag-aware document write. Given a new path-data `d` from a gesture,
+ * Native-attribute writeback. Given a new path-data `d` from a gesture,
  * project it back into the source tag's native attrs and write those —
- * unless the source is `<path>`, in which case `d` is written
- * directly.
+ * `<path>` takes `d` directly; `<line>` takes `x1/y1/x2/y2`;
+ * `<polyline>` / `<polygon>` take `points`.
  *
- * Returns `true` on success. Returns `false` for non-path sources when
- * the model can no longer be expressed in the source tag's native attrs
- * (tangent introduced, topology change). v1 treats `false` as gesture
- * refusal — the caller should NOT fall through and write `d` on a non-
- * path element. Promotion to `<path>` lives in v1.1+.
+ * Returns `true` if the geometry was written natively. Returns `false`
+ * when the source tag cannot express the geometry — a curve was introduced
+ * or the topology left the tag's canonical form, OR the source is a
+ * geometry primitive (rect / circle / ellipse) which has no native vector
+ * form at all. A `false` return is the re-type-to-`<path>` signal; the
+ * caller ({@link vector_apply}) handles it. This function never re-types.
  *
- * Symmetric across apply / revert: gesture handlers call this for both
- * the in-flight write and the undo-revert (since both are just "set the
- * geometry to this d"), so apply/revert stay consistent even when one
- * writes native attrs and the other would.
+ * Symmetric across apply / revert: callers use it for both the in-flight
+ * write and the undo-revert (both are just "set the geometry to this d").
  */
 export function apply_session_d(
   doc: SvgDocument,
@@ -89,8 +129,74 @@ export function apply_session_d(
   }
   const native = PathModel.fromSvgPathD(d).toNativeAttrs(source.kind);
   if (native === null) return false;
-  // Both non-path kinds write the same `points=` attr.
+  if (native.kind === "line") {
+    doc.set_attr(node_id, "x1", String(native.x1));
+    doc.set_attr(node_id, "y1", String(native.y1));
+    doc.set_attr(node_id, "x2", String(native.x2));
+    doc.set_attr(node_id, "y2", String(native.y2));
+    return true;
+  }
+  // polyline / polygon both write the same `points=` attr.
   const points = native.points.map((p) => `${p[0]},${p[1]}`).join(" ");
   doc.set_attr(node_id, "points", points);
   return true;
+}
+
+/**
+ * Session-aware geometry write — the single commit chokepoint the DOM
+ * gesture handlers call so re-typing stays in one place rather than being
+ * reimplemented per gesture. One uniform rule across every source:
+ *
+ *   1. Try native writeback ({@link apply_session_d}). For `<path>` and for
+ *      a vertex tag (`line` / `polyline` / `polygon`) whose edit still fits
+ *      its native form, this writes and we're done — the element keeps its
+ *      tag.
+ *   2. If native writeback refused (a curve was introduced, the topology
+ *      escaped the canonical chain, or the source is a geometry primitive
+ *      with no native form), re-type the element to `<path>` via
+ *      {@link SvgDocument.retype_to_path} and flip the session source to
+ *      `path` (so every downstream reader — overlay, gates, the
+ *      external-mutation reconciler — behaves correctly).
+ *
+ * Returns the {@link RetypeRecord} token iff this call performed a re-type
+ * (so the caller can pair it with the edit in one history bracket and hand
+ * it to {@link vector_revert} on undo); otherwise `null`.
+ */
+export function vector_apply(
+  doc: SvgDocument,
+  session: VectorEditSession,
+  d: string
+): RetypeRecord | null {
+  // Native writeback covers <path> and any vertex tag whose edit still fits.
+  if (apply_session_d(doc, session.node_id, session.source, d)) return null;
+  // Not natively expressible → re-type to <path>.
+  const token = doc.retype_to_path(session.node_id, d);
+  if (token) {
+    session.promote_source_to_path();
+    return token;
+  }
+  // Already re-typed earlier this gesture (idempotent) — just update `d`.
+  doc.set_attr(session.node_id, "d", d);
+  return null;
+}
+
+/**
+ * Counterpart to {@link vector_apply}. If this gesture re-typed the element
+ * (a non-null `promotion` token), restore the original tag/attrs and the
+ * session source — the re-type and the edit undo as one step. Otherwise
+ * re-write the baseline geometry natively; for a geometry primitive that
+ * never re-typed, {@link apply_session_d} writes nothing (a correct no-op).
+ */
+export function vector_revert(
+  doc: SvgDocument,
+  session: VectorEditSession,
+  baseline_d: string,
+  promotion: RetypeRecord | null
+): void {
+  if (promotion) {
+    doc.revert_retype(session.node_id, promotion);
+    session.restore_source();
+    return;
+  }
+  apply_session_d(doc, session.node_id, session.source, baseline_d);
 }

--- a/packages/grida-svg-editor/src/core/vector-edit/index.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/index.ts
@@ -21,7 +21,12 @@ export type {
 export { VectorEditSession, sub_selection_equal } from "./session";
 export type { HoveredControl, SubSelectionSnapshot } from "./session";
 
-export { source_to_session_d, apply_session_d } from "./apply";
+export {
+  source_to_session_d,
+  apply_session_d,
+  vector_apply,
+  vector_revert,
+} from "./apply";
 
 export { marquee } from "./marquee";
 export type { SubpathSelectCandidates } from "./marquee";

--- a/packages/grida-svg-editor/src/core/vector-edit/model.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/model.ts
@@ -219,34 +219,59 @@ export class PathModel {
    *
    * - **path** — always `null` (no native fallback; the canonical form
    *   IS `<path d>`, so callers should just write `d` directly).
+   * - **line** — exactly two vertices joined by one straight segment
+   *   `0→1`. (Topology after a 2-point `vn.fromPolyline` and any sequence
+   *   of endpoint translates.)
    * - **polyline** — segments form the canonical open chain
    *   `0→1, 1→2, …, (n-2)→(n-1)`. (Topology after `vn.fromPolyline` and
    *   any sequence of vertex translates.)
    * - **polygon** — segments form the canonical closed chain
    *   `0→1, 1→2, …, (n-1)→0`. (Topology after `vn.fromPolygon` and any
    *   sequence of vertex translates.)
+   * - **rect / circle / ellipse** — always `null`. These geometry
+   *   primitives have no native writeback target; any vector gesture on
+   *   them re-types the element to `<path>` (see `vector_apply` /
+   *   `SvgDocument.retype_to_path`), so they never round-trip through here.
    *
    * Anything that changes segment topology (insert-vertex, delete-vertex,
-   * close/open shape) leaves the canonical chain and returns `null` here;
-   * the higher layer is responsible for routing those to tag-promotion
-   * (intra-Vertex or to-path).
+   * close/open shape) or introduces a curve leaves the canonical chain and
+   * returns `null` here; the caller re-types the element to `<path>`.
    */
   toNativeAttrs(
     source_tag: VectorEditSource["kind"]
-  ): Exclude<VectorEditSource, { kind: "path" }> | null {
-    if (source_tag === "path") return null;
+  ): Extract<
+    VectorEditSource,
+    { kind: "line" | "polyline" | "polygon" }
+  > | null {
+    if (
+      source_tag !== "line" &&
+      source_tag !== "polyline" &&
+      source_tag !== "polygon"
+    ) {
+      return null;
+    }
 
     const { vertices, segments } = this._network;
 
     // All-zero-tangent gate. Any non-zero tangent means the user has
     // promoted a straight segment to a curve — not expressible in
-    // <polyline>/<polygon> native attrs.
+    // <line>/<polyline>/<polygon> native attrs.
     for (const s of segments) {
       if (s.ta[0] !== 0 || s.ta[1] !== 0) return null;
       if (s.tb[0] !== 0 || s.tb[1] !== 0) return null;
     }
 
     const n = vertices.length;
+
+    if (source_tag === "line") {
+      // Exactly two vertices joined by one straight segment 0→1.
+      if (n !== 2 || segments.length !== 1) return null;
+      const s = segments[0];
+      if (s.a !== 0 || s.b !== 1) return null;
+      const [x1, y1] = vertices[0];
+      const [x2, y2] = vertices[1];
+      return { kind: "line", x1, y1, x2, y2 };
+    }
 
     if (source_tag === "polyline") {
       if (segments.length !== n - 1 || n < 2) return null;

--- a/packages/grida-svg-editor/src/core/vector-edit/session.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/session.ts
@@ -171,6 +171,26 @@ export class VectorEditSession {
     this._source_before_promotion = null;
   }
 
+  /**
+   * Re-sync the source to the document's current tag, outright. Unlike
+   * {@link promote_source_to_path} / {@link restore_source} (which manage a
+   * single primitive→path flip within one gesture), this sets the source to
+   * an authoritative value derived from the live document and clears the
+   * promotion bookkeeping.
+   *
+   * The host calls this when an undo/redo re-types the node out from under a
+   * *different* live session object than the one that performed the original
+   * flip (exit + undo-exit creates a fresh session; the captured session's
+   * `restore_source` then no-ops). Without it the live session could keep
+   * `source.kind === "path"` while the node is back to a primitive, and the
+   * next gesture would write a stray `d` onto the native tag. Re-deriving
+   * from the document keeps the live session authoritative.
+   */
+  sync_source(source: VectorEditSource): void {
+    this._source = source;
+    this._source_before_promotion = null;
+  }
+
   /** The session's current PathModel-form `d`. Gesture handlers read
    *  this instead of `doc.get_attr(node_id, "d")` so they stay tag-
    *  oblivious (non-path sources have no `d` on the document). */

--- a/packages/grida-svg-editor/src/core/vector-edit/session.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/session.ts
@@ -105,9 +105,17 @@ export class VectorEditSession {
   readonly node_id: string;
   /** Source tag + authored attrs captured at session entry. Tells the
    *  apply.ts shim how to project a path-form `d` back to the document.
-   *  Stable across the session — the source tag itself does not change
-   *  in v1 (promotion is deferred). */
-  readonly source: VectorEditSource;
+   *
+   *  Flips **at most once**, primitive → `path`, when a promotable
+   *  primitive (rect / circle / ellipse) is promoted to `<path>` on its
+   *  first committed gesture (see `vector_apply`). The flip is what keeps
+   *  every downstream reader (overlay neighbours, tangent/bend gates, the
+   *  external-mutation reconciler) consistent after the element re-types.
+   *  `restore_source()` reverses it for gesture undo. */
+  private _source: VectorEditSource;
+  /** The pre-promotion source, retained so `restore_source` can reverse a
+   *  single primitive→path flip. `null` when not promoted. */
+  private _source_before_promotion: VectorEditSource | null;
 
   /** The in-session PathModel-form `d`. Gesture handlers parse from
    *  here and write back through `apply_session_d`; the writeback may
@@ -127,13 +135,40 @@ export class VectorEditSession {
 
   constructor(node_id: string, source: VectorEditSource, session_d: string) {
     this.node_id = node_id;
-    this.source = source;
+    this._source = source;
+    this._source_before_promotion = null;
     this._session_d = session_d;
     this._last_seen_d = session_d;
     this._selected_vertices = [];
     this._selected_segments = [];
     this._selected_tangents = [];
     this._hovered_control = null;
+  }
+
+  /** Source tag the session currently projects through. See `_source`. */
+  get source(): VectorEditSource {
+    return this._source;
+  }
+
+  /**
+   * Flip the source to `path` after the underlying element was promoted
+   * (rect / circle / ellipse → `<path>`). Idempotent: a second call while
+   * already promoted does nothing, so the pre-promotion source captured by
+   * the first flip is never clobbered.
+   */
+  promote_source_to_path(): void {
+    if (this._source_before_promotion !== null) return;
+    if (this._source.kind === "path") return;
+    this._source_before_promotion = this._source;
+    this._source = { kind: "path", d: this._session_d };
+  }
+
+  /** Reverse a {@link promote_source_to_path} (gesture undo). No-op if the
+   *  source was never promoted. */
+  restore_source(): void {
+    if (this._source_before_promotion === null) return;
+    this._source = this._source_before_promotion;
+    this._source_before_promotion = null;
   }
 
   /** The session's current PathModel-form `d`. Gesture handlers read

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -3498,7 +3498,21 @@ class DomSurface implements Surface {
   ): void {
     const cur = this.vector_edit;
     if (!cur || cur.node_id !== target_node_id) return;
-    if (d !== null) cur.mark_seen(d);
+    if (d !== null) {
+      cur.mark_seen(d);
+      // A geometry delta may have re-typed the node (promote on redo, demote
+      // on undo). `vector_apply` / `vector_revert` flip the *captured*
+      // session's source, but after exit + undo-exit the live session is a
+      // fresh object that the captured flip never touched — leaving it with
+      // `source.kind === "path"` while the document is back to a primitive,
+      // so the next gesture would write a stray `d`. Re-derive the live
+      // session's source from the now-current document tag, same as we
+      // already replay the watermark and selection here.
+      const live_source = this.editor_internal().doc.is_vector_edit_target(
+        cur.node_id
+      );
+      if (live_source) cur.sync_source(live_source);
+    }
     cur.restore_selection(selection);
     this.sync_selection_mirror();
   }

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -3003,11 +3003,11 @@ class DomSurface implements Surface {
       return this.enter_text_edit(id);
     }
     // Vector-edit: the doc-side `is_vector_edit_target` predicate is the
-    // single authority over which tags are eligible (path / polyline /
-    // polygon, and the promotable primitives rect / circle / ellipse).
-    // Routing off it directly — rather than a hardcoded tag list — keeps
-    // this gate in lock-step with the predicate, so a future eligibility
-    // change lands in one place. (`<line>` / `<image>` / `<use>` stay
+    // single authority over which tags are eligible (the native vector tags
+    // path / line / polyline / polygon, and the promotable primitives rect /
+    // circle / ellipse). Routing off it directly — rather than a hardcoded
+    // tag list — keeps this gate in lock-step with the predicate, so a future
+    // eligibility change lands in one place. (`<image>` / `<use>` stay
     // ineligible there.)
     if (this.editor_internal().doc.is_vector_edit_target(id) !== null) {
       return this.enter_vector_edit(id);

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -88,9 +88,11 @@ import {
   marquee,
   sub_selection_equal,
   source_to_session_d,
-  apply_session_d,
+  vector_apply,
+  vector_revert,
   type SubSelectionSnapshot,
 } from "./core/vector-edit";
+import type { RetypeRecord } from "./core/document";
 import type {
   InsertableTag,
   InsertPreviewSession,
@@ -164,12 +166,6 @@ const IS_MODIFIER_KEY: Record<string, true> = {
  *  surface skips render() during the in-flight mount and doesn't yank the
  *  live `<text>` element out from under the about-to-mount text surface. */
 const TEXT_EDIT_PENDING = { __pending: true } as const;
-
-/** Per-frame `neighbours: []` for the `vector_of` HUD projection. Polyline
- *  and polygon sources never render tangent handles in v1 (curve edits would
- *  promote to `<path>`); using a frozen module-level array avoids allocating
- *  a fresh empty array per redraw frame. */
-const EMPTY_NEIGHBOURS: readonly number[] = Object.freeze([]);
 
 export type DomSurfaceOptions = {
   /** Mount the SVG inside this container. */
@@ -321,6 +317,11 @@ class DomSurface implements Surface {
     | {
         kind: "vector_vertex_translate";
         node_id: NodeId;
+        /** Promotion reversal token for a promotable-primitive source.
+         *  Holds the demote-to-primitive token once the first gesture
+         *  frame promotes the element to `<path>`; shared by reference
+         *  with the committed step's closures so undo demotes. */
+        promo: { token: RetypeRecord | null };
         indices: readonly number[];
         /** Snapshot of `d` at gesture start; used by `revert`. */
         initial_d: string;
@@ -341,6 +342,7 @@ class DomSurface implements Surface {
     | {
         kind: "vector_set_tangent";
         node_id: NodeId;
+        promo: { token: RetypeRecord | null };
         tangent: readonly [number, 0 | 1];
         initial_d: string;
         baseline_model: PathModel;
@@ -351,6 +353,7 @@ class DomSurface implements Surface {
     | {
         kind: "vector_bend_segment";
         node_id: NodeId;
+        promo: { token: RetypeRecord | null };
         segment: number;
         ca: number;
         /** Frozen segment state in path-LOCAL coords, captured at gesture
@@ -383,6 +386,7 @@ class DomSurface implements Surface {
          */
         kind: "vector_translate_selection";
         node_id: NodeId;
+        promo: { token: RetypeRecord | null };
         indices: readonly number[];
         tangent_refs: readonly (readonly [number, 0 | 1])[];
         initial_d: string;
@@ -2998,18 +3002,14 @@ class DomSurface implements Surface {
     if (tag === "text" || tag === "tspan") {
       return this.enter_text_edit(id);
     }
-    // Vector-edit: path / polyline / polygon. Eligibility is checked
-    // inside `enter_vector_edit` via `is_vector_edit_target`; the tag pre-
-    // filter here just avoids the extra predicate lookup on unrelated
-    // tags. `<line>` is intentionally NOT routed in v1: a line has no
-    // useful vertex-edit gestures that stay within the source tag
-    // (insert-vertex would promote to <polyline>, tangent would promote
-    // to <path>), and promotions are out of scope for v1. Updating this
-    // list without widening the doc-side predicate would silently route
-    // ineligible tags to a rejecting path; updating the predicate
-    // without widening this list would make those tags silently fall
-    // through to "no content edit".
-    if (tag === "path" || tag === "polyline" || tag === "polygon") {
+    // Vector-edit: the doc-side `is_vector_edit_target` predicate is the
+    // single authority over which tags are eligible (path / polyline /
+    // polygon, and the promotable primitives rect / circle / ellipse).
+    // Routing off it directly — rather than a hardcoded tag list — keeps
+    // this gate in lock-step with the predicate, so a future eligibility
+    // change lands in one place. (`<line>` / `<image>` / `<use>` stay
+    // ineligible there.)
+    if (this.editor_internal().doc.is_vector_edit_target(id) !== null) {
       return this.enter_vector_edit(id);
     }
     return false;
@@ -3412,20 +3412,15 @@ class DomSurface implements Surface {
       };
     });
     // Neighbouring vertices — those whose tangent handles should render.
-    //
-    // v1 carves out the vertex-chain sources (`<polyline>` / `<polygon>`):
-    // a tangent edit would force promotion to `<path>`, and promotions
-    // are out of scope. Hiding the affordance IS the contract — the
-    // gesture handlers (`handle_set_tangent_intent`,
-    // `handle_bend_segment`) also refuse at the door for these sources.
-    const neighbours: readonly number[] =
-      this.vector_edit.source.kind === "path"
-        ? model.neighbouringVertices({
-            vertices: this.vector_edit.selected_vertices,
-            segments: this.vector_edit.selected_segments,
-            tangents: this.vector_edit.selected_tangents,
-          })
-        : EMPTY_NEIGHBOURS;
+    // Shown for every vector source: dragging a tangent on a vertex tag
+    // (`line` / `polyline` / `polygon`) introduces a curve, which re-types
+    // the element to `<path>` (see `vector_apply`). The affordance is
+    // therefore always live.
+    const neighbours: readonly number[] = model.neighbouringVertices({
+      vertices: this.vector_edit.selected_vertices,
+      segments: this.vector_edit.selected_segments,
+      tangents: this.vector_edit.selected_tangents,
+    });
 
     return {
       vertices,
@@ -3506,6 +3501,64 @@ class DomSurface implements Surface {
     if (d !== null) cur.mark_seen(d);
     cur.restore_selection(selection);
     this.sync_selection_mirror();
+  }
+
+  /**
+   * Build the `{ apply, revert }` history step for a vector-edit geometry
+   * delta — the single chokepoint that routes the write through
+   * {@link vector_apply} / {@link vector_revert} so promote-to-path of a
+   * primitive source (rect / circle / ellipse) is handled in one place
+   * rather than per gesture.
+   *
+   * `promo` is the per-gesture token holder (shared by reference across an
+   * `active_preview`'s preview frames and its committed step) so the
+   * promotion that fires on the first frame is the one undo reverses —
+   * promotion + first edit collapse into a single undo step. On redo after
+   * an undo-demote, `apply` re-promotes and refreshes the token.
+   *
+   * `after_selection` / `before_selection` drive sub-selection replay;
+   * pass `null` (preview frames) to skip it.
+   */
+  private vector_geometry_step(
+    node_id: NodeId,
+    target_d: string,
+    baseline_d: string,
+    promo: { token: RetypeRecord | null },
+    after_selection: SubSelectionSnapshot | null,
+    before_selection: SubSelectionSnapshot | null
+  ): { providerId: string; apply: () => void; revert: () => void } {
+    const internal = this.editor_internal();
+    const doc = internal.doc;
+    const emit = internal.emit;
+    // Capture the session OBJECT (not its source value): `vector_apply`
+    // reads its live `source` and flips it primitive→path on promotion, so
+    // the closures must observe later mutations. A disposed session (exit +
+    // undo) makes these calls harmless no-ops; the document write keyed on
+    // `node_id` is the real effect.
+    const session = this.vector_edit;
+    return {
+      providerId: "svg-editor",
+      apply: () => {
+        if (session) {
+          const tok = vector_apply(doc, session, target_d);
+          if (tok) promo.token = tok;
+        }
+        if (after_selection)
+          this.replay_vector_session_state(node_id, target_d, after_selection);
+        emit();
+      },
+      revert: () => {
+        if (session) vector_revert(doc, session, baseline_d, promo.token);
+        promo.token = null;
+        if (before_selection)
+          this.replay_vector_session_state(
+            node_id,
+            baseline_d,
+            before_selection
+          );
+        emit();
+      },
+    };
   }
 
   /**
@@ -3627,13 +3680,7 @@ class DomSurface implements Surface {
     if (!this.vector_edit || this.vector_edit.node_id !== intent.node_id)
       return;
     const internal = this.editor_internal();
-    const doc = internal.doc;
-    const emit = internal.emit;
     const node_id = intent.node_id;
-    // Capture source for the apply/revert closures — they fire later
-    // (undo, redo) when `this.vector_edit` may have been cleared.
-    const source = this.vector_edit.source;
-    const commit = (d: string) => apply_session_d(doc, node_id, source, d);
 
     // Open / refresh the preview session.
     if (
@@ -3655,6 +3702,7 @@ class DomSurface implements Surface {
       this.active_preview = {
         kind: "vector_vertex_translate",
         node_id,
+        promo: { token: null },
         indices: [...intent.indices],
         initial_d,
         baseline_model,
@@ -3715,37 +3763,29 @@ class DomSurface implements Surface {
       // keep each gesture handler readable in isolation.
       const before_selection = this.active_preview.before_selection;
       const after_selection = this.vector_edit.snapshot_selection();
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          this.replay_vector_session_state(node_id, target_d, after_selection);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          this.replay_vector_session_state(
-            node_id,
-            baseline_d,
-            before_selection
-          );
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          after_selection,
+          before_selection
+        )
+      );
       this.active_preview.session.commit();
       this.active_preview = null;
     } else {
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          null,
+          null
+        )
+      );
     }
   }
 
@@ -3782,11 +3822,7 @@ class DomSurface implements Surface {
     if (!this.vector_edit || this.vector_edit.node_id !== intent.node_id)
       return;
     const internal = this.editor_internal();
-    const doc = internal.doc;
-    const emit = internal.emit;
     const node_id = intent.node_id;
-    const source = this.vector_edit.source;
-    const commit = (d: string) => apply_session_d(doc, node_id, source, d);
 
     // Resolve the set of vertices and tangents to act on — reads the host's
     // authoritative sub-selection. Session doesn't cache the model
@@ -3849,6 +3885,7 @@ class DomSurface implements Surface {
       this.active_preview = {
         kind: "vector_translate_selection",
         node_id,
+        promo: { token: null },
         indices: [...indices],
         tangent_refs: [...tangent_refs],
         initial_d,
@@ -3915,37 +3952,29 @@ class DomSurface implements Surface {
     if (intent.phase === "commit") {
       const before_selection = this.active_preview.before_selection;
       const after_selection = this.vector_edit.snapshot_selection();
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          this.replay_vector_session_state(node_id, target_d, after_selection);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          this.replay_vector_session_state(
-            node_id,
-            baseline_d,
-            before_selection
-          );
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          after_selection,
+          before_selection
+        )
+      );
       this.active_preview.session.commit();
       this.active_preview = null;
     } else {
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          null,
+          null
+        )
+      );
     }
   }
 
@@ -3979,21 +4008,12 @@ class DomSurface implements Surface {
   ): void {
     if (!this.vector_edit || this.vector_edit.node_id !== intent.node_id)
       return;
-    // v1: tangent edits force a curve, which only `<path>` can carry as
-    // native attrs. For polyline/polygon sources `apply_session_d` would
-    // refuse silently (returns `false`) while `mark_seen` still advanced
-    // `last_seen_d`, leaving the external-mutation watcher permanently
-    // out of sync. Refuse the intent at the door instead — the HUD
-    // already hides tangent handles for these sources (`vector_of`), so
-    // a reachable invocation here can only come from a programmatic
-    // intent.
-    if (this.vector_edit.source.kind !== "path") return;
+    // Tangent edits introduce a curve. Any source accepts the gesture: a
+    // vertex tag (`line` / `polyline` / `polygon`) re-types to `<path>` on
+    // commit, the geometry primitives likewise, and `<path>` carries the
+    // curve directly (see `vector_geometry_step` → `vector_apply`).
     const internal = this.editor_internal();
-    const doc = internal.doc;
-    const emit = internal.emit;
     const node_id = intent.node_id;
-    const source = this.vector_edit.source;
-    const commit = (d: string) => apply_session_d(doc, node_id, source, d);
 
     // Open / refresh the preview session.
     if (
@@ -4012,6 +4032,7 @@ class DomSurface implements Surface {
       this.active_preview = {
         kind: "vector_set_tangent",
         node_id,
+        promo: { token: null },
         tangent: [intent.tangent[0], intent.tangent[1]],
         initial_d,
         baseline_model,
@@ -4044,37 +4065,29 @@ class DomSurface implements Surface {
       // closure, then write the captured selection back.
       const before_selection = this.active_preview.before_selection;
       const after_selection = this.vector_edit.snapshot_selection();
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          this.replay_vector_session_state(node_id, target_d, after_selection);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          this.replay_vector_session_state(
-            node_id,
-            baseline_d,
-            before_selection
-          );
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          after_selection,
+          before_selection
+        )
+      );
       this.active_preview.session.commit();
       this.active_preview = null;
     } else {
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          null,
+          null
+        )
+      );
     }
   }
 
@@ -4090,8 +4103,6 @@ class DomSurface implements Surface {
     if (!this.vector_edit || this.vector_edit.node_id !== intent.node_id)
       return;
     const node_id = intent.node_id;
-    const source = this.vector_edit.source;
-    const commit = (d: string) => apply_session_d(doc, node_id, source, d);
     const baseline_d = this.read_session_d();
     if (baseline_d === null) return;
     const baseline_model = PathModel.fromSvgPathD(baseline_d);
@@ -4102,8 +4113,6 @@ class DomSurface implements Surface {
     const target_d = next_model.toSvgPathD();
 
     const internal = this.editor_internal();
-    const doc = internal.doc;
-    const emit = internal.emit;
     // Split is a one-shot edit — we want it to be one undo entry. The
     // simplest way to compose this with the existing preview/commit
     // sessions used by other vector edits is `preview() + set() +
@@ -4120,20 +4129,19 @@ class DomSurface implements Surface {
       segments: Object.freeze([] as number[]),
       tangents: Object.freeze([] as ReadonlyArray<readonly [number, 0 | 1]>),
     });
+    // One-shot gesture → local promotion-token holder (no active_preview).
+    const promo: { token: RetypeRecord | null } = { token: null };
     const split_session = internal.history.preview("vector/split-segment");
-    split_session.set({
-      providerId: "svg-editor",
-      apply: () => {
-        commit(target_d);
-        this.replay_vector_session_state(node_id, target_d, after_selection);
-        emit();
-      },
-      revert: () => {
-        commit(baseline_d);
-        this.replay_vector_session_state(node_id, baseline_d, before_selection);
-        emit();
-      },
-    });
+    split_session.set(
+      this.vector_geometry_step(
+        node_id,
+        target_d,
+        baseline_d,
+        promo,
+        after_selection,
+        before_selection
+      )
+    );
     split_session.commit();
     this.redraw();
   }
@@ -4150,16 +4158,12 @@ class DomSurface implements Surface {
   private handle_bend_segment(intent: Intent & { kind: "bend_segment" }): void {
     if (!this.vector_edit || this.vector_edit.node_id !== intent.node_id)
       return;
-    // v1: bending a straight segment introduces tangents — only `<path>`
-    // can carry them as native attrs. See the same carve-out on
-    // `handle_set_tangent_intent` for the full rationale.
-    if (this.vector_edit.source.kind !== "path") return;
+    // Bending a straight segment introduces a curve. Any source accepts it:
+    // a vertex tag (`line` / `polyline` / `polygon`) re-types to `<path>` on
+    // commit, as do the geometry primitives; `<path>` carries it directly
+    // (see `vector_geometry_step` → `vector_apply`).
     const internal = this.editor_internal();
-    const doc = internal.doc;
-    const emit = internal.emit;
     const node_id = intent.node_id;
-    const source = this.vector_edit.source;
-    const commit = (d: string) => apply_session_d(doc, node_id, source, d);
 
     if (
       !this.active_preview ||
@@ -4182,6 +4186,7 @@ class DomSurface implements Surface {
       this.active_preview = {
         kind: "vector_bend_segment",
         node_id,
+        promo: { token: null },
         segment: intent.segment,
         ca: intent.ca,
         frozen: {
@@ -4215,37 +4220,29 @@ class DomSurface implements Surface {
     if (intent.phase === "commit") {
       const before_selection = this.active_preview.before_selection;
       const after_selection = this.vector_edit.snapshot_selection();
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          this.replay_vector_session_state(node_id, target_d, after_selection);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          this.replay_vector_session_state(
-            node_id,
-            baseline_d,
-            before_selection
-          );
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          after_selection,
+          before_selection
+        )
+      );
       this.active_preview.session.commit();
       this.active_preview = null;
     } else {
-      this.active_preview.session.set({
-        providerId: "svg-editor",
-        apply: () => {
-          commit(target_d);
-          emit();
-        },
-        revert: () => {
-          commit(baseline_d);
-          emit();
-        },
-      });
+      this.active_preview.session.set(
+        this.vector_geometry_step(
+          node_id,
+          target_d,
+          baseline_d,
+          this.active_preview.promo,
+          null,
+          null
+        )
+      );
     }
   }
 

--- a/test/svg-editor-vector-promote-to-path.md
+++ b/test/svg-editor-vector-promote-to-path.md
@@ -1,0 +1,94 @@
+---
+id: TC-SVGEDITOR-VECTOR-001
+title: Primitive shapes promote to <path> on first vector edit
+module: svg-editor
+area: vector
+tags: [vector, content-edit, promotion, history, undo, round-trip]
+status: untested
+severity: medium
+date: 2026-06-04
+updated: 2026-06-04
+automatable: false
+covered_by:
+  - packages/grida-svg-editor/__tests__/promote-to-path.test.ts
+  - packages/grida-svg-editor/__tests__/vector-edit-promote.test.ts
+  - packages/grida-svg-editor/__tests__/is-vector-edit-target.test.ts
+---
+
+## Behavior
+
+`<rect>`, `<circle>`, and `<ellipse>` can be vector-edited (anchors, segments,
+tangents) even though their native attribute forms have no addressable interior
+vertices. Honoring such a gesture requires re-typing the element to `<path>` —
+**promotion** (design: `docs/wg/feat-svg-editor/promote-to-path.md`).
+
+Promotion is **lazy**: entering vector-edit mode on a primitive shows a
+path-equivalent vertex overlay (a circle/ellipse appears as four cubic-Bézier
+segments with anchors at the cardinal points; a rect as its four corners) but
+**mutates nothing in the document**. The element re-types to `<path>` only on
+the first geometry-committing gesture. Promotion and that first edit collapse
+into a **single undo step**: undo restores the original primitive byte-for-byte
+(tag, geometry attributes, all other attributes, and source trivia intact).
+
+The full automatable surface — eligibility, the cubic/rect geometry, the
+byte-equal round-trip, and the `vector_apply`/`vector_revert` commit path — is
+covered by the unit tests listed in `covered_by`. This TC covers the parts that
+only manifest through real pointer interaction in a mounted editor: that the
+overlay tracks the drag, that the live shape re-renders as a path, and that the
+enter-then-escape (no edit) case truly leaves the file untouched.
+
+## Steps
+
+1. Mount the editor on a document containing `<circle cx="50" cy="50" r="30"
+fill="red"/>` and at least one comment or extra attribute on the circle.
+2. Double-click the circle to enter vector-edit (content-edit) mode.
+   - Expected: a vertex overlay appears with four anchors at the cardinal
+     points (top/right/bottom/left) and tangent handles; the document is still
+     a `<circle>` (serialize is byte-identical to the input).
+3. Press Escape to exit without editing.
+   - Expected: still a `<circle>`; `serialize()` is byte-identical to the input
+     (lazy promotion — no edit, no diff).
+4. Re-enter vector-edit, then drag one anchor and release.
+   - Expected: the overlay tracks the anchor during the drag; on release the
+     rendered shape is a `<path>` whose `d` reflects the moved anchor, with
+     `fill="red"` and the comment/extra attribute preserved, and no leftover
+     `cx`/`cy`/`r` attributes.
+5. Press Cmd/Ctrl+Z once.
+   - Expected: a single undo restores the original `<circle …/>` exactly
+     (geometry, attributes, and trivia) — not a `<path>` holding the
+     circle-shaped geometry.
+6. Repeat steps 1–5 for `<rect>` (including a rounded `<rect rx>`) and
+   `<ellipse>`. A rect with no `rx`/`ry` promotes to a four-line closed path; a
+   rounded rect keeps its corner radii in the resulting `d`.
+
+7. **Vertex tags — native edits stay, curves escape.** For `<polyline>`,
+   `<polygon>`, and `<line>`:
+   - Double-click to enter vector-edit, then **drag a vertex** (straight
+     move). Expected: the element stays a `<polyline>` / `<polygon>` /
+     `<line>` — only its `points` (or `x1/y1/x2/y2`) change; no `d`, no tag
+     change.
+   - **Cmd/Ctrl-drag a vertex or drag a tangent handle** to curve a segment.
+     Expected: the element re-types to `<path>` whose `d` carries the curve;
+     other attributes/trivia are preserved. A single undo restores the
+     original `<polyline>` / `<polygon>` / `<line>` exactly.
+   - Adding a vertex to a `<line>` (a 2-point tag) re-types it to `<path>`;
+     inserting a vertex into a `<polyline>` keeps it a `<polyline>`.
+
+## Notes
+
+- Lazy timing is the decisive choice over eager (promote-on-mode-entry): it is
+  what preserves the "inspect anchors, press Escape → byte-equal" guarantee.
+- Conics use a four-cubic-Bézier representation (cardinal anchors) rather than
+  arcs — chosen as the better _editing_ surface (four anchors + tangent handles
+  vs. two), and arcs would collapse to cubics on the first tangent edit anyway.
+- One uniform rule spans all non-path shapes: write the edit back to the native
+  tag while the tag can express the result, otherwise re-type to `<path>`. The
+  geometry primitives (`rect` / `circle` / `ellipse`) are the degenerate case —
+  they have no native vector form, so every vector edit re-types them.
+- `<image>` / `<use>` remain ineligible for vector-edit (raster / reference
+  bounding boxes, no editable outline).
+- Curving a `<line>` that declares no fill must render **stroke-only** — no
+  black fill. A line has no fill region so its (default) fill never paints;
+  the re-type pins `fill="none"` so the resulting path matches. Undo removes
+  it (byte-equal). Other shapes need no such guard — they fill the same way a
+  path does.


### PR DESCRIPTION
## What

Lets users vector-edit (anchors / segments / tangents) the non-path SVG shapes — `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, `<polygon>` — in the same overlay used for `<path>`.

**One uniform rule, decided per edit:** write the edit back to the native tag while the tag can express the result; otherwise re-type the element to `<path>`.

- **Vertex tags** (`line` / `polyline` / `polygon`) stay native on a plain point drag, and re-type only when an edit escapes their form (a curve, or a topology change that leaves the canonical chain).
- **Geometry primitives** (`rect` / `circle` / `ellipse`) have no native vector form, so every vector edit re-types them. Conics use a four-cubic-Bézier representation (cardinal anchors + tangent handles).

## Why it's safe to round-trip

Re-typing is **lazy** — the source stays byte-equal until the first re-typing edit — and **reversible**: the re-type and that first edit collapse into a **single undo step** that restores the original element byte-for-byte (tag, geometry attrs, other attrs, and source trivia).

All logic lives in the DOM-free core (`document.ts` `retype_to_path`/`revert_retype` + `vector-edit/apply.ts` `vector_apply`/`vector_revert` + a one-time session source flip); `dom.ts` stays a thin pointer→core shell. The document layer carries **no editing-intent vocabulary** (`retype_to_path` / `RetypeRecord` / `RETYPABLE_GEOMETRY_ATTRS`).

## Fill fidelity — the `<line>` exception

A `<line>` has no fill region, so its (default `black`) fill never paints; an open `<path>` *does* fill via implicit close. Re-typing a `<line>` that declares no fill of its own pins `fill="none"` so the result renders stroke-only. Undo removes it, keeping the revert byte-equal. Other shapes need no such guard.

## Eligibility hardening

A retypable shape that already carries an **unprefixed `d`** is refused at the gate — re-type appends a `d`, and a pre-authored one would collide into an invalid double-`d` `<path>`. A single guard keyed off `RETYPABLE_GEOMETRY_ATTRS` now covers all six retypable tags uniformly (previously only `rect`/`circle`/`ellipse` were guarded; the vertex tags were not — surfaced by code review). The guard is precise to unprefixed `d`, so a foreign `foo:d` survives verbatim and does not disqualify.

## Tests

- New core suites: `promote-to-path.test.ts`, `vector-edit-promote.test.ts`; extended `is-vector-edit-target.test.ts` and `vector-edit-vertex-chain.test.ts`.
- Manual TC `TC-SVGEDITOR-VECTOR-001` for the mounted-editor UX (overlay tracking, live re-render, enter-then-escape byte-equality).
- WG design note: `docs/wg/feat-svg-editor/promote-to-path.md`.

**Verification:** `pnpm test --filter=@grida/svg-editor` → 1041 passed (71 files); typecheck clean; oxfmt/oxlint clean.

## Reviewer notes

- `is_vector_edit_target` return union widened with the new kinds — every consumer branch handles them.
- `session.source` is now a getter that flips at most once (primitive→path) on re-type; the reconciler is gated on `!active_preview`, and the commit phase advances `last_seen_d` before `active_preview` clears, so no spurious sub-selection clears mid-gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector editing now supports primitives (rect, circle, ellipse, line, polyline, polygon) with native write-back when edits remain expressible.
  * Primitive shapes are lazily promoted to paths on the first geometry-committing edit; promotion is reversible via undo and restores the original serialization.

* **Behavior / Fixes**
  * Circles/ellipses convert to stable cubic‑Bezier representations; lines preserve visual fill (adds/removes explicit none only when needed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->