### PR TITLE
fix(ci): run desktop package-build step under bash on Windows

### DIFF
--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -66,7 +66,11 @@ jobs:
         # on launch. Build the closure from the repo root so the link:
         # targets have dist/ before packaging. --ignore-scripts skips native
         # postinstalls we don't need (these are pure tsdown packages, no wasm).
+        # `shell: bash` so the `\` line-continuations work on Windows too —
+        # the default Windows shell is PowerShell, where `\` is not a
+        # continuation and `--filter` parses as a unary operator.
         working-directory: ${{ github.workspace }}
+        shell: bash
         run: |
           pnpm install --frozen-lockfile --ignore-scripts
           pnpm turbo run build \


### PR DESCRIPTION
## What

Follow-up to #776. That PR's new **"Build linked workspace packages"** step uses `\` line-continuations, which only work in bash. The Windows runner defaults to **PowerShell**, where `\` is not a line-continuation and `--filter` parses as a unary operator:

```
ParserError: Missing expression after unary operator '--'.
   4 |   --filter=@grida/desktop-bridge \
```

macOS and Linux (bash) ran the step fine — the [post-merge dispatch](https://github.com/gridaco/grida/actions/runs/26970948551) was **green on macOS and Linux**, red only on Windows.

## Fix

Pin that one step to `shell: bash` (available on GitHub's Windows runners), so the `\`-continued `pnpm turbo` command runs identically on all three OSes. It's the only multi-line step that runs ungated across OSes — the others (`Install Snapcraft`, `Stage App Store Connect API key`, `Update release notes`) are linux/macOS-gated, so no other step is affected.

## Note

#776 is already merged, so `main` currently has the Windows-broken step. This unblocks the next `Publish Desktop App` run on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to ensure consistent build behavior across platforms.

**Note:** This is an infrastructure update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->