### PR TITLE
fix(svg-editor): nested-viewport translate fidelity, browser tests, and serialize_node (#775)

### DIFF
--- a/docs/wg/feat-svg-editor/durable-node-identity.md
+++ b/docs/wg/feat-svg-editor/durable-node-identity.md
@@ -1,0 +1,158 @@
+---
+title: "Durable node identity — referencing a node across reloads and rewrites"
+description: "RFD for the open problem behind #775: NodeId is parse-ephemeral, so there is no reference that survives a load() — let alone an external rewrite of the file. Frames the gap, scopes the candidate identity contracts (positional path, id attribute, semantic anchor), and sets the promotion gate before any public API lands."
+keywords:
+  - svg
+  - svg-editor
+  - identity
+  - node-id
+  - reference
+  - round-trip
+tags:
+  - internal
+  - svg
+  - wg
+format: md
+---
+
+# Durable node identity
+
+**Status:** Open — problem framing, no committed design.
+**Originating request:** [gridaco/grida#775](https://github.com/gridaco/grida/issues/775).
+
+This RFD owns the reference half of #775. The serialization half
+(`serialize_node`) shipped; see the package README. The positional
+`node_path` / `node_at_path` proposal in #775 is **superseded by this
+document** — see [Why the obvious answer is insufficient](#why-the-obvious-answer-is-insufficient).
+
+## The gap
+
+The editor identifies a node with a `NodeId`. That id is a random
+per-parse string, minted when the document is parsed and discarded on the
+next parse. It has two properties that matter here:
+
+1. It **never appears in serialized output.** It is an in-memory handle,
+   not a document fact.
+2. It **regenerates on every parse.** `load()` the same bytes twice and
+   the same logical element carries two different ids.
+
+So there is no answer today to: _"the user selected this element; give me
+a reference I can store, persist, or hand to another process, and later
+resolve back to the same element."_ The `NodeId` cannot do it — it is gone
+the moment the document is reloaded.
+
+The need is real. The motivating scenario in #775: embed the editor as a
+function over SVG, let the user select an element, and hand a downstream
+process — concretely an AI coding agent — _that element_ for further work.
+A `NodeId` is useless across that boundary: the agent sees SVG text, not
+the editor's in-memory handles, and any reload re-mints the ids.
+
+## What "durable" has to mean — two distinct contracts
+
+"Survives a reload" hides two very different requirements. They must not be
+conflated, because a mechanism that satisfies one can fail the other
+completely.
+
+- **C1 — survives a deterministic re-parse.** The same (or
+  whitespace/comment-only-different) bytes are parsed again. The reference
+  must resolve to the same logical element. Use case: app restart, reload
+  of an unchanged file on disk, undo/redo across a `load()`.
+- **C2 — survives a structural rewrite.** A _different agent_ — a human in
+  another tool, or an AI pass — edits the file: inserts, removes, reorders,
+  re-types elements, then the editor reloads the result. The reference must
+  still resolve to "the same element the user meant."
+
+C2 is the one #775's motivating scenario actually needs (the whole point is
+to let the agent _edit_), and it is strictly harder. A reference scheme can
+ace C1 and be worthless for C2.
+
+## Candidate contracts, with honest scope
+
+### Positional child-index path
+
+Address a node by the chain of child indices from the root: "first element
+child of root, then its third element child." Resolution walks the chain.
+
+- **C1: yes.** Parsing is deterministic, so the index chain is stable
+  across re-parse of the same bytes. Element-only indices (ignoring
+  text/comment nodes) additionally tolerate whitespace/comment churn.
+- **C2: no.** Any insert, remove, or reorder before the target shifts its
+  index. The reference silently resolves to a _different_ element, or to
+  none. Exactly the edits an editing agent performs are the edits that
+  break it — so under C2 it is not merely weak, it is _misleading_: it
+  resolves successfully to the wrong node.
+
+#### Why the obvious answer is insufficient
+
+This is the `node_path` / `node_at_path` shape proposed in #775. It is
+cheap and it is derivable today from the editor's public `tree()` snapshot
+(walk parents for the path; descend children to resolve) in a few lines —
+which is itself a reason not to mint it as a public contract prematurely
+(no second consumer has shaped it). But the deeper objection is the C1/C2
+gap above: shipping it under a "survives a reload" headline would advertise
+durability it does not have for the scenario that asked for it. If a
+positional path is ever exposed, its contract must say **C1 only**, in
+those words.
+
+### The `id` attribute
+
+SVG already has a serialized, author-facing identity mechanism: `id=""`.
+The editor already reads it (display labels, `tree()` names).
+
+- **C1: yes.** It is a document fact; it round-trips.
+- **C2: mostly.** An agent that preserves ids keeps the reference valid
+  across structural edits — `id` is position-independent. It breaks only if
+  the agent renames or drops the id, which a cooperative agent need not do.
+- **The catch — sovereignty (P1).** Not every node has an `id`, so this
+  cannot be a _universal_ reference without the editor _minting_ ids. And
+  minting ids is exactly the proprietary-noise the package exists to refuse
+  — cf. the README's complaint about Illustrator stamping `SVGID_1_`. Any
+  design that leans on `id` must answer: who writes the id, when, with the
+  user's knowledge, and is an editor-authored id distinguishable from an
+  authored one. "Silently inject ids so we have a handle" is a P1
+  violation, not a design.
+
+### Semantic anchor / selector
+
+Address a node by a matchable description — a CSS/XPath-like selector, or a
+structural fingerprint (tag + key attributes + neighborhood).
+
+- **C1: yes. C2: best of the three** — a selector keyed on stable authored
+  attributes tolerates reordering and unrelated inserts.
+- **Cost.** Needs a matching engine, a disambiguation rule when more than
+  one node matches, and a defined failure mode when zero match. This is the
+  most capable and the most expensive option, and it has the largest design
+  surface to get wrong.
+
+## Non-goals / boundaries
+
+- **Not a private id baked into the file.** Writing an editor-namespaced
+  attribute (`grida:nodeid`) onto every element to carry identity is the
+  proprietary-noise anti-goal in another costume. Rejected up front; if
+  identity must be carried _in_ the file, it rides the author's own `id`,
+  on the author's terms.
+- **Not a sync/CRDT identity.** This is single-document reference
+  resolution, not multiplayer node identity. "Not a Figma-style multiplayer
+  canvas" still holds.
+
+## Open questions
+
+1. Is C1 alone worth a public API, or does exposing a C1-only reference
+   just invite the C2 misuse it can't support?
+2. For `id`-based identity: what is the honest UX for "this element needs a
+   stable handle but has no id" — refuse, prompt, or an explicit
+   user-invoked "assign id" command (never silent)?
+3. Does the downstream consumer (the agent embedding) actually need
+   _editor_-resolvable identity, or does it need a _document_-level anchor
+   it resolves itself (in which case the editor's job is only to _report_ a
+   good anchor for a selection, not to resolve one back)?
+
+## Promotion gate
+
+No public reference API lands until **≥2 internal consumers** have shaped
+the contract (the package's P6 / promotion rule). The agent-embedding in
+#775 is the first. A second — a persistence layer that stores selections,
+or a layers panel that pins a node across reloads — must exist and exert
+pressure on the shape before it escapes the package. Until then the
+capability stays a documented recipe over `tree()` (for the C1 case) and
+this RFD (for the rest).

--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -65,6 +65,13 @@ preserving the author's source on round-trip.
   (byte-equal until the first re-typing edit), a single `<path>` target,
   and a cubic-Bézier conic representation, with the round-trip invariants
   that keep the conversion honest.
+- [`durable-node-identity.md`](./durable-node-identity.md) — the open
+  problem behind #775: `NodeId` is parse-ephemeral, so no reference
+  survives a `load()`, let alone an external rewrite of the file. Frames
+  the two distinct contracts (survives a re-parse vs. survives a
+  structural rewrite) and scopes the candidate identity schemes
+  (positional path, `id` attribute, semantic anchor) against them. The
+  `serialize_node` half of #775 shipped; this owns the reference half.
 
 ### Glossary
 

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/README.md
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/README.md
@@ -96,9 +96,10 @@ constraint. It grows along two tracks:
 
 **Track 1 — more fixtures + cards, as the package ships features.** Shipped
 fixtures (`_fixtures.ts`): every primitive shape, path (vector edit), line (the
-2-point exception), text + tspan, groups + transform, symbol + use (shared
-instances), and a CSS-cascade harness (fill _and_ geometry via a document
-`<style>` block). The backlog, roughly in package-maturity order:
+2-point exception), text + tspan, groups + transform, nested `<svg>` (a viewport
+within a viewport — preserved/rendered, geometry editing out of scope for v1),
+symbol + use (shared instances), and a CSS-cascade harness (fill _and_ geometry
+via a document `<style>` block). The backlog, roughly in package-maturity order:
 
 - Clean round-trip / minimal-diff (live `serialize()` next to the canvas — the
   package's headline guarantee; this is the highest-value card to add next).

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
@@ -11,6 +11,7 @@ import {
   CSS,
   GROUP_TRANSFORM,
   LINE,
+  NESTED_SVG,
   PATH,
   SHAPES,
   SYMBOL_USE,
@@ -110,6 +111,21 @@ export function GroupTransformExample() {
       svg={GROUP_TRANSFORM}
       tool={{ type: "cursor" }}
       selectName="card"
+    />
+  );
+}
+
+/**
+ * Nested <svg>. A node *inside* the inner viewport is pre-selected, so the card
+ * lands on exactly the open case: chrome must cross the nested-viewport boundary
+ * (`getCTM` stops at the nearest viewport today).
+ */
+export function NestedSvgExample() {
+  return (
+    <SvgStage
+      svg={NESTED_SVG}
+      tool={{ type: "cursor" }}
+      selectName="inner-dot"
     />
   );
 }

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
@@ -133,6 +133,31 @@ export const GROUP_TRANSFORM = `<svg xmlns="http://www.w3.org/2000/svg" viewBox=
   </g>
 </svg>`;
 
+// ─── Nested <svg> — a viewport within a viewport ─────────────────────────────
+// An inner <svg> with its own `x`/`y` origin and its own `viewBox` establishes
+// an independent user-space coordinate system (SVG 2 §7.2). The editor parses,
+// preserves, and renders it — but clean *geometry editing* across the nested
+// viewport boundary is out of scope for v1: `getCTM` stops at the nearest
+// viewport, so the selection chrome for a node inside the inner <svg> is the
+// open question this fixture is a harness for. See
+// `packages/grida-svg-editor/docs/geometry.md` and the nested-svg notes in
+// `src/dom.ts`. Here the inner viewport maps its own 0…120 user space into the
+// 240×170 region placed at (244, 70).
+export const NESTED_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 300" width="520" height="300">
+  <rect id="frame" x="0" y="0" width="520" height="300" fill="#f8fafc"/>
+  <text id="outer-label" x="24" y="34" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#334155">outer viewport · user space 0…520</text>
+
+  <circle id="outer-dot" cx="78" cy="150" r="28" fill="#6366f1"/>
+  <rect id="outer-box" x="44" y="214" width="132" height="50" rx="8" fill="#22c55e"/>
+
+  <svg id="inner" x="244" y="70" width="240" height="170" viewBox="0 0 120 85">
+    <rect x="0" y="0" width="120" height="85" fill="#ffffff" stroke="#94a3b8"/>
+    <text x="6" y="13" font-family="ui-sans-serif, system-ui, sans-serif" font-size="7.5" fill="#64748b">inner viewport · own 0…120</text>
+    <circle id="inner-dot" cx="34" cy="48" r="22" fill="#f59e0b"/>
+    <rect id="inner-box" x="64" y="24" width="44" height="48" rx="6" fill="#ec4899"/>
+  </svg>
+</svg>`;
+
 // ─── Symbol & use — one source, many instances ───────────────────────────────
 // A <symbol> defines the geometry once; each <use> instantiates it. The `color`
 // attribute on each instance flows into `fill="currentColor"` inside the symbol,

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
@@ -267,7 +267,7 @@ export default function SvgEditorPackagePage() {
                     viewport is pre-selected.
                   </>
                 }
-                caption="Nested-svg geometry editing is out of scope for v1: getCTM stops at the nearest viewport, so chrome for a node across the inner-viewport boundary is the open question. See packages/grida-svg-editor/docs/geometry.md and the nested-svg notes in src/dom.ts."
+                caption="Translating a node inside an inner viewport now projects the delta into that viewport's frame, so it moves correctly. Still open: getCTM stops at the nearest viewport, so HUD chrome for a node spanning the inner-viewport boundary is unresolved. See packages/grida-svg-editor/docs/geometry.md and the nested-svg notes in src/dom.ts."
               >
                 <NestedSvgExample />
               </SpecCard>

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
@@ -4,6 +4,7 @@ import {
   CssExample,
   GroupTransformExample,
   LineExample,
+  NestedSvgExample,
   PathExample,
   ShapesExample,
   SymbolUseExample,
@@ -41,6 +42,7 @@ const SECTIONS: { id: string; label: string }[] = [
   { id: "line", label: "Line" },
   { id: "text", label: "Text & tspan" },
   { id: "groups", label: "Groups & transform" },
+  { id: "nested-svg", label: "Nested <svg>" },
   { id: "symbol-use", label: "Symbol & use" },
   { id: "css", label: "CSS cascade" },
 ];
@@ -250,6 +252,24 @@ export default function SvgEditorPackagePage() {
                 caption="Profiles intersect with structure here: 'no structural edits' would keep selection + transform but disable group / ungroup / reorder."
               >
                 <GroupTransformExample />
+              </SpecCard>
+
+              <SpecCard
+                id="nested-svg"
+                title="Nested <svg> — a viewport within a viewport"
+                description={
+                  <>
+                    An inner <code>&lt;svg&gt;</code> with its own{" "}
+                    <code>x</code>/<code>y</code> origin and its own{" "}
+                    <code>viewBox</code> establishes an independent user-space
+                    coordinate system (SVG 2 §7.2). The editor parses,
+                    preserves, and renders it; a node <em>inside</em> the inner
+                    viewport is pre-selected.
+                  </>
+                }
+                caption="Nested-svg geometry editing is out of scope for v1: getCTM stops at the nearest viewport, so chrome for a node across the inner-viewport boundary is the open question. See packages/grida-svg-editor/docs/geometry.md and the nested-svg notes in src/dom.ts."
+              >
+                <NestedSvgExample />
               </SpecCard>
 
               <SpecCard

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -249,8 +249,31 @@ editor.dispose(): void; // permanent teardown
 ```ts
 editor.load(svg: string): void; // replace the document (e.g. file-on-disk changed)
 editor.serialize(): string; // emit clean SVG — guaranteed round-trip per P1
+editor.serialize_node(id: NodeId): string; // emit ONE element's subtree — a fragment, see below
 editor.reset(): void; // back to last load() input, clears history
 ```
+
+`serialize_node(id)` exports the markup of a single element — the bridge from
+"what the user selected" (a `NodeId`) to "the SVG for that element," e.g. to
+hand a downstream consumer (an AI agent) the selected subtree without
+re-serializing the whole document. It reuses `serialize()`'s trivia-preserving
+rules (attribute order, quotes, whitespace, comments — emitted as authored).
+
+It is deliberately **weaker** than `serialize()`, and the two must not be
+conflated: `serialize()` emits the whole document and carries the P1
+round-trip guarantee; `serialize_node()` emits a **fragment** and does not.
+Namespace declarations that live on an ancestor (`xmlns:xlink` and friends,
+normally on the root `<svg>`) are **not** inlined into the fragment — a node
+using `xlink:href` serializes without `xmlns:xlink`. The fragment is the
+element's markup as authored, not a standalone parseable document. Throws on
+an unknown id or a non-element node (selections are always elements).
+
+> A stable reference to a node that survives a `load()` — and survives an
+> external rewrite of the file — is a separate, unsolved problem (`NodeId`
+> regenerates on each parse). Positional child-index paths address only the
+> deterministic-re-parse case, not structural edits; durable node identity is
+> under design — see
+> [durable node identity](https://grida.co/docs/wg/feat-svg-editor/durable-node-identity).
 
 ### Observation — state
 

--- a/packages/grida-svg-editor/__tests__/_browser-helpers.ts
+++ b/packages/grida-svg-editor/__tests__/_browser-helpers.ts
@@ -195,8 +195,12 @@ export function committedWorldRect(editor: SvgEditor, id: string): WorldRect {
   if (!svg.getAttribute("height")) svg.setAttribute("height", "650");
   document.body.appendChild(svg);
   try {
-    const el = svg.querySelector<SVGGraphicsElement>(`[id="${id}"]`);
-    if (!el) throw new Error(`no element with id="${id}" in serialized svg`);
+    // `getElementById` over a selector: ids with CSS metacharacters would
+    // break an interpolated `[id="..."]` selector.
+    const el = svg.getElementById(id);
+    if (!(el instanceof SVGGraphicsElement)) {
+      throw new Error(`no element with id="${id}" in serialized svg`);
+    }
     return worldRectOf(el);
   } finally {
     svg.remove();

--- a/packages/grida-svg-editor/__tests__/_browser-helpers.ts
+++ b/packages/grida-svg-editor/__tests__/_browser-helpers.ts
@@ -1,0 +1,204 @@
+// Shared helpers for `*.browser.test.ts` (Vitest browser mode / real DOM).
+//
+// The premise: these tests run in a real headless Chromium, so `getBBox` and
+// `getCTM` reflect the actual SVG layout engine — including ancestor `<g>`
+// transforms and text flow that jsdom cannot model. We assert on **computed
+// geometry values**, not pixels.
+//
+// Not named `*.test.ts` so Vitest does not collect it as a suite.
+
+import { createSvgEditor, type SvgEditor } from "../src";
+import { attach_dom_surface, type DomSurfaceHandle } from "../src/dom";
+
+/** Attribute selector for the DOM element the surface renders for a node. */
+const GRIDA_ID_ATTR = "data-grida-id";
+
+/** A live, attached DOM surface with helpers to inspect the rendered tree. */
+export type AttachedSurface = {
+  editor: SvgEditor;
+  handle: DomSurfaceHandle;
+  container: HTMLElement;
+  /** The rendered SVG element for a node, resolved by its authored SVG id. */
+  elementByName: (name: string) => SVGGraphicsElement;
+  /** World rect of the rendered element for a node (live, via getCTM). */
+  worldRectByName: (name: string) => WorldRect;
+  dispose: () => void;
+};
+
+/**
+ * Create an editor and attach a real DOM surface, mounted at the document
+ * origin so world coords map 1:1 to client px (identity camera, no auto-fit).
+ * This is the gesture path's real entry point: the surface installs pointer
+ * handlers, so {@link dragByClient} drives the actual translate/snap pipeline.
+ */
+export function attachSurface(svgText: string): AttachedSurface {
+  const container = document.createElement("div");
+  // Pin to the top-left of the viewport with a concrete size so client
+  // coordinates equal world coordinates under the identity camera.
+  Object.assign(container.style, {
+    position: "fixed",
+    left: "0px",
+    top: "0px",
+    width: "900px",
+    height: "650px",
+    margin: "0",
+    padding: "0",
+    background: "#fff",
+  });
+  document.body.appendChild(container);
+
+  const editor = createSvgEditor({ svg: svgText });
+  const handle = attach_dom_surface(editor, {
+    container,
+    gestures: true,
+    fit: false,
+  });
+
+  const elementByName = (name: string): SVGGraphicsElement => {
+    const id = nodeIdByName(editor, name);
+    const el = container.querySelector<SVGGraphicsElement>(
+      `[${GRIDA_ID_ATTR}="${id}"]`
+    );
+    if (!el)
+      throw new Error(`no rendered element for node "${name}" (id=${id})`);
+    return el;
+  };
+
+  return {
+    editor,
+    handle,
+    container,
+    elementByName,
+    worldRectByName: (name) => worldRectOf(elementByName(name)),
+    dispose: () => {
+      handle.detach();
+      container.remove();
+    },
+  };
+}
+
+/** Center of an element in client (page CSS-px) coordinates. */
+export function clientCenter(el: Element): { x: number; y: number } {
+  const r = el.getBoundingClientRect();
+  return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+}
+
+function pointer(
+  target: EventTarget,
+  type: string,
+  x: number,
+  y: number,
+  buttons: number
+): void {
+  const ev = new PointerEvent(type, {
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true,
+    button: type === "pointermove" ? -1 : 0,
+    buttons,
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  target.dispatchEvent(ev);
+}
+
+/**
+ * Drive a real pointer drag from one client point to another. pointerdown on
+ * the container, an intermediate move to clear the drag threshold, a move to
+ * the destination, then pointerup. This exercises the surface's actual gesture
+ * → translate → snap pipeline, not a shortcut API.
+ */
+export function dragByClient(
+  container: HTMLElement,
+  from: { x: number; y: number },
+  to: { x: number; y: number }
+): void {
+  const win = container.ownerDocument.defaultView!;
+  pointer(container, "pointerdown", from.x, from.y, 1);
+  // Two-step move so the HUD promotes "pending" → "translate" before the
+  // final positioning frame. The midpoint is always between from and to, so
+  // it never overshoots the target (a fixed step could, on a short drag).
+  pointer(win, "pointermove", (from.x + to.x) / 2, (from.y + to.y) / 2, 1);
+  pointer(win, "pointermove", to.x, to.y, 1);
+  pointer(win, "pointerup", to.x, to.y, 0);
+}
+
+/** World-space axis-aligned bounding box, in the root SVG's user units. */
+type WorldRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/**
+ * Resolve a node's internal id from the SVG `id` attribute it was authored
+ * with. The editor stores the SVG `id` as `node.name`; the DOM is keyed by
+ * the internal `node.id`.
+ */
+export function nodeIdByName(editor: SvgEditor, name: string): string {
+  const found = [...editor.tree().nodes.values()].find((n) => n.name === name);
+  if (!found) throw new Error(`no node named "${name}"`);
+  return found.id;
+}
+
+/**
+ * Project a local bbox through an element's CTM (local → nearest viewport),
+ * returning the world-space AABB. This is the ground-truth world rect — the
+ * same computation `SvgGeometryDriver.bounds_of` performs, and the value snap
+ * geometry *should* agree with. Deliberately an independent oracle: it does
+ * NOT call into the package, so it can't mask a bug in the code under test.
+ */
+function worldRectOf(el: SVGGraphicsElement): WorldRect {
+  const b = el.getBBox();
+  const ctm = el.getCTM();
+  if (!ctm) return { x: b.x, y: b.y, width: b.width, height: b.height };
+  const project = (px: number, py: number) => ({
+    x: ctm.a * px + ctm.c * py + ctm.e,
+    y: ctm.b * px + ctm.d * py + ctm.f,
+  });
+  const corners = [
+    project(b.x, b.y),
+    project(b.x + b.width, b.y),
+    project(b.x + b.width, b.y + b.height),
+    project(b.x, b.y + b.height),
+  ];
+  const xs = corners.map((c) => c.x);
+  const ys = corners.map((c) => c.y);
+  const left = Math.min(...xs);
+  const top = Math.min(...ys);
+  return {
+    x: left,
+    y: top,
+    width: Math.max(...xs) - left,
+    height: Math.max(...ys) - top,
+  };
+}
+
+/**
+ * World rect of the element with authored SVG `id`, read from the editor's
+ * CURRENT serialized model: serialize → mount in the real document → measure
+ * via getBBox+getCTM → unmount. Use this to assert a COMMITTED position
+ * without depending on the live surface's re-render timing.
+ */
+export function committedWorldRect(editor: SvgEditor, id: string): WorldRect {
+  const parsed = new DOMParser().parseFromString(
+    editor.serialize(),
+    "image/svg+xml"
+  ).documentElement;
+  const svg = document.importNode(parsed, true) as unknown as SVGSVGElement;
+  // A concrete pixel size so the viewport is established for getCTM.
+  if (!svg.getAttribute("width")) svg.setAttribute("width", "900");
+  if (!svg.getAttribute("height")) svg.setAttribute("height", "650");
+  document.body.appendChild(svg);
+  try {
+    const el = svg.querySelector<SVGGraphicsElement>(`[id="${id}"]`);
+    if (!el) throw new Error(`no element with id="${id}" in serialized svg`);
+    return worldRectOf(el);
+  } finally {
+    svg.remove();
+  }
+}

--- a/packages/grida-svg-editor/__tests__/group-child-snap.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/group-child-snap.browser.test.ts
@@ -1,0 +1,77 @@
+// Bug 1 — dragging an element INSIDE a translated `<g>` snapped in the
+// group's LOCAL frame instead of world space, so the child got spuriously
+// snapped to its own parent group (and the guide rendered near the wrong
+// place — at the group-local origin rather than where the child actually is).
+//
+// Why this needs a real browser: the snap input rects used to come from
+// `bbox_world`, which projects `getBBox()` through the element's OWN
+// `transform=` only and explicitly dropped ancestor `<g transform>`. The
+// CORRECT world rect comes from `getCTM()` (the geometry provider's
+// `bounds_of`), which folds ancestor transforms in. jsdom returns an identity
+// CTM, so the two are indistinguishable there — only a real SVG layout engine
+// exposes the gap.
+//
+// Mechanism of the bug: for a child at local (50,50) under g translate(100,50),
+// the world rect is (150,100). When dragged right by 146, the world left edge
+// lands at ~296 — far from every snap neighbor, so it must NOT snap. But the
+// old code measured the agent in the GROUP-LOCAL frame (left 50+146=196) while
+// the only in-scope neighbor — the parent `<g>` — was world-frame (150,100,
+// 80,80, center x=190). 196 lands ~6px from 190, so a SPURIOUS snap pulled the
+// child to world left ~290.
+//
+// The fix routes snap rects through the CTM-based geometry provider, so agent
+// and neighbors share the world frame. These tests assert the corrected
+// behavior; they failed before the fix.
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  attachSurface,
+  clientCenter,
+  committedWorldRect,
+  dragByClient,
+  type AttachedSurface,
+} from "./_browser-helpers";
+
+// child: local (50,50,80,80) under g translate(100,50) → world (150,100,80,80).
+const FIXTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="900" height="650" viewBox="0 0 900 650"><g id="grp" transform="translate(100,50)"><rect id="child" x="50" y="50" width="80" height="80" fill="#f33"/></g></svg>`;
+
+let surface: AttachedSurface | null = null;
+
+afterEach(() => {
+  surface?.dispose();
+  surface = null;
+  document.body.innerHTML = "";
+});
+
+/** Committed world rect of `child`, from the serialized model (so the
+ *  assertion does not depend on live re-render timing). */
+const committedChildWorldRect = (s: AttachedSurface) =>
+  committedWorldRect(s.editor, "child");
+
+describe("bug 1: snap for a child inside a translated group (real DOM)", () => {
+  it("sanity: the grouped child renders at its world position", () => {
+    surface = attachSurface(FIXTURE);
+    const r = surface.worldRectByName("child");
+    expect(r).toMatchObject({ x: 150, y: 100, width: 80, height: 80 });
+  });
+
+  it("a grouped child lands exactly where dragged — no spurious snap to its own group", () => {
+    surface = attachSurface(FIXTURE);
+    expect(committedChildWorldRect(surface).x).toBe(150);
+
+    // Drag right by 146 world px. World left edge → ~296, far from every snap
+    // neighbor (the parent group's edges are 150 / 190 / 230) → must not snap.
+    const center = clientCenter(surface.elementByName("child"));
+    dragByClient(surface.container, center, {
+      x: center.x + 146,
+      y: center.y,
+    });
+
+    const after = committedChildWorldRect(surface);
+    // CORRECT: lands at the raw dragged position (world left 296).
+    // BUG (pre-fix): the group-local agent (left 196) snapped to the parent
+    // group's world center (190) and committed to world left ~290.
+    expect(after.x).toBeCloseTo(296, 0);
+    expect(after.y).toBeCloseTo(100, 0);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/nested-svg-translate.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/nested-svg-translate.browser.test.ts
@@ -1,0 +1,66 @@
+// Bug 3 — a child INSIDE a nested `<svg>` viewport that scales its user
+// space gets translated by the WRONG amount: the pipeline writes the
+// world-space drag delta straight into the child's local `x`/`y`, but those
+// attributes live in the inner viewport's user space. When the inner
+// viewport scales (e.g. width=240 over viewBox 0…120 → 2×), the child moves
+// `scale ×` too far on screen — a +100px drag lands +200px ("2× accumulated").
+//
+// Why this needs a real browser: the bug is a coordinate-frame error between
+// world space and the inner viewport's user space. jsdom returns an identity
+// CTM, so world ≡ local there and the scale gap is invisible. Only a real SVG
+// layout engine exposes it via getBBox + getCTM.
+//
+// inner: x=100 y=50 width=240 height=170 viewBox="0 0 120 85" → 2× scale.
+// child: local (20,20,40,40) → world (100+20·2, 50+20·2, 40·2, 40·2)
+//        = (140, 90, 80, 80).
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  attachSurface,
+  clientCenter,
+  committedWorldRect,
+  dragByClient,
+  type AttachedSurface,
+} from "./_browser-helpers";
+
+const FIXTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="900" height="650" viewBox="0 0 900 650"><svg id="inner" x="100" y="50" width="240" height="170" viewBox="0 0 120 85"><rect id="child" x="20" y="20" width="40" height="40" fill="#f33"/></svg></svg>`;
+
+let surface: AttachedSurface | null = null;
+
+afterEach(() => {
+  surface?.dispose();
+  surface = null;
+  document.body.innerHTML = "";
+});
+
+const committedChildWorldRect = (s: AttachedSurface) =>
+  committedWorldRect(s.editor, "child");
+
+describe("bug 3: translate a child inside a scaled nested <svg> (real DOM)", () => {
+  it("sanity: the nested child renders at its world position", () => {
+    surface = attachSurface(FIXTURE);
+    const r = surface.worldRectByName("child");
+    expect(r).toMatchObject({ x: 140, y: 90, width: 80, height: 80 });
+  });
+
+  it("a +100px world drag moves the child +100px in world space — not 2×", () => {
+    surface = attachSurface(FIXTURE);
+    // Snap off: this asserts the translate-projection fix in isolation.
+    // World-space bounds for a NESTED `<svg>` element are a separate, known
+    // v1 limitation (`svg_viewport_bounds` reports the inner viewBox, not
+    // the projected world rect), so leaving snap on would let the child
+    // spuriously snap to the inner viewport's mis-framed edges. That bug is
+    // tracked independently of the doubling fix under test here.
+    surface.editor.set_style({ snap_enabled: false });
+    expect(committedChildWorldRect(surface).x).toBeCloseTo(140, 0);
+
+    const center = clientCenter(surface.elementByName("child"));
+    dragByClient(surface.container, center, { x: center.x + 100, y: center.y });
+
+    const after = committedChildWorldRect(surface);
+    // CORRECT: world left 140 → 240 (the drag distance, exactly).
+    // BUG: the world delta (100) is written to the local frame and re-scaled
+    // by 2×, landing the child at world left 340.
+    expect(after.x).toBeCloseTo(240, 0);
+    expect(after.y).toBeCloseTo(90, 0);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/serialize-node.test.ts
+++ b/packages/grida-svg-editor/__tests__/serialize-node.test.ts
@@ -1,0 +1,93 @@
+// Producer contract for `SvgDocument.serialize_node` — the selection→source
+// bridge accepted from #775.
+//
+// serialize_node emits ONE element's subtree as a fragment, reusing the
+// trivia-preserving serializer. It is deliberately weaker than `serialize()`
+// (sdk-design D3): a fragment is NOT a standalone round-trippable document.
+// These tests pin both the fidelity it DOES guarantee and the guarantee it
+// deliberately does NOT make (ancestor xmlns declarations are not inlined).
+//
+// Producer-only: no editor mounted, no consumer named.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import { createSvgEditor } from "../src/index";
+import { first_rect } from "./_helpers";
+
+function first_of_tag(doc: SvgDocument, tag: string): string {
+  for (const id of doc.all_elements()) {
+    if (doc.tag_of(id) === tag) return id;
+  }
+  throw new Error(`no <${tag}> in document`);
+}
+
+describe("SvgDocument.serialize_node", () => {
+  it("emits the node's subtree byte-for-byte as authored", () => {
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><g id="layer"><rect width="50" height="40" x="10" y="10" fill="red"/></g></svg>`;
+    const doc = new SvgDocument(src);
+    const g = first_of_tag(doc, "g");
+    expect(doc.serialize_node(g)).toBe(
+      `<g id="layer"><rect width="50" height="40" x="10" y="10" fill="red"/></g>`
+    );
+  });
+
+  it("preserves comments and whitespace inside the subtree", () => {
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><g>\n  <!-- keep me -->\n  <rect width="10" height="10"/>\n</g></svg>`;
+    const doc = new SvgDocument(src);
+    const g = first_of_tag(doc, "g");
+    expect(doc.serialize_node(g)).toBe(
+      `<g>\n  <!-- keep me -->\n  <rect width="10" height="10"/>\n</g>`
+    );
+  });
+
+  it("matches what serialize() emits for that node, in place", () => {
+    // The fragment a node serializes to must be a substring of the full
+    // document serialization — same bytes, just scoped.
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect x="1" y="2" width="3" height="4"/></svg>`;
+    const doc = new SvgDocument(src);
+    const rect = first_of_tag(doc, "rect");
+    expect(doc.serialize()).toContain(doc.serialize_node(rect));
+  });
+
+  it("on a node using xlink:href does NOT inline xmlns:xlink (fragment, not document)", () => {
+    // The xmlns:xlink declaration lives on the ancestor <svg>. A fragment is
+    // the element's markup as authored; it does NOT carry ancestor namespace
+    // declarations. This is the intended fragment≠document asymmetry, locked
+    // here so a future "make it round-trip" change is a conscious choice.
+    const src = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#a"/></svg>`;
+    const doc = new SvgDocument(src);
+    const use = first_of_tag(doc, "use");
+    const fragment = doc.serialize_node(use);
+    expect(fragment).toBe(`<use xlink:href="#a"/>`);
+    expect(fragment).not.toContain("xmlns:xlink");
+  });
+
+  it("throws on an unknown id", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>`
+    );
+    expect(() => doc.serialize_node("does-not-exist")).toThrow(
+      /unknown node id/
+    );
+  });
+
+  it("throws on a non-element node", () => {
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><text>hello</text></svg>`;
+    const doc = new SvgDocument(src);
+    const text = first_of_tag(doc, "text");
+    // The <text> element's child is a text node; reach it via the IR.
+    const textChild = doc.children_of(text)[0];
+    expect(() => doc.serialize_node(textChild)).toThrow(/not an element/);
+  });
+});
+
+describe("editor.serialize_node (public surface)", () => {
+  it("exposes the document fragment serializer on the editor", () => {
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect x="1" y="2" width="3" height="4" fill="blue"/></svg>`;
+    const editor = createSvgEditor({ svg: src });
+    const rect = first_rect(editor);
+    expect(editor.serialize_node(rect)).toBe(
+      `<rect x="1" y="2" width="3" height="4" fill="blue"/>`
+    );
+  });
+});

--- a/packages/grida-svg-editor/__tests__/serialize-node.test.ts
+++ b/packages/grida-svg-editor/__tests__/serialize-node.test.ts
@@ -71,6 +71,16 @@ describe("SvgDocument.serialize_node", () => {
     );
   });
 
+  it("throws on a node detached from the live tree (removed but kept for undo)", () => {
+    // remove() keeps the node in the id map so undo can restore it. A stale
+    // id must fail fast rather than serialize content no longer in the doc.
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect id="r" width="10" height="10"/></svg>`;
+    const doc = new SvgDocument(src);
+    const rect = first_of_tag(doc, "rect");
+    doc.remove(rect);
+    expect(() => doc.serialize_node(rect)).toThrow(/detached/);
+  });
+
   it("throws on a non-element node", () => {
     const src = `<svg xmlns="http://www.w3.org/2000/svg"><text>hello</text></svg>`;
     const doc = new SvgDocument(src);

--- a/packages/grida-svg-editor/__tests__/tspan-translate-offsets.test.ts
+++ b/packages/grida-svg-editor/__tests__/tspan-translate-offsets.test.ts
@@ -1,0 +1,59 @@
+// Model-level coverage for `<tspan>` translation via relative `dx`/`dy`
+// (the fix for the "tspan teleports to 0,0" bug). Pure / headless — no DOM
+// needed, since this asserts on the serialized attribute model, not layout.
+// The browser test (`tspan-translate.browser.test.ts`) covers the rendered
+// result; this one pins the attribute composition + faithful revert, including
+// the per-glyph offset-list tail that the browser test's simple fixture omits.
+
+import { describe, expect, it } from "vitest";
+import { createSvgEditor, type SvgEditor } from "../src";
+
+function svg(textInner: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"><text id="t" x="10" y="20">Hi <tspan id="s">${textInner}</tspan></text></svg>`;
+}
+
+function spanId(editor: SvgEditor): string {
+  const n = [...editor.tree().nodes.values()].find((n) => n.name === "s");
+  if (!n) throw new Error("no node named 's'");
+  return n.id;
+}
+
+function spanAttrs(editor: SvgEditor): {
+  dx: string | null;
+  dy: string | null;
+} {
+  const out = editor.serialize();
+  const tag = out.match(/<tspan id="s"[^>]*>/)?.[0] ?? "";
+  return {
+    dx: tag.match(/\bdx="([^"]*)"/)?.[1] ?? null,
+    dy: tag.match(/\bdy="([^"]*)"/)?.[1] ?? null,
+  };
+}
+
+describe("tspan translate composes relative dx/dy", () => {
+  it("a flow tspan gains dx/dy on translate and loses them on undo", () => {
+    const editor = createSvgEditor({ svg: svg("world") });
+    editor.commands.select(spanId(editor));
+
+    editor.commands.translate({ dx: 7, dy: -3 });
+    expect(spanAttrs(editor)).toEqual({ dx: "7", dy: "-3" });
+
+    editor.commands.undo();
+    // Faithful revert: the attributes are removed, not left as dx="0".
+    expect(spanAttrs(editor)).toEqual({ dx: null, dy: null });
+  });
+
+  it("preserves a per-glyph dx/dy tail, shifting only the leading value", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"><text id="t" x="10" y="20"><tspan id="s" dx="5 1 2" dy="3">abc</tspan></text></svg>`,
+    });
+    editor.commands.select(spanId(editor));
+
+    editor.commands.translate({ dx: 4, dy: 6 });
+    // Leading offset shifts (5→9, 3→9); the kerning tail "1 2" is untouched.
+    expect(spanAttrs(editor)).toEqual({ dx: "9 1 2", dy: "9" });
+
+    editor.commands.undo();
+    expect(spanAttrs(editor)).toEqual({ dx: "5 1 2", dy: "3" });
+  });
+});

