### PR TITLE
feat(svg-editor): keyboard nudge-resize (Ctrl+⌥+Arrow)

### DIFF
--- a/packages/grida-svg-editor/__tests__/_helpers.ts
+++ b/packages/grida-svg-editor/__tests__/_helpers.ts
@@ -7,7 +7,8 @@ import type {
   SvgEditorInternal,
 } from "../src/core/editor";
 import type { SvgDocument } from "../src/core/document";
-import type { Rect } from "../src/types";
+import type { GeometryProvider } from "../src/core/geometry";
+import type { NodeId, Rect } from "../src/types";
 
 /**
  * Test-only factory that returns the wide `SvgEditorInternal` type so
@@ -45,4 +46,69 @@ export function first_rect(
     }
   }
   throw new Error("no <rect> in document");
+}
+
+/**
+ * Install a headless `GeometryProvider` that derives bbox from the doc's own
+ * attrs — covers `<rect>` / `<image>` / `<use>` / `<circle>` / `<ellipse>`.
+ * Required by any command that needs world bounds (`resize_to`, `resize_by`,
+ * `rotate`, `align`). Returns `null` for other tags (e.g. `<g>`).
+ */
+export function install_geometry(
+  editor: ReturnType<typeof createSvgEditor>
+): void {
+  const internal = editor as SvgEditorInternal;
+  const doc = editor.document;
+  const num = (id: NodeId, name: string, fallback = 0): number => {
+    const raw = doc.get_attr(id, name);
+    if (raw == null) return fallback;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) ? n : fallback;
+  };
+  const driver: GeometryProvider = {
+    bounds_of(id: NodeId): Rect | null {
+      const tag = doc.tag_of(id);
+      switch (tag) {
+        case "rect":
+        case "image":
+        case "use":
+          return {
+            x: num(id, "x"),
+            y: num(id, "y"),
+            width: num(id, "width"),
+            height: num(id, "height"),
+          };
+        case "circle": {
+          const cx = num(id, "cx");
+          const cy = num(id, "cy");
+          const r = num(id, "r");
+          return { x: cx - r, y: cy - r, width: 2 * r, height: 2 * r };
+        }
+        case "ellipse": {
+          const cx = num(id, "cx");
+          const cy = num(id, "cy");
+          const rx = num(id, "rx");
+          const ry = num(id, "ry");
+          return { x: cx - rx, y: cy - ry, width: 2 * rx, height: 2 * ry };
+        }
+        default:
+          return null;
+      }
+    },
+    bounds_of_many(ids) {
+      const out = new Map<NodeId, Rect>();
+      for (const id of ids) {
+        const r = this.bounds_of(id);
+        if (r) out.set(id, r);
+      }
+      return out;
+    },
+    nodes_in_rect() {
+      return [];
+    },
+    node_at_point() {
+      return null;
+    },
+  };
+  internal._internal.set_geometry(driver);
 }

--- a/packages/grida-svg-editor/__tests__/keymap-defaults.test.ts
+++ b/packages/grida-svg-editor/__tests__/keymap-defaults.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from "vitest";
 import { getKeyboardOS } from "@grida/keybinding";
 import { createSvgEditor } from "../src/index";
-import { createSvgEditorWithInternals } from "./_helpers";
+import { createSvgEditorWithInternals, install_geometry } from "./_helpers";
 
 // "Mod" is Meta on Mac, Ctrl elsewhere — match the keymap's platform
 // resolution so these tests pass under both local macOS and Linux CI.
