### PR TITLE
chore(desktop): bump version to 0.0.3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],


### PR DESCRIPTION
## What

Bumps the Grida Desktop app version `0.0.2` → `0.0.3`.

## Why

[PR #770](https://github.com/gridaco/grida/pull/770) ("feat: Grida Desktop V1 + @grida/agent system") shipped a large desktop feature set but **did not include a version bump** — `desktop/package.json` stayed at `0.0.2` (the latest published release).

The release workflow [`realease-desktop-app.yml`](.github/workflows/realease-desktop-app.yml) derives the release tag from `desktop/package.json`:

```sh
VERSION=$(node -p "require('./desktop/package.json').version")
TAG="v${VERSION}"
```

So a bump is required before we can cut a new desktop release. Without it, re-running the publish workflow would collide with the existing `v0.0.2` tag/release.

## Changes

- `desktop/package.json`: `version` `0.0.2` → `0.0.3`

## Release

After merge, dispatch the **Publish Desktop App** workflow to build and publish `v0.0.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->