### PR TITLE
fix(desktop): correct 404 macOS dmg link in release notes

### DIFF
--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -6,7 +6,7 @@
 
 | Platform | Arch  | Format | Signed | Download                                                                                                                        |
 | -------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-arm64-{{version}}.dmg) |
+| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-{{version}}-arm64.dmg) |
 | `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)    |
 | `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)   |
 | `linux`  | x64   | deb    |        | see Assets below                                                                                                                |


### PR DESCRIPTION
## Problem

The macOS **dmg** download link in the desktop release notes 404s.

The release-notes template ([`.github/release-notes/desktop.md`](https://github.com/gridaco/grida/blob/main/.github/release-notes/desktop.md)) hand-writes each asset filename into its download URL. The dmg link had **version and arch swapped**:

| | filename in link | real asset (maker-dmg output) |
|---|---|---|
| **dmg** | `Grida-arm64-0.0.3.dmg` ❌ → 404 | `Grida-0.0.3-arm64.dmg` |
| zip | `Grida-darwin-arm64-0.0.3.zip` ✓ | matches |
| exe | `Grida.Setup.0.0.3.x64.exe` ✓ | matches |

`maker-dmg` names the file `<productName>-<version>-<arch>.dmg`. The zip/exe links happened to match, so only the dmg was broken — clicking "Download for Mac (Apple Silicon)" on the [0.0.3 release](https://github.com/gridaco/grida/releases/tag/v0.0.3) gives a 404; the zip works.

## Fix

One character: swap the dmg filename to `Grida-{{version}}-arm64.dmg`. Same length, so the markdown table alignment is unchanged.

## Notes

- The template is rendered at publish time, so this fixes **future** releases. The already-published 0.0.3 notes still have the broken link — they can be repaired in place by re-running the release-notes step or a manual `gh release edit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the macOS arm64 download filename format in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->