@@ -53,6 +53,17 @@ function findByElementId(
   const found = [...editor.tree().nodes.values()].find((n) => n.name === id);
   if (!found) throw new Error(`no node with element id "${id}"`);
   return found.id;
+}
+
+/** Read a numeric geometry attr (defaulting to 0) — shared by the
+ *  transform.nudge and nudge-resize keymap suites. */
+function rectAttr(
+  editor: ReturnType<typeof createSvgEditor>,
+  id: string,
+  name: "x" | "y" | "width" | "height"
+): number {
+  const v = editor.document.get_attr(id, name);
+  return v === null ? 0 : parseFloat(v);
 }
 
 describe("default keymap — hierarchy.enter / hierarchy.exit", () => {
@@ -104,15 +115,6 @@ describe("default keymap — hierarchy.enter / hierarchy.exit", () => {
 });
 
 describe("default keymap — transform.nudge (arrows / shift+arrows)", () => {
-  function rectAttr(
-    editor: ReturnType<typeof createSvgEditor>,
-    id: string,
-    name: "x" | "y"
-  ): number {
-    const v = editor.document.get_attr(id, name);
-    return v === null ? 0 : parseFloat(v);
-  }
-
   it("ArrowRight nudges +1 in x", () => {
     const editor = createSvgEditorWithInternals({ svg: NESTED });
     const a = findByElementId(editor, "a");
@@ -287,5 +289,83 @@ describe("default keymap — claim vs consume (preventDefault contract)", () => 
     // KeyY without modifier — no binding exists.
     const e = mkEvent({ code: "KeyY" });
     expect(editor.keymap.claims(e)).toBe(false);
+  });
+});
+
+describe("default keymap — nudge-resize (Ctrl+Alt+Arrow)", () => {
+  // rect "a" in NESTED: x=10 y=20 width=30 height=40.
+  it("Ctrl+Alt+ArrowRight grows width and consumes it (resize, not move — x unchanged)", () => {
+    const editor = createSvgEditorWithInternals({ svg: NESTED });
+    install_geometry(editor);
+    const a = findByElementId(editor, "a");
+    editor.commands.select(a);
+    const x0 = rectAttr(editor, a, "x");
+    const w0 = rectAttr(editor, a, "width");
+    expect(
+      editor.keymap.dispatch(
+        mkEvent({ code: "ArrowRight", ctrlKey: true, altKey: true })
+      )
+    ).toBe(true);
+    // resize_to is factor-based → sub-epsilon float drift on non-integer
+    // factors (30 * 31/30 ≈ 31). toBeCloseTo, not toBe.
+    expect(rectAttr(editor, a, "width")).toBeCloseTo(w0 + 1, 6);
+    expect(rectAttr(editor, a, "x")).toBe(x0); // NOT moved — this is resize, not nudge
+  });
+
+  it("Ctrl+Alt+ArrowDown grows height", () => {
+    const editor = createSvgEditorWithInternals({ svg: NESTED });
+    install_geometry(editor);
+    const a = findByElementId(editor, "a");
+    editor.commands.select(a);
+    const h0 = rectAttr(editor, a, "height");
+    expect(
+      editor.keymap.dispatch(
+        mkEvent({ code: "ArrowDown", ctrlKey: true, altKey: true })
+      )
+    ).toBe(true);
+    expect(rectAttr(editor, a, "height")).toBeCloseTo(h0 + 1, 6);
+  });
+
+  it("Ctrl+Alt+Shift+ArrowRight grows width by 10", () => {
+    const editor = createSvgEditorWithInternals({ svg: NESTED });
+    install_geometry(editor);
+    const a = findByElementId(editor, "a");
+    editor.commands.select(a);
+    const w0 = rectAttr(editor, a, "width");
+    expect(
+      editor.keymap.dispatch(
+        mkEvent({
+          code: "ArrowRight",
+          ctrlKey: true,
+          altKey: true,
+          shiftKey: true,
+        })
+      )
+    ).toBe(true);
+    expect(rectAttr(editor, a, "width")).toBeCloseTo(w0 + 10, 6);
+  });
+
+  it("Alt+ArrowRight still moves (x+1, width unchanged) — measurement-HUD nudge preserved", () => {
+    const editor = createSvgEditorWithInternals({ svg: NESTED });
+    install_geometry(editor);
+    const a = findByElementId(editor, "a");
+    editor.commands.select(a);
+    const x0 = rectAttr(editor, a, "x");
+    const w0 = rectAttr(editor, a, "width");
+    expect(
+      editor.keymap.dispatch(mkEvent({ code: "ArrowRight", altKey: true }))
+    ).toBe(true);
+    expect(rectAttr(editor, a, "x")).toBe(x0 + 1); // moved
+    expect(rectAttr(editor, a, "width")).toBe(w0); // not resized
+  });
+
+  it("Ctrl+Alt+Arrow returns false with empty selection", () => {
+    const editor = createSvgEditorWithInternals({ svg: NESTED });
+    install_geometry(editor);
+    expect(
+      editor.keymap.dispatch(
+        mkEvent({ code: "ArrowRight", ctrlKey: true, altKey: true })
+      )
+    ).toBe(false);
   });
 });

--- a/packages/grida-svg-editor/__tests__/multi-selection.test.ts
+++ b/packages/grida-svg-editor/__tests__/multi-selection.test.ts
@@ -6,74 +6,10 @@
 import { describe, expect, it } from "vitest";
 import cmath from "@grida/cmath";
 import { createSvgEditor } from "../src/index";
-import type { SvgEditorInternal } from "../src/core/editor";
 import { SvgDocument } from "../src/core/document";
-import type { GeometryProvider } from "../src/core/geometry";
 import type { NodeId, Rect } from "../src/types";
 import { resize_pipeline, type ResizePlan } from "../src/core/resize-pipeline";
-
-// ─── Geometry stub ──────────────────────────────────────────────────────────
-//
-// `commands.resize_to` requires a surface-attached geometry provider.
-// For headless tests we install one that derives bbox from the doc's
-// own attrs — covers <rect>, <circle>, <ellipse> for the cases below.
-
-function install_geometry(editor: ReturnType<typeof createSvgEditor>): void {
-  const internal = editor as SvgEditorInternal;
-  const doc = editor.document;
-  const num = (id: NodeId, name: string, fallback = 0): number => {
-    const raw = doc.get_attr(id, name);
-    if (raw == null) return fallback;
-    const n = parseFloat(raw);
-    return Number.isFinite(n) ? n : fallback;
-  };
-  const driver: GeometryProvider = {
-    bounds_of(id: NodeId): Rect | null {
-      const tag = doc.tag_of(id);
-      switch (tag) {
-        case "rect":
-        case "image":
-        case "use":
-          return {
-            x: num(id, "x"),
-            y: num(id, "y"),
-            width: num(id, "width"),
-            height: num(id, "height"),
-          };
-        case "circle": {
-          const cx = num(id, "cx");
-          const cy = num(id, "cy");
-          const r = num(id, "r");
-          return { x: cx - r, y: cy - r, width: 2 * r, height: 2 * r };
-        }
-        case "ellipse": {
-          const cx = num(id, "cx");
-          const cy = num(id, "cy");
-          const rx = num(id, "rx");
-          const ry = num(id, "ry");
-          return { x: cx - rx, y: cy - ry, width: 2 * rx, height: 2 * ry };
-        }
-        default:
-          return null;
-      }
-    },
-    bounds_of_many(ids) {
-      const out = new Map<NodeId, Rect>();
-      for (const id of ids) {
-        const r = this.bounds_of(id);
-        if (r) out.set(id, r);
-      }
-      return out;
-    },
-    nodes_in_rect() {
-      return [];
-    },
-    node_at_point() {
-      return null;
-    },
-  };
-  internal._internal.set_geometry(driver);
-}
+import { first_rect, install_geometry } from "./_helpers";
 
 // ─── Phase A: SelectionGroup builder (parity sanity) ─────────────────────────
 //
@@ -420,6 +356,272 @@ describe("commands.resize_to — multi member", () => {
     expect(editor.document.get_attr(b, "x")).toBe("70");
     expect(editor.document.get_attr(b, "y")).toBe("60");
     expect(editor.document.get_attr(b, "width")).toBe("10");
+  });
+});
+
+// ─── commands.resize_to — transform-safety gate (is_resizable_node) ──────────
+//
+// resize_to scales LOCAL attrs around a WORLD-space origin, which is only
+// correct when world ≡ local. A member with a non-trivial transform (rotate
+// without explicit pivot, matrix, scale, skew) must be skipped — gating on the
+// tag-only `is_resizable` used to let such members through and mis-resize them.
+// The gate is now `is_resizable_node`, matching the HUD resize path.
+
+describe("commands.resize_to — transform-safety gate", () => {
+  it("skips a member with an unsafe transform (rotate without explicit pivot) and resizes the rest", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10"/><rect x="20" y="0" width="10" height="10" transform="rotate(30)"/></svg>`,
+    });
+    install_geometry(editor);
+    const [plain, rotated] = editor.document
+      .all_elements()
+      .filter((id) => editor.document.tag_of(id) === "rect");
+    editor.commands.select([plain, rotated]);
+    // Only `plain` is a member → union = (0,0,10,10). Target doubles width.
+    const ok = editor.commands.resize_to({ x: 0, y: 0, width: 20, height: 10 });
+    expect(ok).toBe(true);
+    // plain resized:
+    expect(editor.document.get_attr(plain, "width")).toBe("20");
+    // rotated untouched (skipped):
+    expect(editor.document.get_attr(rotated, "x")).toBe("20");
+    expect(editor.document.get_attr(rotated, "width")).toBe("10");
+    expect(editor.document.get_attr(rotated, "transform")).toBe("rotate(30)");
+  });
+
+  it("is a no-op (false) when the only member has an unsafe transform", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10" transform="rotate(30)"/></svg>`,
+    });
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    const ok = editor.commands.resize_to({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    });
+    expect(ok).toBe(false);
+    expect(editor.document.get_attr(r, "width")).toBe("10");
+    expect(editor.document.get_attr(r, "transform")).toBe("rotate(30)");
+  });
+
+  it("still resizes a member with a leading translate", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10" transform="translate(5 5)"/></svg>`,
+    });
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    const ok = editor.commands.resize_to({ x: 0, y: 0, width: 20, height: 10 });
+    expect(ok).toBe(true);
+    expect(editor.document.get_attr(r, "width")).toBe("20");
+    // leading translate preserved (apply_resize never touches transform):
+    expect(editor.document.get_attr(r, "transform")).toBe("translate(5 5)");
+  });
+});
+
+// ─── commands.resize_by — keyboard nudge-resize core verb ────────────────────
+//
+// Grows/shrinks the selection's union bbox by a {dw, dh} delta, NW corner
+// fixed. Sugar over resize_to with an ALL-OR-NOTHING is_resizable_node gate
+// (matches the HUD: a mixed/unsafe selection is refused, not partially
+// resized — the distinction from resize_to's per-member skip).
+
+describe("commands.resize_by", () => {
+  const mkRect = () =>
+    createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="10" y="10" width="50" height="20"/></svg>`,
+    });
+
+  it("grows width with the NW corner fixed (+dw)", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(true);
+    expect(editor.document.get_attr(r, "x")).toBe("10");
+    expect(editor.document.get_attr(r, "y")).toBe("10");
+    expect(editor.document.get_attr(r, "width")).toBe("80");
+    expect(editor.document.get_attr(r, "height")).toBe("20");
+  });
+
+  it("shrinks width with the NW corner fixed (-dw)", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    expect(editor.commands.resize_by({ dw: -20, dh: 0 })).toBe(true);
+    expect(editor.document.get_attr(r, "x")).toBe("10");
+    expect(editor.document.get_attr(r, "width")).toBe("30");
+  });
+
+  it("grows height with the NW corner fixed (+dh)", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    expect(editor.commands.resize_by({ dw: 0, dh: 10 })).toBe(true);
+    expect(editor.document.get_attr(r, "y")).toBe("10");
+    expect(editor.document.get_attr(r, "height")).toBe("30");
+    expect(editor.document.get_attr(r, "width")).toBe("50");
+  });
+
+  it("shrinks height with the NW corner fixed (-dh)", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    expect(editor.commands.resize_by({ dw: 0, dh: -5 })).toBe(true);
+    expect(editor.document.get_attr(r, "height")).toBe("15");
+  });
+
+  it("grows each member in place (multi) — members do not move relative to one another", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10"/><rect x="20" y="0" width="10" height="10"/></svg>`,
+    });
+    install_geometry(editor);
+    const [a, b] = editor.document
+      .all_elements()
+      .filter((id) => editor.document.tag_of(id) === "rect");
+    editor.commands.select([a, b]);
+    // PER-ELEMENT: each rect grows by +30 around its OWN NW. Neither member is
+    // translated — b keeps its x=20 (contrast: resize_to would push it to 40).
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(true);
+    expect(editor.document.get_attr(a, "x")).toBe("0");
+    expect(editor.document.get_attr(a, "width")).toBe("40");
+    expect(editor.document.get_attr(b, "x")).toBe("20"); // NOT translated
+    expect(editor.document.get_attr(b, "width")).toBe("40");
+  });
+
+  it("refuses the whole gesture (false, no mutation) when selection includes a <g>", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10"/><g><rect x="50" y="50" width="10" height="10"/></g></svg>`,
+    });
+    install_geometry(editor);
+    const r = editor.document
+      .all_elements()
+      .find((id) => editor.document.tag_of(id) === "rect")!;
+    const g = editor.document
+      .all_elements()
+      .find((id) => editor.document.tag_of(id) === "g")!;
+    editor.commands.select([r, g]);
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(false);
+    // resizable member is NOT partially resized — all-or-nothing.
+    expect(editor.document.get_attr(r, "width")).toBe("10");
+  });
+
+  it("refuses the whole gesture when a member has an unsafe transform (all-or-nothing, unlike resize_to)", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10"/><rect x="20" y="0" width="10" height="10" transform="rotate(30)"/></svg>`,
+    });
+    install_geometry(editor);
+    const [plain, rotated] = editor.document
+      .all_elements()
+      .filter((id) => editor.document.tag_of(id) === "rect");
+    editor.commands.select([plain, rotated]);
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(false);
+    expect(editor.document.get_attr(plain, "width")).toBe("10");
+    expect(editor.document.get_attr(rotated, "width")).toBe("10");
+  });
+
+  it("is a no-op (false) when no geometry provider is attached (headless)", () => {
+    const editor = mkRect();
+    // Do NOT install geometry.
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(false);
+    expect(editor.document.get_attr(r, "width")).toBe("50");
+  });
+
+  it("shrinking past zero stays non-negative (floors at the resize minimum)", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    // resize_by clamps the target width to 0; the per-tag resize handler then
+    // floors the written width at its 0.001 minimum so the shape never
+    // collapses or flips negative. The contract is "never negative / NaN".
+    expect(editor.commands.resize_by({ dw: -1000, dh: 0 })).toBe(true);
+    const w = parseFloat(editor.document.get_attr(r, "width")!);
+    expect(Number.isFinite(w)).toBe(true);
+    expect(w).toBeGreaterThanOrEqual(0);
+    expect(w).toBeLessThan(1);
+  });
+
+  it("is a no-op (false, no history step) on a geometrically identity gesture", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="0"/></svg>`,
+    });
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    // height is 0 → the height nudge can't scale a zero-extent axis (factor 1)
+    // and width is untouched → identity gesture → no history step pushed.
+    expect(editor.commands.resize_by({ dw: 0, dh: 5 })).toBe(false);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("pushes one undo step", () => {
+    const editor = mkRect();
+    install_geometry(editor);
+    const r = first_rect(editor);
+    editor.commands.select(r);
+    editor.commands.resize_by({ dw: 30, dh: 0 });
+    expect(editor.document.get_attr(r, "width")).toBe("80");
+    expect(editor.state.can_undo).toBe(true);
+    editor.commands.undo();
+    expect(editor.document.get_attr(r, "width")).toBe("50");
+    expect(editor.document.get_attr(r, "x")).toBe("10");
+  });
+});
+
+// ─── resize semantics — GROUP (resize_to) vs PER-ELEMENT (resize_by) ─────────
+//
+// The two verbs share one path (collect_resize_members + commit_resize) but
+// parameterize it to OPPOSITE multi-member semantics. These two tests pin the
+// divergence on identical input so the contract is explicit:
+//
+//   fixture: two 10×10 rects, a@(0,0) and b@(20,0); union = (0,0,30,10).
+//   widen so the union/each grows +30 in width.
+//
+//   • resize_to (group / HUD handle-drag): scale the whole selection around the
+//     union NW → the off-origin member b TRANSLATES (x 20 → 40) and scales.
+//   • resize_by (per-element / keyboard nudge): grow each member around its OWN
+//     NW → b stays at x=20, just grows. Nobody moves relative to anyone.
+
+describe("resize semantics — group (resize_to) vs per-element (resize_by)", () => {
+  const TWO_RECTS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect x="0" y="0" width="10" height="10"/><rect x="20" y="0" width="10" height="10"/></svg>`;
+  const select_two = (editor: ReturnType<typeof createSvgEditor>) => {
+    install_geometry(editor);
+    const [a, b] = editor.document
+      .all_elements()
+      .filter((id) => editor.document.tag_of(id) === "rect");
+    editor.commands.select([a, b]);
+    return { a, b };
+  };
+
+  it("resize_to (GROUP) scales the union — the off-origin member translates", () => {
+    const editor = createSvgEditor({ svg: TWO_RECTS });
+    const { a, b } = select_two(editor);
+    // union (0,0,30,10) → target (0,0,60,10): sx=2 around union NW (0,0).
+    expect(
+      editor.commands.resize_to({ x: 0, y: 0, width: 60, height: 10 })
+    ).toBe(true);
+    expect(editor.document.get_attr(a, "x")).toBe("0");
+    expect(editor.document.get_attr(a, "width")).toBe("20");
+    expect(editor.document.get_attr(b, "x")).toBe("40"); // TRANSLATED (20 → 40)
+    expect(editor.document.get_attr(b, "width")).toBe("20");
+  });
+
+  it("resize_by (PER-ELEMENT) grows each member in place — nobody translates", () => {
+    const editor = createSvgEditor({ svg: TWO_RECTS });
+    const { a, b } = select_two(editor);
+    expect(editor.commands.resize_by({ dw: 30, dh: 0 })).toBe(true);
+    expect(editor.document.get_attr(a, "x")).toBe("0");
+    expect(editor.document.get_attr(a, "width")).toBe("40");
+    expect(editor.document.get_attr(b, "x")).toBe("20"); // NOT translated
+    expect(editor.document.get_attr(b, "width")).toBe("40");
   });
 });
 

