### PR TITLE
feat(agent-chat): long-message collapse, pre-first-token "Thinking" indicator, and refresh-resume fix

### DIFF
--- a/editor/app/(dev)/ui/components/ai-chat/_chat-shell.tsx
+++ b/editor/app/(dev)/ui/components/ai-chat/_chat-shell.tsx
@@ -15,6 +15,7 @@ import { cn } from "@app/ui/lib/utils";
 import {
   ChatMessageView,
   CompactingIndicator,
+  PendingTurnIndicator,
   type ChatMessage,
   type ChatMessageActions,
 } from "@/kits/agent-chat";
@@ -23,6 +24,7 @@ export function DemoChatShell({
   messages,
   isStreaming,
   compacting,
+  pending,
   error,
   onDismissError,
   className,
@@ -32,12 +34,18 @@ export function DemoChatShell({
   isStreaming: boolean;
   /** Show the in-flight compaction shimmer at the transcript tail. */
   compacting?: boolean;
+  /** Force the pre-first-token "Thinking" indicator (static showcase). */
+  pending?: boolean;
   error?: Error;
   onDismissError: () => void;
   className?: string;
   /** Per-turn rewind/branch affordances under user bubbles (demo). */
   actions?: ChatMessageActions;
 }) {
+  // Mirrors the desktop surfaces: a turn is streaming but no assistant turn has
+  // begun. The `pending` prop forces it for the static showcase scenario.
+  const pendingTurn =
+    pending || (isStreaming && messages.at(-1)?.role !== "assistant");
   return (
     <div
       data-testid="demo-ai-chat-shell"
@@ -56,6 +64,7 @@ export function DemoChatShell({
               actions={m.role === "user" ? actions : undefined}
             />
           ))}
+          {pendingTurn && <PendingTurnIndicator />}
           {compacting && <CompactingIndicator />}
         </ConversationContent>
         <ConversationScrollButton />

--- a/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
+++ b/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
@@ -31,6 +31,13 @@ export type Scenario = {
    * message in `initialMessages`.
    */
   compacting?: boolean;
+  /**
+   * Render the pre-first-token "Thinking" indicator at the transcript tail —
+   * the dead-air window between a send and the first streamed chunk. A static
+   * state (like {@link compacting}) so the shimmer + elapsed timer animate
+   * continuously and are tunable, without timing a live stream.
+   */
+  pending?: boolean;
 };
 
 const MARKDOWN = `## Plan
@@ -112,6 +119,21 @@ export const SCENARIOS: Scenario[] = [
   },
 
   // --- G. Lifecycle (compaction) ---
+  {
+    id: "lifecycle-pending",
+    label: "Awaiting first token (Thinking)",
+    group: "Lifecycle",
+    // The dead-air window after a send, before the first chunk. The user
+    // message is settled; the assistant turn hasn't begun, so the tail shows
+    // the "Thinking" shimmer (its elapsed timer reveals after a few seconds).
+    pending: true,
+    initial_messages: [
+      userMsg(
+        "Refactor the logo into its own component and tighten the viewBox."
+      ),
+    ],
+    chunks: [],
+  },
   {
     id: "lifecycle-compacting",
     label: "Compacting (in progress)",

--- a/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
+++ b/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
@@ -55,6 +55,20 @@ const LONG_CONTENT = Array.from(
     `  <rect x="${i}" y="${i}" width="10" height="10" fill="#${i}${i}f" />`
 ).join("\n");
 
+// A pasted-spec wall of text — overflows the user bubble's collapse threshold
+// so the "Show more" affordance (clamp + fade-to-bubble gradient) appears.
+const LONG_USER_MESSAGE = [
+  "Here's the full spec for the logo refactor — please read all of it before you start.",
+  "",
+  "1. Extract the inline SVG in `src/header.tsx` into its own `<Logo>` component under `src/logo.tsx`. It should take an optional `size` prop (default 24) and forward `className` so callers can recolor it.",
+  "2. Tighten the artboard: the current `viewBox` is `0 0 48 48` with a lot of dead margin. Crop it to `0 0 24 24` and re-center the glyph.",
+  "3. Normalize the palette down to three tokens — `teal`, `coral`, and `ink` — and move them into `tokens.css`. Every hard-coded hex in the markup should reference a token instead.",
+  "4. Add a subtle drop shadow, but only on the light theme; the dark theme should stay flat.",
+  "5. Wire the new `<Logo>` into the header and the footer, and delete the two inline copies.",
+  "",
+  "Once that's done, run the typecheck and the snapshot tests, and show me the before/after of the header. Thanks!",
+].join("\n");
+
 export const SCENARIOS: Scenario[] = [
   // --- D. Composition (default) ---
   {
@@ -396,6 +410,19 @@ export const SCENARIOS: Scenario[] = [
     label: "Markdown-rich text",
     group: "Markdown",
     chunks: text("t1", MARKDOWN),
+  },
+  {
+    id: "long-user-message",
+    label: "Long user message (collapsible)",
+    group: "Markdown",
+    // The pasted spec overflows the user bubble's collapse threshold, so it
+    // renders clamped behind a fade with a "Show more" toggle; the streamed
+    // reply confirms the assistant turn still flows normally below it.
+    initial_messages: [userMsg(LONG_USER_MESSAGE)],
+    chunks: text(
+      "t1",
+      "Got it — I'll start by extracting `<Logo>` into `src/logo.tsx`, then tighten the viewBox to `0 0 24 24`."
+    ),
   },
   {
     id: "overflow-json",

--- a/editor/app/(dev)/ui/components/ai-chat/page.tsx
+++ b/editor/app/(dev)/ui/components/ai-chat/page.tsx
@@ -83,6 +83,9 @@ export default function AiChatDemoPage() {
   // scenario — the shimmer animates continuously so it's tunable; the settled
   // summary is a separate scenario carrying a `data-compaction` message.
   const compacting = scenario.compacting === true;
+  // Pre-first-token "Thinking" indicator. Static per scenario like `compacting`
+  // so the shimmer + elapsed timer animate without timing a live stream.
+  const pending = scenario.pending === true;
 
   return (
     <div className="container mx-auto max-w-screen-xl py-10">
@@ -158,6 +161,7 @@ export default function AiChatDemoPage() {
             messages={messages}
             isStreaming={isStreaming}
             compacting={compacting}
+            pending={pending}
             error={error}
             onDismissError={clearError}
             actions={{

--- a/editor/kits/agent-chat/index.ts
+++ b/editor/kits/agent-chat/index.ts
@@ -1,2 +1,7 @@
-export { ChatMessageView, CompactingIndicator, ForkedNotice } from "./message";
+export {
+  ChatMessageView,
+  CompactingIndicator,
+  ForkedNotice,
+  PendingTurnIndicator,
+} from "./message";
 export type { ChatMessage, ChatMessageActions, ToolCallEntry } from "./message";

--- a/editor/kits/agent-chat/message.tsx
+++ b/editor/kits/agent-chat/message.tsx
@@ -478,6 +478,42 @@ export function CompactingIndicator() {
 }
 
 /**
+ * Pre-first-token indicator — the dead-air window between a send and the first
+ * streamed chunk. The AI-SDK reducer doesn't create the assistant message until
+ * the first content chunk arrives, so the per-turn "Thinking" shimmer that lives
+ * inside the assistant bubble ({@link ChatMessageView}) has nothing to mount on
+ * yet. A surface renders this at the transcript tail while a turn is in flight
+ * and no assistant turn has begun (`isStreaming && last message is not the
+ * assistant`); it's framed as an assistant turn so it sits exactly where the
+ * real response will, then is replaced by it the moment the first chunk lands.
+ *
+ * Mirrors {@link CompactingIndicator}: the elapsed counter stays hidden for the
+ * first few seconds — a fast first token never grows a timer — and only a wait
+ * long enough to feel slow surfaces it, so a slow time-to-first-token reads as
+ * progress rather than a hang. The timer is a sibling of the `Shimmer`, not its
+ * child: `Shimmer` recreates its motion element whenever its string child
+ * changes, so feeding it the ticking label would restart the shimmer each second.
+ */
+export function PendingTurnIndicator() {
+  const elapsed = useElapsedSeconds();
+  return (
+    <Message from="assistant" className="w-full max-w-none">
+      <MessageContent className="w-full max-w-full">
+        <span className="flex items-center gap-1.5 text-xs">
+          <Shimmer as="span">Thinking</Shimmer>
+          {elapsed * 1000 >= ELAPSED_REVEAL_AFTER_MS && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="tabular-nums">{formatElapsed(elapsed)}</span>
+            </>
+          )}
+        </span>
+      </MessageContent>
+    </Message>
+  );
+}
+
+/**
  * Transient confirmation that a fork happened (RFC `session / fork`). Forking
  * switches to a copy that looks identical to the source, so without this the
  * action reads as a no-op. A surface renders it while

--- a/editor/kits/agent-chat/message.tsx
+++ b/editor/kits/agent-chat/message.tsx
@@ -437,42 +437,52 @@ function formatElapsed(totalSeconds: number): string {
 }
 
 /**
+ * How long an in-flight indicator runs bare before the elapsed-time counter
+ * appears, in milliseconds. Below this only the shimmering label shows; at or
+ * past it the "· {time}" counter is revealed.
+ */
+const ELAPSED_REVEAL_AFTER_MS = 3000;
+
+/**
+ * A shimmering label trailed by a live elapsed-time counter — the shared body
+ * of the transcript's in-flight indicators ({@link CompactingIndicator},
+ * {@link PendingTurnIndicator}) so they tick identically.
+ *
+ * The counter stays hidden for the first {@link ELAPSED_REVEAL_AFTER_MS}: a fast
+ * operation settles before a timer grows, and only a wait long enough to feel
+ * slow surfaces the elapsed time as reassurance.
+ *
+ * The counter is a sibling of the `Shimmer`, not its child: `Shimmer` requires a
+ * string child and recreates its motion element whenever that child changes, so
+ * feeding it the ticking label would restart the shimmer every second.
+ */
+function ShimmerWithElapsed({ label }: { label: string }) {
+  const elapsed = useElapsedSeconds();
+  return (
+    <span className="flex items-center gap-1.5 whitespace-nowrap text-xs">
+      <Shimmer as="span">{label}</Shimmer>
+      {elapsed * 1000 >= ELAPSED_REVEAL_AFTER_MS && (
+        <>
+          <span aria-hidden>·</span>
+          <span className="tabular-nums">{formatElapsed(elapsed)}</span>
+        </>
+      )}
+    </span>
+  );
+}
+
+/**
  * In-flight compaction (RFC `session / compaction`). A divider whose centered
  * label shimmers while the summarizer runs, trailed by a live elapsed-time
  * counter so a slow summarize reads as progress, not a hang. The host renders
  * this at the tail of the conversation while a manual `/compact` is awaiting;
  * once the summary message hydrates it is replaced by the settled
  * {@link CompactionNotice}.
- *
- * The timer is a sibling of the shimmer, not inside it: `Shimmer` requires a
- * string child and recreates its motion element whenever that child changes,
- * so feeding it the ticking label would restart the shimmer every second.
- *
- * The counter stays hidden for the first few seconds: a fast compaction never
- * grows a timer (the indicator settles before it appears), and only a wait long
- * enough to feel slow surfaces the elapsed time as reassurance.
  */
-
-/**
- * How long the indicator runs bare before the elapsed-time counter appears,
- * in milliseconds. Below this, only the "Compacting conversation" shimmer
- * shows; at or past it the "· {time}" counter is revealed.
- */
-const ELAPSED_REVEAL_AFTER_MS = 3000;
-
 export function CompactingIndicator() {
-  const elapsed = useElapsedSeconds();
   return (
     <CompactionDivider>
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-xs">
-        <Shimmer as="span">Compacting conversation</Shimmer>
-        {elapsed * 1000 >= ELAPSED_REVEAL_AFTER_MS && (
-          <>
-            <span aria-hidden>·</span>
-            <span className="tabular-nums">{formatElapsed(elapsed)}</span>
-          </>
-        )}
-      </span>
+      <ShimmerWithElapsed label="Compacting conversation" />
     </CompactionDivider>
   );
 }
@@ -486,28 +496,12 @@ export function CompactingIndicator() {
  * and no assistant turn has begun (`isStreaming && last message is not the
  * assistant`); it's framed as an assistant turn so it sits exactly where the
  * real response will, then is replaced by it the moment the first chunk lands.
- *
- * Mirrors {@link CompactingIndicator}: the elapsed counter stays hidden for the
- * first few seconds — a fast first token never grows a timer — and only a wait
- * long enough to feel slow surfaces it, so a slow time-to-first-token reads as
- * progress rather than a hang. The timer is a sibling of the `Shimmer`, not its
- * child: `Shimmer` recreates its motion element whenever its string child
- * changes, so feeding it the ticking label would restart the shimmer each second.
  */
 export function PendingTurnIndicator() {
-  const elapsed = useElapsedSeconds();
   return (
     <Message from="assistant" className="w-full max-w-none">
       <MessageContent className="w-full max-w-full">
-        <span className="flex items-center gap-1.5 text-xs">
-          <Shimmer as="span">Thinking</Shimmer>
-          {elapsed * 1000 >= ELAPSED_REVEAL_AFTER_MS && (
-            <>
-              <span aria-hidden>·</span>
-              <span className="tabular-nums">{formatElapsed(elapsed)}</span>
-            </>
-          )}
-        </span>
+        <ShimmerWithElapsed label="Thinking" />
       </MessageContent>
     </Message>
   );

--- a/editor/kits/agent-chat/message.tsx
+++ b/editor/kits/agent-chat/message.tsx
@@ -19,8 +19,15 @@
 
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { isFileUIPart, isTextUIPart, type FileUIPart } from "ai";
+import { cn } from "@app/ui/lib/utils";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
@@ -139,27 +146,32 @@ export function ChatMessageView({
     return (
       <Message from="user">
         <MessageContent>
-          {images.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {images.map((image, index) => (
-                // Index key: a sent user message's attachments are immutable and
-                // never reorder, so the index is stable — and it avoids putting a
-                // multi-MB data-URL into the key (which React keeps + compares).
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  key={index}
-                  src={image.url}
-                  alt={image.filename ?? ""}
-                  loading="lazy"
-                  decoding="async"
-                  className="max-h-48 max-w-full rounded-md border object-contain"
-                />
-              ))}
-            </div>
-          )}
-          {text.length > 0 && (
-            <MessageResponse plugins={markdown.plugins}>{text}</MessageResponse>
-          )}
+          <CollapsibleBubbleBody>
+            {images.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {images.map((image, index) => (
+                  // Index key: a sent user message's attachments are immutable
+                  // and never reorder, so the index is stable — and it avoids
+                  // putting a multi-MB data-URL into the key (which React keeps
+                  // + compares).
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    key={index}
+                    src={image.url}
+                    alt={image.filename ?? ""}
+                    loading="lazy"
+                    decoding="async"
+                    className="max-h-48 max-w-full rounded-md border object-contain"
+                  />
+                ))}
+              </div>
+            )}
+            {text.length > 0 && (
+              <MessageResponse plugins={markdown.plugins}>
+                {text}
+              </MessageResponse>
+            )}
+          </CollapsibleBubbleBody>
         </MessageContent>
         {/* Subtle until hover so the transcript stays clean; right-aligned
             to sit under the user bubble. Copy is always available (a pure
@@ -247,6 +259,97 @@ export function ChatMessageView({
         </MessageActions>
       )}
     </Message>
+  );
+}
+
+/**
+ * Height (px) a user bubble is clamped to before the "Show more" affordance
+ * kicks in. Roughly ten lines at the bubble's `leading-6` — tall enough that
+ * an ordinary message never collapses, short enough that a pasted wall of text
+ * doesn't push the rest of the transcript off-screen.
+ */
+const BUBBLE_COLLAPSE_THRESHOLD_PX = 240;
+
+// Layout-effect that degrades to a no-op on the server. The transcript is
+// client-state-driven (messages arrive after mount), so this effectively only
+// runs in the browser — but the demo seeds `initial_messages` through SSR, and
+// a bare `useLayoutEffect` warns there. Measuring before paint (vs `useEffect`)
+// avoids a flash where a long bubble renders full-height then snaps closed.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/**
+ * Wraps a user bubble's body and, when it exceeds
+ * {@link BUBBLE_COLLAPSE_THRESHOLD_PX}, clamps it to that height behind a
+ * fade-to-bubble gradient with a "Show more" / "Show less" toggle. The
+ * affordance only appears when the content actually overflows — short messages
+ * render untouched, with no measurement cost beyond a single observed element.
+ *
+ * The fade fills to `secondary` to match the bubble's own `bg-secondary`, so it
+ * reads as the text dissolving into the bubble rather than a separate band. It
+ * is `pointer-events-none` so text selection underneath still works.
+ */
+function CollapsibleBubbleBody({ children }: { children: ReactNode }) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useIsomorphicLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const measure = () =>
+      setOverflowing(el.scrollHeight > BUBBLE_COLLAPSE_THRESHOLD_PX);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    // Re-measure on reflow — a late-loading image or a window resize can flip
+    // a bubble across the threshold after the first paint.
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const collapsed = overflowing && !expanded;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {/* Measured directly: `scrollHeight` reports the full content height
+          even while the box is clamped, so the fade host and the measured
+          element are one and the same — no separate inner wrapper needed. */}
+      <div
+        ref={contentRef}
+        className={cn(
+          "relative flex flex-col gap-2",
+          collapsed && "overflow-hidden"
+        )}
+        style={
+          collapsed ? { maxHeight: BUBBLE_COLLAPSE_THRESHOLD_PX } : undefined
+        }
+      >
+        {children}
+        {collapsed && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-b from-transparent to-secondary"
+          />
+        )}
+      </div>
+      {overflowing && (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+          className="flex w-fit items-center gap-1 text-xs font-medium text-foreground/60 transition-colors hover:text-foreground"
+        >
+          {expanded ? "Show less" : "Show more"}
+          <ChevronDownIcon
+            className={cn(
+              "size-3 transition-transform",
+              expanded && "rotate-180"
+            )}
+          />
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/editor/lib/agent-chat/index.ts
+++ b/editor/lib/agent-chat/index.ts
@@ -53,6 +53,12 @@ export {
   type CoreRunState,
 } from "./use-session-status";
 export {
+  useResumeInFlight,
+  decideResumeInFlight,
+  type ResumeInFlightDecision,
+  type UseResumeInFlightArgs,
+} from "./use-resume-in-flight";
+export {
   computeContextUsage,
   estimateContextBreakdown,
   estimateTokens,

--- a/editor/lib/agent-chat/use-chat-session.ts
+++ b/editor/lib/agent-chat/use-chat-session.ts
@@ -23,10 +23,12 @@
  * `grida.lastChatSession.<agent>[.<workspaceId>]`. On mount the hook
  * reads that key, validates the session still exists on the agent sidecar
  * (and discards stale ids cleanly), and sets `currentId`. Streaming
- * continuity is then automatic: the chat panel's
- * `useChat({chat, resume: true})` calls `transport.reconnectToStream`
- * on mount; the agent sidecar serves replay + live tail if the run is still
- * in flight, or 404s into a clean no-op. The DB is the snapshot;
+ * continuity is then automatic: the chat panel's `useResumeInFlight`
+ * calls `transport.reconnectToStream` once the rebuilt chat carries the
+ * restored session id; the agent sidecar serves replay + live tail if the
+ * run is still in flight, or 404s into a clean no-op. (The SDK's own
+ * `resume: true` can't do this — it fires once on mount, before the async
+ * restore resolves the id.) The DB is the snapshot;
  * localStorage is the "what was I last looking at" — pure UX state, by
  * design not in SQL.
  */

--- a/editor/lib/agent-chat/use-resume-in-flight.test.ts
+++ b/editor/lib/agent-chat/use-resume-in-flight.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Contract tests for the resume-in-flight decision core (RFC
+ * docs/wg/ai/agent/session.md — abort-vs-tcp-close / resume).
+ *
+ * The bug this guards against: `useChat({ resume: true })` resumes only
+ * once on mount, against the placeholder chat that has no session id yet
+ * (the id is restored async from localStorage), so a renderer refresh
+ * never reconnects to the still-running turn. `decideResumeInFlight`
+ * encodes the replacement rule — resume once per chat instance that has a
+ * real session id, but NEVER over a turn this client is streaming itself
+ * (fresh-chat mid-stream id adoption). If either regresses, these fail
+ * here rather than only in a hard-to-reproduce desktop session.
+ */
+
+import { describe, expect, it } from "vitest";
+import { decideResumeInFlight } from "./use-resume-in-flight";
+
+describe("decideResumeInFlight", () => {
+  it("skips while no session id is known (the placeholder-chat mount frame)", () => {
+    // This is exactly the refresh race: at mount `current_id` is still null
+    // (restored async), so there is nothing to reconnect to yet.
+    expect(
+      decideResumeInFlight({
+        hasSession: false,
+        isStreaming: false,
+        alreadyClaimed: false,
+      })
+    ).toBe("skip");
+  });
+
+  it("resumes once a real session id is known and the client is idle", () => {
+    // The fix: after the async restore rebuilds the Chat with the real id,
+    // THIS is the frame that must reconnect — the one `resume: true` missed.
+    expect(
+      decideResumeInFlight({
+        hasSession: true,
+        isStreaming: false,
+        alreadyClaimed: false,
+      })
+    ).toBe("resume");
+  });
+
+  it("claims WITHOUT resuming when this client is streaming the turn", () => {
+    // Fresh-chat mid-stream id adoption: sessionId flips null→known while the
+    // Chat instance is unchanged and actively streaming. Resuming here would
+    // open a 2nd stream over the live send (the supervised-approval cut-off).
+    expect(
+      decideResumeInFlight({
+        hasSession: true,
+        isStreaming: true,
+        alreadyClaimed: false,
+      })
+    ).toBe("claim-only");
+  });
+
+  it("skips an instance it already claimed (no double-resume)", () => {
+    expect(
+      decideResumeInFlight({
+        hasSession: true,
+        isStreaming: false,
+        alreadyClaimed: true,
+      })
+    ).toBe("skip");
+    // A claimed instance stays skipped even if it later streams.
+    expect(
+      decideResumeInFlight({
+        hasSession: true,
+        isStreaming: true,
+        alreadyClaimed: true,
+      })
+    ).toBe("skip");
+  });
+});

--- a/editor/lib/agent-chat/use-resume-in-flight.ts
+++ b/editor/lib/agent-chat/use-resume-in-flight.ts
@@ -1,0 +1,119 @@
+/**
+ * `useResumeInFlight` — reconnect a desktop chat surface to its
+ * still-running agent turn after a renderer remount / page refresh
+ * (RFC [session / abort-vs-tcp-close](../../../docs/wg/ai/agent/session.md)).
+ *
+ * ## Why this exists (the bug it replaces)
+ *
+ * Both surfaces previously used `useChat({ resume: true })`. That option
+ * compiles to a single mount effect with deps `[resume, chatRef]`:
+ *
+ *   useEffect(() => { if (resume) chatRef.current.resumeStream(); },
+ *             [resume, chatRef]);   // chatRef is a STABLE ref — never changes
+ *
+ * so `resumeStream()` fires **exactly once, on mount**, and never again
+ * even when the SDK swaps `chatRef.current` to a new `Chat`. On a real
+ * page refresh the active session id is restored ASYNCHRONOUSLY from
+ * localStorage (an IPC `sessions.get` round-trip — see
+ * `use-chat-session.ts`), so that single mount-time resume runs against the
+ * placeholder `Chat` (`id: undefined`, transport `session_id: undefined`)
+ * and `reconnectToStream` returns null → no-op. When the `Chat` is then
+ * rebuilt with the real session id, the SDK's resume effect does NOT
+ * re-fire — so the in-flight run is never reconnected. The transcript only
+ * advances when the user manually refreshes again and re-hydrates a
+ * fresher DB snapshot. The server stream was resumable the whole time; the
+ * client just never asked.
+ *
+ * ## What this does instead
+ *
+ * Fires `resumeStream()` **once per `Chat` instance that carries a real
+ * session id** — so the resume tracks the rebuilt instance, not just the
+ * mount. Session SWITCHES get the same treatment (selecting a busy session
+ * now attaches to its live turn), which `resume: true` never did.
+ *
+ * ## The "never resume over a live send" guard
+ *
+ * A fresh chat adopts its server session id MID-STREAM without rebuilding
+ * the `Chat` (`apply_resolved_session_id` deliberately keeps the streaming
+ * instance — see `use-chat-session.ts`). So `sessionId` can flip
+ * null→known while THIS client is the one streaming the turn. Resuming
+ * there would open a second `reconnectToStream` over the live send and run
+ * `onResumeStart` (which drops the in-progress assistant) — the same
+ * cut-off hazard `useCoreTurnSync` guards against. When `isStreaming`, we
+ * therefore CLAIM the instance without resuming: this client already holds
+ * the live turn, and the claim ensures we never reconnect that instance
+ * later (e.g. after the stream settles). `isStreaming` is read through a
+ * ref so the effect keys only on `[chat, sessionId]` and never re-fires on
+ * a stream-end edge.
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/** What to do for the current `(chat, sessionId, isStreaming)` tuple. */
+export type ResumeInFlightDecision =
+  /** Reconnect to the session's in-flight run (and claim the instance). */
+  | "resume"
+  /** Claim the instance WITHOUT resuming — this client is streaming the
+   *  turn itself (fresh-chat mid-stream id adoption). Prevents a later
+   *  spurious reconnect over what was a live send. */
+  | "claim-only"
+  /** Nothing to do: no session yet, or this instance is already claimed. */
+  | "skip";
+
+/**
+ * Pure decision core (no React, no transport) so the resume rule is
+ * provable in a plain unit test — mirrors `decideSubmit` / `coreTurnSyncAction`.
+ */
+export function decideResumeInFlight(input: {
+  /** Is a real (server) session id known for this chat instance? */
+  hasSession: boolean;
+  /** Is a turn streaming THROUGH THIS CLIENT right now? */
+  isStreaming: boolean;
+  /** Has this exact `Chat` instance already been claimed by a prior run? */
+  alreadyClaimed: boolean;
+}): ResumeInFlightDecision {
+  if (!input.hasSession) return "skip";
+  if (input.alreadyClaimed) return "skip";
+  if (input.isStreaming) return "claim-only";
+  return "resume";
+}
+
+export type UseResumeInFlightArgs<TChat> = {
+  /** The live `Chat` instance — identity is the claim key. */
+  chat: TChat;
+  /** Active server session id, or `null` before it is known/restored. */
+  sessionId: string | null;
+  /** `useChat` status projected to "a turn is streaming through this client". */
+  isStreaming: boolean;
+  /** `useChat`'s `resumeStream` — reconnects to the in-flight run (no-op on 404). */
+  resumeStream: () => void | Promise<void>;
+};
+
+export function useResumeInFlight<TChat>(
+  args: UseResumeInFlightArgs<TChat>
+): void {
+  const { chat, sessionId, resumeStream } = args;
+  // Streaming is read through a ref so the effect keys on `[chat, sessionId]`
+  // only — adding `isStreaming` as a dep would re-run it on the stream-end
+  // edge and reconnect a just-finished turn.
+  const streamingRef = useRef(args.isStreaming);
+  streamingRef.current = args.isStreaming;
+  // Per-instance claim: at most one resume attempt per `Chat`.
+  const claimedRef = useRef<TChat | null>(null);
+
+  useEffect(() => {
+    const decision = decideResumeInFlight({
+      hasSession: sessionId != null,
+      isStreaming: streamingRef.current,
+      alreadyClaimed: claimedRef.current === chat,
+    });
+    if (decision === "skip") return;
+    // Both "resume" and "claim-only" take ownership of the instance so it is
+    // never (re-)resumed. The claim is synchronous and happens before the
+    // async `resumeStream`, so a concurrent effect run can't double-fire.
+    claimedRef.current = chat;
+    if (decision === "resume") void resumeStream();
+  }, [chat, sessionId, resumeStream]);
+}

--- a/editor/lib/agent-chat/use-session-status.ts
+++ b/editor/lib/agent-chat/use-session-status.ts
@@ -103,8 +103,8 @@ export type CoreTurnSyncAction =
  * `busy` edge. Ignored cases:
  *
  *   - no transition / first frame / non-`busy` target,
- *   - the mount frame (`prevState === null`) — `resume: true` covers an
- *     already-in-flight run,
+ *   - the mount frame (`prevState === null`) — `useResumeInFlight` covers an
+ *     already-in-flight run on remount/refresh,
  *   - `isStreaming` — a turn THIS client started,
  *   - **no queued head** — the decisive guard. A bare `busy` edge with nothing
  *     to promote is NOT a drain; the likeliest cause is the client's OWN

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -43,6 +43,7 @@ import {
   useChatSession,
   useCoreTurnSync,
   useRefreshOnStreamEnd,
+  useResumeInFlight,
   useSessionFork,
   useSessionStatus,
   useTurnQueueController,
@@ -141,14 +142,16 @@ export function AISidebarChat({ className }: { className?: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fs, chatSession.initial_messages]);
 
-  // `resume: true` is the AI SDK v6 built-in for "on mount, ask the
-  // transport to reconnect to any in-flight run for this chat id."
-  // Same behavior as a manual `useEffect(() => chat.resumeStream(), …)`,
-  // just less code. Our transport returns null on the agent sidecar's 404 →
-  // clean no-op; on success the agent sidecar replays from its in-memory
-  // chunk log and live-tails until finish. See `bridge-transport.ts`
-  // for the renderer side and `agent/stream-registry.ts` for the
-  // agent sidecar's chunk log + multiplex.
+  // Reconnect to an in-flight run on remount/refresh via `useResumeInFlight`
+  // (NOT the SDK's `resume: true`). `resume: true` fires `resumeStream()`
+  // exactly once on mount, against the placeholder chat that has no session
+  // id yet — the id is restored async from localStorage, so the rebuilt chat
+  // that DOES carry it never resumes, and the refresh silently shows a stale
+  // DB snapshot. The hook resumes once per chat instance that has a real
+  // session id, and never over a turn this client is streaming itself. Our
+  // transport returns null on the agent sidecar's 404 → clean no-op; on
+  // success the agent sidecar replays from its in-memory chunk log and
+  // live-tails until finish. See `bridge-transport.ts` + `agent/stream-registry.ts`.
   const {
     messages,
     status,
@@ -158,16 +161,23 @@ export function AISidebarChat({ className }: { className?: string }) {
     clearError,
     setMessages,
     resumeStream,
-  } = useChat({
-    chat,
-    resume: true,
-  });
+  } = useChat({ chat });
   // `isStreaming` = a turn is actively streaming THROUGH THIS CLIENT. Used
   // where that is the honest concept: the typing indicator, the Stop/Send
   // button, and "did I start this turn?" (vs. the core). It is the AI-SDK
   // client's optimistic per-request status — NOT the authoritative session
   // state.
   const isStreaming = status === "submitted" || status === "streaming";
+
+  // Reconnect to the session's in-flight run after a remount/refresh. Keyed on
+  // the chat instance + session id so the resume tracks the chat the async
+  // localStorage restore rebuilds — the gap `resume: true` left open.
+  useResumeInFlight({
+    chat,
+    sessionId: chatSession.current_id,
+    isStreaming,
+    resumeStream,
+  });
 
   // Manual compaction (RFC `session / compaction`) runs as a separate op that
   // does NOT move `useChat` status. Declared here so the single `busy` signal

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -54,6 +54,7 @@ import {
   ChatMessageView,
   CompactingIndicator,
   ForkedNotice,
+  PendingTurnIndicator,
   type ChatMessageActions,
 } from "@/kits/agent-chat";
 import { ChatSessionPicker } from "../shared/chat-session-picker";
@@ -378,6 +379,13 @@ export function AISidebarChat({ className }: { className?: string }) {
 
   const isEmpty = messages.length === 0;
 
+  // Pre-first-token "Thinking" indicator: a turn is streaming through this
+  // client, but the AI-SDK reducer hasn't created the assistant message yet (it
+  // does so on the first content chunk), so the per-bubble shimmer has nothing
+  // to mount on. Bridge that dead-air window with a tail indicator until an
+  // assistant turn begins.
+  const pendingTurn = isStreaming && messages.at(-1)?.role !== "assistant";
+
   return (
     <div className={cn("flex h-full flex-col bg-background", className)}>
       <ChatSessionPicker
@@ -399,6 +407,7 @@ export function AISidebarChat({ className }: { className?: string }) {
           ) : (
             settledList
           )}
+          {pendingTurn && <PendingTurnIndicator />}
           {compacting && <CompactingIndicator />}
         </ConversationContent>
         <ConversationScrollButton />

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -66,6 +66,7 @@ import {
   ChatMessageView,
   CompactingIndicator,
   ForkedNotice,
+  PendingTurnIndicator,
   type ChatMessageActions,
 } from "@/kits/agent-chat";
 import { QueuedMessages } from "../shared/queued-messages";
@@ -516,6 +517,13 @@ function AgentPaneContent({
     [messages, isStreaming, messageActions]
   );
 
+  // Pre-first-token "Thinking" indicator: a turn is streaming through this
+  // client, but the AI-SDK reducer hasn't created the assistant message yet (it
+  // does so on the first content chunk), so the per-bubble shimmer has nothing
+  // to mount on. Bridge that dead-air window with a tail indicator until an
+  // assistant turn begins.
+  const pendingTurn = isStreaming && messages.at(-1)?.role !== "assistant";
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <ChatSessionPicker
@@ -531,6 +539,7 @@ function AgentPaneContent({
               user needs to begin. No "Ask the workspace agent" hero,
               no example prompts; the surface stays quiet until used. */}
           {settledList}
+          {pendingTurn && <PendingTurnIndicator />}
           {compacting && <CompactingIndicator />}
         </ConversationContent>
         <ConversationScrollButton />

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -57,6 +57,7 @@ import {
   useChatSession,
   useCoreTurnSync,
   useRefreshOnStreamEnd,
+  useResumeInFlight,
   useSessionFork,
   useSessionStatus,
   useTurnQueueController,
@@ -217,11 +218,15 @@ function AgentPaneContent({
   useEffect(() => {
     chatRef.current = chat;
   }, [chat]);
-  // `resume: true` — AI SDK v6 built-in. On mount the SDK calls our
-  // transport's `reconnectToStream({chatId})`; the transport returns
-  // null on 404 (no in-flight run) → clean no-op; on success the
-  // agent sidecar replays from its chunk log and live-tails until finish.
-  // See `bridge-transport.ts` + `agent/stream-registry.ts`.
+  // Reconnect to an in-flight run on remount/refresh via `useResumeInFlight`
+  // (NOT the SDK's `resume: true`). `resume: true` resumes once on mount,
+  // against the placeholder chat that has no session id yet — the id is
+  // restored async from localStorage, so the rebuilt chat that carries it
+  // never resumes and a refresh silently shows a stale DB snapshot. The hook
+  // resumes once per chat instance that has a real session id, never over a
+  // turn this client is streaming itself. Transport returns null on the agent
+  // sidecar's 404 → clean no-op; on success it replays the chunk log and
+  // live-tails. See `bridge-transport.ts` + `agent/stream-registry.ts`.
   const {
     messages,
     status,
@@ -231,16 +236,23 @@ function AgentPaneContent({
     clearError,
     setMessages,
     resumeStream,
-  } = useChat({
-    chat,
-    resume: true,
-  });
+  } = useChat({ chat });
   // `isStreaming` = a turn is actively streaming THROUGH THIS CLIENT. Used
   // where that is the honest concept: the typing indicator, the Stop/Send
   // button, and "did I start this turn?" (vs. the core). It is the AI-SDK
   // client's optimistic per-request status — NOT the authoritative session
   // state.
   const isStreaming = status === "submitted" || status === "streaming";
+
+  // Reconnect to the session's in-flight run after a remount/refresh. Keyed on
+  // the chat instance + session id so the resume tracks the chat the async
+  // localStorage restore rebuilds — the gap `resume: true` left open.
+  useResumeInFlight({
+    chat,
+    sessionId: chatSession.current_id,
+    isStreaming,
+    resumeStream,
+  });
 
   // Manual compaction (RFC `session / compaction`) runs as a separate op that
   // does NOT move `useChat` status. Declared here so the single `busy` signal


### PR DESCRIPTION
## Summary

Three agent-chat improvements landing together — two message-UX features and one streaming-reliability fix — all in the shared layer (`@/kits/agent-chat` renderer / `@/lib/agent-chat` brain) so the desktop **sidebar** and **workspace pane** get them from one place, plus a small refactor.

**1. Collapse long user message bubbles behind "Show more."** A pasted wall of text in a user bubble used to push the rest of the transcript off-screen. Long bubbles now clamp to a max height behind a fade-to-bubble gradient with a **Show more / Show less** toggle. Short messages render untouched — the affordance only appears once a `ResizeObserver` measures real overflow.

**2. "Thinking" indicator during the pre-first-token window.** Between a send and the first streamed chunk, the AI-SDK reducer hasn't created the assistant message yet (it does so on the first content chunk), so the per-bubble shimmer had nothing to mount on — the user saw only the composer's Stop button for that dead-air window (real provider TTFT, not an artificial delay). A new `PendingTurnIndicator` renders an assistant-framed **"Thinking"** shimmer (with an elapsed counter revealed after a few seconds, mirroring `CompactingIndicator`) at the transcript tail while `isStreaming && last message is not the assistant`; the real turn replaces it the moment the first chunk lands.

**3. Reconnect to the in-flight run after a page refresh (fix).** Refreshing mid-stream froze the transcript — it only advanced if you kept manually refreshing (each reload re-hydrated a fresher DB snapshot). **Root cause:** `useChat({ resume: true })` fires `resumeStream()` exactly once on mount (effect deps `[resume, chatRef]`, and `chatRef` is a stable ref that never changes), but the active session id is restored **asynchronously** from localStorage — so that single mount-time resume runs against the placeholder `Chat` (no session id yet) and no-ops; when the `Chat` is rebuilt with the real id, resume never re-fires. The server stream was resumable the whole time; the client just stopped asking. **Fix:** replaced `resume: true` on both surfaces with a shared, unit-tested `useResumeInFlight` hook that resumes **once per `Chat` instance that carries a real session id**, and **never over a turn this client is itself streaming** (the fresh-chat mid-stream id-adoption hazard `useCoreTurnSync` already guards). Bonus: it also attaches when you switch into an already-busy session — something `resume: true` never did.

**4. Refactor.** Extracted `ShimmerWithElapsed`, now shared by `CompactingIndicator` and `PendingTurnIndicator` (no behavior change).

## Why this shape

- **Thinking indicator** is a **view concern**, so it's fixed in the view — a tail indicator mirroring the established `{compacting && <CompactingIndicator />}` pattern — rather than by emitting an early server `start` chunk, which would touch the recorder + resume-replay machinery for a purely visual win. (opencode takes the server-side route, but can afford it via its bespoke session protocol; we ride the AI-SDK UI-message stream.)
- **Resume fix** is at the right layer too: a small view-side hook, because the defect is that the SDK's once-only mount effect doesn't survive async session-id restore + a `Chat` rebuild. The decision core (`decideResumeInFlight`) is a pure function with contract tests, matching the repo's `decideSubmit` / `coreTurnSyncAction` pattern.

## Showcase

The two message-UX states are demoable on `/ui/components/ai-chat`:
- **Long user message (collapsible)** — Markdown group
- **Awaiting first token (Thinking)** — Lifecycle group

The resume fix can't be shown in the mock demo (it needs a live in-flight run) — verified live in the desktop app instead (refresh mid-stream now reconnects + live-tails).

## Test plan

- [x] `oxfmt` + `oxlint` clean
- [x] `tsc --noEmit` (editor) clean
- [x] `useResumeInFlight` decision-core unit tests (4 cases: no-session skip / resume / claim-only-while-streaming / no-double-resume)
- [x] `/ui/components/ai-chat` → collapse (clamp + fade + toggle) and Thinking (shimmer + elapsed timer)
- [x] Desktop sidebar + workspace pane: long pasted message collapses; "Thinking" appears immediately on send, replaced by the response on first token
- [x] Verified live: refresh mid-stream now reconnects to the running turn and live-tails (previously froze until manual reloads)

## Notes

- No server / stream-contract changes.
- Streaming cadence (the perceived "token burst" after the first token) was measured live across all four model tiers and is **upstream provider chunk-granularity** — Anthropic relays coarse ~15-block deltas, OpenAI relays near-token deltas; our pipeline forwards 1:1 with no buffering. Left **faithful** (no `smoothStream`); the dead-air before the first token is what the "Thinking" indicator covers.
- Deferred (discussed): an opencode-style reasoning-summary heading — additive and independent of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Thinking" indicator appears before the first assistant token when a response is pending
  * Long user messages collapse with a "Show more/less" control and gradient fade
  * Improved elapsed-time display for in-flight message indicators
  * Better reconnect behavior to resume in-flight AI responses after refresh/remount

* **Tests**
  * Added contract tests covering resume/claim decision logic for in-flight resumes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->