--- a/packages/grida-svg-editor/__tests__/tspan-translate.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/tspan-translate.browser.test.ts
@@ -1,0 +1,79 @@
+// Bug 2 — translating a `<tspan>` with no explicit x/y jumps it to absolute
+// (≈0,0) instead of moving it by the drag delta, and undo fails to restore it.
+//
+// Why this needs a real browser: the truth here is the *rendered* position of
+// the tspan, which depends on text flow (the tspan inherits its baseline from
+// the parent `<text>`). jsdom reports zero-size text bboxes, so the layout
+// regression is invisible in the node test suite. Here we serialize the
+// editor's model after each step and measure the real SVG layout.
+//
+// Etiology (see core/translate-pipeline/translate-pipeline.ts):
+//   - capture_baseline reads absent tspan x/y as 0
+//   - apply writes x = 0 + dx, y = 0 + dy  → absolute jump to (dx, dy)
+//   - revert writes x="0", y="0"           → undo lands at (0,0), not restored
+//
+// These tests assert the CORRECT behavior and therefore FAIL on current code,
+// capturing the bug.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createSvgEditor, type SvgEditor } from "../src";
+import { committedWorldRect, nodeIdByName } from "./_browser-helpers";
+
+// A tspan that flows after "Hello " on the parent text's baseline (y=80).
+// It has NO explicit x/y — its position comes from text layout, which is
+// exactly the case the translate pipeline mishandles.
+const FIXTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200"><text id="t" x="40" y="80" font-size="20" font-family="sans-serif">Hello <tspan id="span">world</tspan></text></svg>`;
+
+/** World rect of the tspan, from the editor's current serialized model. */
+const measureSpan = (editor: SvgEditor) => committedWorldRect(editor, "span");
+
+describe("bug 2: tspan translate (real DOM layout)", () => {
+  let editor: SvgEditor;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    editor = createSvgEditor({ svg: FIXTURE });
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.innerHTML = "";
+  });
+
+  it("the tspan starts flowed after 'Hello ' (not at the origin)", () => {
+    const r = measureSpan(editor);
+    // Sanity: the flowed tspan sits to the right of the text x (40) and on
+    // the baseline near y=80 — nowhere near (0,0). This anchors the later
+    // delta assertions.
+    expect(r.x).toBeGreaterThan(60);
+    expect(r.y).toBeGreaterThan(40);
+  });
+
+  it("translating by (0, +10) moves the tspan down 10 — not to absolute 0,0", () => {
+    const before = measureSpan(editor);
+
+    const span = nodeIdByName(editor, "span");
+    editor.commands.select(span);
+    editor.commands.translate({ dx: 0, dy: 10 });
+
+    const after = measureSpan(editor);
+
+    // Correct: pure vertical move by the delta, horizontal unchanged.
+    expect(after.y - before.y).toBeCloseTo(10, 1);
+    expect(after.x - before.x).toBeCloseTo(0, 1);
+  });
+
+  it("undo restores the tspan to its original flowed position", () => {
+    const before = measureSpan(editor);
+
+    const span = nodeIdByName(editor, "span");
+    editor.commands.select(span);
+    editor.commands.translate({ dx: 0, dy: 10 });
+    editor.commands.undo();
+
+    const after = measureSpan(editor);
+
+    expect(after.x).toBeCloseTo(before.x, 1);
+    expect(after.y).toBeCloseTo(before.y, 1);
+  });
+});

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,7 +1,24 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-alpha.15",
   "description": "Headless SVG editor (experimental).",
