### PR TITLE
chore: bump pnpm to v11.5.2

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -28,5 +28,5 @@
     "tailwindcss": "^4",
     "typescript": "^6"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@11.5.2"
 }

--- a/desktop/.npmrc
+++ b/desktop/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -68,14 +68,6 @@
     "vite": "^8.0.13",
     "vitest": "^4"
   },
-  "packageManager": "pnpm@10.24.0",
-  "pnpm": {
-    "overrides": {
-      "@grida/agent": "link:../packages/grida-ai-agent",
-      "@grida/desktop-bridge": "link:../packages/grida-desktop-bridge",
-      "@grida/ai-models": "link:../packages/grida-ai-models",
-      "@grida/home": "link:../packages/grida-home"
-    }
-  },
+  "packageManager": "pnpm@11.5.2",
   "comment:dependencies": "Runtime deps that MUST ship on disk in the packaged app — i.e. the modules left `external` in vite.*.config.ts (everything else is bundled into .vite and belongs in devDependencies). electron-packager's prune ships exactly this set; scripts/verify-packaged-bundle.mjs enforces it. See GRIDA-DESKTOP-BUILD-GUARD in forge.config.ts."
 }

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -291,7 +291,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true

--- a/desktop/pnpm-workspace.yaml
+++ b/desktop/pnpm-workspace.yaml
@@ -1,7 +1,21 @@
 packages:
   - .
-onlyBuiltDependencies:
-  - electron
-  - electron-winstaller
-  - fs-xattr
-  - macos-alias
+# electron-forge requires a hoisted node_modules layout (forge.config.ts relies on
+# prod deps being real dirs at the top level). pnpm 11 no longer reads `node-linker`
+# from .npmrc — pnpm-specific settings must live here. Was: desktop/.npmrc.
+nodeLinker: hoisted
+# pnpm 11 replaced onlyBuiltDependencies with the allowBuilds map. These native
+# deps must run their install scripts (e.g. electron downloads its binary).
+# strictDepBuilds: false keeps all other (unlisted) build scripts as warnings,
+# matching the pnpm 10 onlyBuiltDependencies whitelist behavior.
+strictDepBuilds: false
+allowBuilds:
+  electron: true
+  electron-winstaller: true
+  fs-xattr: true
+  macos-alias: true
+overrides:
+  "@grida/agent": "link:../packages/grida-ai-agent"
+  "@grida/desktop-bridge": "link:../packages/grida-desktop-bridge"
+  "@grida/ai-models": "link:../packages/grida-ai-models"
+  "@grida/home": "link:../packages/grida-home"

