### PR TITLE
feat(ai-models): add video model catalog (Veo 3.1, Seedance 2.0, Grok Imagine Video 1.5)

### DIFF
--- a/.agents/skills/ai-models/SKILL.md
+++ b/.agents/skills/ai-models/SKILL.md
@@ -2,8 +2,8 @@
 name: ai-models
 description: >
   Research, compare, and update AI model configurations.
-  Covers text model tiers, image generation models, image tool models, pricing
-  data sourcing, and the budget/rate-limit system.
+  Covers text model tiers, image and video generation models, image tool models,
+  pricing data sourcing, and the budget/rate-limit system.
   Use when bumping model versions, adding new models, updating pricing, or
   auditing model specs against provider documentation.
 ---
@@ -12,9 +12,9 @@ description: >
 
 ## When to Use This Skill
 
-- Bumping a text or image model to a newer version
-- Adding a new image generation model or provider
-- Updating pricing data (per-token, per-image flat, per-image tiered)
+- Bumping a text, image, or video model to a newer version
+- Adding a new image/video generation model or provider (Vercel gateway, Replicate, fal.ai)
+- Updating pricing data (per-token, per-image flat, per-image tiered, per-second)
 - Verifying model specs (context window, output limit, cost) against providers
 - Auditing the budget/rate-limit system
 
@@ -22,15 +22,15 @@ description: >
 
 ## Key Files
 
-| File                                       | Role                                                                                                                                                                              |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/grida-ai-models/src/models.ts`   | Central catalogue. Sole export is the `models` namespace: `models.text` (`ModelSpec`, `catalog`, `byTier`, `modelSpecById`), `models.image`, `models.audio`, `models.image_tools` |
-| `packages/grida-ai-models/src/tiers.ts`    | `ModelTier` set + `TIER_MODEL_IDS` (type-uses `models.text.CatalogId` from `models.ts`)                                                                                           |
-| `editor/lib/ai/models.ts`                  | AI Gateway + BYOK provider seam (catalogue is re-exported from `@grida/ai-models`)                                                                                                |
-| `editor/lib/ai/ai.ts`                      | `toMills()` + Replicate call shapes; re-aggregates catalogue under `models.*`                                                                                                     |
-| `editor/app/(api)/private/ai/ratelimit.ts` | Budget enforcement (Upstash sliding window, mills)                                                                                                                                |
-| `editor/app/(www)/(ai)/ai/models/page.tsx` | Public models catalog page                                                                                                                                                        |
-| `docs/models/index.md`                     | User-facing models & pricing documentation                                                                                                                                        |
+| File                                       | Role                                                                                                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/grida-ai-models/src/models.ts`   | Central catalogue. Sole export is the `models` namespace: `models.text` (`ModelSpec`, `catalog`, `byTier`, `modelSpecById`), `models.image`, `models.audio`, `models.video`, `models.image_tools` |
+| `packages/grida-ai-models/src/tiers.ts`    | `ModelTier` set + `TIER_MODEL_IDS` (type-uses `models.text.CatalogId` from `models.ts`)                                                                                                           |
+| `editor/lib/ai/models.ts`                  | AI Gateway + BYOK provider seam (catalogue is re-exported from `@grida/ai-models`)                                                                                                                |
+| `editor/lib/ai/ai.ts`                      | `toMills()` + Replicate call shapes; re-aggregates catalogue under `models.*`                                                                                                                     |
+| `editor/app/(api)/private/ai/ratelimit.ts` | Budget enforcement (Upstash sliding window, mills)                                                                                                                                                |
+| `editor/app/(www)/(ai)/ai/models/page.tsx` | Public models catalog page                                                                                                                                                                        |
+| `docs/models/index.md`                     | User-facing models & pricing documentation                                                                                                                                                        |
 
 ## Tools
 
@@ -53,12 +53,37 @@ Note: `models.dev` has per-token costs but not per-image tier breakdowns. For pe
 
 ### Provider pricing pages
 
