### PR TITLE
fix(desktop): ship runtime-external deps in the packaged app + cross-platform packaging oracle

### DIFF
--- a/.github/workflows/verify-desktop-package.yml
+++ b/.github/workflows/verify-desktop-package.yml
@@ -1,0 +1,69 @@
+permissions:
+  contents: read
+
+name: Verify Desktop Package
+
+# Proves the desktop app PACKAGES correctly on every OS — i.e. the bundles'
+# externalized dependencies are actually shipped — without publishing. The
+# `electron-forge package` step runs the GRIDA-DESKTOP-BUILD-GUARD oracle
+# (desktop/scripts/verify-packaged-bundle.mjs, a postPackage hook) which fails
+# the build if the packaged app would crash on launch with "Cannot find module"
+# or ship packages outside the runtime closure. No signing/secrets required.
+on:
+  pull_request:
+    paths:
+      - "desktop/**"
+      - "packages/grida-ai-agent/**"
+      - "packages/grida-ai-models/**"
+      - "packages/grida-desktop-bridge/**"
+      - "packages/grida-home/**"
+      - ".github/workflows/verify-desktop-package.yml"
+  workflow_dispatch:
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./desktop
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build linked workspace packages
+        # The desktop bundles several @grida/* workspace packages whose dist/ is
+        # gitignored; build their closure from the repo root so the Vite build
+        # can resolve them. `shell: bash` so the `\` continuations work on the
+        # Windows runner (default shell is PowerShell). Mirrors the publish
+        # workflow's step.
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm turbo run build \
+            --filter=@grida/desktop-bridge \
+            --filter=@grida/agent \
+            --filter=@grida/ai-models \
+            --filter=@grida/home
+
+      - name: Package (runs the GRIDA-DESKTOP-BUILD-GUARD oracle)
+        # `electron-forge package` produces the unsigned .app/.exe + app.asar and
+        # runs the postPackage oracle. No makers, no publish, no secrets.
+        run: pnpm exec electron-forge package

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -11,6 +11,7 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import * as dotenv from "dotenv";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 // cli flags
@@ -58,6 +59,42 @@ const osxNotarize =
       }
     : undefined;
 
