### PR TITLE
feat(svg-editor): public pick (tap) observation channel (#779)

### DIFF
--- a/packages/grida-canvas-hud/README.md
+++ b/packages/grida-canvas-hud/README.md
@@ -266,7 +266,10 @@ const surface = new Surface(canvasElement, {
   // required wiring
   pick:    (point_doc) => editor.hitTest(point_doc),      // (point) => NodeId | null
   shapeOf: (id)        => editor.shapeOf(id),             // (id)    => SelectionShape | null
-  onIntent:  (intent)    => editor.commitIntent(intent),  // surface → host
+  onIntent:  (intent)    => editor.commitIntent(intent),  // surface → host (commit)
+
+  // optional wiring
+  onTap:   (tap)         => tool.anchorAt(tap),           // surface → host (observe; see "Tap outcome")
 
   // optional config
   style: { chromeColor: "#2563eb", handleSize: 8 },
@@ -462,6 +465,62 @@ This package's implementation:
   per named scenario.
 
 Skim the spec before changing the classifier or its dispatch.
+
+## Tap outcome
+
+A **tap** is the surface's observe-only report that a discrete press+release
+landed at a document-space point over a particular node (or empty canvas),
+WITHOUT becoming a drag. It is delivered through the optional `onTap` wiring
+callback — a sibling of `pick` / `shapeOf` / `onIntent`, deliberately NOT an
+`Intent`:
+
+- An `Intent` is an **actionable change the host commits** (the surface never
+  mutates the document; the host wraps `preview`/`commit`). A tap is a **fact
+  to observe** — there is nothing to commit. Folding it into `onIntent` would
+  contradict that union's documented meaning.
+- A tap must be able to fire **without changing selection** — most importantly
+  the secondary button, which produces a tap and nothing else. Keeping it off
+  the selection-bearing intents preserves "Not a selection store" (Anti-goals).
+
+```ts
+import { type TapOutcome } from "@grida/hud";
+
+const surface = new Surface(canvas, {
+  pick,
+  shapeOf,
+  onIntent,
+  onTap: (tap: TapOutcome) => {
+    // tap.point  — document-space DOWN point the tap resolved against
+    // tap.button — "primary" | "secondary"  (never "middle")
+    // tap.hit    — topmost pick at point, or null for empty canvas
+    // tap.mods   — modifier snapshot at press time
+  },
+});
+```
+
+**Firing rules (the contract a consumer reads from the exports):**
+
+- Fires on the press+release of `primary` and `secondary` buttons when the
+  pointer never crosses the drag threshold (`DRAG_THRESHOLD_PX = 3`).
+- `point` is the **pointer-down** point, never the up point. For a tap on an
+  already-selected node — where the selection commits on pointer-**up** via the
+  deferred drag-candidate path — the down and up points differ by up to the
+  threshold; the surface reports the down point because that is what the tap
+  resolved against and the only one it still holds at release.
+- A drag past the threshold emits **no** tap (it became a gesture). A press
+  that opens a handle gesture (resize / rotate / corner-radius / …) emits no
+  tap either — it is a handle interaction, not a content tap.
+- `middle` never taps — it is reserved for pan.
+- A secondary tap never mutates selection; the tap is its only outcome.
+
+`hit` is carried (host-`pick`-resolved at down time), not host-re-derived — the
+host observes the SAME node the surface resolved the tap against, consistent
+with `select` carrying resolved ids.
+
+> **`@unstable`.** `TapOutcome` is marked `@unstable` per the promotion bar
+> ("two consumers shape the contract"): it ships against one consumer today.
+> Fields may change without a semver bump until a second consumer exercises it.
+> There is no reader in this package; it is a contract-first producer surface.
 
 ## Coordinate model
 
@@ -872,6 +931,9 @@ Non-exhaustive index — open the test files for the full surface.
 | Dblclick on vertex / tangent / segment-strip WHILE in content-edit → handler runs (no exit) | `decision.test.ts`                             |
 | Marquee starts from empty-space pointer-down                                                | `state.test.ts`                                |
 | Drag past threshold cancels a deferred select (drag-vs-click discriminator)                 | `state.test.ts`                                |
+| Tap (press+release, no drag) reports the DOWN point — incl. the deferred commit-on-up path  | `state.test.ts`                                |
+| Tap fires for primary + secondary, never middle (pan); drag past threshold emits no tap     | `state.test.ts`                                |
+| Secondary tap changes no selection; empty-canvas tap carries `hit: null`                    | `state.test.ts`                                |
 | Tangent knob renders as a 45°-rotated square ("diamond"), smaller than vertex               | `classes/vector-path/surface-extended.test.ts` |
 | Vertex knob renders as a circle, selected fills with chrome color                           | `classes/vector-path/surface-extended.test.ts` |
 | Selected tangent line is thicker than idle                                                  | `classes/vector-path/surface-extended.test.ts` |
@@ -890,7 +952,7 @@ Non-exhaustive index — open the test files for the full surface.
 | `handles.test.ts`                              | 8 resize + 4 rotate positions; screen-space hit-test; visibility threshold                                                                                                                                                                     |
 | `click-tracker.test.ts`                        | single vs double within window; position threshold; multi-button isolation                                                                                                                                                                     |
 | `gesture.test.ts`                              | legal transitions (idle↔translate/resize/marquee/cancel; deferred selection)                                                                                                                                                                   |
-| `state.test.ts`                                | dispatch sequences: click selects, drag-empty marquees, drag-handle resizes, drag-node translates, exit-edit                                                                                                                                   |
+| `state.test.ts`                                | dispatch sequences: click selects, drag-empty marquees, drag-handle resizes, drag-node translates, exit-edit; observe-only tap outcome (down-point fidelity, primary/secondary, middle excluded, drag emits none, empty-canvas null hit)       |
 | `intent.test.ts`                               | intent stream + `phase` correctness across a full drag (preview·N → commit)                                                                                                                                                                    |
 | `decision.test.ts`                             | one test per named scenario in the selection-intent classifier, including ExitEdit gating                                                                                                                                                      |
 | `chrome.test.ts`                               | given state + bounds, assert resulting `HUDDraw` shape — primitive counts and coords                                                                                                                                                           |

--- a/packages/grida-canvas-hud/__tests__/state.test.ts
+++ b/packages/grida-canvas-hud/__tests__/state.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import cmath from "@grida/cmath";
 import { SurfaceState, type StateDeps } from "../event/state";
 import type { Intent } from "../event/intent";
+import type { TapOutcome } from "../event/tap";
 import type { NodeId, Rect } from "../event/gesture";
 import { NO_MODS } from "../event/event";
 
@@ -22,8 +23,13 @@ function pointInRect(p: [number, number], r: Rect): boolean {
   );
 }
 
-function makeDeps(): { deps: StateDeps; intents: Intent[] } {
+function makeDeps(): {
+  deps: StateDeps;
+  intents: Intent[];
+  taps: TapOutcome[];
+} {
   const intents: Intent[] = [];
+  const taps: TapOutcome[] = [];
   const deps: StateDeps = {
     pick: (p) => {
       for (const [id, r] of Object.entries(SCENE)) {
@@ -36,8 +42,9 @@ function makeDeps(): { deps: StateDeps; intents: Intent[] } {
       return r ? { kind: "rect", rect: r } : null;
     },
     emitIntent: (i) => intents.push(i),
+    emitTap: (t) => taps.push(t),
   };
-  return { deps, intents };
+  return { deps, intents, taps };
 }
 
 function makeState(selection: NodeId[] = []): SurfaceState {
@@ -519,6 +526,126 @@ describe("SurfaceState dispatch", () => {
     if (typeof state.cursor === "string" || state.cursor.kind !== "rotate")
       return;
     expect(state.cursor.baseAngle).toBeCloseTo((3 * Math.PI) / 4, 9);
+  });
+});
+
+// ── Tap outcome (observe-only press+release) ─────────────────────────────────
+//
+// A tap is the surface's report that a discrete press+release landed at a
+// document-space point over a particular node (or empty canvas), WITHOUT it
+// being a drag. It is observe-only — delivered through `emitTap`, never the
+// intent stream — so a host can anchor a tap-driven tool to the click point
+// and scope it to the hit without the surface mutating selection. Only the
+// surface owns the press/release stream, the camera, and the click-vs-drag
+// discrimination, so only the surface can report this fact.
+describe("SurfaceState tap outcome", () => {
+  let state: SurfaceState;
+  let deps: StateDeps;
+  let intents: Intent[];
+  let taps: TapOutcome[];
+
+  beforeEach(() => {
+    state = makeState();
+    const m = makeDeps();
+    deps = m.deps;
+    intents = m.intents;
+    taps = m.taps;
+  });
+
+  type Btn = "primary" | "secondary" | "middle";
+  const down = (x: number, y: number, button: Btn = "primary") =>
+    state.dispatch({ kind: "pointer_down", x, y, button, mods: NO_MODS }, deps);
+  const up = (x: number, y: number, button: Btn = "primary") =>
+    state.dispatch({ kind: "pointer_up", x, y, button, mods: NO_MODS }, deps);
+  const move = (x: number, y: number) =>
+    state.dispatch({ kind: "pointer_move", x, y, mods: NO_MODS }, deps);
+
+  // UX spec: a primary click-no-drag on a node taps with the down point and
+  // the node hit. This is the base case the whole contract exists for — a
+  // tap-driven tool wants "a click landed at P; the topmost hit was N." The
+  // surface resolves the hit via the host's own `pick`, so the host observes
+  // the same node the surface saw.
+  it("primary click-no-drag on a node taps with the down point and hit id", () => {
+    down(50, 50);
+    up(50, 50);
+    expect(taps).toEqual([
+      { point: [50, 50], button: "primary", hit: "a", mods: NO_MODS },
+    ]);
+  });
+
+  // UX spec: a tap on an ALREADY-SELECTED node — which commits selection on
+  // pointer-UP via the deferred drag-candidate path — still reports the
+  // pointer-DOWN point, not the up point. This is the test that justifies the
+  // whole contract living in the surface: the down and up points differ by up
+  // to the drag threshold, and only the surface still holds the down point at
+  // commit time. A host watching pointer-up would anchor its UI to the wrong
+  // place by a few pixels every time.
+  it("tap on already-selected node (deferred, commits on up) reports the DOWN point, not the up point", () => {
+    state.setSelection(["a"]);
+    down(50, 50);
+    // Sub-threshold wobble between down and up (2px < 3px threshold): the
+    // selection still commits on up (it's a click, not a drag), and the tap
+    // must report the DOWN point (50,50), not the up point (52,51).
+    move(52, 51);
+    up(52, 51);
+    // The deferred select still fired (it was a click) …
+    expect(intents).toEqual([{ kind: "select", ids: ["a"], mode: "replace" }]);
+    // … and the tap reports the DOWN point.
+    expect(taps).toEqual([
+      { point: [50, 50], button: "primary", hit: "a", mods: NO_MODS },
+    ]);
+  });
+
+  // UX spec: a primary drag past the threshold is a gesture, not a tap — it
+  // emits NO tap. The whole point of the drag-vs-click discriminator is that
+  // dragging expresses a different intent (translate / marquee); a tap-driven
+  // tool must not fire mid-drag or on drag-release.
+  it("primary drag past threshold emits NO tap", () => {
+    state.setSelection(["a"]);
+    down(50, 50);
+    move(60, 60); // 14px > 3px threshold → promotes to translate gesture
+    move(80, 70);
+    up(80, 70);
+    expect(taps).toEqual([]);
+  });
+
+  // UX spec: a secondary click taps AND leaves selection untouched. A
+  // right-click-driven tool (context action) needs the same "click landed at
+  // P over N" fact, but the secondary button must never mutate selection —
+  // the surface is not a selection store, and a context click changing the
+  // selection out from under the user is the classic right-click bug. The tap
+  // is the ONLY thing a secondary click produces.
+  it("secondary click taps AND emits no select (selection unchanged)", () => {
+    state.setSelection(["a"]);
+    down(200, 50, "secondary"); // over node "b", which is NOT selected
+    up(200, 50, "secondary");
+    expect(intents).toEqual([]); // selection untouched
+    expect(taps).toEqual([
+      { point: [200, 50], button: "secondary", hit: "b", mods: NO_MODS },
+    ]);
+  });
+
+  // UX spec: the middle button is pan, not a click — it produces NO tap. The
+  // requested outcome is button-agnostic across primary/secondary, but the
+  // middle button is reserved for panning the viewport; firing a tap there
+  // would mis-report a pan-start as a click.
+  it("middle-button press emits NO tap", () => {
+    down(50, 50, "middle");
+    up(50, 50, "middle");
+    expect(taps).toEqual([]);
+  });
+
+  // UX spec: an empty-canvas click taps with `hit: null`. The host's
+  // tap-driven tool must be able to distinguish "clicked node N" from
+  // "clicked empty canvas" — which it can't do from `deselect_all` alone (a
+  // selection that happened to become empty is indistinguishable from an
+  // empty-canvas click). The tap carries the point AND the null hit.
+  it("empty-canvas click taps with hit: null", () => {
+    down(500, 500); // no node there
+    up(500, 500);
+    expect(taps).toEqual([
+      { point: [500, 500], button: "primary", hit: null, mods: NO_MODS },
+    ]);
   });
 });
 

--- a/packages/grida-canvas-hud/__tests__/state.test.ts
+++ b/packages/grida-canvas-hud/__tests__/state.test.ts
@@ -609,6 +609,20 @@ describe("SurfaceState tap outcome", () => {
     expect(taps).toEqual([]);
   });
 
+  // UX spec: a SECONDARY (right-button) drag past the threshold also emits NO
+  // tap. Regression guard: a secondary press never creates a `pending`, so the
+  // primary gesture-promotion path cannot drop its tap candidate — the
+  // candidate must be dropped by the button-agnostic drag-cancel in
+  // `onPointerMove`. Without it, a right-button drag mis-fires as a context
+  // click at the down point (a tap-driven tool would treat a drag as a click).
+  it("secondary drag past threshold emits NO tap", () => {
+    down(50, 50, "secondary");
+    move(60, 60); // 14px > 3px threshold
+    move(80, 70);
+    up(80, 70, "secondary");
+    expect(taps).toEqual([]);
+  });
+
   // UX spec: a secondary click taps AND leaves selection untouched. A
   // right-click-driven tool (context action) needs the same "click landed at
   // P over N" fact, but the secondary button must never mutate selection —

--- a/packages/grida-canvas-hud/event/state.ts
+++ b/packages/grida-canvas-hud/event/state.ts
@@ -29,6 +29,7 @@ import {
 import { type SelectionShape, type SelectionGroup, shapeBounds } from "./shape";
 import { type CursorIcon, cursorEquals } from "./cursor";
 import type { Intent, IntentHandler, IntentPhase } from "./intent";
+import type { TapHandler } from "./tap";
 import { ClickTracker } from "./click-tracker";
 import { HitRegions } from "./hit-regions";
 import {
@@ -66,6 +67,24 @@ interface PendingPointerDown {
 }
 
 /**
+ * Down-point snapshot for an in-flight tap. Captured at pointer-down for
+ * primary / secondary; consumed at pointer-up iff the pointer never crossed
+ * the drag threshold. Distinct from `PendingPointerDown` because a tap is
+ * button-agnostic and selection-independent — the secondary button records
+ * a candidate without ever opening a `pending`.
+ */
+interface TapCandidate {
+  /** DOWN point in document-space — the point the tap resolves against. */
+  anchor_doc: Vector2;
+  /** Which button pressed. Middle never reaches here. */
+  button: Exclude<PointerButton, "middle">;
+  /** Topmost host pick at the down point, captured at press time. */
+  hit: NodeId | null;
+  /** Modifier snapshot at press time. */
+  mods: Modifiers;
+}
+
+/**
  * Provider callbacks the host wires into the surface at construction.
  *
  * Two verbs, deliberately distinct:
@@ -85,6 +104,13 @@ export interface StateDeps {
   pick: (point_doc: Vector2) => NodeId | null;
   shapeOf: (id: NodeId) => SelectionShape | null;
   emitIntent: IntentHandler;
+  /**
+   * Optional observe-only tap sink. Called once per discrete tap (press +
+   * release within the drag threshold) for primary and secondary buttons.
+   * Distinct from `emitIntent` — a tap is a fact to observe, not a change
+   * to commit. Omitted by hosts that don't run a tap-driven tool.
+   */
+  emitTap?: TapHandler;
 }
 
 /**
@@ -188,6 +214,15 @@ export class SurfaceState {
   private hit_regions = new HitRegions();
   private click_tracker = new ClickTracker();
   private pending: PendingPointerDown | null = null;
+  /**
+   * Live tap candidate, captured at pointer-down for primary / secondary
+   * buttons (never middle). Holds the DOWN-point data the tap will report
+   * if the pointer releases without crossing the drag threshold. Cleared
+   * the moment the press promotes to a drag/gesture — so a drag emits no
+   * tap. Independent of `pending` (which exists only for the primary
+   * selection flow); the secondary button has no `pending` but still taps.
+   */
+  private tap_candidate: TapCandidate | null = null;
   /**
    * Vector-edit selection mirror. Set by the host via `setVectorSelection`
    * when entering content-edit on a path. Non-null = surface should render
@@ -476,6 +511,9 @@ export class SurfaceState {
         const promote = this.pending.promote_to;
         // Cancel deferred selection — drag preserves multi-selection.
         this.pending.deferred = undefined;
+        // The press became a drag — it is no longer a tap. Drop the
+        // candidate so pointer-up emits no tap.
+        this.tap_candidate = null;
         if (promote) {
           // Explicit promote (e.g. segment-strip → bend_segment or
           // translate_vector_selection per drag mode).
@@ -1115,17 +1153,40 @@ export class SurfaceState {
     deps: StateDeps
   ): SurfaceResponse {
     const response = emptyResponse();
-    if (button !== "primary") return response;
 
     const point_doc = screenToDoc(this.transform, sx, sy);
     const screen: Vector2 = [sx, sy];
+
+    // Tap candidate — captured at down for primary AND secondary (never
+    // middle, which is pan). The candidate freezes the DOWN point + pick so
+    // a tap reports the press point even when the primary selection commits
+    // on pointer-up (deferred path). Cleared on drag-promotion in
+    // `onPointerMove`; consumed in `onPointerUp` iff no drag happened. The
+    // pick used here is the SAME pick the primary flow resolves selection
+    // against below — one `pick` per down, no host disagreement.
+    let tap_hit: NodeId | null = null;
+    if (button !== "middle") {
+      tap_hit = deps.pick(point_doc);
+      this.tap_candidate = {
+        anchor_doc: point_doc,
+        button,
+        hit: tap_hit,
+        mods: { ...this.modifiers },
+      };
+    }
+
+    // Secondary / middle never run the selection-intent flow: secondary must
+    // not mutate selection (the tap is its only outcome), middle is pan.
+    if (button !== "primary") return response;
 
     // Gather inputs and ask the decision module what to do. ALL UX-level
     // branching lives in `event/decision.ts` — keep this handler purely
     // mechanical so the table in `docs/intent-decision-tree.md` stays the
     // single source of truth.
     const ui_action = this.hit_regions.hitTest(screen);
-    const hovered_id = deps.pick(point_doc);
+    // Reuse the pick already resolved for the tap candidate — primary always
+    // captured one above, so this is never a second `pick` call.
+    const hovered_id = tap_hit;
     const click_count = this.click_tracker.register(sx, sy);
 
     // Corner-radius handle intercept — its own affordance family,
@@ -1643,6 +1704,26 @@ export class SurfaceState {
     deps: StateDeps
   ): SurfaceResponse {
     const response = emptyResponse();
+
+    // Tap resolution — button-agnostic, BEFORE the primary-only gate below.
+    // A tap fires iff a candidate from this press survived to release (the
+    // pointer never crossed the drag threshold — `onPointerMove` clears the
+    // candidate on promotion) AND no gesture is active (an eager handle
+    // press opened a gesture at down, which is a handle interaction, not a
+    // content tap). The candidate carries the DOWN point + the down-time
+    // pick, so the deferred (commit-on-up) primary path still reports the
+    // press point, not this release point.
+    const tap = this.tap_candidate;
+    this.tap_candidate = null;
+    if (tap && tap.button === button && this.gesture.kind === "idle") {
+      deps.emitTap?.({
+        point: tap.anchor_doc,
+        button: tap.button,
+        hit: tap.hit,
+        mods: tap.mods,
+      });
+    }
+
     if (button !== "primary") return response;
 
     // Apply deferred intent on click (no drag occurred).
@@ -1984,6 +2065,9 @@ export class SurfaceState {
   private onBlur(deps: StateDeps): SurfaceResponse {
     const response = emptyResponse();
     this.pending = null;
+    // A press interrupted by blur never releases on the surface — drop the
+    // candidate so no tap fires when focus returns.
+    this.tap_candidate = null;
     if (this.gesture.kind !== "idle") {
       deps.emitIntent({ kind: "cancel_gesture" });
       this.gesture = IDLE;

--- a/packages/grida-canvas-hud/event/state.ts
+++ b/packages/grida-canvas-hud/event/state.ts
@@ -76,6 +76,10 @@ interface PendingPointerDown {
 interface TapCandidate {
   /** DOWN point in document-space — the point the tap resolves against. */
   anchor_doc: Vector2;
+  /** DOWN point in screen-space — used to drop the candidate when the press
+   *  drags past the threshold. This is the ONLY drag-cancel path for
+   *  secondary / middle presses, which never create a `pending`. */
+  anchor_screen: Vector2;
   /** Which button pressed. Middle never reaches here. */
   button: Exclude<PointerButton, "middle">;
   /** Topmost host pick at the down point, captured at press time. */
@@ -500,6 +504,19 @@ export class SurfaceState {
     const response = emptyResponse();
     const point_doc = screenToDoc(this.transform, sx, sy);
 
+    // A press that drags past the threshold is no longer a tap — drop the
+    // candidate regardless of button. The `pending` promotion path below
+    // resolves the primary button's gesture, but secondary / middle presses
+    // never create a `pending`, so this is the only place a right-button drag
+    // is caught. Threshold is screen-space px, matching the gesture path.
+    if (this.tap_candidate) {
+      const tdx = sx - this.tap_candidate.anchor_screen[0];
+      const tdy = sy - this.tap_candidate.anchor_screen[1];
+      if (tdx * tdx + tdy * tdy >= DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) {
+        this.tap_candidate = null;
+      }
+    }
+
     // 1. Pending pointer-down → translate / marquee / promote-override
     //    promotion when threshold crossed
     if (this.pending && this.gesture.kind === "idle") {
@@ -510,10 +527,9 @@ export class SurfaceState {
       if (dx * dx + dy * dy >= DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) {
         const promote = this.pending.promote_to;
         // Cancel deferred selection — drag preserves multi-selection.
+        // (The tap candidate was already dropped by the button-agnostic
+        // drag-cancel at the top of this handler.)
         this.pending.deferred = undefined;
-        // The press became a drag — it is no longer a tap. Drop the
-        // candidate so pointer-up emits no tap.
-        this.tap_candidate = null;
         if (promote) {
           // Explicit promote (e.g. segment-strip → bend_segment or
           // translate_vector_selection per drag mode).
@@ -1169,6 +1185,7 @@ export class SurfaceState {
       tap_hit = deps.pick(point_doc);
       this.tap_candidate = {
         anchor_doc: point_doc,
+        anchor_screen: screen,
         button,
         hit: tap_hit,
         mods: { ...this.modifiers },

--- a/packages/grida-canvas-hud/event/tap.ts
+++ b/packages/grida-canvas-hud/event/tap.ts
@@ -1,0 +1,59 @@
+import type { Modifiers, PointerButton, Vector2 } from "./event";
+import type { NodeId } from "./gesture";
+
+/**
+ * Observe-only outcome: a discrete **tap** resolved on the surface.
+ *
+ * A tap is a press + release that stayed within the drag threshold — the
+ * surface owns the press/release stream, the camera, and the click-vs-drag
+ * discrimination, so it is the only layer that can report this fact
+ * authoritatively. A pointer movement that crosses the drag threshold
+ * becomes a gesture and produces NO tap.
+ *
+ * This is NOT an {@link import("./intent").Intent}. An `Intent` is an
+ * actionable change the host commits (and the surface itself never mutates
+ * the document); a tap is a pure observation — there is nothing to commit.
+ * It is delivered through its own `onTap` callback, a sibling of `pick` /
+ * `shapeOf` / `onIntent`, precisely so it can fire WITHOUT changing
+ * selection (most importantly for the secondary button, which must never
+ * mutate selection). Keeping it off the intent stream also keeps the
+ * "selection store lives in the host" boundary clean: a tap that selects
+ * nothing is still a first-class outcome.
+ *
+ * @unstable Shape is provisional until ≥2 consumers exercise it (the
+ * package's promotion bar — "two consumers shape the contract"). Fields may
+ * change without a semver bump until then.
+ */
+export interface TapOutcome {
+  /**
+   * Document-space point the tap resolved against — the **pointer-down**
+   * point, never the pointer-up point. For the deferred path (a tap on an
+   * already-selected node, which commits selection on pointer-up) the down
+   * and up points differ by up to the drag threshold; the surface reports
+   * the down point because that is the point the tap was resolved against
+   * and the only one it still holds at release time.
+   */
+  point: Vector2;
+  /**
+   * Which button produced the tap. `"primary"` or `"secondary"` only —
+   * `"middle"` is reserved for pan and never produces a tap.
+   */
+  button: Exclude<PointerButton, "middle">;
+  /**
+   * Topmost host pick at `point` at press time, or `null` for empty canvas.
+   * Carried (not host-re-derived) so the host observes the SAME node the
+   * surface resolved the tap against — consistent with `select` carrying
+   * resolved ids. Resolved via the host's own `pick` callback, so it
+   * introduces no scene-graph awareness the surface didn't already have.
+   */
+  hit: NodeId | null;
+  /** Modifier snapshot at press time — already in hand on the surface event. */
+  mods: Modifiers;
+}
+
+/**
+ * Callback the host wires to observe taps. Optional in `SurfaceOptions` /
+ * `StateDeps` — hosts that don't run a tap-driven tool simply omit it and
+ * pay nothing.
+ */
+export type TapHandler = (tap: TapOutcome) => void;

--- a/packages/grida-canvas-hud/index.ts
+++ b/packages/grida-canvas-hud/index.ts
@@ -99,6 +99,7 @@ export type { SurfaceEvent, Modifiers, PointerButton } from "./event/event";
 export { NO_MODS } from "./event/event";
 export type { SurfaceGesture } from "./event/gesture";
 export type { Intent, IntentPhase, SelectMode } from "./event/intent";
+export type { TapOutcome, TapHandler } from "./event/tap";
 export type {
   CursorIcon,
   CursorRenderer,

--- a/packages/grida-canvas-hud/react.tsx
+++ b/packages/grida-canvas-hud/react.tsx
@@ -39,9 +39,11 @@ export function useHUDSurface(
   const pickRef = React.useRef(options.pick);
   const shapeOfRef = React.useRef(options.shapeOf);
   const onIntentRef = React.useRef(options.onIntent);
+  const onTapRef = React.useRef(options.onTap);
   pickRef.current = options.pick;
   shapeOfRef.current = options.shapeOf;
   onIntentRef.current = options.onIntent;
+  onTapRef.current = options.onTap;
 
   React.useLayoutEffect(() => {
     if (!canvasRef.current) return;
@@ -49,6 +51,9 @@ export function useHUDSurface(
       pick: (p) => pickRef.current(p),
       shapeOf: (id) => shapeOfRef.current(id),
       onIntent: (i) => onIntentRef.current(i),
+      // Forward taps through a stable ref so the host can pass a fresh
+      // closure each render. `undefined` if the host never wired `onTap`.
+      onTap: (t) => onTapRef.current?.(t),
       style: options.style,
       readonly: options.readonly,
       color: options.color,

--- a/packages/grida-canvas-hud/surface/surface.ts
+++ b/packages/grida-canvas-hud/surface/surface.ts
@@ -30,6 +30,7 @@ import {
   cursorToCss,
 } from "../event/cursor";
 import type { Intent, IntentHandler } from "../event/intent";
+import type { TapHandler, TapOutcome } from "../event/tap";
 import type { Transform } from "../event/transform";
 import type { SelectionShape, SelectionGroup } from "../event/shape";
 import { type HUDStyle, DEFAULT_STYLE, mergeStyle } from "./style";
@@ -87,6 +88,22 @@ export interface SurfaceOptions {
   vectorOf?: (id: NodeId) => VectorOverlay | null;
   /** Surface emits intents the host commits. */
   onIntent: IntentHandler;
+  /**
+   * Optional observe-only tap sink. Fires once per discrete tap (press +
+   * release within the drag threshold) for the primary and secondary
+   * buttons — never the middle button (pan), never a drag. The outcome
+   * carries the document-space DOWN point, the button, the topmost host
+   * pick at that point (or `null` for empty canvas), and the modifier
+   * snapshot.
+   *
+   * Distinct from `onIntent` by design: a tap is a fact to observe, not a
+   * change to commit, and it must be able to fire WITHOUT mutating
+   * selection (most importantly for the secondary button). Hosts that don't
+   * run a tap-driven tool omit it and pay nothing.
+   *
+   * @unstable — see {@link TapOutcome}.
+   */
+  onTap?: TapHandler;
   /** Initial style (partial; merged with defaults). */
   style?: Partial<HUDStyle>;
   /** Initial readonly flag. Default `false`. */
@@ -496,6 +513,7 @@ export class Surface {
       pick: this.opts.pick,
       shapeOf: this.opts.shapeOf,
       emitIntent: this.opts.onIntent,
+      emitTap: this.opts.onTap,
     });
   }
 
@@ -935,6 +953,7 @@ function selectionRectFromShape(
 
 export type { SurfaceResponse, SurfaceEvent, PointerButton, Modifiers };
 export type { Intent, IntentHandler };
+export type { TapHandler, TapOutcome };
 export type { HUDStyle };
 export type { SelectionShape, SelectionGroup };
 

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -304,6 +304,25 @@ editor.subscribe_with_selector<T>(
 
 `state` is a frozen snapshot. Consumers never destructure into internals; if a view they need isn't here or in the purpose-built views below, that's an API gap.
 
+### Observation — pick (tap)
+
+A **pick** is a discrete tap on the canvas — a press and release within the drag threshold, no drag. It is observe-only and deliberately **separate from selection**: selection answers "what do commands target," a pick answers "what did the user just click, and where." A primary tap on a node both selects it _and_ emits a pick; a tap on empty canvas emits a pick with `node_id: null` (distinguishable from "nothing is selected," which selection alone cannot express); a secondary (right-button) tap emits a pick and does **not** change selection. This is the seam a click-driven host tool needs — a comment / annotation tool anchors UI at `point` and scopes its action to `node_id`, or to the whole document when `null`.
+
+```ts
+type PickEvent = {
+  point: Vec2; // document-space — the pointer-DOWN point the tap resolved against
+  node_id: NodeId | null; // topmost node under point; null = empty canvas
+  button: "primary" | "secondary"; // middle is pan, never taps
+  mods: { shift: boolean; alt: boolean; meta: boolean; ctrl: boolean };
+};
+
+editor.subscribe_pick(fn: (e: PickEvent) => void): Unsubscribe;
+```
+
+The point is document-space and always the pointer-**down** point — so it stays correct even for a tap on an already-selected node (whose selection commits on pointer-up). The channel does **not** bump `state.version`. In React, wire it with `useEditorPick(handler)`.
+
+> **Status:** `@unstable` — shipped against one consumer; the shape is open until a second click-driven tool exercises it (P6).
+
 ### Observation — properties
 
 This section is about **property semantics on a single node**, following the CSS / SVG spec. Multi-selection ("mixed values") is a separate concern; see the [Multi-selection](#multi-selection-mixed-values) section below. The two are kept apart on purpose: property semantics is defined by the spec; mixed semantics is an aggregation layer the editor adds because it supports multi-select.
@@ -880,6 +899,7 @@ What this editor will never be. Each one is a defensive perimeter for the princi
 - **Not customizable in HUD layout.** Style spec only — no overlay slots, no handle replacement, no custom chrome components.
 - **Not a private IR.** SVG is the source of truth. The editor does not maintain an alternative on-disk format, and the bytes are not projected from any in-memory canonical store. (The internal typed element IR described under [Paradigm § Element IR (internal)](#element-ir-internal) is a typed view over the parsed AST, not a store the file is derived from — the AST and the file are the source of truth, and the IR is rebuilt from them on each load.)
 - **Not a serializer playground.** Round-trip rules are fixed (P1). No "compact mode," no "Prettier mode," no consumer-supplied formatter.
+- **Not an input-interception hook.** The pick/tap observation (`subscribe_pick`) reports a click that already happened; it cannot prevent, delay, or replace the editor's own selection and gesture handling. A host that needs to intercept input owns the container and splices its own layer in (the DOM escape hatch) — it does not get a veto through the observation surface.
 
 If a consumer needs any of the above, the right answer is "this is the wrong tool." Saying yes to any one is the path that turned the Grida main editor into a 6,800-line god-class.
 

--- a/packages/grida-svg-editor/__tests__/editor.test.ts
+++ b/packages/grida-svg-editor/__tests__/editor.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, expect, it } from "vitest";
 import { createSvgEditor } from "../src/index";
+import type { SvgEditorInternal } from "../src/core/editor";
+import type { PickEvent } from "../src/types";
 
 const TRIVIAL = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect x="10" y="10" width="50" height="40" fill="red"/></svg>`;
 
@@ -135,5 +137,55 @@ describe("createSvgEditor (headless)", () => {
     editor.reset();
     expect(editor.serialize()).toBe(TRIVIAL);
     expect(editor.state.can_undo).toBe(false);
+  });
+});
+
+describe("pick channel (subscribe_pick)", () => {
+  // A pick is a transient tap outcome the surface pushes in. It is observed
+  // through its own channel — deliberately separate from selection and from
+  // the EditorState snapshot stream, so a pointer-rate tap never forces a
+  // full state re-render and never mutates selection.
+  function internal(editor: ReturnType<typeof createSvgEditor>) {
+    return (editor as unknown as SvgEditorInternal)._internal;
+  }
+
+  const PICK: PickEvent = {
+    point: { x: 12, y: 34 },
+    node_id: "n1",
+    button: "primary",
+    mods: { shift: false, alt: false, meta: false, ctrl: false },
+  };
+
+  it("push_pick notifies subscribers with the point, node id and button", () => {
+    const editor = createSvgEditor({ svg: TRIVIAL });
+    const seen: PickEvent[] = [];
+    const unsub = editor.subscribe_pick((e) => seen.push(e));
+
+    internal(editor).push_pick(PICK);
+    expect(seen).toEqual([PICK]);
+
+    // unsubscribe stops delivery
+    unsub();
+    internal(editor).push_pick({ ...PICK, node_id: null });
+    expect(seen).toEqual([PICK]);
+  });
+
+  it("an empty-canvas tap reports node_id null", () => {
+    const editor = createSvgEditor({ svg: TRIVIAL });
+    const seen: PickEvent[] = [];
+    editor.subscribe_pick((e) => seen.push(e));
+    internal(editor).push_pick({ ...PICK, node_id: null });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].node_id).toBeNull();
+  });
+
+  it("a pick does NOT bump state.version (separate from the snapshot stream)", () => {
+    const editor = createSvgEditor({ svg: TRIVIAL });
+    const versions: number[] = [];
+    editor.subscribe((s) => versions.push(s.version));
+    const before = editor.state.version;
+    internal(editor).push_pick(PICK);
+    expect(versions).toEqual([]); // no state emission fired
+    expect(editor.state.version).toBe(before);
   });
 });

--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -33,6 +33,7 @@ type Internal = {
   set_content_edit_driver: (fn: unknown) => void;
   set_surface_hover_override_driver: (fn: unknown) => void;
   push_surface_hover: (id: unknown) => void;
+  push_pick: (e: unknown) => void;
   set_computed_resolver: (fn: unknown) => void;
   set_geometry: (p: unknown) => void;
 };
@@ -52,6 +53,7 @@ describe("editor._internal contract", () => {
         "history",
         "insert_text_preview",
         "notify_translate_commit",
+        "push_pick",
         "push_surface_hover",
         "set_computed_resolver",
         "set_content_edit_driver",

--- a/packages/grida-svg-editor/__tests__/pick.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/pick.browser.test.ts
@@ -1,0 +1,97 @@
+// Real-DOM verification of the pick (tap) wire: a discrete click on the canvas
+// surfaces a PickEvent on `editor.subscribe_pick`, carrying the document-space
+// point and the node under it. Runs in headless Chromium so the SVG layout
+// engine (getBBox / getCTM) is real and, under the identity camera mounted at
+// the origin, client px map 1:1 to world coords (see _browser-helpers.ts).
+//
+// This is the consumer end of the `@grida/hud` `onTap` contract. The surface
+// is a thin wire: it re-expresses the HUD's already-resolved tap (down point,
+// hit node, click-vs-drag) as a PickEvent — it does NOT re-hit-test, so the
+// pick and any selection that accompanies it can never disagree.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  attachSurface,
+  clientCenter,
+  nodeIdByName,
+  type AttachedSurface,
+} from "./_browser-helpers";
+import type { PickEvent } from "../src/types";
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" width="400" height="300">
+  <rect id="box" x="40" y="40" width="120" height="80" fill="#39f"/>
+</svg>`;
+
+let s: AttachedSurface | null = null;
+afterEach(() => {
+  s?.dispose();
+  s = null;
+});
+
+/** A discrete click: press + release at the same client point (no drag), so
+ *  the HUD resolves a tap rather than a gesture. Mirrors the surface's event
+ *  binding — pointerdown on the container, pointerup on the window. */
+function clickClient(
+  container: HTMLElement,
+  x: number,
+  y: number,
+  button = 0
+): void {
+  const win = container.ownerDocument.defaultView!;
+  const init = (type: string): PointerEventInit => ({
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true,
+    button,
+    buttons: type === "pointerup" ? 0 : button === 0 ? 1 : 2,
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  container.dispatchEvent(new PointerEvent("pointerdown", init("pointerdown")));
+  win.dispatchEvent(new PointerEvent("pointerup", init("pointerup")));
+}
+
+describe("pick wire (click → subscribe_pick)", () => {
+  it("a primary click on a node picks that node at the click point", () => {
+    s = attachSurface(SVG);
+    const picks: PickEvent[] = [];
+    s.editor.subscribe_pick((e) => picks.push(e));
+
+    const c = clientCenter(s.elementByName("box"));
+    clickClient(s.container, c.x, c.y);
+
+    expect(picks).toHaveLength(1);
+    expect(picks[0].node_id).toBe(nodeIdByName(s.editor, "box"));
+    expect(picks[0].button).toBe("primary");
+    // identity camera mounted at origin → click client px == world point
+    expect(picks[0].point.x).toBeCloseTo(c.x, 0);
+    expect(picks[0].point.y).toBeCloseTo(c.y, 0);
+  });
+
+  it("a click on empty canvas picks with node_id null", () => {
+    s = attachSurface(SVG);
+    const picks: PickEvent[] = [];
+    s.editor.subscribe_pick((e) => picks.push(e));
+
+    clickClient(s.container, 350, 260); // inside the svg, outside the rect
+    expect(picks).toHaveLength(1);
+    expect(picks[0].node_id).toBeNull();
+  });
+
+  it("a secondary (right-button) click picks but leaves selection untouched", () => {
+    s = attachSurface(SVG);
+    const picks: PickEvent[] = [];
+    s.editor.subscribe_pick((e) => picks.push(e));
+
+    const c = clientCenter(s.elementByName("box"));
+    clickClient(s.container, c.x, c.y, 2);
+
+    expect(picks).toHaveLength(1);
+    expect(picks[0].button).toBe("secondary");
+    expect(picks[0].node_id).toBe(nodeIdByName(s.editor, "box"));
+    expect(s.editor.state.selection).toEqual([]); // right-click never selects
+  });
+});

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -1874,6 +1874,15 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   function dispose() {
     detach();
     listeners.clear();
+    // Release every transient observation-channel subscriber too. `detach()`
+    // already stops the surface from pushing to them, so they're inert by
+    // here; clearing drops any closures a disposed-but-still-referenced editor
+    // would otherwise retain. Clearing all of them (not just one) keeps the
+    // disposal contract uniform across the subscribe channels.
+    surface_hover_listeners.clear();
+    geometry_listeners.clear();
+    translate_commit_listeners.clear();
+    pick_listeners.clear();
   }
 
   function set_style(partial: Partial<EditorStyle>) {

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -42,6 +42,7 @@ import type {
   Paint,
   PaintPreviewSession,
   PaintValue,
+  PickEvent,
   PreviewSession,
   Providers,
   ReorderDirection,
@@ -1740,6 +1741,16 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     notify_surface_hover();
   }
 
+  // Pick channel — a transient "the user tapped here, on this node" event.
+  // Like surface-hover, kept out of EditorState (a pick is an edge, not steady
+  // state) and off the `version` stream so it never triggers snapshot
+  // re-renders. The surface pushes a fully-resolved PickEvent; the editor only
+  // fans it out. Observe-only: emitting a pick never mutates editor state.
+  const pick_listeners = new Set<(e: PickEvent) => void>();
+  function notify_pick(e: PickEvent) {
+    for (const cb of pick_listeners) cb(e);
+  }
+
   function enter_content_edit(target?: NodeId): boolean {
     const id = target ?? (selection.length === 1 ? selection[0] : null);
     if (!id) return false;
@@ -1988,6 +1999,23 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     },
 
     /**
+     * Subscribe to pick (tap) outcomes — a discrete click on the canvas,
+     * reporting the document-space point and the node under it (`null` for
+     * empty canvas), plus the button and modifier snapshot. Fires once per
+     * tap, after the editor's own selection handling. Observe-only: a pick
+     * cannot alter selection, and the channel does NOT bump `state.version`.
+     * See {@link PickEvent}.
+     *
+     * @unstable
+     */
+    subscribe_pick(cb: (e: PickEvent) => void): Unsubscribe {
+      pick_listeners.add(cb);
+      return () => {
+        pick_listeners.delete(cb);
+      };
+    },
+
+    /**
      * Subscribe to bounds-affecting changes. Fires when any document
      * mutation advances `state.geometry_version` — drag, resize, text
      * edit, structural insert/remove. Skips presentation-only writes
@@ -2073,6 +2101,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       },
       push_surface_hover(id: NodeId | null) {
         _set_current_surface_hover(id);
+      },
+      push_pick(e: PickEvent) {
+        notify_pick(e);
       },
       set_computed_resolver(fn: DomComputedResolver | null) {
         computed_resolver = fn;

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -13,7 +13,7 @@
 //     a fact or open a history bracket.
 
 import type { Preview } from "@grida/history";
-import type { NodeId, Unsubscribe } from "../types";
+import type { NodeId, PickEvent, Unsubscribe } from "../types";
 import type { DomComputedResolver } from "./editor";
 import type { GeometryProvider } from "./geometry";
 import type { SvgDocument } from "./document";
@@ -73,6 +73,13 @@ export interface SurfaceBridge {
    *  `editor.subscribe_surface_hover()` listeners; does NOT bump
    *  `state.version`. */
   push_surface_hover(id: NodeId | null): void;
+
+  /** surface → editor: publish a discrete tap (press + release within the
+   *  drag threshold). Goes to `editor.subscribe_pick()` listeners; does NOT
+   *  bump `state.version`. The surface resolves the document-space point and
+   *  the hit node; the editor only fans the event out. Observe-only — never
+   *  mutates selection or any other editor state. */
+  push_pick(e: PickEvent): void;
 
   /** editor → surface: register the cascade resolver. The DOM surface
    *  implements this with `getComputedStyle()`; headless surfaces may

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -27,6 +27,7 @@ import {
   type PointerButton,
   type SelectionShape,
   type SelectionGroup,
+  type TapOutcome,
 } from "@grida/hud";
 import { cursors as hud_cursors } from "@grida/hud/cursors";
 import { measure, type Measurement } from "@grida/cmath/_measurement";
@@ -628,6 +629,7 @@ class DomSurface implements Surface {
       shapeOf: (id) => this.shape_of(id),
       vectorOf: (id) => this.vector_of(id),
       onIntent: (i) => this.commit_intent(i),
+      onTap: (t) => this.handle_tap(t),
       style: {
         chromeColor: editor.style.chrome_color,
         // v1 ships rotation: the chrome builder draws a rotation knob
@@ -2408,6 +2410,26 @@ class DomSurface implements Surface {
     // host owns preventDefault because only it sees the DOM event.
     if (this.editor.keymap.claims(e)) e.preventDefault();
     this.editor.keymap.dispatch(e);
+  }
+
+  // ─── Pick (tap) handler ───────────────────────────────────────────────────
+
+  /**
+   * Re-express a HUD tap as an editor {@link PickEvent} and fan it out on the
+   * editor's pick channel. The HUD already resolved everything that matters —
+   * the pointer-down point, the hit node, and click-vs-drag — so this is a
+   * pure translation (HUD `[x, y]` tuple → editor `{ x, y }` doc-space point)
+   * with NO re-hit-testing. Taking the hit from the HUD (not a fresh
+   * `node_at_point`) guarantees the pick and the selection it accompanies can
+   * never disagree. Observe-only: this mutates no editor state.
+   */
+  private handle_tap(tap: TapOutcome): void {
+    this.editor._internal.push_pick({
+      point: { x: tap.point[0], y: tap.point[1] },
+      node_id: tap.hit,
+      button: tap.button,
+      mods: tap.mods,
+    });
   }
 
   // ─── Intent handler ──────────────────────────────────────────────────────

--- a/packages/grida-svg-editor/src/react.tsx
+++ b/packages/grida-svg-editor/src/react.tsx
@@ -20,6 +20,7 @@ import type {
   NodeId,
   Paint,
   PaintPreviewSession,
+  PickEvent,
   PreviewSession,
   Providers,
   Tool,
@@ -418,6 +419,34 @@ export function useHoverOverride(): (id: NodeId | null) => void {
       lastSetRef.current = id;
       editor.set_surface_hover_override(id);
     },
+    [editor]
+  );
+}
+
+// ─── Pick (tap) observation ────────────────────────────────────────────────
+
+/**
+ * Observe pick (tap) outcomes — a discrete click on the canvas, reporting the
+ * document-space `point`, the `node_id` under it (`null` for empty canvas),
+ * the `button`, and `mods`. The handler fires once per tap, after the editor's
+ * own selection handling. Observe-only: it cannot prevent or alter selection.
+ *
+ * This is the React edge-wire over `editor.subscribe_pick`. The handler is
+ * kept in a ref so re-subscription is never triggered by handler identity —
+ * pass an inline closure freely. Pick is editor-scoped (it survives surface
+ * detach), so this is a hook, not a `SvgEditorCanvas` prop.
+ *
+ * Typical use: a comment / annotation tool anchors a popover at `e.point` and
+ * scopes its action to `e.node_id` (or to the whole document when `null`).
+ *
+ * @unstable See {@link PickEvent}.
+ */
+export function useEditorPick(handler: (e: PickEvent) => void): void {
+  const editor = useSvgEditor();
+  const handler_ref = useRef(handler);
+  handler_ref.current = handler;
+  useEffect(
+    () => editor.subscribe_pick((e) => handler_ref.current(e)),
     [editor]
   );
 }

--- a/packages/grida-svg-editor/src/types.ts
+++ b/packages/grida-svg-editor/src/types.ts
@@ -10,6 +10,37 @@ export type Vec2 = { x: number; y: number };
 
 export type Rect = { x: number; y: number; width: number; height: number };
 
+/**
+ * Observe-only outcome of a discrete pointer **tap** on the canvas: the user
+ * pressed and released within the drag threshold, without dragging. Delivered
+ * through {@link SvgEditor.subscribe_pick} — a transient event, never part of
+ * `EditorState` (it would be stale on the next snapshot).
+ *
+ * A pick is deliberately **separate from selection**. Selection answers "what
+ * do commands target"; a pick answers "what did the user just click, and
+ * where". A primary tap on a node both selects it and emits a pick; a tap on
+ * empty canvas emits a pick with `node_id: null` (distinguishable from "nothing
+ * is selected"); a secondary (right-button) tap emits a pick and does NOT
+ * change selection. This is what a click-driven host tool (annotation, context
+ * menu, custom selection) needs and selection alone cannot express.
+ *
+ * Observe-only: a pick reports a click that already happened. It cannot
+ * prevent or replace the editor's own selection handling.
+ *
+ * @unstable Shape is provisional until ≥2 consumers exercise it. Fields may
+ * change without a semver bump until then.
+ */
+export type PickEvent = {
+  /** Document-space point the tap resolved against (the pointer-DOWN point). */
+  point: Vec2;
+  /** Topmost node under `point`, or `null` for empty canvas / background. */
+  node_id: NodeId | null;
+  /** Which button produced the tap. `"middle"` is pan and never taps. */
+  button: "primary" | "secondary";
+  /** Modifier snapshot at press time. */
+  mods: { shift: boolean; alt: boolean; meta: boolean; ctrl: boolean };
+};
+
 export type Mode = "select" | "edit-content";
 
 // ─── Tool (orthogonal to Mode — what does pointer-down do in select mode?) ─


### PR DESCRIPTION
Closes #779.

## What

Adds a public, **observe-only** way for a host to learn that a click landed on the canvas — the **document-space point** and the **node under it** (`null` = empty canvas) — plus the button and modifiers.

```ts
// headless editor (works without a surface, survives surface detach)
const unsub = editor.subscribe_pick((e) => {
  // e: { point: Vec2; node_id: NodeId | null; button: "primary" | "secondary"; mods }
  if (e.node_id) commentOn(e.node_id, e.point);
  else commentOnWholeDoc(e.point);
});

// React
useEditorPick((e) => { /* … */ });
```

## Why

`@grida/svg-editor` exposed no way to detect a canvas click. Selection alone can't express it — it can't distinguish an empty-canvas click from an empty selection, and it carries no point. This is what click-driven tools need: a comment/annotation tool, a context menu anchored at the point, custom selection. Pairs with `serialize_node` (#775): `subscribe_pick` says **what/where**, `serialize_node(node_id)` gives that element's markup.

## How (design)

Run through the `sdk-design` / `sdk-seam` doctrine, the issue's `onPick`-on-`DomSurfaceOptions` sketch was re-shaped to land at the right layer:

- **Pick lives on the headless core editor**, not the DOM surface — a transient event channel (`subscribe_pick` / `_internal.push_pick`, `PickEvent`) that mirrors the existing `surface_hover` channel, is surface-agnostic, survives detach, and never bumps `state.version`. A pick is an event, not state.
- **Separate from selection** (different outputs, different constraints) and **observe-only** — added the anti-goal *"not an input-interception hook."*
- **The DOM shell is a thin wire.** `handle_tap` re-expresses the HUD's already-resolved tap as a `PickEvent` (`[x,y]`→`{x,y}`); the hit node comes from the HUD, **not** a fresh `node_at_point`, so the pick and any selection it accompanies can never disagree.
- **React:** `useEditorPick(handler)` is an editor-scoped hook (pick survives surface detach), not a `SvgEditorCanvas` prop.
- **`PickEvent` is the editor's own type** (not a re-exported `@grida/hud` type), keeping the public API self-contained. Marked `@unstable` until a second consumer shapes it (P6).

### Two commits, contract-first across the seam

1. **`feat(hud): add observe-only onTap outcome`** — the producer contract. A button-agnostic `onTap` callback + `TapOutcome`, kept **off** the `Intent` stream (an Intent is an actionable change the host commits; a tap is a fact to observe — and it must fire for the secondary button without mutating selection). Ships with no reader, locked by 6 event-layer UX specs.
2. **`feat(svg-editor): public pick channel`** — consumes that contract.

"Treat buttons equally" (secondary-button taps fire without changing selection) is what makes context menus first-class — a deliberate extension beyond the original sketch.

## Verification

- `@grida/hud`: 555 tests, typecheck clean.
- `@grida/svg-editor`: typecheck clean; **1078 node tests** + **3 real-Chromium browser tests** (primary picks the node at the click point, empty canvas picks `null`, right-click picks without selecting).
- oxlint 0/0, oxfmt clean.

## Reviewer notes

- **Known firing-order nuance (follow-up).** The HUD emits the tap *before* the deferred select intent on pointer-up, so for a click on an **already-selected** node a `subscribe_pick` handler that reads `editor.state.selection` sees the *pre-click* selection, while the eager path (click on an unselected node, which commits on pointer-down) sees the post-click selection. The issue's use cases read `e.node_id`/`e.point` directly and are unaffected; only a host reading `state.selection` inside the callback hits the eager/deferred inconsistency. Tightening this is a small `@grida/hud` `onPointerUp` restructure (emit the tap last) + an emission-order test — proposed as a fast follow rather than bundled here, since it touches the gesture-commit path.
- The `PickEvent`/`TapOutcome` types are intentionally **not unified** — each side owns its public type at the boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tap/pick observation: discrete click events (primary/secondary only) that don't change selection; deliver document-space point, button, topmost hit (or null), and modifiers
  * Exposed via surface onTap, editor subscribe_pick, and a React useEditorPick hook; Tap/Pick event types exported

* **Documentation**
  * Updated docs with tap/pick semantics, examples, and anti-goals

* **Tests**
  * Added coverage for tap delivery, button exclusion, drag suppression, empty-canvas taps, and subscription behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->