--- a/docs/contributing/desktop-release.md
+++ b/docs/contributing/desktop-release.md
@@ -78,7 +78,7 @@ These are silent footguns. Pinned, do not change without a plan:
 - **`appBundleId: "co.grida.desktop"`** in `forge.config.ts`. Changing it strands every installed user (Squirrel won't apply updates across bundle-id boundaries). Insiders use `co.grida.insiders` — separate track on purpose.
 - **Plain semver tags.** `update.electronjs.org` skips tags that don't pass `semver.valid()`. No `desktop-v…` or other prefixes.
 - **`hardenedRuntime: true`** in `osxSign.optionsForFile`. Required for notarization; required for the entitlements plist to apply.
-- **`onlyBuiltDependencies` in `pnpm-workspace.yaml`** (not `package.json`). pnpm 10 silently disables native module builds without it; in pnpm 10, when both files exist, only the workspace file's list is consulted. Removing it breaks the DMG maker (`Cannot find module '../build/Release/volume.node'`).
+- **`allowBuilds` in `pnpm-workspace.yaml`** (not `package.json`). pnpm 11 replaced the old `onlyBuiltDependencies` list with the `allowBuilds` map and ignores the `pnpm` field in `package.json` entirely. The native deps (`electron`, `electron-winstaller`, `fs-xattr`, `macos-alias`) must be set to `true` so their install scripts run; pnpm otherwise silently disables native module builds. Removing them breaks the DMG maker (`Cannot find module '../build/Release/volume.node'`).
 
 ---
 

--- a/docs/contributing/desktop-release.md
+++ b/docs/contributing/desktop-release.md
@@ -53,7 +53,7 @@ To promote a prerelease to stable: edit the GitHub Release in the UI and uncheck
 | Build + signing config        | [`desktop/forge.config.ts`](https://github.com/gridaco/grida/blob/main/desktop/forge.config.ts)                                       |
 | Hardened-runtime entitlements | [`desktop/build/entitlements.mac.plist`](https://github.com/gridaco/grida/blob/main/desktop/build/entitlements.mac.plist)             |
 | In-app updater wiring         | [`desktop/src/main.ts`](https://github.com/gridaco/grida/blob/main/desktop/src/main.ts) — `updateElectronApp({ notifyUser: true })`   |
-| pnpm native-module allowlist  | [`desktop/pnpm-workspace.yaml`](https://github.com/gridaco/grida/blob/main/desktop/pnpm-workspace.yaml) — `onlyBuiltDependencies`     |
+| pnpm native-module allowlist  | [`desktop/pnpm-workspace.yaml`](https://github.com/gridaco/grida/blob/main/desktop/pnpm-workspace.yaml) — `allowBuilds`               |
 | Apple secrets                 | `release` environment on `gridaco/grida` — `gh secret list --env release --repo gridaco/grida`                                        |
 
 Secrets (all 6 env-scoped, not repo-wide):
@@ -91,7 +91,7 @@ These are silent footguns. Pinned, do not change without a plan:
 3. No asset matching `<platform>-<arch>` (e.g. `darwin-arm64`) on the release. Check artifact filenames in forge `makers` config.
 
 **Workflow logs: `Cannot find module '../build/Release/volume.node'`**
-`onlyBuiltDependencies` is missing or in the wrong file. Must be in `desktop/pnpm-workspace.yaml`, not `desktop/package.json`. See [Hard constraints](#hard-constraints).
+The native dep is missing from `allowBuilds` (or set to `false`), or the config is in the wrong file. The `allowBuilds` map must be in `desktop/pnpm-workspace.yaml`, not `desktop/package.json` (pnpm 11 ignores the `pnpm` field in `package.json`). See [Hard constraints](#hard-constraints).
 
 **Workflow logs: `Error parsing workflow file ... HTTP 422` on `workflow_dispatch`.**
 A step `if:` references `${{ secrets.* }}` directly — not allowed. Map secrets to job-level `env:` booleans (`HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' }}`) and gate on `env.HAS_SIGNING == 'true'`.

--- a/editor/package.json
+++ b/editor/package.json
@@ -262,5 +262,5 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@11.5.2"
 }

--- a/package.json
+++ b/package.json
@@ -33,24 +33,7 @@
   "resolutions": {},
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
   },
-  "packageManager": "pnpm@10.24.0",
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.1.3",
-      "@types/react-dom": "19.1.3",
-      "tsx": "4.21.0",
-      "typescript": "6.0.3",
-      "axios": "1.16.1",
-      "prosemirror-model": "1.23.0",
-      "prosemirror-view": "1.36.0",
-      "next": "16.2.6",
-      "@next/mdx": "16.2.6",
-      "@next/third-parties": "16.2.6",
-      "openai": "6.18.0",
-      "react": "19.2.5",
-      "react-dom": "19.2.5"
-    }
-  }
+  "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,33 @@ packages:
   - "packages/*"
   - "packages/lib/*"
   - "services/*"
+# pnpm 11 errors on un-approved dependency build scripts by default
+# (strictDepBuilds). pnpm 10 only warned and ran none of them for this workspace,
+# so we keep that behavior. strictDepBuilds: false avoids failing CI when a new
+# dependency ships a build script; the explicit allowBuilds entries below record
+# the reviewed decision (all skipped, as under pnpm 10). Flip one to `true` to opt in.
+strictDepBuilds: false
+allowBuilds:
+  "@sentry/cli": false
+  canvas: false
+  core-js: false
+  core-js-pure: false
+  esbuild: false
+  lefthook: false
+  msw: false
+  sharp: false
+  workerd: false
+overrides:
+  "@types/react": "19.1.3"
+  "@types/react-dom": "19.1.3"
+  tsx: "4.21.0"
+  typescript: "6.0.3"
+  axios: "1.16.1"
+  prosemirror-model: "1.23.0"
+  prosemirror-view: "1.36.0"
+  next: "16.2.6"
+  "@next/mdx": "16.2.6"
+  "@next/third-parties": "16.2.6"
+  openai: "6.18.0"
+  react: "19.2.5"
+  react-dom: "19.2.5"


### PR DESCRIPTION
## What

Bumps the package manager from **pnpm 10.x → 11.5.2** across the repo (`packageManager` in root, `editor`, `apps/viewer`, `desktop`; `engines.pnpm >= 11.0.0`).

## Why it's more than a version string

pnpm 11 ships three breaking changes that each *silently* break this repo's build, so settings had to be migrated:

1. **`pnpm` field in `package.json` is no longer read.** Moved `overrides` (root + desktop) into the respective `pnpm-workspace.yaml`.
2. **Build scripts now error by default** (`strictDepBuilds: true`), and `onlyBuiltDependencies` / `ignoredBuiltDependencies` were replaced by the **`allowBuilds`** map.
   - Root: `strictDepBuilds: false` + explicit `allowBuilds` (all `false`) — preserves pnpm 10 behavior (none of these scripts ran before).
   - Desktop: migrated `onlyBuiltDependencies` → `allowBuilds` with `electron`, `electron-winstaller`, `fs-xattr`, `macos-alias` set to `true` so their install scripts (e.g. the electron binary download) still run. **Without this the packaged app breaks.**
3. **`node-linker` is no longer read from `.npmrc`.** Moved desktop's `node-linker=hoisted` into `pnpm-workspace.yaml` as `nodeLinker: hoisted` (electron-forge requires a hoisted layout) and removed `desktop/.npmrc`.

Also updated `docs/contributing/desktop-release.md`, which documented the old `onlyBuiltDependencies` footgun.

## Verification

- **Root lockfile: byte-identical** — zero dependency drift; all overrides preserved.
- **Desktop**: clean `out/` + `.vite/`, fresh `pnpm package` succeeds, the `GRIDA-DESKTOP-BUILD-GUARD` bundle verification passes ("ships EXACTLY the runtime closure (9 packages)"), and the packaged `.app` launches & runs (full Electron process tree, agent sidecar up).
- **Lint**: `pnpm lint` — 0 errors.
- **Tests**: `turbo test` (packages + editor) — **56/56 pass**.
- **Typecheck**: `turbo typecheck` — green (editor 37/37 + all package tasks).

## Reviewer notes

- CI workflows use `pnpm/action-setup@v4` with no pinned version → they read `packageManager`, so no workflow edits were needed.
- `desktop/pnpm-lock.yaml` has a one-line pnpm-11 metadata enrichment (`gitHosted: true`); root lockfile unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project to use a newer package manager version across workspaces.
  * Adjusted workspace dependency and build-script configuration for better compatibility with packaging tools.
* **Documentation**
  * Revised desktop release and troubleshooting guidance to reflect the new workspace build settings and allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->