--- a/packages/grida-svg-editor/__tests__/multi-selection.test.ts
+++ b/packages/grida-svg-editor/__tests__/multi-selection.test.ts
@@ -364,7 +364,7 @@ describe("commands.resize_to — multi member", () => {
 // resize_to scales LOCAL attrs around a WORLD-space origin, which is only
 // correct when world ≡ local. A member with a non-trivial transform (rotate
 // without explicit pivot, matrix, scale, skew) must be skipped — gating on the
-// tag-only `is_resizable` used to let such members through and mis-resize them.
+// tag-only `is_resizable` used to let such members through and resize them incorrectly.
 // The gate is now `is_resizable_node`, matching the HUD resize path.
 
 describe("commands.resize_to — transform-safety gate", () => {

--- a/packages/grida-svg-editor/docs/keybindings.md
+++ b/packages/grida-svg-editor/docs/keybindings.md
@@ -75,15 +75,15 @@ source of truth for what svg-editor ships out of the box.
 
 ## Transformation
 
-| Action                    | macOS            | Windows/Linux    | Status | Command                      | Notes                                                                       |
-| ------------------------- | ---------------- | ---------------- | ------ | ---------------------------- | --------------------------------------------------------------------------- |
-| Nudge                     | `Arrow Keys`     | `Arrow Keys`     | [x]    | `transform.nudge`            | 1 doc-unit per press; `args: { dx, dy }`                                    |
-| Nudge (large)             | `⇧ + Arrow Keys` | `⇧ + Arrow Keys` | [x]    | `transform.nudge`            | 10 doc-units per press                                                      |
-| Nudge resize (right/up/…) | `Ctrl + ⌥ + …`   | `Ctrl + Alt + …` | [x]    | `selection.nudge_resize`     | NW-fixed; ±1 / ±10 with Shift; refused on non-resizable/transformed members |
-| Move to front             | `]`              | `]`              | [x]    | `reorder` (`bring_to_front`) | shipped                                                                     |
-| Move to back              | `[`              | `[`              | [x]    | `reorder` (`send_to_back`)   | shipped                                                                     |
-| Move forward              | `⌘ + ]`          | `Ctrl + ]`       | [x]    | `reorder` (`bring_forward`)  | shipped                                                                     |
-| Move backward             | `⌘ + [`          | `Ctrl + [`       | [x]    | `reorder` (`send_backward`)  | shipped                                                                     |
+| Action                    | macOS            | Windows/Linux    | Status | Command                      | Notes                                                                                                  |
+| ------------------------- | ---------------- | ---------------- | ------ | ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Nudge                     | `Arrow Keys`     | `Arrow Keys`     | [x]    | `transform.nudge`            | 1 doc-unit per press; `args: { dx, dy }`                                                               |
+| Nudge (large)             | `⇧ + Arrow Keys` | `⇧ + Arrow Keys` | [x]    | `transform.nudge`            | 10 doc-units per press                                                                                 |
+| Nudge resize (right/up/…) | `⌃ + ⌥ + …`      | `Ctrl + Alt + …` | [x]    | `selection.nudge_resize`     | per-element, each around its own NW; ±1 / ±10 with Shift; refused on non-resizable/transformed members |
+| Move to front             | `]`              | `]`              | [x]    | `reorder` (`bring_to_front`) | shipped                                                                                                |
+| Move to back              | `[`              | `[`              | [x]    | `reorder` (`send_to_back`)   | shipped                                                                                                |
+| Move forward              | `⌘ + ]`          | `Ctrl + ]`       | [x]    | `reorder` (`bring_forward`)  | shipped                                                                                                |
+| Move backward             | `⌘ + [`          | `Ctrl + [`       | [x]    | `reorder` (`send_backward`)  | shipped                                                                                                |
 
 ## Alignment & Distribution
 

--- a/packages/grida-svg-editor/docs/keybindings.md
+++ b/packages/grida-svg-editor/docs/keybindings.md
@@ -75,15 +75,15 @@ source of truth for what svg-editor ships out of the box.
 
 ## Transformation
 
-| Action                    | macOS            | Windows/Linux    | Status | Command                      | Notes                                    |
-| ------------------------- | ---------------- | ---------------- | ------ | ---------------------------- | ---------------------------------------- |
-| Nudge                     | `Arrow Keys`     | `Arrow Keys`     | [x]    | `transform.nudge`            | 1 doc-unit per press; `args: { dx, dy }` |
-| Nudge (large)             | `⇧ + Arrow Keys` | `⇧ + Arrow Keys` | [x]    | `transform.nudge`            | 10 doc-units per press                   |
-| Nudge resize (right/up/…) | `Ctrl + ⌥ + …`   | `Ctrl + Alt + …` | [~]    | `selection.nudge_resize`     | resize() not implemented in editor yet   |
-| Move to front             | `]`              | `]`              | [x]    | `reorder` (`bring_to_front`) | shipped                                  |
-| Move to back              | `[`              | `[`              | [x]    | `reorder` (`send_to_back`)   | shipped                                  |
-| Move forward              | `⌘ + ]`          | `Ctrl + ]`       | [x]    | `reorder` (`bring_forward`)  | shipped                                  |
-| Move backward             | `⌘ + [`          | `Ctrl + [`       | [x]    | `reorder` (`send_backward`)  | shipped                                  |
+| Action                    | macOS            | Windows/Linux    | Status | Command                      | Notes                                                                       |
+| ------------------------- | ---------------- | ---------------- | ------ | ---------------------------- | --------------------------------------------------------------------------- |
+| Nudge                     | `Arrow Keys`     | `Arrow Keys`     | [x]    | `transform.nudge`            | 1 doc-unit per press; `args: { dx, dy }`                                    |
+| Nudge (large)             | `⇧ + Arrow Keys` | `⇧ + Arrow Keys` | [x]    | `transform.nudge`            | 10 doc-units per press                                                      |
+| Nudge resize (right/up/…) | `Ctrl + ⌥ + …`   | `Ctrl + Alt + …` | [x]    | `selection.nudge_resize`     | NW-fixed; ±1 / ±10 with Shift; refused on non-resizable/transformed members |
+| Move to front             | `]`              | `]`              | [x]    | `reorder` (`bring_to_front`) | shipped                                                                     |
+| Move to back              | `[`              | `[`              | [x]    | `reorder` (`send_to_back`)   | shipped                                                                     |
+| Move forward              | `⌘ + ]`          | `Ctrl + ]`       | [x]    | `reorder` (`bring_forward`)  | shipped                                                                     |
+| Move backward             | `⌘ + [`          | `Ctrl + [`       | [x]    | `reorder` (`send_backward`)  | shipped                                                                     |
 
 ## Alignment & Distribution
 

--- a/packages/grida-svg-editor/src/commands/defaults.ts
+++ b/packages/grida-svg-editor/src/commands/defaults.ts
@@ -95,6 +95,20 @@ export function registerDefaultCommands(
     return editor.commands.resize_to(target);
   });
 
+  // Ctrl+Alt+Arrow — grow/shrink each selected element by the delta around its
+  // own NW corner (per-element; see `editor.commands.resize_by` — NOT a
+  // union/group resize). `args` is `{dw, dh}` (±1 / ±10 with Shift). The
+  // all-or-nothing resizability gate lives in `resize_by`; this handler only
+  // guards mode + non-empty selection and returns false when the verb refuses
+  // (selection includes a `<g>` or a transformed member) — the chord is then
+  // a no-op.
+  reg.register("selection.nudge_resize", (args) => {
+    if (editor.state.mode !== "select") return false;
+    if (editor.state.selection.length === 0) return false;
+    const { dw, dh } = args as { dw: number; dh: number };
+    return editor.commands.resize_by({ dw, dh });
+  });
+
   // Rotate the selection by `args.angle` radians. Pivot defaults to the
   // union-bbox center; pass `args.pivot = {x, y}` to override. Returns
   // false if `is_rotatable` refuses any selected member (composite

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -209,9 +209,13 @@ export type Commands = {
     opts?: { ids?: ReadonlyArray<NodeId>; label?: string }
   ): boolean;
   /**
-   * Resize the selection's union bbox by a delta, keeping the union NW
-   * corner fixed. `delta.dw` / `delta.dh` add to the union width / height
-   * (each clamped to >= 0). Sugar over {@link resize_to}.
+   * Resize the selection by a delta — PER-ELEMENT: each selected member
+   * grows/shrinks around its OWN NW corner, so members keep their positions
+   * relative to one another (NOT a union/group resize — contrast
+   * {@link resize_to}, which scales the whole selection around the shared
+   * union origin and so translates off-origin members). `delta.dw` /
+   * `delta.dh` are applied additively to each member (clamped to >= 0). The
+   * core verb behind keyboard nudge-resize.
    *
    * ALL-OR-NOTHING gate: refuses (returns `false`, no history step) unless
    * EVERY member passes `is_resizable_node` — the same tag + transform-class
@@ -220,9 +224,8 @@ export type Commands = {
    * rejected when any member is unsafe). Also refuses on empty selection or
    * when no geometry provider (DOM surface) is attached.
    *
-   * Per-tag constraints (circle uniform, text edge no-op) run inside
-   * `resize_to`. The default selection is `state.selection`; pass `opts.ids`
-   * to override.
+   * Per-tag constraints (circle uniform, text edge no-op) apply per member.
+   * The default selection is `state.selection`; pass `opts.ids` to override.
    */
   resize_by(
     delta: { dw: number; dh: number },
@@ -887,7 +890,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       // tag-only `is_resizable`: scaling local attrs around a world-space
       // origin is only correct when world ≡ local; a non-trivial transform
       // (rotate-without-pivot, matrix, scale, skew) breaks that and would
-      // mis-resize / violate P1. Mirrors the HUD resize gate. Admitted:
+      // resize it incorrectly / violate P1. Mirrors the HUD resize gate. Admitted:
       // identity, leading-translate, `rotate(θ cx cy)` with explicit pivot.
       if (!resize_pipeline.intent.is_resizable_node(doc, id)) {
         if (mode === "all_or_nothing") return null;

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -195,13 +195,37 @@ export type Commands = {
    * member.
    *
    * The default selection is `state.selection`. Pass `opts.ids` to
-   * override. Members whose tag is not resizable
-   * (e.g. `<g>`) are skipped silently; the gesture is a no-op when no
-   * resizable member remains. Returns `true` when a history step was
-   * pushed.
+   * override. Members that are not resizable are skipped silently: this
+   * means both an unresizable tag (e.g. `<g>`) AND a resizable tag carrying
+   * a non-trivial transform (rotate-without-pivot, matrix, scale, skew),
+   * which can't be resized in local space without breaking round-trip — the
+   * same `is_resizable_node` gate the resize HUD applies. The gesture is a
+   * no-op when no resizable member remains. Returns `true` when a history
+   * step was pushed. `opts.label` overrides the atomic history label
+   * (default `"resize-to"`).
    */
   resize_to(
     target: { x: number; y: number; width: number; height: number },
+    opts?: { ids?: ReadonlyArray<NodeId>; label?: string }
+  ): boolean;
+  /**
+   * Resize the selection's union bbox by a delta, keeping the union NW
+   * corner fixed. `delta.dw` / `delta.dh` add to the union width / height
+   * (each clamped to >= 0). Sugar over {@link resize_to}.
+   *
+   * ALL-OR-NOTHING gate: refuses (returns `false`, no history step) unless
+   * EVERY member passes `is_resizable_node` — the same tag + transform-class
+   * check the resize HUD uses, applied wholesale (a mixed selection is
+   * refused, not partially resized — matches a HUD handle-drag, which is
+   * rejected when any member is unsafe). Also refuses on empty selection or
+   * when no geometry provider (DOM surface) is attached.
+   *
+   * Per-tag constraints (circle uniform, text edge no-op) run inside
+   * `resize_to`. The default selection is `state.selection`; pass `opts.ids`
+   * to override.
+   */
+  resize_by(
+    delta: { dw: number; dh: number },
     opts?: { ids?: ReadonlyArray<NodeId> }
   ): boolean;
   /**
@@ -822,17 +846,156 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     }
   }
 
+  // ─── resize: shared path (resize_to / resize_by go through these) ──────────
+  //
+  // `resize_to` (group / set-bbox) and `resize_by` (per-element nudge) are the
+  // same operation — "for each member apply (sx, sy, origin), optionally a
+  // group translate, in one atomic history step" — differing only in (a) the
+  // gate refusal mode and (b) how each member's (sx, sy, origin) is derived.
+  // Those two pieces are extracted so the callers stay tiny and can't drift.
+
+  type ResizeMember = {
+    id: NodeId;
+    rz: ResizeBaseline;
+    transform_pre: string | null;
+    bbox: { x: number; y: number; width: number; height: number };
+  };
+
+  /**
+   * Gate + capture for a resize gesture. Returns the resizable members (with
+   * captured baseline / pre-transform / bbox), or `null` if the gesture can't
+   * run: no geometry provider, empty selection, or — in `all_or_nothing` mode
+   * — any member fails the gate.
+   *
+   * `mode`:
+   *  - `"skip"`           — drop members failing the `is_resizable_node` gate
+   *    (tag + transform class) or lacking a bbox; resize the rest. Used by the
+   *    inspector `resize_to` (set-bbox) path.
+   *  - `"all_or_nothing"` — refuse the WHOLE gesture (return `null`) if ANY
+   *    member fails. Used by keyboard `resize_by` (nudge), matching the resize
+   *    HUD, whose handle-drag is rejected when any member is unsafe.
+   */
+  function collect_resize_members(
+    ids: ReadonlyArray<NodeId>,
+    mode: "skip" | "all_or_nothing"
+  ): ResizeMember[] | null {
+    if (ids.length === 0) return null;
+    if (!geometry_provider) return null;
+    const members: ResizeMember[] = [];
+    for (const id of ids) {
+      // Gate on `is_resizable_node` (tag AND transform class), not the
+      // tag-only `is_resizable`: scaling local attrs around a world-space
+      // origin is only correct when world ≡ local; a non-trivial transform
+      // (rotate-without-pivot, matrix, scale, skew) breaks that and would
+      // mis-resize / violate P1. Mirrors the HUD resize gate. Admitted:
+      // identity, leading-translate, `rotate(θ cx cy)` with explicit pivot.
+      if (!resize_pipeline.intent.is_resizable_node(doc, id)) {
+        if (mode === "all_or_nothing") return null;
+        continue;
+      }
+      const bbox = geometry_provider.bounds_of(id);
+      if (!bbox) {
+        if (mode === "all_or_nothing") return null;
+        continue;
+      }
+      members.push({
+        id,
+        rz: resize_pipeline.intent.capture_baseline(doc, id, bbox),
+        transform_pre: doc.get_attr(id, "transform"),
+        bbox,
+      });
+    }
+    return members.length === 0 ? null : members;
+  }
+
+  /**
+   * Apply a resize to each member, optionally followed by a uniform group
+   * translate, as ONE atomic history step. `op` resolves each member's scale
+   * factors + scale origin; `group_translate` is the post-scale envelope shift
+   * (group resize only — `null` for per-element). Callers guarantee `members`
+   * is non-empty. Returns `true` when a history step was pushed; `false` when
+   * the gesture is geometrically identity (no member scales and no group
+   * translate) so undo isn't polluted with an empty step. NOTE: a per-tag
+   * constraint that collapses a non-1 factor to identity *inside* the handler
+   * (e.g. `<circle>` uniform `min` on a single-axis nudge) is not detected
+   * here — the op-level factor is still ≠ 1, so that case still pushes a step.
+   */
+  function commit_resize(
+    members: ResizeMember[],
+    op: (m: ResizeMember) => {
+      sx: number;
+      sy: number;
+      origin: { x: number; y: number };
+    },
+    group_translate: { dx: number; dy: number } | null,
+    label: string
+  ): boolean {
+    const ops = members.map((m) => ({ m, ...op(m) }));
+    // Identity gesture → no history step (avoids empty undo entries, e.g.
+    // nudging the zero-extent axis of a degenerate shape).
+    const scales = ops.some(({ sx, sy }) => sx !== 1 || sy !== 1);
+    const translates =
+      !!group_translate &&
+      (group_translate.dx !== 0 || group_translate.dy !== 0);
+    if (!scales && !translates) return false;
+    const apply = () => {
+      for (const { m, sx, sy, origin } of ops) {
+        resize_pipeline.intent.apply(doc, m.id, m.rz, sx, sy, origin);
+      }
+      if (
+        group_translate &&
+        (group_translate.dx !== 0 || group_translate.dy !== 0)
+      ) {
+        // Re-capture translate baselines after scale wrote new attrs —
+        // otherwise apply_translate would offset the pre-scale values and
+        // double-account or back-step.
+        for (const m of members) {
+          const tx_after = translate_pipeline.intent.capture_baseline(
+            doc,
+            m.id
+          );
+          translate_pipeline.intent.apply(
+            doc,
+            m.id,
+            tx_after,
+            group_translate.dx,
+            group_translate.dy
+          );
+        }
+      }
+      emit();
+    };
+    const revert = () => {
+      for (const { m, origin } of ops) {
+        // apply_resize at sx=sy=1 writes attrs back to baseline regardless of
+        // origin; transform is restored directly (apply_translate.viaTransform
+        // may have rewritten it during apply; apply_resize never touches it).
+        resize_pipeline.intent.apply(doc, m.id, m.rz, 1, 1, origin);
+        doc.set_attr(m.id, "transform", m.transform_pre);
+      }
+      emit();
+    };
+    apply();
+    history.atomic(label, (tx) => {
+      tx.push({ providerId: PROVIDER_ID, apply, revert });
+    });
+    return true;
+  }
+
   /**
    * One-shot multi-member resize to an explicit target rect. Mirrors a
    * drag-resize gesture in mechanics — capture per-member baselines,
    * scale around the union's NW corner, translate the result so the
    * union NW lands at the requested position — but as a single
-   * atomic step rather than a preview session.
+   * atomic step rather than a preview session. This is the GROUP path:
+   * the whole selection is treated as one envelope.
    *
    * The function does its own geometry lookup via the
    * `geometry_provider` registered by the DOM surface. When no surface
-   * is attached, the call is a no-op (returns `false`). Members whose
-   * tag is not resizable are silently filtered.
+   * is attached, the call is a no-op (returns `false`). Members that fail
+   * the `is_resizable_node` gate — an unresizable tag (e.g. `<g>`) OR a
+   * non-trivially-transformed element — are silently skipped (see
+   * `collect_resize_members`).
    *
    * Revert restores the captured `transform` attribute and all
    * geometry attrs the apply step wrote — so a `<rect>` with an
@@ -841,80 +1004,69 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
    */
   function resize_to(
     target: { x: number; y: number; width: number; height: number },
-    opts?: { ids?: ReadonlyArray<NodeId> }
+    opts?: { ids?: ReadonlyArray<NodeId>; label?: string }
   ): boolean {
-    const ids = opts?.ids ?? selection;
-    if (ids.length === 0) return false;
-    if (!geometry_provider) return false;
-
-    type Member = {
-      id: NodeId;
-      rz: ResizeBaseline;
-      tx_pre: TranslateBaseline;
-      transform_pre: string | null;
-      bbox: { x: number; y: number; width: number; height: number };
-    };
-    const members: Member[] = [];
-    for (const id of ids) {
-      if (!resize_pipeline.intent.is_resizable(doc.tag_of(id))) continue;
-      const bbox = geometry_provider.bounds_of(id);
-      if (!bbox) continue;
-      members.push({
-        id,
-        rz: resize_pipeline.intent.capture_baseline(doc, id, bbox),
-        tx_pre: translate_pipeline.intent.capture_baseline(doc, id),
-        transform_pre: doc.get_attr(id, "transform"),
-        bbox,
-      });
-    }
-    if (members.length === 0) return false;
+    const members = collect_resize_members(opts?.ids ?? selection, "skip");
+    if (!members) return false;
 
     const union = cmath.rect.union(members.map((m) => m.bbox));
     const sx = union.width === 0 ? 1 : target.width / union.width;
     const sy = union.height === 0 ? 1 : target.height / union.height;
-    // Origin = union NW: scale keeps NW fixed; we follow with an explicit
-    // translate so NW lands at target NW. Decoupling scale-anchor from
-    // target-anchor sidesteps the `(1 - sx) === 0` degenerate case in the
-    // single-step origin formula.
+    // Origin = union NW: scale keeps the union NW fixed; an explicit group
+    // translate then lands it at target NW. Every member shares this one
+    // (sx, sy, origin) — the whole selection scales as one envelope, so
+    // off-origin members move relative to the union (group semantics).
     const origin = { x: union.x, y: union.y };
-    const dx = target.x - union.x;
-    const dy = target.y - union.y;
+    return commit_resize(
+      members,
+      () => ({ sx, sy, origin }),
+      { dx: target.x - union.x, dy: target.y - union.y },
+      opts?.label ?? "resize-to"
+    );
+  }
 
-    const apply = () => {
-      for (const m of members) {
-        resize_pipeline.intent.apply(doc, m.id, m.rz, sx, sy, origin);
-      }
-      if (dx !== 0 || dy !== 0) {
-        // Re-capture translate baselines after scale wrote new attrs —
-        // otherwise `apply_translate` would offset the pre-scale values
-        // and double-account or back-step.
-        for (const m of members) {
-          const tx_after = translate_pipeline.intent.capture_baseline(
-            doc,
-            m.id
-          );
-          translate_pipeline.intent.apply(doc, m.id, tx_after, dx, dy);
-        }
-      }
-      emit();
-    };
-    const revert = () => {
-      for (const m of members) {
-        // apply_resize at sx=sy=1 writes attrs as `origin + (a - origin) * 1
-        // = a` for every per-tag arm — restores resize baseline exactly.
-        resize_pipeline.intent.apply(doc, m.id, m.rz, 1, 1, origin);
-        // Restore `transform` directly — `apply_translate.viaTransform`
-        // may have rewritten it during apply; `apply_resize` never
-        // touches it.
-        doc.set_attr(m.id, "transform", m.transform_pre);
-      }
-      emit();
-    };
-    apply();
-    history.atomic("resize-to", (tx) => {
-      tx.push({ providerId: PROVIDER_ID, apply, revert });
-    });
-    return true;
+  /**
+   * Resize by a `{dw, dh}` delta — the core verb behind keyboard nudge-resize
+   * (`Ctrl+Alt+Arrow`). This is the PER-ELEMENT path: each selected member
+   * grows/shrinks by the delta around ITS OWN NW corner, so members keep their
+   * positions relative to one another. This deliberately differs from
+   * {@link resize_to} (the group/envelope path): a HUD group-resize scales the
+   * whole selection around the shared union origin, translating off-origin
+   * members — correct for a drag handle, wrong for a keyboard nudge, whose UX
+   * is "apply the delta to each".
+   *
+   * ALL-OR-NOTHING gate (`collect_resize_members("all_or_nothing")`): refuses
+   * (returns `false`, no history step) on empty selection, no geometry
+   * provider, or any member failing the `is_resizable_node` gate — matching
+   * the resize HUD rather than `resize_to`'s per-member skip.
+   */
+  function resize_by(
+    delta: { dw: number; dh: number },
+    opts?: { ids?: ReadonlyArray<NodeId> }
+  ): boolean {
+    const members = collect_resize_members(
+      opts?.ids ?? selection,
+      "all_or_nothing"
+    );
+    if (!members) return false;
+    // Each member around its OWN NW (origin = member bbox NW), its OWN factor
+    // from its OWN bbox + delta. No group translate → members do not move
+    // relative to one another. The factor `(size + d)/size` makes the resize
+    // additive (size·factor = size + d), so each member grows by exactly
+    // `dw` / `dh`; the guard handles a degenerate zero-size axis, the clamp
+    // keeps it non-negative.
+    const axis = (size: number, d: number) =>
+      size === 0 ? 1 : Math.max(0, size + d) / size;
+    return commit_resize(
+      members,
+      (m) => ({
+        sx: axis(m.bbox.width, delta.dw),
+        sy: axis(m.bbox.height, delta.dh),
+        origin: { x: m.bbox.x, y: m.bbox.y },
+      }),
+      null,
+      "nudge-resize"
+    );
   }
 
   /** Shared helper: compute a default rotation pivot from the live
@@ -1641,6 +1793,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     translate,
     nudge,
     resize_to,
+    resize_by,
     rotate,
     rotate_to,
     flatten_transform,

--- a/packages/grida-svg-editor/src/keymap/defaults.ts
+++ b/packages/grida-svg-editor/src/keymap/defaults.ts
@@ -14,13 +14,20 @@ import { KeyCode, M, kb } from "@grida/keybinding";
 import { TOOL_SET } from "../commands/defaults";
 import type { Keymap, KeymapBinding } from "./keymap";
 
-// Arrow-key nudge should fire regardless of Alt/Cmd/Ctrl — Alt-hold powers
-// the measurement HUD, and the user expects to keep nudging while it's on.
-// Only Shift carries meaning (1px vs 10px); the rest are "don't care".
+// Arrow-key nudge (move). Shift carries meaning (1px vs 10px). Ctrl is ALSO
+// meaningful and must be RELEASED for move: `Ctrl+Alt+Arrow` is reserved for
+// nudge-resize below, so move must not also fire on that chord. Alt stays
+// don't-care — Alt-hold powers the measurement HUD and the user expects to
+// keep nudging (moving) while it's on. Meta is don't-care.
 //
-// Expressed as a `meaningful` mask: only Shift is meaningful, so Ctrl/Alt/Meta
-// are don't-care. `kb()` expands to the 2^3 = 8 power-set internally.
-const NUDGE_MEANINGFUL = M.Shift;
+// Expressed as a `meaningful` mask: Shift|Ctrl are meaningful, Alt/Meta are
+// don't-care. `kb()` expands the don't-care bits to a power-set internally.
+const NUDGE_MEANINGFUL = M.Shift | M.Ctrl;
+
+// Nudge-resize chord (Ctrl+Alt+Arrow). Shift|Ctrl|Alt are all meaningful;
+// Meta is don't-care. Literal Ctrl (not CtrlCmd) — the chord is `Ctrl+⌥` on
+// both macOS and Windows/Linux.
+const RESIZE_MEANINGFUL = M.Shift | M.Ctrl | M.Alt;
 
 export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
   // ─── history ──────────────────────────────────────────────────────────────
@@ -99,9 +106,9 @@ export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
   { keybinding: kb(KeyCode.Enter, M.Shift), command: "hierarchy.exit" },
 
   // ─── nudge — Arrow (1px) and Shift+Arrow (10px) ──────────────────────────
-  // Only Shift is meaningful; Alt/Cmd/Ctrl are don't-care. Alt-hold is
-  // the measurement-HUD trigger and must not block movement; Cmd/Ctrl
-  // are free for future "snap-override" semantics without rebinding here.
+  // Meaningful = Shift|Ctrl (see NUDGE_MEANINGFUL). Move fires only with Ctrl
+  // RELEASED — Ctrl+Alt+Arrow is the nudge-resize chord below. Alt stays
+  // don't-care so Alt-hold (measurement HUD) keeps moving the selection.
   {
     keybinding: kb(KeyCode.LeftArrow, 0, NUDGE_MEANINGFUL),
     command: "transform.nudge",
@@ -141,6 +148,71 @@ export const DEFAULT_BINDINGS: readonly KeymapBinding[] = [
     keybinding: kb(KeyCode.DownArrow, M.Shift, NUDGE_MEANINGFUL),
     command: "transform.nudge",
     args: { dx: 0, dy: 10 },
+  },
+
+  // ─── nudge-resize — Ctrl+Alt+Arrow (1px) and +Shift (10px) ───────────────
+  // Grow/shrink each selected element by the delta around its OWN NW corner —
+  // per-element, NOT a union/group resize (members keep their positions
+  // relative to one another). Right/Left = width, Down/Up = height. The
+  // all-or-nothing gate lives in `editor.commands.resize_by`; on refusal (the
+  // selection includes a non-resizable / transformed member) the chord is a
+  // no-op — the move-nudge mask forbids Ctrl, so nothing else catches it.
+  // That same mask is why move and resize never both fire on this chord.
+  {
+    keybinding: kb(KeyCode.RightArrow, M.Ctrl | M.Alt, RESIZE_MEANINGFUL),
+    command: "selection.nudge_resize",
+    args: { dw: 1, dh: 0 },
+  },
+  {
+    keybinding: kb(KeyCode.LeftArrow, M.Ctrl | M.Alt, RESIZE_MEANINGFUL),
+    command: "selection.nudge_resize",
+    args: { dw: -1, dh: 0 },
+  },
+  {
+    keybinding: kb(KeyCode.DownArrow, M.Ctrl | M.Alt, RESIZE_MEANINGFUL),
+    command: "selection.nudge_resize",
+    args: { dw: 0, dh: 1 },
+  },
+  {
+    keybinding: kb(KeyCode.UpArrow, M.Ctrl | M.Alt, RESIZE_MEANINGFUL),
+    command: "selection.nudge_resize",
+    args: { dw: 0, dh: -1 },
+  },
+  {
+    keybinding: kb(
+      KeyCode.RightArrow,
+      M.Ctrl | M.Alt | M.Shift,
+      RESIZE_MEANINGFUL
+    ),
+    command: "selection.nudge_resize",
+    args: { dw: 10, dh: 0 },
+  },
+  {
+    keybinding: kb(
+      KeyCode.LeftArrow,
+      M.Ctrl | M.Alt | M.Shift,
+      RESIZE_MEANINGFUL
+    ),
+    command: "selection.nudge_resize",
+    args: { dw: -10, dh: 0 },
+  },
+  {
+    keybinding: kb(
+      KeyCode.DownArrow,
+      M.Ctrl | M.Alt | M.Shift,
+      RESIZE_MEANINGFUL
+    ),
+    command: "selection.nudge_resize",
+    args: { dw: 0, dh: 10 },
+  },
+  {
+    keybinding: kb(
+      KeyCode.UpArrow,
+      M.Ctrl | M.Alt | M.Shift,
+      RESIZE_MEANINGFUL
+    ),
+    command: "selection.nudge_resize",
+    args: { dw: 0, dh: -10 },
   },
 
   // ─── tools — V (cursor) / R (rect) / O (ellipse) / L (line) / T (text) ──


### PR DESCRIPTION
Adds keyboard nudge-resize to `@grida/svg-editor`: **`Ctrl+⌥+Arrow`** grows/shrinks the selection by 1px (10px with Shift). Closes the `[~]` row in `docs/keybindings.md`.

## What & why

**Per-element semantics.** Each selected element resizes around its own NW corner, so members keep their positions relative to one another — deliberately distinct from a HUD group-resize (which scales the whole selection around the shared union origin and translates off-origin members). A drag handle wants group; a keyboard nudge wants "apply the delta to each".

**Shared resize path.** `resize_to` (group) and the new `resize_by` (per-element) now go through one extracted path — `collect_resize_members(ids, mode)` + `commit_resize(members, op, group_translate, label)` — parameterized by gate-refusal mode and per-member factor/origin. No duplicated apply/revert/history.

**Included fix.** `resize_to`'s member gate was tightened from tag-only `is_resizable` to `is_resizable_node` (tag + transform class), so it no longer mis-resizes elements carrying an unsafe transform (rotate / matrix / skew) by scaling local attrs around a world origin. Net safety improvement for the inspector set-bbox path; **not a regression** (it narrows what's admitted).

**Keymap.** Move-nudge's `meaningful` mask gains `M.Ctrl` so `Ctrl+⌥+Arrow` no longer doubles as a move; `⌥+Arrow` still moves (the measurement-HUD-while-nudging interaction is preserved). The two chord families are provably disjoint.

## Tests

- Per-element vs group semantics pinned side-by-side (the off-origin member translates under `resize_to`, stays put under `resize_by`).
- Transform-safety gate (skips/refuses unsafe-transform members), all-or-nothing refusal on mixed selections, identity-gesture (no phantom undo step).
- `1075` package tests pass; typecheck + oxlint + oxfmt clean.

## Known limitations (tracked, not regressions)

- **Transformed-element resize** uses a world-origin / local-attr frame that mis-positions `translate`-d elements on a real DOM surface — pre-existing in `resize_to`, inherited by `resize_by`. Headless tests use local bounds so it isn't reproduced there. Follow-up task filed.
- **Circle / single-axis text nudge** is a no-op (consistent with a HUD edge-drag on those shapes); accepted for v1.
- **Factor-based resize** has sub-epsilon float drift on non-integer factors; follow-up task filed (affects the inspector path too).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nudge-resize: resize selected elements with Ctrl+Alt+Arrow (±1px; ±10px with Shift). Resizing is applied per-element around each item's NW corner and preserves transforms; non-resizable or unsafe-transformed members are skipped/refused as appropriate. Arrow+Alt still nudges/moves.
* **Documentation**
  * Keybindings updated to reflect the shipped nudge-resize behavior and modifier expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->