+  "keywords": [
+    "bezier",
+    "design-tool",
+    "editor",
+    "grida",
+    "headless",
+    "path-editor",
+    "pen-tool",
+    "react",
+    "svg",
+    "svg-editor",
+    "typescript",
+    "vector",
+    "vector-editor",
+    "vector-graphics"
+  ],
+  "homepage": "https://grida.co/packages/@grida/svg-editor",
   "license": "MIT",
   "author": "Grida",
   "repository": "https://github.com/gridaco/grida",
@@ -43,6 +60,7 @@
     "dev": "tsdown --watch",
     "prepack": "tsdown",
     "test": "vitest run",
+    "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
@@ -57,6 +75,9 @@
   },
   "devDependencies": {
     "@types/react": "^19",
+    "@vitest/browser": "4.0.18",
+    "@vitest/browser-playwright": "^4.0.18",
+    "playwright": "^1.58.2",
     "react": "^19",
     "tsdown": "^0.22.1",
     "typescript": "^6",

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -961,6 +961,39 @@ export class SvgDocument implements DocumentEvents {
     return out;
   }
 
+  /**
+   * Serialize a single element's subtree as an SVG **fragment**, using the
+   * same trivia-preserving rules as {@link serialize} (attribute order,
+   * quote style, whitespace, comments — emitted exactly as authored).
+   *
+   * This is NOT {@link serialize} scoped to a node — it is a deliberately
+   * weaker output (sdk-design D3, asymmetric outputs stay separate):
+   *
+   *   - `serialize()` emits the whole document and carries the P1
+   *     whole-document round-trip guarantee.
+   *   - `serialize_node()` emits a fragment and does NOT. Namespace
+   *     declarations that live on an ancestor (`xmlns:xlink` and friends,
+   *     normally on the root `<svg>`) are NOT inlined — a node using
+   *     `xlink:href` serializes without `xmlns:xlink`. The fragment is the
+   *     element's markup as authored, not a standalone parseable document.
+   *
+   * Throws on an unknown id or a non-element node: the contract is "the
+   * markup for a selected element," selections are always elements, and a
+   * string return of `""` for a bad id would hide consumer bugs.
+   */
+  serialize_node(id: NodeId): string {
+    const n = this.nodes.get(id);
+    if (!n) {
+      throw new Error(`serialize_node: unknown node id ${JSON.stringify(id)}`);
+    }
+    if (n.kind !== "element") {
+      throw new Error(
+        `serialize_node: node ${JSON.stringify(id)} is a ${n.kind} node, not an element`
+      );
+    }
+    return this.emit_node(n);
+  }
+
   private emit_node(n: AnyNode): string {
     switch (n.kind) {
       case "text":

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -977,9 +977,13 @@ export class SvgDocument implements DocumentEvents {
    *     `xlink:href` serializes without `xmlns:xlink`. The fragment is the
    *     element's markup as authored, not a standalone parseable document.
    *
-   * Throws on an unknown id or a non-element node: the contract is "the
-   * markup for a selected element," selections are always elements, and a
-   * string return of `""` for a bad id would hide consumer bugs.
+   * Throws on an unknown id, a non-element node, or a node detached from
+   * the live tree: the contract is "the markup for a selected element,"
+   * selections are always live elements, and a string return of `""` for a
+   * bad id would hide consumer bugs. The detached case matters because
+   * `remove()` keeps the node in the id map for undo — a stale id from a
+   * removed node would otherwise serialize content no longer in the
+   * document, silently feeding a consumer deleted markup.
    */
   serialize_node(id: NodeId): string {
     const n = this.nodes.get(id);
@@ -989,6 +993,11 @@ export class SvgDocument implements DocumentEvents {
     if (n.kind !== "element") {
       throw new Error(
         `serialize_node: node ${JSON.stringify(id)} is a ${n.kind} node, not an element`
+      );
+    }
+    if (!this.contains(this.root, id)) {
+      throw new Error(
+        `serialize_node: node ${JSON.stringify(id)} is detached from the current document`
       );
     }
     return this.emit_node(n);

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -1864,6 +1864,21 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     // external control
     load,
     serialize,
+    /**
+     * Serialize a single element's subtree as an SVG **fragment**, using the
+     * same trivia-preserving rules as {@link serialize} — for handing "the
+     * markup of the element the user selected" to a downstream consumer
+     * (e.g. an AI agent) without re-serializing the whole document.
+     *
+     * Fragment, not document (see `SvgDocument.serialize_node`): it does NOT
+     * carry `serialize()`'s whole-document round-trip guarantee. Namespace
+     * declarations on an ancestor (`xmlns:xlink`, normally on the root
+     * `<svg>`) are NOT inlined — a node using `xlink:href` serializes without
+     * `xmlns:xlink`. Throws on an unknown id or a non-element node.
+     */
+    serialize_node(id: NodeId): string {
+      return doc.serialize_node(id);
+    },
     reset,
 
     // lifecycle

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -798,6 +798,10 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       },
       emit,
       stages,
+      // Nested-viewport / transformed-ancestor correctness: write the delta
+      // in each mover's local frame. Identity for flat docs and DOM-less
+      // hosts (no provider, or a provider without a layout engine).
+      project: (id, d) => geometry_provider?.world_delta_to_local?.(id, d) ?? d,
     });
     apply();
     history.atomic(label, (tx) => {

--- a/packages/grida-svg-editor/src/core/geometry.ts
+++ b/packages/grida-svg-editor/src/core/geometry.ts
@@ -44,6 +44,21 @@ export interface GeometryProvider {
    * is hit. "Topmost" is defined by the renderer's z-order.
    */
   node_at_point(p: Vec2): NodeId | null;
+
+  /**
+   * Re-express a **world-space** delta vector in the frame a node's
+   * position attributes are written in — its parent user-space. For a
+   * node under a scaled/rotated `<g>` ancestor, or inside a nested
+   * `<svg>` viewport that scales its user space, the local frame differs
+   * from world by that linear transform; a translate must be written in
+   * the local frame so the on-screen motion matches the world delta
+   * (otherwise it moves `scale ×` too far).
+   *
+   * Optional: only DOM-backed providers (with a real layout engine) can
+   * derive the frame. Providers that omit it imply the flat-doc identity
+   * (world ≡ local), and callers fall back to the raw delta.
+   */
+  world_delta_to_local?(id: NodeId, delta: Vec2): Vec2;
 }
 
 export type GeometrySignals = {
@@ -110,6 +125,13 @@ export class MemoizedGeometryProvider implements GeometryProvider {
 
   node_at_point(p: Vec2): NodeId | null {
     return this.driver.node_at_point(p);
+  }
+
+  /** Pass-through. Frame projection depends on live layout, not on the
+   *  bounds cache, so there is nothing to memoize. Falls back to the raw
+   *  delta when the driver can't resolve a frame. */
+  world_delta_to_local(id: NodeId, delta: Vec2): Vec2 {
+    return this.driver.world_delta_to_local?.(id, delta) ?? delta;
   }
 
   /** Unsubscribe from both signals. Call on surface detach. */

--- a/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
@@ -52,6 +52,10 @@ export type OrchestratorDeps = {
    *  Called per drive() so a runtime style flip (e.g. flipping
    *  snap_to_pixel_grid mid-drag) takes effect on the next frame. */
   options: () => TranslateOptions;
+  /** World→local delta projector (nested-viewport / transformed-ancestor
+   *  correctness). Omit for flat-doc / DOM-less hosts; absent ⇒ raw world
+   *  delta is written. See `translate_pipeline.DeltaProjector`. */
+  project_delta?: translate_pipeline.DeltaProjector;
 };
 
 const PROVIDER_ID = "svg-editor";
@@ -198,10 +202,11 @@ export class TranslateOrchestrator {
   ): void {
     const doc = this.deps.get_doc();
     const emit = this.deps.emit;
+    const project = this.deps.project_delta;
     session.preview.set({
       providerId: PROVIDER_ID,
       apply: () => {
-        translate_pipeline.apply(doc, plan);
+        translate_pipeline.apply(doc, plan, project);
         emit();
       },
       revert: () => {

--- a/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
@@ -38,7 +38,21 @@ export type TranslateBaseline =
   | { type: "polygon"; points: string }
   | { type: "path"; d: string }
   | { type: "text"; x: number; y: number }
-  | { type: "tspan"; x: number; y: number }
+  // A `<tspan>` is positioned by text flow, not (necessarily) by `x`/`y`.
+  // Translating it via absolute `x`/`y` would teleport a flow-positioned span
+  // to the origin (absent attr read as 0). SVG `transform` does not apply to
+  // `<tspan>` either. So we move it with RELATIVE `dx`/`dy` offsets, composed
+  // on top of whatever positioning it already has. `d{x,y}` is the leading
+  // offset value (0 when absent); `d{x,y}_attr` is the original attribute
+  // string, retained so revert restores it exactly — including removal when
+  // the attribute was absent.
+  | {
+      type: "tspan";
+      dx: number;
+      dy: number;
+      dx_attr: string | null;
+      dy_attr: string | null;
+    }
   | { type: "image"; x: number; y: number }
   | { type: "use"; x: number; y: number }
   | { type: "unsupported" };
@@ -166,12 +180,19 @@ export namespace translate_pipeline {
           return { type: "path", d: doc.get_attr(id, "d") ?? "" };
         case "text":
           return { type: "text", x: num(doc, id, "x"), y: num(doc, id, "y") };
-        case "tspan":
+        case "tspan": {
+          // Move via relative `dx`/`dy`; capture the leading offset (whole-run
+          // shift) plus the original attribute string for faithful revert.
+          const dx_attr = doc.get_attr(id, "dx");
+          const dy_attr = doc.get_attr(id, "dy");
           return {
             type: "tspan",
-            x: num(doc, id, "x"),
-            y: num(doc, id, "y"),
+            dx: svg_parse.parse_number(dx_attr),
+            dy: svg_parse.parse_number(dy_attr),
+            dx_attr,
+            dy_attr,
           };
+        }
         case "image":
           return {
             type: "image",
@@ -221,10 +242,13 @@ export namespace translate_pipeline {
       switch (b.type) {
         case "rect":
         case "text":
-        case "tspan":
         case "image":
         case "use":
           return { x: b.x, y: b.y };
+        case "tspan":
+          // Moved by relative `dx`/`dy`, so there is no absolute document-
+          // space anchor to align to a lattice (pixel-grid / custom snap).
+          return null;
         case "circle":
         case "ellipse":
           return { x: b.cx, y: b.cy };
@@ -296,6 +320,25 @@ export namespace translate_pipeline {
       return `translate(${dx} ${dy}) ${existing}`;
     }
 
+    /** Rewrite the leading value of a `dx`/`dy` offset list to `value`,
+     *  preserving any per-glyph kerning tail (`compose("3 1 2", 9)` →
+     *  `"9 1 2"`). Empty separators are dropped, so a stray leading comma
+     *  doesn't lose the tail. With no original attribute (or a single
+     *  value), emit just `value`. The leading value shifts the whole run. */
+    function compose_leading_offset(
+      attr: string | null,
+      value: number
+    ): string {
+      if (attr === null) return String(value);
+      const tokens = attr
+        .trim()
+        .split(/[\s,]+/)
+        .filter((t) => t !== "");
+      if (tokens.length <= 1) return String(value);
+      tokens[0] = String(value);
+      return tokens.join(" ");
+    }
+
     function shift_path_d(d: string, dx: number, dy: number): string {
       if (dx === 0 && dy === 0) return d;
       try {
@@ -326,9 +369,22 @@ export namespace translate_pipeline {
         case "image":
         case "use":
         case "text":
-        case "tspan":
           doc.set_attr(id, "x", String(baseline.x + dx));
           doc.set_attr(id, "y", String(baseline.y + dy));
+          return;
+        case "tspan":
+          // Relative offsets — never absolute x/y (would teleport a
+          // flow-positioned span). Composed on top of the original offsets.
+          doc.set_attr(
+            id,
+            "dx",
+            compose_leading_offset(baseline.dx_attr, baseline.dx + dx)
+          );
+          doc.set_attr(
+            id,
+            "dy",
+            compose_leading_offset(baseline.dy_attr, baseline.dy + dy)
+          );
           return;
         case "circle":
         case "ellipse":
@@ -355,6 +411,24 @@ export namespace translate_pipeline {
         case "unsupported":
           return;
       }
+    }
+
+    /** Restore an element to its pre-translate state. For most kinds this is
+     *  `apply(..., 0, 0)` (baseline values, delta zero). `<tspan>` is special:
+     *  its `dx`/`dy` must be restored to the EXACT original attribute strings
+     *  — including removal when they were absent — so undo cannot leave a
+     *  fabricated `dx="0"` / `dy="0"` behind. */
+    export function revert(
+      doc: SvgDocument,
+      id: NodeId,
+      baseline: TranslateBaseline
+    ): void {
+      if (baseline.type === "tspan") {
+        doc.set_attr(id, "dx", baseline.dx_attr);
+        doc.set_attr(id, "dy", baseline.dy_attr);
+        return;
+      }
+      apply(doc, id, baseline, 0, 0);
     }
   }
 
@@ -473,7 +547,7 @@ export namespace translate_pipeline {
     for (const id of plan.ids) {
       const baseline = plan.baselines.get(id);
       if (!baseline) continue;
-      intent.apply(doc, id, baseline, 0, 0);
+      intent.revert(doc, id, baseline);
     }
   }
 

--- a/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
@@ -530,14 +530,30 @@ export namespace translate_pipeline {
     return { plan, guides };
   }
 
+  /** Projects a world-space delta into the frame the target element's
+   *  position attributes are written in (its parent user-space). Identity
+   *  for flat docs; non-trivial under a scaled/rotated `<g>` ancestor or a
+   *  nested `<svg>` viewport that scales its user space. Supplied by the
+   *  DOM layer (see `GeometryProvider.world_delta_to_local`); the pure
+   *  pipeline cannot derive it without a layout engine. */
+  export type DeltaProjector = (id: NodeId, delta: Vec2) => Vec2;
+
   /** Apply the plan: for each id, run `intent.apply` with the baseline
-   *  + world-space delta. Does NOT emit; caller wraps with history
+   *  + world-space delta. When `project` is given, the world delta is
+   *  re-expressed in each element's local frame first (nested-viewport /
+   *  transformed-ancestor correctness); absent, the raw world delta is
+   *  used (flat-doc fast path). Does NOT emit; caller wraps with history
    *  machinery and calls `emit()` after. */
-  export function apply(doc: SvgDocument, plan: TranslatePlan): void {
+  export function apply(
+    doc: SvgDocument,
+    plan: TranslatePlan,
+    project?: DeltaProjector
+  ): void {
     for (const id of plan.ids) {
       const baseline = plan.baselines.get(id);
       if (!baseline) continue;
-      intent.apply(doc, id, baseline, plan.delta.x, plan.delta.y);
+      const d = project ? project(id, plan.delta) : plan.delta;
+      intent.apply(doc, id, baseline, d.x, d.y);
     }
   }
 
@@ -563,6 +579,9 @@ export namespace translate_pipeline {
     options: TranslateOptions;
     emit: () => void;
     stages?: ReadonlyArray<TranslateStage>;
+    /** World→local delta projector (nested-viewport / transformed-ancestor
+     *  correctness). Omit for flat-doc callers. See {@link DeltaProjector}. */
+    project?: DeltaProjector;
   }): { plan: TranslatePlan; apply: () => void; revert: () => void } {
     const {
       doc,
@@ -571,6 +590,7 @@ export namespace translate_pipeline {
       options,
       emit,
       stages: stage_list = stages.RPC,
+      project,
     } = args;
     // Drop descendants whose ancestor is also in the gesture set —
     // otherwise both the parent's `transform` AND the child's own
@@ -593,7 +613,7 @@ export namespace translate_pipeline {
     return {
       plan,
       apply: () => {
-        apply(doc, plan);
+        apply(doc, plan, project);
         emit();
       },
       revert: () => {

--- a/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/translate-pipeline.ts
@@ -228,7 +228,8 @@ export namespace translate_pipeline {
      * snap).
      *
      * Rules per element kind:
-     *   - rect / text / tspan / image / use: `(x, y)`
+     *   - rect / text / image / use: `(x, y)`
+     *   - tspan: `null` (moved via relative `dx`/`dy`; no absolute anchor)
      *   - circle / ellipse: `(cx, cy)` (no radius subtracted —
      *     consistent anchor across all kinds, not a true bounds top-
      *     left)

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -1625,14 +1625,24 @@ class DomSurface implements Surface {
     for (const id of ids) {
       for (const inner of snap_descent(doc, id)) agent_id_set.add(inner);
     }
+    // Snap rects come from the canonical world-space geometry provider
+    // (`bounds_of` → `getBBox` + `getCTM`). getCTM folds in ancestor
+    // `<g transform>`, so a child inside a translated group contributes its
+    // true world rect — not the group-local box that `getBBox` + own-
+    // `transform=` would yield. Mixing those frames produced spurious snaps
+    // (guides rendering near the canvas origin) for grouped children.
+    // `bounds_of` already applies the `<svg>` viewport special-case, so it is
+    // a strict superset of the old `bbox_world_for_snap`.
+    const bounds_of = (id: NodeId): Rect | null =>
+      this._geometry_provider?.bounds_of(id) ?? null;
     const agents: Rect[] = [];
     for (const id of agent_id_set) {
-      const r = this.bbox_world_for_snap(id);
+      const r = bounds_of(id);
       if (r) agents.push(r);
     }
     const neighbors: Rect[] = [];
     for (const id of neighbor_ids) {
-      const r = this.bbox_world_for_snap(id);
+      const r = bounds_of(id);
       if (r) neighbors.push(r);
     }
     return new SnapSession({ agents, neighbors });
@@ -4325,25 +4335,6 @@ class DomSurface implements Surface {
     if (!local) return null;
     const transform_str = this.editor.document.get_attr(id, "transform");
     return transform.project(local, transform_str);
-  }
-
-  /** World-space rect for snap purposes. Differs from `bbox_world` for
-   *  `<svg>` viewport-establishing elements: `getBBox()` on an `<svg>`
-   *  reports the union of descendant geometry (SVG 2 §4.6.4), which —
-   *  when the dragged element is a descendant — silently turns the
-   *  dragged element's own pre-gesture position into a snap target via
-   *  the parent's edges. Use the viewport extent instead so the root
-   *  SVG's snap edges represent the canvas boundary, not "wherever the
-   *  children happen to be right now". */
-  private bbox_world_for_snap(id: NodeId): Rect | null {
-    if (this.tag_of(id) === "svg") {
-      const el = this.element_index.get(id);
-      if (el instanceof SVGSVGElement) {
-        const vp = svg_viewport_bounds(el);
-        if (vp) return vp;
-      }
-    }
-    return this.bbox_world(id);
   }
 
   private editor_internal() {

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -540,6 +540,11 @@ class DomSurface implements Surface {
       open_preview: (label) => this.editor_internal().history.preview(label),
       open_snap: (ids) => this.open_snap_session_for(ids),
       options: translate_options,
+      // Re-express the world delta in each mover's local frame so a child
+      // of a scaled `<g>` / nested `<svg>` viewport tracks the cursor 1:1
+      // (lazy: the geometry provider is wired later in this ctor).
+      project_delta: (id, d) =>
+        this._geometry_provider?.world_delta_to_local(id, d) ?? d,
     });
 
     // Resize funnel — same shape as translate, distinct lifecycle.
@@ -4676,6 +4681,44 @@ class SvgGeometryDriver implements GeometryProvider {
 
   node_at_point(p: Vec2): NodeId | null {
     return this.accessors.pick_at_world(p, true);
+  }
+
+  /** World→local delta projection. The frame an element's position is
+   *  written in is its PARENT user-space: a `<rect>`'s `x`/`y` and the
+   *  leading `translate(...)` composed onto a `<g>`/transformed node are
+   *  both interpreted there. We take the parent element's frame (not the
+   *  element's own) so that translating a node whose OWN transform has a
+   *  scale/rotation is not double-counted.
+   *
+   *  Camera-free: `inv(root.getScreenCTM) ∘ parent.getScreenCTM` maps
+   *  parent user-space → root world-space, cancelling the shared CSS /
+   *  camera transform. Inverting its linear part turns a world delta into
+   *  the local delta. Identity (→ delta unchanged) for flat frames,
+   *  top-level nodes, and any degenerate / unavailable matrix. */
+  world_delta_to_local(id: NodeId, delta: Vec2): Vec2 {
+    const el = this.accessors.element_for(id);
+    const parent = el?.parentNode;
+    const root = this.accessors.root();
+    if (!(parent instanceof SVGGraphicsElement) || !root) return delta;
+    // Flat fast-path: a direct child of the root `<svg>` is already in world
+    // space (its parent frame IS world), so skip the getScreenCTM reflow.
+    // The common case for non-nested documents.
+    if (parent === root) return delta;
+    if (
+      typeof parent.getScreenCTM !== "function" ||
+      typeof root.getScreenCTM !== "function"
+    ) {
+      return delta;
+    }
+    const parent_ctm = parent.getScreenCTM();
+    const root_ctm = root.getScreenCTM();
+    if (!parent_ctm || !root_ctm) return delta;
+    // parent user-space → root world-space (camera/CSS cancelled).
+    const m = root_ctm.inverse().multiply(parent_ctm);
+    const det = m.a * m.d - m.c * m.b;
+    if (!Number.isFinite(det) || det === 0) return delta;
+    const [x, y] = project_delta_inverse_ctm(delta.x, delta.y, m);
+    return { x, y };
   }
 }
 

--- a/packages/grida-svg-editor/vitest.browser.config.ts
+++ b/packages/grida-svg-editor/vitest.browser.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+
+// Real-DOM test project. Runs `*.browser.test.ts` inside headless Chromium
+// (via Playwright) so tests get a real SVG layout engine — `getBBox`,
+// `getCTM`, `getScreenCTM`. The default `vitest.config.ts` (node env) cannot
+// observe these: jsdom returns identity CTMs and zero-size bboxes, which is
+// exactly why the snap/translate world-geometry bugs are invisible there.
+//
+// Run with: `pnpm test:browser` (see package.json).
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.browser.test.ts"],
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      headless: true,
+      screenshotFailures: false,
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/packages/grida-svg-editor/vitest.config.ts
+++ b/packages/grida-svg-editor/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["__tests__/**/*.test.ts"],
+    // Real-DOM tests run in headless Chromium via `vitest.browser.config.ts`
+    // (`pnpm test:browser`); they must not run under node (no getBBox/getCTM).
+    // node_modules / dist are excluded by Vitest's defaults already.
+    exclude: ["**/*.browser.test.ts"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   apps/backgrounds:
     dependencies:
@@ -1070,7 +1070,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-ai-models:
     devDependencies:
@@ -1082,7 +1082,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-canvas-bitmap:
     dependencies:
@@ -1121,7 +1121,7 @@ importers:
         version: 19.2.5
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-canvas-io:
     dependencies:
@@ -1300,7 +1300,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-canvas-tailwind: {}
 
@@ -1353,7 +1353,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-fonts:
     devDependencies:
@@ -1377,7 +1377,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-home:
     devDependencies:
@@ -1389,7 +1389,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-keybinding:
     devDependencies:
@@ -1401,7 +1401,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-mixed-properties:
     dependencies:
@@ -1462,7 +1462,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-svg: {}
 
@@ -1493,6 +1493,15 @@ importers:
       '@types/react':
         specifier: 19.1.3
         version: 19.1.3
+      '@vitest/browser':
+        specifier: 4.0.18
+        version: 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)
+      '@vitest/browser-playwright':
+        specifier: ^4.0.18
+        version: 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.58.2)(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -1504,7 +1513,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-text-editor:
     devDependencies:
@@ -1516,7 +1525,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/grida-tokens: {}
 
@@ -1541,7 +1550,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   packages/lib/treearray: {}
 
@@ -7314,6 +7323,17 @@ packages:
     resolution: {integrity: sha512-JmxkOROPkjnMEdFGnnSKLo5BkFHgOkLe/N5KkWR02cA5bE+bmEkfAh7DJfrtVsPkqSPvwGH1TrMWWthJwoivPA==}
     peerDependencies:
       react: 19.2.5
+
+  '@vitest/browser-playwright@4.0.18':
+    resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.0.18
+
+  '@vitest/browser@4.0.18':
+    resolution: {integrity: sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==}
+    peerDependencies:
+      vitest: 4.0.18
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -13454,6 +13474,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -13934,6 +13958,10 @@ packages:
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
@@ -21854,6 +21882,36 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.5
 
+  '@vitest/browser-playwright@4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.58.2)(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/browser': 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+      playwright: 1.58.2
+      tinyrainbow: 3.1.0
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)':
+    dependencies:
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/utils': 4.0.18
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -21861,7 +21919,7 @@ snapshots:
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
@@ -21874,7 +21932,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@4.0.18':
     dependencies:
@@ -29136,6 +29194,12 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.0
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@7.1.2:
@@ -29634,6 +29698,8 @@ snapshots:
   tinyqueue@3.0.0: {}
 
   tinyrainbow@3.0.3: {}
+
+  tinyrainbow@3.1.0: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -30154,7 +30220,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
@@ -30179,6 +30245,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.12.2
+      '@vitest/browser-playwright': 4.0.18(msw@2.12.10(@types/node@24.12.2)(typescript@6.0.3))(playwright@1.58.2)(vite@7.3.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))(vitest@4.0.18)
       jsdom: 20.0.3(canvas@2.11.2(encoding@0.1.13))
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
SVG-editor cleanup branch bundling several geometry-fidelity fixes, a new browser-mode test harness, and the `serialize_node` API.

## What changed

### Geometry / translate fidelity
- **Nested & scaled viewports** — translate deltas are now projected into the target's local frame, so dragging an element inside a nested `<svg>` or a scaled viewport moves it by the intended screen distance (`translate-pipeline`, `geometry.ts`, `dom.ts`). New `nested-svg-translate.browser.test.ts`.
- **`<tspan>` translate** — corrects `dx`/`dy` offset accumulation for tspan children (`tspan-translate-offsets.test.ts`, `tspan-translate.browser.test.ts`).
- **Grouped-child snap** — fixes snap geometry for a child selected inside a group (`group-child-snap.browser.test.ts`).

### Browser-mode test harness
- Adds a Playwright-backed `vitest.browser.config.ts` + `_browser-helpers.ts` so geometry that depends on real `getBBox` / `getScreenCTM` can be asserted against a real layout engine, alongside the existing headless suite.

### `serialize_node` API (#775)
- `editor.serialize_node(id)` / `SvgDocument.serialize_node(id)` — export one selected element's subtree as clean SVG, reusing the trivia-preserving serializer.
- It is a **fragment, not a document**: it deliberately does *not* carry `serialize()`'s P1 whole-document round-trip guarantee — ancestor `xmlns:` declarations (e.g. `xmlns:xlink` on the root `<svg>`) are not inlined. Throws on unknown / non-element id. Locked by producer-side tests that pin both the fidelity it guarantees and the asymmetry it intentionally does not.
- The positional `node_path` / `node_at_path` half of #775 was **declined** (derivable from the public `tree()` view; "survives a `load()`" is false for the agent-editing use case — positional indices break under structural edits) and escalated to an RFD: `docs/wg/feat-svg-editor/durable-node-identity.md`.

### Demo
- Adds a nested-`<svg>` fixture + card to the svg-editor playground.

## Why
The translate fixes address real mis-tracking when elements live under nested/scaled viewport transforms. `serialize_node` closes the selection→source gap for embedding the editor as a function over SVG (handing a downstream consumer the selected element's markup).

## Reviewer notes
- The `serialize_node` fragment≠document asymmetry is intentional and test-locked — see the `xlink:href` test; "make it round-trip" would be a conscious future change, not a bug fix.
- New browser tests require the Playwright vitest provider (added to `package.json` / `pnpm-lock.yaml`).
- Full suite green: `vitest run` 1053 passed; `tsc` clean; `oxlint` / `oxfmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export individual SVG elements as serialized fragments
  * More accurate translation behavior across nested/transformed viewports
  * Added a nested-SVG editing example

* **Bug Fixes**
  * Corrected child translation inside transformed groups
  * Fixed tspan translation/undo to preserve relative offsets
  * Fixed coordinate calculations for scaled nested viewports

* **Documentation**
  * Added durable node identity design note and updated fixtures/examples

* **Tests**
  * Added browser and unit regression tests plus real-DOM test helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->