-| Provider   | URL                                                        |
-| ---------- | ---------------------------------------------------------- |
-| OpenAI     | `https://developers.openai.com/api/docs/models/<model_id>` |
-| Anthropic  | `https://docs.anthropic.com/en/docs/about-claude/models`   |
-| Google     | `https://ai.google.dev/pricing`                            |
-| BFL (Flux) | `https://docs.bfl.ml/pricing`                              |
+| Provider   | URL                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| OpenAI     | `https://developers.openai.com/api/docs/models/<model_id>`                                                  |
+| Anthropic  | `https://docs.anthropic.com/en/docs/about-claude/models`                                                    |
+| Google     | `https://ai.google.dev/pricing`                                                                             |
+| BFL (Flux) | `https://docs.bfl.ml/pricing`                                                                               |
+| fal.ai     | `https://fal.ai/models/<endpoint-id>` · pricing API: `https://fal.ai/docs/documentation/model-apis/pricing` |
+| OpenRouter | `https://openrouter.ai/<vendor>/<model>`                                                                    |
+
+### Providers & model IDs
+
+The same model has different ids — and different availability and pricing — across
+providers; an id is never portable. Two cataloguing patterns:
+
+- **text / image / audio / image_tools** — one card = one provider; `id` is in that
+  provider's format, and the `provider` field (or the namespace) fixes the route.
+- **video** — the ecosystem is fragmented, so a card is **canonical** (`vendor/model`,
+  e.g. `google/veo-3.1`) and carries a `providers` record (keyed by provider) of bindings,
+  each with its own call id + meter. Default-provider choice is deferred (see Video Models).
+  Pick a route with `video.binding(card, provider)`.
+
+| Provider          | Used in catalogue for      | ID format / example                                                            |
+| ----------------- | -------------------------- | ------------------------------------------------------------------------------ |
+| Vercel AI Gateway | text, image, video binding | `google/veo-3.1-generate-001`, `bytedance/seedance-2.0`                        |
+| Replicate         | audio, image_tools         | `google/lyria-3`, `nightmareai/real-esrgan`                                    |
+| fal.ai            | video binding (+ image)    | `fal-ai/veo3.1`, `fal-ai/kling-video/v3/pro/image-to-video`, `fal-ai/flux/dev` |
+| OpenRouter        | video binding              | `google/veo-3.1`, `google/veo-3.1-fast`, `google/veo-3.1-lite`                 |
+
+- **Availability + price differ per provider.** **Veo 3.1 Lite** is on OpenRouter/fal.ai but **not** the Vercel gateway — a canonical card just omits the Vercel binding. Veo 3.1 audio-on is `$0.40/s` on both Vercel and fal, but fal also meters silent (`$0.20/s`) and 4K, while **OpenRouter exposes only `$0/MTok` token pricing for video — no usable per-second meter (don't invent one).**
+- **fal.ai** is the broadest video/image catalogue (pay-per-use); billing unit is per-model — per-image, per-megapixel, or per-second video — retrievable from its Platform pricing API.
+- Image is still Vercel-gateway-only in code; a non-Vercel image provider would mirror video's binding shape (or add a `provider` label like audio's `"replicate"`).
 
 ---
 
@@ -101,11 +126,47 @@ per_token         — charged by token (e.g. Google Gemini)
 
 ### New providers
 
-All image generation routes through the Vercel AI Gateway (`gateway.image(id)`). For a new provider:
+Image generation currently routes through the Vercel AI Gateway (`gateway.image(id)`); fal.ai is the main alternative for models the gateway lacks (see Providers & model IDs). For a new provider:
 
-- Verify the gateway supports it
+- Verify the gateway supports it (or wire a new `provider` label for fal.ai / OpenRouter)
 - Add to the `Vendor` type if needed
 - Add a logo component and register in the `Logos` map on the models page
