### PR TITLE
fix: allow creating folders from desktop open dialog

### DIFF
--- a/desktop/src/menu.ts
+++ b/desktop/src/menu.ts
@@ -46,8 +46,12 @@ async function open_folder_picker_and_register(app: App): Promise<void> {
   if (!agentSidecar) return; // pre-ready / between restarts
   const focused = BrowserWindow.getFocusedWindow() ?? undefined;
   const result = focused
-    ? await dialog.showOpenDialog(focused, { properties: ["openDirectory"] })
-    : await dialog.showOpenDialog({ properties: ["openDirectory"] });
+    ? await dialog.showOpenDialog(focused, {
+        properties: ["openDirectory", "createDirectory"],
+      })
+    : await dialog.showOpenDialog({
+        properties: ["openDirectory", "createDirectory"],
+      });
   if (result.canceled || result.filePaths.length === 0) return;
   let workspaceId: string;
   try {

--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -115,7 +115,9 @@ export default function DesktopWelcomePage() {
     try {
       setBusy(true);
       setError(null);
-      const paths = await bridge.dialog.open({ properties: ["openDirectory"] });
+      const paths = await bridge.dialog.open({
+        properties: ["openDirectory", "createDirectory"],
+      });
       if (!paths || paths.length === 0) return;
       const ws = await workspacesNs.openFolder(paths[0]);
       await refreshWorkspaces();

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -69,7 +69,9 @@ export type FileFilter = { name: string; extensions: string[] };
 export type OpenDialogOptions = {
   default_path?: string;
   filters?: FileFilter[];
-  properties?: Array<"openFile" | "openDirectory" | "multiSelections">;
+  properties?: Array<
+    "openFile" | "openDirectory" | "multiSelections" | "createDirectory"
+  >;
 };
 
 export type SaveDialogOptions = {


### PR DESCRIPTION
## Summary

- allow the macOS directory picker to create folders from the File menu Open Folder flow
- pass the same dialog option through the desktop welcome screen Open folder flow
- include `createDirectory` in the desktop bridge dialog option type

## Testing

- `git diff --check`
- Static source check confirming both Open Folder call sites now include `createDirectory`

Not run: `pnpm typecheck` or package tests, because this checkout does not have the package manager or dependencies installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create new directories directly within the "Open Folder…" dialog when opening or selecting folders. This streamlines the workflow by enabling on-the-fly directory creation, eliminating the need to prepare folder structures outside the application beforehand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->