+// ───────────────────────────────────────────────────────────────────────────
+// GRIDA-DESKTOP-BUILD-GUARD — ship the runtime-external dependencies.
+//
+// The Vite plugin bundles main/preload/sidecar and, by default, sets
+// `packagerConfig.ignore` to drop everything except `.vite` — so NO
+// node_modules ships, and anything the bundles leave `external` crashes the app
+// on launch with "Cannot find module" (0.0.3: @grida/desktop-bridge; 0.0.4:
+// @anthropic-ai/sandbox-runtime). This is a known forge bug
+// (electron/forge#3738, #3917, #4045).
+//
+// Idiomatic fix: package.json `dependencies` are EXACTLY the modules left
+// `external` in vite.*.config.ts; everything bundled lives in devDependencies.
+// electron-packager's `prune` (default) then ships exactly the production
+// dependency closure — no hand-rolled walker. We only override `ignore` to undo
+// the Vite plugin's node_modules strip. scripts/verify-packaged-bundle.mjs (the
+// postPackage hook) fails the build if any external is still missing, so a
+// misclassified dependency can't ship.
+//
+// `@grida/*` are bundled (devDependencies, never external — enforced by
+// vite.guards.ts); keeping them out of `dependencies` also keeps their `link:`
+// symlinks out of the pruner's path.
+function packageIgnore(file: string): boolean {
+  if (!file) return false; // app root
+  if (file === "/package.json") return false;
+  if (file.startsWith("/.vite")) return false;
+  // `@grida/*` are bundled (devDependencies); their node_modules entries are
+  // `link:` symlinks to ../../packages that point out of the package and make
+  // asar fail ("links out of the package"). Exclude them explicitly.
+  if (file.startsWith("/node_modules/@grida")) return true;
+  // pnpm internals (.pnpm store, .bin shims, lockfile metadata) — not needed at
+  // runtime; the hoisted prod deps are real dirs at the top level.
+  if (file.startsWith("/node_modules/.")) return true;
+  if (file.startsWith("/node_modules")) return false; // pruner keeps only prod deps
+  return true; // src, tsconfig, configs — Vite already bundled what's needed
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     extraResource: [
@@ -66,7 +103,16 @@ const config: ForgeConfig = {
     ],
     name: productName,
     executableName: "desktop",
-    asar: true,
+    // Undo the Vite plugin's node_modules strip so the production deps
+    // (package.json `dependencies` = the vite externals) ship; `prune` then
+    // keeps just those. See GRIDA-DESKTOP-BUILD-GUARD above.
+    ignore: packageIgnore,
+    // @anthropic-ai/sandbox-runtime ships executable vendored binaries
+    // (vendor/seccomp/*/apply-seccomp) that cannot run from inside an asar —
+    // unpack it so they land on a real filesystem.
+    asar: {
+      unpack: "**/node_modules/@anthropic-ai/sandbox-runtime/**",
+    },
     appBundleId: appBundleId,
     icon: icon,
     osxSign,
@@ -84,7 +130,25 @@ const config: ForgeConfig = {
     appCategoryType: "public.app-category.developer-tools",
   },
   rebuildConfig: {},
-  hooks: {},
+  hooks: {
+    // GRIDA-DESKTOP-BUILD-GUARD — after packaging, verify every externalized
+    // require (and its full transitive closure) actually resolves in the
+    // packaged app. A missing dependency fails the build HERE instead of
+    // crashing on a user's machine with "Cannot find module". Runs on
+    // package / make / publish, locally and in CI.
+    postPackage: async (_forgeConfig, { outputPaths }) => {
+      const script = path.join(
+        __dirname,
+        "scripts",
+        "verify-packaged-bundle.mjs"
+      );
+      for (const outputPath of outputPaths) {
+        execFileSync(process.execPath, [script, outputPath], {
+          stdio: "inherit",
+        });
+      }
+    },
+  },
   makers: [
     new MakerSquirrel((arch) => {
       const version = process.env.npm_package_version;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -20,28 +20,18 @@
     "publish:prerelease": "node scripts/prepare-dev-electron-branding.mjs && electron-forge publish",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify:package": "node scripts/verify-packaged-bundle.mjs"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "3.0.66",
-    "@ai-sdk/openai-compatible": "2.0.47",
     "@anthropic-ai/sandbox-runtime": "^0.0.52",
-    "@grida/agent": "link:../packages/grida-ai-agent",
-    "@grida/ai-models": "link:../packages/grida-ai-models",
-    "@grida/desktop-bridge": "link:../packages/grida-desktop-bridge",
-    "@grida/home": "link:../packages/grida-home",
     "@hono/node-server": "^1.13.7",
-    "ai": "6.0.116",
-    "clsx": "^2.1.1",
-    "electron-squirrel-startup": "^1.0.1",
     "hono": "^4.6.14",
-    "react": "19.2.5",
-    "react-dom": "19.2.5",
-    "tailwind-merge": "^3.5.0",
-    "undici": "^7.24.4",
-    "update-electron-app": "^3.2.0"
+    "undici": "^7.24.4"
   },
   "devDependencies": {
+    "@ai-sdk/gateway": "3.0.66",
+    "@ai-sdk/openai-compatible": "2.0.47",
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",
     "@electron-forge/maker-dmg": "^7.11.1",
@@ -54,16 +44,27 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron-forge/shared-types": "^7.11.1",
     "@electron/fuses": "^1.8.0",
+    "@grida/agent": "link:../packages/grida-ai-agent",
+    "@grida/ai-models": "link:../packages/grida-ai-models",
+    "@grida/desktop-bridge": "link:../packages/grida-desktop-bridge",
+    "@grida/home": "link:../packages/grida-home",
     "@tailwindcss/vite": "^4.2.2",
     "@types/electron-squirrel-startup": "^1.0.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.2",
+    "ai": "6.0.116",
+    "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
     "electron": "^42.2.0",
+    "electron-squirrel-startup": "^1.0.1",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "ts-node": "^10.0.0",
     "typescript": "^6",
+    "update-electron-app": "^3.2.0",
     "vite": "^8.0.13",
     "vitest": "^4"
   },
@@ -75,5 +76,6 @@
       "@grida/ai-models": "link:../packages/grida-ai-models",
       "@grida/home": "link:../packages/grida-home"
     }
-  }
+  },
+  "comment:dependencies": "Runtime deps that MUST ship on disk in the packaged app — i.e. the modules left `external` in vite.*.config.ts (everything else is bundled into .vite and belongs in devDependencies). electron-packager's prune ships exactly this set; scripts/verify-packaged-bundle.mjs enforces it. See GRIDA-DESKTOP-BUILD-GUARD in forge.config.ts."
 }

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -14,58 +14,25 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sandbox-runtime':
+        specifier: ^0.0.52
+        version: 0.0.52
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.23)
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.23
+      undici:
+        specifier: ^7.24.4
+        version: 7.25.0
+    devDependencies:
       '@ai-sdk/gateway':
         specifier: 3.0.66
         version: 3.0.66(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.47
         version: 2.0.47(zod@4.4.3)
-      '@anthropic-ai/sandbox-runtime':
-        specifier: ^0.0.52
-        version: 0.0.52
-      '@grida/agent':
-        specifier: link:../packages/grida-ai-agent
-        version: link:../packages/grida-ai-agent
-      '@grida/ai-models':
-        specifier: link:../packages/grida-ai-models
-        version: link:../packages/grida-ai-models
-      '@grida/desktop-bridge':
-        specifier: link:../packages/grida-desktop-bridge
-        version: link:../packages/grida-desktop-bridge
-      '@grida/home':
-        specifier: link:../packages/grida-home
-        version: link:../packages/grida-home
-      '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.23)
-      ai:
-        specifier: 6.0.116
-        version: 6.0.116(zod@4.4.3)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      electron-squirrel-startup:
-        specifier: ^1.0.1
-        version: 1.0.1
-      hono:
-        specifier: ^4.6.14
-        version: 4.12.23
-      react:
-        specifier: 19.2.5
-        version: 19.2.5
-      react-dom:
-        specifier: 19.2.5
-        version: 19.2.5(react@19.2.5)
-      tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.6.0
-      undici:
-        specifier: ^7.24.4
-        version: 7.25.0
-      update-electron-app:
-        specifier: ^3.2.0
-        version: 3.2.0
-    devDependencies:
       '@electron-forge/cli':
         specifier: ^7.11.1
         version: 7.11.1(encoding@0.1.13)
@@ -102,6 +69,18 @@ importers:
       '@electron/fuses':
         specifier: ^1.8.0
         version: 1.8.0
+      '@grida/agent':
+        specifier: link:../packages/grida-ai-agent
+        version: link:../packages/grida-ai-agent
+      '@grida/ai-models':
+        specifier: link:../packages/grida-ai-models
+        version: link:../packages/grida-ai-models
+      '@grida/desktop-bridge':
+        specifier: link:../packages/grida-desktop-bridge
+        version: link:../packages/grida-desktop-bridge
+      '@grida/home':
+        specifier: link:../packages/grida-home
+        version: link:../packages/grida-home
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.3.0(vite@8.0.13(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1))
@@ -117,12 +96,30 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.13(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1))
+      ai:
+        specifier: 6.0.116
+        version: 6.0.116(zod@4.4.3)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       electron:
         specifier: ^42.2.0
         version: 42.2.0