+
+## Video Models
+
+Live in `models.video.models` in `packages/grida-ai-models/src/models.ts`. The video provider ecosystem is **fragmented**, so unlike image/audio (one card = one provider) a video card is **canonical**: `id` is provider-agnostic (`vendor/model`, e.g. `google/veo-3.1`) and holds the intrinsic specs; per-provider routes live in `providers`, a record keyed by provider.
+
+### Card shape
+
+- **Model (intrinsic):** `id` (canonical), `label`, `vendor`, `aspect_ratios`, `min_duration`/`max_duration`, `audio`, `default` (resolution/aspect/duration/audio), `url` (original vendor's model card).
+- **`providers: Partial<Record<VideoProvider, VideoProviderBinding>>`** — one binding per serving provider: `provider`, `id`, `pricing`, `avg_cost_usd`, optional `url`/`deprecated`. **No preference order** — the default-provider choice is deliberately deferred to the runtime. Look a route up with `video.binding(card, provider)`.
+
+Cards catalogue the **image-to-video** route only (canvas-relevant; Grok's sole mode), so each binding has a single `id` — on fal the capability is keyed into the id (`fal-ai/veo3.1/image-to-video`). Don't add a per-capability `endpoints` map until a second capability is actually served: identical ids across capabilities are YAGNI, and divergent ones (other fal endpoints) are a new binding/id when needed.
+
+`provider` is a bare routing tag — auth (incl. BYOK) is a runtime concern, not catalogue data, so there is no provider registry or `byok` flag. The catalogue's only job is to hold each provider's real id + rate.
+
+### Cost
+
+`avg_cost_usd` (per binding) = its rate at the model's default `(resolution, audio)` × default duration. **Video dwarfs image costs** (Veo 3.1 ≈ `$3.20` for an 8s 1080p clip) and a single clip exceeds the current `$1.00`/window budget — revisit `ratelimit.ts` before wiring video into the editor.
+
+### Pricing (lives on the binding)
+
+`per_second`, nested `resolution → audio-mode → USD/s`. The rate varies by both resolution **and** whether audio is generated, so the keys are the exact `(resolution, mode)` combos that provider serves & meters:
+
+```
+{ type: "per_second", usd_per_second: {
+    "720p":  { audio: 0.4, silent: 0.2 },   // fal: meters both modes
+    "1080p": { audio: 0.4, silent: 0.2 },
+    "4k":    { audio: 0.6, silent: 0.4 },
+} }
+// Vercel Veo omits "4k" + "silent" (gateway sells neither); Seedance lists only "audio" (bundled free).
+```
+
+### Adding a model / route
+
+- New model → add the canonical id to `VideoModelId` and a card with ≥1 binding. Every binding must price the model's `default` `(resolution, audio)` — enforced by catalogue-invariant tests (plus: provider field matches key).
+- New route for an existing model → add a `VideoProviderBinding` under its provider key, **only with a verified rate** (e.g. OpenRouter surfaces `$0/MTok` for video — not usable; leave it out).
+- New capability (e.g. text-to-video) → only when actually used. If a provider keys it into a separate id (fal), that's a new binding/id; revisit the single-`id` shape only then.
 
 ## Image Tool Models
 

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -19,6 +19,8 @@ and lookup helpers.
   pricing
 - Image generation model cards: labels, vendors, speed hints, supported sizes,
   size constraints, defaults, and pricing
+- Video generation model cards: canonical (provider-agnostic) models, each with
+  per-provider bindings carrying that provider's call id and pricing
 - Audio generation model cards
 - Image tool model cards, such as background removal and upscaling
 - Shared discriminator types for providers, vendors, speed labels, and pricing
@@ -78,6 +80,7 @@ Media model data lives under the `models` namespace:
 
 - `models.image`
 - `models.audio`
+- `models.video`
 - `models.image_tools`
 
 Image cards can describe both preset sizes and continuous size constraints.
@@ -92,6 +95,14 @@ Image pricing is a discriminated union:
 
 Audio models currently use flat per-run pricing. Image tools use flat
 per-invocation pricing.
+
+Video is different: the provider ecosystem is fragmented, so a video card is
+**canonical** (provider-agnostic `vendor/model` id + intrinsic specs) and holds a
+`providers` record of bindings — one per serving provider (`vercel` / `fal` /
+`openrouter`), each with its own call `id` and `per_second` pricing (nested
+`resolution → audio-mode → USD/s`). Cards catalogue the image-to-video route only.
+No default provider is encoded; resolve a route with
+`models.video.binding(card, provider)`.
 
 ## Lookups
 
@@ -109,7 +120,7 @@ per-invocation pricing.
 
 ## Updating The Catalog
 
-To add or update a text model (or any image / audio / image-tool model),
+To add or update a text model (or any image / audio / video / image-tool model),
 edit `src/models.ts`. That file is the central catalogue and also the
 type source — `models.text.CatalogId` is derived from the text-model table.
 

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -59,6 +59,66 @@ describe("models.image catalogue invariants", () => {
   });
 });
 
