### PR TITLE
fix(desktop): hard-fail builds that externalize @grida/* workspace packages

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -56,6 +56,25 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build linked workspace packages
+        # The isolated ./desktop pnpm project `link:`s several @grida/*
+        # workspace packages whose dist/ is gitignored and is therefore
+        # absent on a clean checkout. The desktop Vite build resolves and
+        # bundles them from source-built dist/ — without this they can't be
+        # resolved and (per desktop/vite.guards.ts, GRIDA-DESKTOP-BUILD-GUARD)
+        # the build now hard-fails instead of shipping a binary that crashes
+        # on launch. Build the closure from the repo root so the link:
+        # targets have dist/ before packaging. --ignore-scripts skips native
+        # postinstalls we don't need (these are pure tsdown packages, no wasm).
+        working-directory: ${{ github.workspace }}
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm turbo run build \
+            --filter=@grida/desktop-bridge \
+            --filter=@grida/agent \
+            --filter=@grida/ai-models \
+            --filter=@grida/home
+
       - name: Import Apple signing certificate
         if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' }}
         uses: apple-actions/import-codesign-certs@v2

--- a/desktop/vite.agent-sidecar.config.ts
+++ b/desktop/vite.agent-sidecar.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { builtinModules } from "module";
+import { gridaBundleGuard } from "./vite.guards";
 
 // Agent sidecar, built as a third Forge/Vite entry alongside the
 // Electron main process and preload. Runs in Electron-as-Node
@@ -35,6 +36,9 @@ export default defineConfig({
       ],
     },
   },
+  // GRIDA-DESKTOP-BUILD-GUARD — fail the build if a @grida/* workspace
+  // package is left external instead of bundled. See desktop/vite.guards.ts.
+  plugins: [gridaBundleGuard()],
   define: {
     EDITOR_BASE_URL: JSON.stringify(
       process.env.EDITOR_BASE_URL ?? "https://grida.co"

--- a/desktop/vite.guards.test.ts
+++ b/desktop/vite.guards.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { externalizedWorkspaceImports } from "./vite.guards";
+
+// GRIDA-DESKTOP-BUILD-GUARD — see desktop/vite.guards.ts.
+// A bundle that leaves a @grida/* workspace package external will crash
+// on launch with "Cannot find module". Lock that detection.
+describe("externalizedWorkspaceImports", () => {
+  it("flags an unbuilt @grida/* link dep (the 0.0.3 crash)", () => {
+    expect(
+      externalizedWorkspaceImports([
+        "node:fs",
+        "electron",
+        "@anthropic-ai/sandbox-runtime",
+        "@grida/desktop-bridge",
+      ])
+    ).toEqual(["@grida/desktop-bridge"]);
+  });
+
+  it("ignores internal chunks, builtins, and intentional npm externals", () => {
+    expect(
+      externalizedWorkspaceImports([
+        "main.js",
+        "chunk-abc.js",
+        "fs",
+        "node:path",
+        "electron",
+        "hono",
+        "hono/jsx",
+        "undici",
+      ])
+    ).toEqual([]);
+  });
+
+  it("dedupes repeated offenders", () => {
+    expect(
+      externalizedWorkspaceImports(["@grida/agent", "@grida/agent"])
+    ).toEqual(["@grida/agent"]);
+  });
+});

--- a/desktop/vite.guards.ts
+++ b/desktop/vite.guards.ts
@@ -1,0 +1,78 @@
+import type { Plugin } from "vite";
+
+/**
+ * GRIDA-DESKTOP-BUILD-GUARD — fail the build if a workspace package is
+ * left external instead of bundled.
+ *
+ * Incident (desktop 0.0.3): the released `main.js` contained a bare
+ * `require("@grida/desktop-bridge")` that resolved to nothing at runtime,
+ * so the app crashed on launch with "Cannot find module".
+ *
+ * The desktop `link:`s `@grida/*` workspace packages whose `dist/` is
+ * gitignored. If those aren't built (the isolated ./desktop release CI
+ * never built them), Rollup can't resolve the import and silently
+ * downgrades it to an external `require(...)`. This is uniquely dangerous
+ * because EVERY check stays green — the symlink resolves, types exist,
+ * and local dev has `dist/` built — so it only breaks in a clean
+ * packaging run. `@grida/*` packages are always meant to be bundled;
+ * finding one external means the bundle is broken.
+ *
+ * Why a PLUGIN that exits, not `onwarn`/`this.error`: Rollup does emit
+ * `UNRESOLVED_IMPORT`, but forge runs the Vite build with
+ * logLevel:"silent", which swallows both the warning and Rollup's own
+ * errors (a throw in `onwarn` is ignored; `this.error` only surfaces as a
+ * cryptic downstream "main entry point not found"). So we inspect the
+ * EMITTED bundle and, on an offender, print to stderr directly and exit
+ * hard. All verified against `pnpm package`.
+ *
+ * Wire it into every desktop Vite entry (main, preload, agent-sidecar).
+ */
+
+const WORKSPACE_SCOPE = "@grida/";
+
+/** Workspace imports the bundle left external — i.e. unbuilt link deps. */
+export function externalizedWorkspaceImports(
+  imports: Iterable<string>
+): string[] {
+  const offenders = new Set<string>();
+  for (const id of imports) {
+    // Internal emitted chunks and node/npm externals never carry the
+    // workspace scope, so this prefix is the whole test.
+    if (id.startsWith(WORKSPACE_SCOPE)) offenders.add(id);
+  }
+  return [...offenders];
+}
+
+export function gridaBundleGuard(): Plugin {
+  return {
+    name: "grida-desktop-build-guard",
+    // Production packaging only. In dev (`electron-forge start`,
+    // command:"serve") packages may be mid-build under `pnpm dev:packages`,
+    // and exiting on a transient unresolved import would kill the dev
+    // server. Packaging (package/make/publish) is command:"build".
+    apply: "build",
+    generateBundle(_options, bundle) {
+      const imports = new Set<string>();
+      for (const file of Object.values(bundle)) {
+        if (file.type !== "chunk") continue;
+        for (const id of [...file.imports, ...file.dynamicImports]) {
+          imports.add(id);
+        }
+      }
+      const offenders = externalizedWorkspaceImports(imports);
+      if (offenders.length === 0) return;
+
+      const list = offenders.map((o) => `  - ${o}`).join("\n");
+      console.error(
+        `\nGRIDA-DESKTOP-BUILD-GUARD: refusing to ship a broken bundle.\n` +
+          `These ${WORKSPACE_SCOPE}* workspace packages were left external ` +
+          `instead of bundled, so the binary will crash on launch with ` +
+          `"Cannot find module":\n${list}\n` +
+          `Their dist/ is gitignored — build them before packaging:\n` +
+          `  pnpm build:packages   # from the repo root\n` +
+          `See desktop/vite.guards.ts for the full rationale.\n`
+      );
+      process.exit(1);
+    },
+  };
+}

