### PR TITLE
fix(desktop): skip dev icon branding when electron/dist is absent

### DIFF
--- a/desktop/scripts/prepare-dev-electron-branding.mjs
+++ b/desktop/scripts/prepare-dev-electron-branding.mjs
@@ -25,7 +25,13 @@ const isInsiders = process.argv.includes("--insiders");
 // See:
 // https://www.electronjs.org/docs/latest/tutorial/application-distribution#rebranding-with-downloaded-binaries
 // https://www.electronjs.org/docs/latest/api/dock#dockseticonimage-macos
-if (process.platform !== "darwin") {
+// Nothing to brand or restore without a local Electron bundle. Electron 42+
+// no longer auto-downloads it on install (the pre-42 `postinstall` hook is
+// gone), and electron-forge packages from the @electron/get cache — not
+// node_modules/electron/dist — so on a clean checkout (e.g. CI) there is no
+// branding to apply and none that could leak. Skip instead of crashing on a
+// missing source.
+if (process.platform !== "darwin" || !fs.existsSync(appBundle)) {
   process.exit(0);
 }
 


### PR DESCRIPTION
## What

The macOS **Publish Desktop App** job crashes before electron-forge runs, in the dev icon-branding prelude:

```
Error: ENOENT: no such file or directory, copyfile
  '…/desktop/node_modules/electron/dist/Electron.app/Contents/Info.plist'
  -> '…/desktop/.electron/electron-dist-backup/Info.plist'
  at prepare-dev-electron-branding.mjs:34
```

([failing run](https://github.com/gridaco/grida/actions/runs/26961321925/job/79552132065) — Windows/Linux pass, only macOS fails.)

This extends the script's early-exit to also skip when `node_modules/electron/dist/Electron.app` is absent.

## Why (etiology)

`prepare-dev-electron-branding.mjs` (added in #770) assumed `node_modules/electron/dist` is always populated after install. That guarantee disappeared when we bumped **electron 41 → 42** (`6fb4b429a`): electron 42 dropped the `postinstall` hook that older versions used to auto-download the binary into `dist/` (it's now an opt-in `install-electron` bin).

- electron 41: `scripts.postinstall = "node install.js"`
- electron 42: no scripts; `bin: { electron, install-electron }`

So on a clean checkout (CI) `dist/` is never created. `electron-forge publish` itself is unaffected — it pulls electron from the `@electron/get` cache, **not** `node_modules/electron/dist` — so the packaged DMG is fine; only the branding script, which reads that directory directly, breaks. Windows/Linux escaped because the script early-returns on non-darwin. Local dev masked it via a stale, pre-existing `dist/`.

## The fix

```js
if (process.platform !== "darwin" || !fs.existsSync(appBundle)) {
  process.exit(0);
}
```

With no Electron bundle there is nothing to brand or restore, so skipping is semantically correct — not a symptom mask. The non-insiders **restore/containment guard** (which wipes any stray dev `--insiders` branding before `make`/`package`/`publish`) stays fully intact for the only case where it matters: a bundle that actually exists and could carry leftover branding.

## Verification

- **Bundle present** (local) → exit 0, restore path runs as before — unchanged.
- **Bundle absent** (the exact CI condition) → exit 0, silent no-op — previously the ENOENT crash.
- Test bundle restored cleanly afterward.

## Reviewer notes

- Known, acceptable limitation: running `dev:insiders` on a fresh clone before `dist/` exists will no-op the icon on that first run (forge downloads electron, icon applies next invocation) — best-effort dev nicety degrading gracefully, never a crash and never a leak.
- No new install step is added on purpose: forcing `install-electron` on every install would re-download `dist/` even though packaging ignores it, working against keeping the dev-only branding contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes during desktop application builds in environments where the Electron bundle is unavailable (e.g., clean setups or continuous integration systems).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->