+describe("models.video catalogue invariants", () => {
+  it("every dict key resolves to a defined card", () => {
+    for (const id of Object.keys(models.video.models)) {
+      expect(models.video.models[id]).toBeDefined();
+    }
+  });
+
+  it("every card has at least one provider binding", () => {
+    for (const card of Object.values(models.video.models)) {
+      if (!card) continue;
+      expect(Object.keys(card.providers).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each binding's provider field matches its key", () => {
+    for (const card of Object.values(models.video.models)) {
+      if (!card) continue;
+      for (const [key, b] of Object.entries(card.providers)) {
+        if (!b) continue;
+        expect(b.provider).toBe(key);
+      }
+    }
+  });
+
+  it("every binding prices the model's default (resolution, audio mode)", () => {
+    // Provider-selection is deferred, so the contract is route-agnostic: any
+    // provider the runtime later picks must be able to serve the default
+    // config. Every binding therefore prices `default.resolution` at the
+    // default audio mode.
+    for (const card of Object.values(models.video.models)) {
+      if (!card) continue;
+      const mode = card.default.audio ? "audio" : "silent";
+      for (const b of Object.values(card.providers)) {
+        if (!b) continue;
+        expect(
+          b.pricing.usd_per_second[card.default.resolution]?.[mode]
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("binding() resolves a present provider and nulls an absent one", () => {
+    const veo = models.video.models["google/veo-3.1"]!;
+    // fal keys the capability into the id — this is the image-to-video endpoint.
+    expect(models.video.binding(veo, "fal")?.id).toBe(
+      "fal-ai/veo3.1/image-to-video"
+    );
+    expect(models.video.binding(veo, "vercel")?.id).toBe(
+      "google/veo-3.1-generate-001"
+    );
+    // OpenRouter has no verified per-second meter yet → no binding.
+    expect(models.video.binding(veo, "openrouter")).toBeNull();
+
+    const grok = models.video.models["xai/grok-imagine-video-1.5"]!;
+    expect(models.video.binding(grok, "fal")?.id).toBe(
+      "xai/grok-imagine-video/v1.5/image-to-video"
+    );
+  });
+});
+
 describe("models.text.byTier", () => {
   it("exposes a spec for every tier", () => {
     expect(models.text.byTier.nano).toBeDefined();

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -7,6 +7,7 @@
  * - `models.text.*`        — text-model spec table, tier→spec map, lookup
  * - `models.image.*`       — image-generation catalogue
  * - `models.audio.*`       — audio-generation catalogue
+ * - `models.video.*`       — video-generation catalogue
  * - `models.image_tools.*` — non-generator image tools (background removal, upscale)
  * - `models.Provider`, `models.Vendor` — shared discriminator labels
  *
@@ -19,8 +20,9 @@
  * modules — keeping the full `namespace models` declaration in a
  * single source file is the workaround.
  *
- * `provider: "vercel"` and `provider: "replicate"` on the cards are
- * data labels only — see the README for the full contract.
+ * Routing labels on the cards — `Provider` (text/image), `audio.AudioProvider`,
+ * and video's per-binding `video.VideoProvider` — are data labels only; see the
+ * README for the full contract.
  *
  * @module
  */
@@ -47,7 +49,9 @@ export namespace models {
     | "recraft-ai"
     | "black-forest-labs"
     | "google"
-    | "stability-ai";
+    | "stability-ai"
+    | "bytedance"
+    | "xai";
 
   // ── models.text ───────────────────────────────────────────────────
   //
@@ -890,6 +894,328 @@ export namespace models {
     } as const;
 
     export const audio_model_ids = Object.keys(models) as AudioModelId[];
+  }
+
+  // ── models.video ──────────────────────────────────────────────────
+
+  /**
+   * Video-generation model catalogue.
+   *
+   * The video provider ecosystem is **fragmented**: the same model is served
+   * by several providers (Vercel AI Gateway, fal.ai, OpenRouter), each with a
+   * *different id, a different meter, and different availability*. So unlike
+   * `models.image`/`models.audio` — which bind one card to one provider — a
+   * video card is **canonical** (provider-agnostic id + intrinsic specs) and
+   * holds a {@link VideoProviderBinding} per provider that serves it, keyed by
+   * provider in {@link VideoModelCard.providers}. The default-provider choice
+   * is **deliberately not encoded here** — bindings carry no preference order;
+   * selection is a runtime concern. Look up a route with {@link binding}.
+   *
+   * The cards catalogue the **image-to-video** route (a still → clip) — the
+   * canvas-relevant mode and the only one some models (e.g. Grok) offer. Other
+   * capabilities (text-to-video, editing) aren't modelled until used; on fal
+   * they are distinct endpoint ids, so adding one is a new binding id, not a flag.
+   *
+   * **Pricing.** Video bills by output **duration**, and the rate varies by
+   * both resolution and whether audio is generated, so `per_second` is keyed
+   * `resolution → audio-mode → USD/s` (see {@link PerSecondPricing}). Values
+   * are the real provider rate; update if a provider changes its meter.
+   */
+  export namespace video {
+    /**
+     * A provider that can serve a video model. Distinct from the top-level
+     * {@link models.Provider} because video routes through more than the
+     * Vercel gateway. Each provider uses its own id format and meter.
+     */
+    export type VideoProvider = "vercel" | "fal" | "openrouter";
+
+    /**
+     * **Canonical**, provider-agnostic model id in `vendor/model` form
+     * (e.g. `google/veo-3.1`). This is *our* key, not any one provider's id —
+     * the provider-specific call id lives on each {@link VideoProviderBinding}.
+     * Open union (`string & {}`) keeps unrecognized ids assignable.
+     */
+    export type VideoModelId =
+      | "google/veo-3.1"
+      | "bytedance/seedance-2.0"
+      | "xai/grok-imagine-video-1.5"
+      | (string & {});
+
+    /** Resolution label (e.g. `"720p"`, `"1080p"`, `"4k"`). Pricing-map + UI key. */
+    export type ResolutionLabel = string;
+
+    /**
+     * Whether a clip is generated with synchronized audio. A real pricing axis:
+     * fal meters `silent` at roughly half of `audio`; Vercel sells `audio` only;
+     * Seedance bundles audio into its single rate.
+     */
+    export type AudioMode = "audio" | "silent";
+
+    // ── Pricing ─────────────────────────────────────────────────────
+
+    /**
+     * Per-second pricing, nested `resolution → audio-mode → USD/s`. Lives on a
+     * {@link VideoProviderBinding} — meters differ across providers.
+     *
+     * A binding lists only the `(resolution, mode)` combinations its provider
+     * actually serves and meters, so the keys double as that provider's
+     * resolution/audio support: Vercel's Veo card omits `"4k"` and `silent`
+     * because the gateway sells neither; fal lists both. Each value is the real
+     * USD-per-output-second rate for that exact config.
+     */
+    export type PerSecondPricing = {
+      type: "per_second";
+      /** USD/s, by resolution then audio mode. */
+      usd_per_second: Record<
+        ResolutionLabel,
+        Partial<Record<AudioMode, number>>
+      >;
+    };
+
+    export type VideoModelPricing = PerSecondPricing;
+
+    /**
+     * How one provider serves a canonical model: the id you actually call on
+     * that provider, plus that provider's own meter. The unit of
+     * provider-selection. Keyed by {@link VideoProvider} in
+     * {@link VideoModelCard.providers}, so `provider` here must equal that key.
+     */
+    export type VideoProviderBinding = {
+      provider: VideoProvider;
+      /**
+       * Provider-specific call id for the image-to-video route. Format varies —
+       * `google/veo-3.1-generate-001` (Vercel), `fal-ai/veo3.1/image-to-video`
+       * (fal, where the capability is keyed into the endpoint id).
+       */
+      id: string;
+      /** Real upstream pricing for **this** provider — meters differ across providers. */
+      pricing: VideoModelPricing;
+      /**
+       * Coarse provider cost per invocation in USD — this binding's rate at the
+       * model's default `(resolution, audio)` × default duration. For budget
+       * estimation; not for display.
+       */
+      avg_cost_usd: number;
+      /** Per-binding deprecation (a provider may retire a route independently). */
+      deprecated?: boolean;
+      /** Provider's page for this binding; UI falls back to {@link VideoModelCard.url}. */
+      url?: string;
+    };
+
+    export type VideoModelCard = {
+      /** Canonical, provider-agnostic id. */
+      id: VideoModelId;
+      label: string;
+      deprecated: boolean;
+      short_description: string;
+      vendor: Vendor;
+      /** Supported aspect ratios. */
+      aspect_ratios: image.AspectRatioString[];
+      /** Inclusive output-duration bounds, in seconds. */
+      min_duration: number;
+      max_duration: number;
+      /** Whether the model can produce synchronized audio (capability; per-mode pricing lives on each binding). */
+      audio: boolean;
+      speed_label: image.SpeedLabel;
+      /** Default generation request. Every binding must price `(resolution, audio)`. */
+      default: {
+        resolution: ResolutionLabel;
+        aspect_ratio: image.AspectRatioString;
+        duration: number;
+        audio: boolean;
+      };
+      /** Original vendor's model card page (not a serving gateway). */
+      url: string;
+      /**
+       * Providers that serve this model, keyed by provider. **No implied
+       * preference** — default-provider selection is deferred to the runtime.
+       * Non-empty; keying makes providers unique by construction.
+       */
+      providers: Partial<Record<VideoProvider, VideoProviderBinding>>;
+    };
+
+    export const models: Partial<Record<VideoModelId, VideoModelCard>> = {
+      // -----------------------------------------------------------------
+      // Google — Veo 3.1
+      // -----------------------------------------------------------------
+      "google/veo-3.1": {
+        id: "google/veo-3.1",
+        label: "Veo 3.1",
+        deprecated: false,
+        short_description:
+          "Google's flagship video model — strong prompt adherence with native, synchronized audio.",
+        vendor: "google",
+        aspect_ratios: ["16:9", "9:16"],
+        min_duration: 4,
+        max_duration: 8,
+        audio: true,
+        speed_label: "slow",
+        default: {
+          resolution: "1080p",
+          aspect_ratio: "16:9",
+          duration: 8,
+          audio: true,
+        },
+        url: "https://deepmind.google/models/veo/",
+        providers: {
+          // Vercel AI Gateway — gateway.video(id), image-to-video. Audio-on
+          // only, ≤1080p, flat $0.40/s.
+          // https://vercel.com/ai-gateway/models/veo-3.1-generate-001
+          vercel: {
+            provider: "vercel",
+            id: "google/veo-3.1-generate-001",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.4 },
+                "1080p": { audio: 0.4 },
+              },
+            },
+            avg_cost_usd: 3.2, // 1080p audio × 8s default
+            url: "https://vercel.com/ai-gateway/models/veo-3.1-generate-001",
+          },
+          // fal.ai — image-to-video endpoint (capability is keyed into the id;
+          // t2v is a separate `fal-ai/veo3.1` endpoint, not catalogued). Meters
+          // audio/silent and adds 4K. Audio-on matches Vercel ($0.40/s @
+          // 720p/1080p); silent ~half; 4K $0.40 silent / $0.60 audio.
+          // https://fal.ai/models/fal-ai/veo3.1/image-to-video
+          fal: {
+            provider: "fal",
+            id: "fal-ai/veo3.1/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.4, silent: 0.2 },
+                "1080p": { audio: 0.4, silent: 0.2 },
+                "4k": { audio: 0.6, silent: 0.4 },
+              },
+            },
+            avg_cost_usd: 3.2, // 1080p audio × 8s default
+            url: "https://fal.ai/models/fal-ai/veo3.1/image-to-video",
+          },
+          // OpenRouter also serves it as `google/veo-3.1`, but its API surfaces
+          // only token pricing ($0/MTok) for video — no usable per-second
+          // meter confirmed. Add a binding once a real rate is verified.
+        },
+      },
+      // -----------------------------------------------------------------
+      // ByteDance — Seedance 2.0
+      // -----------------------------------------------------------------
+      "bytedance/seedance-2.0": {
+        id: "bytedance/seedance-2.0",
+        label: "Seedance 2.0",
+        deprecated: false,
+        short_description:
+          "ByteDance's state-of-the-art video model — top-tier image-to-video with reference and editing modes.",
+        vendor: "bytedance",
+        aspect_ratios: ["16:9", "9:16", "1:1"],
+        min_duration: 5,
+        max_duration: 15,
+        audio: true,
+        speed_label: "slow",
+        default: {
+          resolution: "720p",
+          aspect_ratio: "16:9",
+          duration: 5,
+          audio: true,
+        },
+        url: "https://seed.bytedance.com/en/seedance2_0",
+        providers: {
+          // Vercel AI Gateway — image-to-video. Per-second by resolution; audio
+          // bundled into the rate (no separate silent meter). 1080p exists but
+          // its per-second rate is unconfirmed; a `bytedance/seedance-2.0-fast`
+          // route also exists (~20% cheaper).
+          // https://vercel.com/changelog/seedance-2.0-video-now-available-on-ai-gateway
+          vercel: {
+            provider: "vercel",
+            id: "bytedance/seedance-2.0",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.092 },
+                "720p": { audio: 0.199 },
+              },
+            },
+            avg_cost_usd: 1.0, // 720p audio × 5s default (≈ $0.995)
+          },
+          // Also served by fal.ai and Replicate — add those bindings once
+          // their per-second rates are verified.
+        },
+      },
+      // -----------------------------------------------------------------
+      // xAI — Grok Imagine Video 1.5
+      // -----------------------------------------------------------------
+      // Image-to-video only (no t2v, per xAI docs); native lip-synced audio
+      // bundled into the rate. Per-second by resolution, identical on Vercel
+      // (no markup) and fal: $0.08/s @480p, $0.14/s @720p. Both also bill
+      // ~$0.01 per input image — an input surcharge not captured by the
+      // per_second (output) meter.
+      "xai/grok-imagine-video-1.5": {
+        id: "xai/grok-imagine-video-1.5",
+        label: "Grok Imagine Video 1.5",
+        deprecated: false,
+        short_description:
+          "xAI's image-to-video model — animates a still into cinematic video with native, lip-synced audio.",
+        vendor: "xai",
+        aspect_ratios: ["16:9", "9:16"],
+        min_duration: 5,
+        max_duration: 15,
+        audio: true,
+        speed_label: "fast",
+        default: {
+          resolution: "720p",
+          aspect_ratio: "16:9",
+          duration: 5,
+          audio: true,
+        },
+        url: "https://docs.x.ai/developers/models/grok-imagine-video-1.5-preview",
+        providers: {
+          // Vercel AI Gateway — image-to-video; mirrors xAI's list price (no markup).
+          // https://vercel.com/changelog/grok-imagine-video-1-5-on-ai-gateway
+          vercel: {
+            provider: "vercel",
+            id: "xai/grok-imagine-video-1.5-preview",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.08 },
+                "720p": { audio: 0.14 },
+              },
+            },
+            avg_cost_usd: 0.7, // 720p audio × 5s default
+            url: "https://vercel.com/ai-gateway/models/grok-imagine-video",
+          },
+          // fal.ai — image-to-video endpoint; same per-second rate.
+          // https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video
+          fal: {
+            provider: "fal",
+            id: "xai/grok-imagine-video/v1.5/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.08 },
+                "720p": { audio: 0.14 },
+              },
+            },
+            avg_cost_usd: 0.7, // 720p audio × 5s default
+            url: "https://fal.ai/models/xai/grok-imagine-video/v1.5/image-to-video",
+          },
+        },
+      },
+    } as const;
+
+    export const video_model_ids = Object.keys(models) as VideoModelId[];
+
+    /**
+     * The binding for a specific provider, or `null` if that provider does
+     * not serve this model.
+     */
+    export function binding(
+      card: VideoModelCard,
+      provider: VideoProvider
+    ): VideoProviderBinding | null {
+      return card.providers[provider] ?? null;
+    }
   }
 
   // ── models.image_tools ────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds `models.video` to `@grida/ai-models` — the first video-generation catalog — with three models: **Veo 3.1** (Google), **Seedance 2.0** (ByteDance), and **Grok Imagine Video 1.5** (xAI).