+      electron-squirrel-startup:
+        specifier: ^1.0.1
+        version: 1.0.1
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.6.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.3.0
@@ -132,6 +129,9 @@ importers:
       typescript:
         specifier: ^6
         version: 6.0.3
+      update-electron-app:
+        specifier: ^3.2.0
+        version: 3.2.0
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)

--- a/desktop/scripts/verify-packaged-bundle.mjs
+++ b/desktop/scripts/verify-packaged-bundle.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+// GRIDA-DESKTOP-BUILD-GUARD (boot oracle) — see desktop/vite.guards.ts.
+//
+// The electron-forge Vite plugin ships only the `.vite` bundle and drops
+// node_modules, assuming the main process is fully self-contained. Any
+// dependency the bundles leave EXTERNAL (`require("x")`) must therefore be
+// physically present in the packaged app, or it crashes on launch with
+// "Cannot find module" — while every other CI check stays green. We
+// learned this the expensive way, one missing module per release
+// (@grida/desktop-bridge, then @anthropic-ai/sandbox-runtime, ...).
+//
+// This oracle inspects the ACTUAL packaged bundles, discovers every
+// external require, and verifies each one resolves in the packaged
+// context. It is the catch-all: a newly-externalized dependency that
+// isn't shipped fails here, not in a user's crash report.
+//
+// Usage: node scripts/verify-packaged-bundle.mjs [path/to/app.asar]
+//   (defaults to the first app.asar found under ./out)
+
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+const builtins = new Set(require_builtins());
+function require_builtins() {
+  // node:module exposes the canonical list.
+  return createRequire(import.meta.url)("node:module").builtinModules;
+}
+
+function findAsar() {
+  const arg = process.argv[2];
+  // arg may be an app.asar file, a directory to search, or omitted (search ./out)
+  let searchRoot;
+  if (arg) {
+    const resolved = path.resolve(arg);
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isFile())
+      return resolved;
+    searchRoot = resolved;
+  } else {
+    searchRoot = path.join(root, "out");
+  }
+  const stack = [searchRoot];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isFile() && e.name === "app.asar") return p;
+      if (e.isDirectory()) stack.push(p);
+    }
+  }
+  return null;
+}
+
+// An external is a bare specifier (not relative, not a node builtin, not
+// electron, which the runtime always provides). `hono/cors` -> base `hono`.
+function isExternalSpecifier(id) {
+  if (id.startsWith(".") || id.startsWith("/") || id.startsWith("node:")) {
+    return false;
+  }
+  const base = id.startsWith("@")
+    ? id.split("/").slice(0, 2).join("/")
+    : id.split("/")[0];
+  if (builtins.has(base)) return false;
+  if (base === "electron" || base.startsWith("electron/")) return false;
+  return true;
+}
+
+function extractExternals(jsFile) {
+  const code = fs.readFileSync(jsFile, "utf8");
+  const found = new Set();
+  // matches require("x"), require('x'), require(`x`)
+  const re = /require\(\s*[`"']([^`"']+)[`"']\s*\)/g;
+  let m;
+  while ((m = re.exec(code))) {
+    if (isExternalSpecifier(m[1])) found.add(m[1]);
+  }
+  return found;
+}
+
+const asar = findAsar();
+if (!asar || !fs.existsSync(asar)) {
+  console.error(
+    `[verify-packaged-bundle] no app.asar found` +
+      (process.argv[2]
+        ? ` at ${process.argv[2]}`
+        : ` under ${path.join(root, "out")}`) +
+      `\nRun \`pnpm package\` first.`
+  );
+  process.exit(2);
+}
+
+// Extract the asar so we can resolve modules against the packaged tree
+// with a plain Node resolver (createRequire). asar.unpack'd files are
+// still listed in the archive, so extraction is sufficient to answer
+// "is this module present".
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "grida-pkg-verify-"));
+const { extractAll } = createRequire(import.meta.url)("@electron/asar");
+extractAll(asar, tmp);
+
+// Find a package dir by walking up node_modules (exports-proof — modern
+// packages block require.resolve("<pkg>/package.json")).
+function findPackageDir(name, fromDir) {
+  let dir = fromDir;
+  for (;;) {
+    const candidate = path.join(dir, "node_modules", name);
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+const buildDir = path.join(tmp, ".vite", "build");
+const bundles = fs
+  .readdirSync(buildDir)
+  .filter((f) => f.endsWith(".js"))
+  .map((f) => path.join(buildDir, f));
+
+// Verify the FULL transitive closure of every external is present in the
+// packaged tree — not just the top-level requires. A direct external can
+// resolve while one of ITS runtime deps is missing (e.g. sandbox-runtime
+// present but `commander` pruned), which still crashes on launch.
+const missing = [];
+const closure = new Set(); // package names that legitimately ship
+const visited = new Set();
+
+function verify(name, fromDir, requiredBy) {
+  const dir = findPackageDir(name, fromDir);
+  if (!dir) {
+    missing.push({ spec: name, requiredBy });
+    return;
+  }
+  if (visited.has(dir)) return;
+  visited.add(dir);
+  closure.add(name);
+  const pj = JSON.parse(
+    fs.readFileSync(path.join(dir, "package.json"), "utf8")
+  );
+  // Follow dependencies + optionalDependencies — both can be installed and ship
+  // alongside the package, so both are legitimate members of the closure.
+  const deps = { ...pj.dependencies, ...pj.optionalDependencies };
+  for (const dep of Object.keys(deps)) {
+    verify(dep, dir, name);
+  }
+}
+
+for (const bundle of bundles) {
+  for (const spec of extractExternals(bundle)) {
+    // a subpath like "hono/cors" ships with its base package "hono"
+    const base = spec.startsWith("@")
+      ? spec.split("/").slice(0, 2).join("/")
+      : spec.split("/")[0];
+    verify(base, path.dirname(bundle), path.basename(bundle));
+  }
+}
+
+// Names of every package (dir with a package.json) shipped at the top level of
+// the packaged node_modules. Empty dirs left behind by the pruner have no
+// package.json and are ignored.
+function shippedPackages(nmDir) {
+  const out = [];
+  if (!fs.existsSync(nmDir)) return out;
+  for (const entry of fs.readdirSync(nmDir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || !entry.isDirectory()) continue;
+    if (entry.name.startsWith("@")) {
+      const scope = path.join(nmDir, entry.name);
+      for (const sub of fs.readdirSync(scope, { withFileTypes: true })) {
+        if (fs.existsSync(path.join(scope, sub.name, "package.json"))) {
+          out.push(`${entry.name}/${sub.name}`);
+        }
+      }
+    } else if (fs.existsSync(path.join(nmDir, entry.name, "package.json"))) {
+      out.push(entry.name);
+    }
+  }
+  return out;
+}
+
+// Bloat gate: the package must ship EXACTLY the runtime closure. Anything with
+// real content outside it means prune misbehaved (electron/forge#4045) and we'd
+// ship a bloated binary — fail loudly instead of silently.
+const extra = shippedPackages(path.join(tmp, "node_modules")).filter(
+  (name) => !closure.has(name)
+);
+
+fs.rmSync(tmp, { recursive: true, force: true });
+
+if (missing.length > 0) {
+  const lines = missing.map(
+    (f) => `  - ${f.spec}  (needed by ${f.requiredBy})`
+  );
+  console.error(
+    `\n✖ GRIDA-DESKTOP-BUILD-GUARD: the packaged app is missing ` +
+      `${missing.length} module(s) from the runtime-external closure. It WILL ` +
+      `crash on launch with "Cannot find module":\n${lines.join("\n")}\n\n` +
+      `These are left external by the Vite config but not shipped. Add them to ` +
+      `package.json "dependencies" (the ships-on-disk set). See forge.config.ts.\n`
+  );
+  process.exit(1);
+}
+
+if (extra.length > 0) {
+  const lines = extra.map((name) => `  - ${name}`);
+  console.error(
+    `\n✖ GRIDA-DESKTOP-BUILD-GUARD: the packaged app ships ` +
+      `${extra.length} package(s) outside the runtime closure (bloat — prune ` +
+      `misbehaved):\n${lines.join("\n")}\n\n` +
+      `Everything bundled by Vite must be a devDependency. Move these out of ` +
+      `package.json "dependencies". See forge.config.ts.\n`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✔ packaged bundle verified: ships EXACTLY the runtime closure ` +
+    `(${closure.size} packages), every externalized require resolves ` +
+    `(${path.relative(root, asar)}).`
+);


### PR DESCRIPTION
## What

Desktop releases crash on launch with `Cannot find module` — **0.0.3** on `@grida/desktop-bridge`, **0.0.4** on `@anthropic-ai/sandbox-runtime` — while every CI check stays green. This ships the runtime-external dependencies correctly and adds a cross-platform oracle so this class of bug can never silently ship again.

(Follow-up to #776, which fixed the *first* missing module by bundling `@grida/*`. This fixes the systemic cause behind all of them.)

## Root cause

The electron-forge **Vite plugin** sets `packagerConfig.ignore` to drop everything except `/.vite`, so the packaged `app.asar` ships **no `node_modules`**. Anything the bundles leave `external` (the `external` arrays in `vite.*.config.ts`) is then absent at runtime. Known forge bug — [electron/forge#3738](https://github.com/electron/forge/issues/3738), [#3917](https://github.com/electron/forge/issues/3917), [#4045](https://github.com/electron/forge/issues/4045). The missing modules surfaced one per release as each prior one got fixed.

## The fix — `package.json` is the spec

The idiomatic Electron pattern (what `electron-vite` enforces automatically): **`dependencies` = what ships on disk; `devDependencies` = what's bundled.**

- `dependencies` is now **exactly** the 4 Vite externals (`@anthropic-ai/sandbox-runtime`, `hono`, `@hono/node-server`, `undici`); everything bundled moved to `devDependencies`.
- electron-packager's default `prune` then ships exactly the production-dependency closure. `forge.config.ts` only overrides `ignore` (**8 lines**) to undo the Vite plugin's `node_modules` strip — excluding the `@grida/*` `link:` symlinks (they point out of the package and break asar) and pnpm internals.
- `@anthropic-ai/sandbox-runtime` is `asar.unpack`'d because it execs vendored binaries (`vendor/seccomp/*/apply-seccomp`) that can't run from inside an asar.
- Moving `@grida/*` to devDependencies also keeps their symlinks out of the pruner's path, fixing the pnpm/prune fragility for free.

## Won't silently break — bidirectional oracle

`scripts/verify-packaged-bundle.mjs` extracts the packaged asar, discovers every external `require` from the **actual** bundles, and asserts the package ships **exactly** the runtime closure:
- **(a)** every external + its full transitive closure is present (else a launch crash), **and**
- **(b)** nothing outside the closure ships (else prune-bloat, #4045).

Both directions exit non-zero — **verified they block**: dropping `undici` and shipping `clsx` each fail the build with the offender named. Wired as a `postPackage` hook (gates package/make/publish, local + CI; chain `publish→make→package→postPackage` verified). Also `pnpm verify:package`.

## Proof it works on every OS

`.github/workflows/verify-desktop-package.yml` packages the app + runs the oracle on **ubuntu / windows / macos** on every PR (no publish, no secrets). **Green on all three = proof the closure ships correctly cross-platform**; red = the oracle caught a platform gap before a user did. It stays as a permanent gate.

## Verified locally (macOS)

- `pnpm package` → *"ships EXACTLY the runtime closure (9 packages)"*.
- Ad-hoc-signed, **asar-integrity-enforced**, fused app **boots** — renderer + GPU helpers spawn, agent sidecar runs, **0** module/integrity errors.
- typecheck, lint, 17 unit tests pass.

## Reviewer notes

- ⚠️ **0.0.4 is published broken** → this needs a **0.0.5** (or re-cut) once merged + CI green on all 3 OSes.
- Cosmetic: `prune` leaves empty devDep dirs in the asar (harmless; the oracle ignores dirs without a `package.json`).
- Fully-native alternative is migrating to `electron-vite` — intentionally out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added continuous integration workflow for automated desktop package verification across Windows, macOS, and Linux platforms
  * Enhanced build configuration to ensure proper runtime dependency management and bundling
  * Implemented strict validation checks to prevent missing or incorrectly included dependencies in desktop releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->