--- a/desktop/vite.main.config.ts
+++ b/desktop/vite.main.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import { builtinModules } from "module";
+import { gridaBundleGuard } from "./vite.guards";
 
 // https://vitejs.dev/config
 //
@@ -14,6 +15,9 @@ export default defineConfig({
       external: [...builtinModules, "@anthropic-ai/sandbox-runtime"],
     },
   },
+  // GRIDA-DESKTOP-BUILD-GUARD — fail the build if a @grida/* workspace
+  // package is left external instead of bundled. See desktop/vite.guards.ts.
+  plugins: [gridaBundleGuard()],
   define: {
     INSIDERS: process.env.INSIDERS === "1" ? 1 : 0,
   },

--- a/desktop/vite.preload.config.ts
+++ b/desktop/vite.preload.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig } from "vite";
+import { gridaBundleGuard } from "./vite.guards";
 
 // https://vitejs.dev/config
-export default defineConfig({});
+//
+// Preload value-imports `@grida/agent`, so it carries the same
+// silent-broken-bundle risk as the main process.
+export default defineConfig({
+  // GRIDA-DESKTOP-BUILD-GUARD — fail the build if a @grida/* workspace
+  // package is left external instead of bundled. See desktop/vite.guards.ts.
+  plugins: [gridaBundleGuard()],
+});


### PR DESCRIPTION
## What

Desktop **0.0.3** shipped a `main.js` containing a bare `require("@grida/desktop-bridge")` that resolved to nothing at runtime — the app crashed on launch with `Cannot find module '@grida/desktop-bridge'`, **while every CI check was green**.

This adds a build-time guard that makes that class of failure a hard, visible error, plus the CI step that fixes the happy path.

## Why it happened (etiology)

The desktop `link:`s several `@grida/*` workspace packages whose `dist/` is **gitignored**. The isolated `./desktop` release CI runs `pnpm install` (which only *symlinks* link deps) and **never builds them**. So at package time Rollup couldn't resolve the import and **silently downgraded it to an external `require`**, and electron-forge runs the Vite build with `logLevel:"silent"` so even the `UNRESOLVED_IMPORT` warning vanished.

It's uniquely dangerous because every gate stays green: the symlink resolves, types exist, and local dev has `dist/` built — so it only breaks in a clean packaging run.

## The fix (two parts)

1. **CI builds the link-dep closure before packaging** (`realease-desktop-app.yml`) — `@grida/desktop-bridge`, `@grida/agent`, `@grida/ai-models`, `@grida/home` — so the green path actually produces a working binary.
2. **A Vite plugin guard** (`desktop/vite.guards.ts`), wired into all three entries (main, preload, agent-sidecar). It inspects the **emitted bundle** and, if any `@grida/*` import was left external, prints to stderr and `process.exit(1)`.

### Why a plugin-that-exits, not `onwarn`

`onwarn` was the obvious first attempt — and it's a trap. Verified against the real packager: Rollup *does* emit `UNRESOLVED_IMPORT` and forge *does* forward it to a user `onwarn`, but a throw inside `onwarn` is **swallowed** and the build still succeeds. Even `this.error()` only surfaces as a cryptic downstream *"main entry point not found"* because forge's logger is silent. Inspecting the emitted bundle + `process.exit(1)` is the only reliable, visible hard-fail. Scoped `apply:"build"` so dev (`electron-forge start`) is unaffected.

## Verification

- **Original crash reproduced locally** on the pre-fix tree (hide `dist/`, build, load `main.js` via electron-as-node → `MODULE_NOT_FOUND` through the same `electron node_init → _load → _resolveFilename` path as the report).
- **Guard hard-fails** in the real `pnpm package` with `dist/` missing — exit 1, clear message, offender named, actionable `pnpm build:packages` fix.
- **No false positive** with `dist/` present — packages cleanly, bridge inlined; intentional externals (`sandbox-runtime`, `hono`, `undici`) untouched.
- Unit tests, `tsc`, oxlint all green.

## Reviewer notes

- ⚠️ **0.0.3 is published broken** — this needs a follow-up **0.0.4** (or re-cut) once merged; current installs keep crashing.
- A **post-package boot smoke test** (launch the packaged binary, assert it survives module init) is the deeper net beyond this guard — recommended follow-up, intentionally **not** included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the desktop build pipeline with additional dependency preparation and validation steps
  * Added build-time safety mechanisms to verify workspace package bundling and prevent runtime issues
  * Improved the overall build workflow reliability

* **Tests**
  * Added new validation tests for build configuration and dependency bundling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->