Catalog + types only. No runtime wiring (no `gateway.video()` call path, no ratelimit/budget changes). `typecheck` + tests green.

## Why this shape (canonical model + provider bindings)

The video provider ecosystem is **fragmented**: the same model is served by several providers (Vercel AI Gateway, fal.ai, OpenRouter) with *different ids, different meters, and different availability*. So unlike `models.image`/`models.audio` (one card = one provider), a video card is **canonical** — a provider-agnostic `vendor/model` id plus intrinsic specs — and holds a `providers` record of bindings, one per serving provider, each carrying its own call `id` and real pricing.

```ts
VideoModelCard   = { id, label, vendor, aspect_ratios, min/max_duration, audio, default, url, providers }
VideoProviderBinding = { provider, id, pricing, avg_cost_usd, url?, deprecated? }
```

## Key decisions

- **New `per_second` pricing variant**, nested `resolution → audio-mode → USD/s`, to hold the real meters: fal prices `silent` ≈ half of `audio` and adds 4K; Vercel sells audio-on only; Seedance bundles audio free. All rates sourced from provider docs/pricing pages.
- **Image-to-video route only** — the canvas-relevant mode and Grok's sole mode — so each binding is a single `id`. No per-capability endpoint map: identical ids across capabilities would be YAGNI, and divergent ones (other fal endpoints) become a new binding when a second capability is actually served.
- **Default provider not encoded** — bindings are a provider-keyed record with no preference order; selection is a runtime concern.
- **Auth/BYOK out of scope** — the catalog holds only each provider's real id + rate; there's no `byok` flag or provider registry (BYOK is always-possible at runtime, not catalog data).
- **No invented numbers** — OpenRouter video bindings are omitted because its API exposes only `$0/MTok` for video (no usable per-second meter); Seedance 1080p and fal/Replicate Seedance routes are likewise left out pending verified rates (documented in comments).

## Also

- Adds `xai` and `bytedance` to the `Vendor` union; `video.binding(card, provider)` lookup helper.
- Catalogue-invariant tests: non-empty providers, `provider` field matches its key, every binding prices the model's default `(resolution, audio)`, `binding()` resolve/null.
- Docs: package `README.md` and the `ai-models` skill document the canonical+bindings shape, the `per_second` pricing, the image-to-video scoping, and the deferred-default / no-BYOK contracts.

## Reviewer notes

- The one product assumption is **image-to-video as the single route**. If text-to-video is wanted in the catalog later, that's the moment the per-capability shape earns its place back (fal would need its distinct `fal-ai/veo3.1` t2v id).
- Per-invocation video cost dwarfs image (`avg_cost_usd` ≈ `$3.20` for an 8s 1080p Veo clip) and exceeds the current `$1.00`/30-day mills budget — `ratelimit.ts` will need revisiting before video is wired into the editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video model catalog now available with multi-provider support and pricing configurations based on resolution and audio modes.

* **Tests**
  * Added comprehensive test suite for video model catalog consistency and provider binding validation.

* **Documentation**
  * Updated model catalog documentation and skill workflows to support video generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->