### PR TITLE
feat(svg-editor): insert_fragment — atomic SVG fragment insertion (+ Library in SVG demos)

### DIFF
--- a/editor/app/(canvas)/svg/_components/fragment.test.ts
+++ b/editor/app/(canvas)/svg/_components/fragment.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { fragment } from "./fragment";
+
+describe("fragment.strip_shell", () => {
+  it("extracts inner markup and viewBox from a standalone document", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>`;
+    const { inner, viewbox } = fragment.strip_shell(svg);
+    expect(inner).toBe(`<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>`);
+    expect(viewbox).toEqual({ min_x: 0, min_y: 0, width: 24, height: 24 });
+  });
+
+  it("keeps inner bytes verbatim — attribute order, comments, whitespace", () => {
+    const inner = `\n  <!-- keep me -->\n  <g  stroke='red'   fill="none">\n    <circle r="4" cx="2"/>\n  </g>\n`;
+    const { inner: out } = fragment.strip_shell(
+      `<svg viewBox="0 0 10 10">${inner}</svg>`
+    );
+    expect(out).toBe(inner);
+  });
+
+  it("passes a bare fragment through with no viewBox", () => {
+    const bare = `<g><rect width="4" height="4"/></g>`;
+    expect(fragment.strip_shell(bare)).toEqual({
+      inner: bare,
+      viewbox: null,
+    });
+  });
+
+  it("handles prolog/doctype before the root element", () => {
+    const svg = `<?xml version="1.0"?><!DOCTYPE svg><svg viewBox="-5 -5 10 10"><rect/></svg>`;
+    const { inner, viewbox } = fragment.strip_shell(svg);
+    expect(inner).toBe("<rect/>");
+    expect(viewbox).toEqual({ min_x: -5, min_y: -5, width: 10, height: 10 });
+  });
+
+  it("reads comma-separated viewBox values", () => {
+    const { viewbox } = fragment.strip_shell(
+      `<svg viewBox="0,0,16,32"><rect/></svg>`
+    );
+    expect(viewbox).toEqual({ min_x: 0, min_y: 0, width: 16, height: 32 });
+  });
+});
+
+describe("fragment.position", () => {
+  it("centers the viewBox on the target point via an authored translate", () => {
+    const svg = `<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>`;
+    expect(fragment.position(svg, { x: 100, y: 50 })).toBe(
+      `<g transform="translate(88 38)"><path d="M0 0h24v24H0z"/></g>`
+    );
+  });
+
+  it("accounts for a non-zero viewBox origin", () => {
+    const svg = `<svg viewBox="10 20 4 8"><rect/></svg>`;
+    // box center is (12, 24) → translate moves it onto (0, 0).
+    expect(fragment.position(svg, { x: 0, y: 0 })).toBe(
+      `<g transform="translate(-12 -24)"><rect/></g>`
+    );
+  });
+
+  it("lands the local origin on the point when no viewBox is declared", () => {
+    expect(fragment.position(`<circle r="3"/>`, { x: 7.125, y: -3 })).toBe(
+      `<g transform="translate(7.13 -3)"><circle r="3"/></g>`
+    );
+  });
+});

--- a/editor/app/(canvas)/svg/_components/fragment.test.ts
+++ b/editor/app/(canvas)/svg/_components/fragment.test.ts
@@ -22,7 +22,24 @@ describe("fragment.strip_shell", () => {
     expect(fragment.strip_shell(bare)).toEqual({
       inner: bare,
       viewbox: null,
+      xmlns: [],
     });
+  });
+
+  it("collects the shell's prefixed xmlns declarations verbatim", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink='http://www.w3.org/1999/xlink' viewBox="0 0 24 24"><path inkscape:label="x"/></svg>`;
+    const { xmlns } = fragment.strip_shell(svg);
+    expect(xmlns).toEqual([
+      `xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"`,
+      `xmlns:xlink='http://www.w3.org/1999/xlink'`,
+    ]);
+  });
+
+  it("does not collect the default xmlns declaration", () => {
+    const { xmlns } = fragment.strip_shell(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><rect/></svg>`
+    );
+    expect(xmlns).toEqual([]);
   });
 
   it("handles prolog/doctype before the root element", () => {
@@ -59,6 +76,13 @@ describe("fragment.position", () => {
   it("lands the local origin on the point when no viewBox is declared", () => {
     expect(fragment.position(`<circle r="3"/>`, { x: 7.125, y: -3 })).toBe(
       `<g transform="translate(7.13 -3)"><circle r="3"/></g>`
+    );
+  });
+
+  it("carries shell xmlns:* declarations onto the wrapper — prefixed content stays namespace-valid", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="0 0 24 24"><path inkscape:label="x" d="M0 0h24v24H0z"/></svg>`;
+    expect(fragment.position(svg, { x: 100, y: 50 })).toBe(
+      `<g xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" transform="translate(88 38)"><path inkscape:label="x" d="M0 0h24v24H0z"/></g>`
     );
   });
 });

--- a/editor/app/(canvas)/svg/_components/fragment.ts
+++ b/editor/app/(canvas)/svg/_components/fragment.ts
@@ -27,19 +27,27 @@ export namespace fragment {
   const SVG_OPEN_RE = /<svg(?:\s[^>]*)?>/i;
   const VIEWBOX_RE =
     /viewBox\s*=\s*["']\s*([-\d.eE+]+)[\s,]+([-\d.eE+]+)[\s,]+([-\d.eE+]+)[\s,]+([-\d.eE+]+)\s*["']/;
+  const XMLNS_DECL_RE = /xmlns:[A-Za-z_][\w.-]*\s*=\s*(?:"[^"]*"|'[^']*')/g;
 
   /**
    * Split a standalone SVG document into its inner markup (bytes between
-   * the root `<svg …>` open tag and the last `</svg>`) and its declared
-   * viewBox. A string with no `<svg>` shell is already a bare fragment —
-   * returned as-is with `viewbox: null`.
+   * the root `<svg …>` open tag and the last `</svg>`), its declared
+   * viewBox, and the shell's prefixed `xmlns:*` declarations (verbatim
+   * `name="value"` tokens). The content may use those prefixes — the
+   * declarations must survive the shell's removal or the result is
+   * namespace-invalid (`<path inkscape:label=…/>` with no
+   * `xmlns:inkscape` in scope). The default `xmlns=` is deliberately NOT
+   * collected: the host document's default namespace governs adopted
+   * content. A string with no `<svg>` shell is already a bare fragment —
+   * returned as-is with `viewbox: null` and no declarations.
    */
   export function strip_shell(svg: string): {
     inner: string;
     viewbox: ViewBox | null;
+    xmlns: readonly string[];
   } {
     const open = SVG_OPEN_RE.exec(svg);
-    if (!open) return { inner: svg, viewbox: null };
+    if (!open) return { inner: svg, viewbox: null, xmlns: [] };
 
     const start = open.index + open[0].length;
     const end = svg.lastIndexOf("</svg");
@@ -55,7 +63,7 @@ export namespace fragment {
         }
       : null;
 
-    return { inner, viewbox };
+    return { inner, viewbox, xmlns: open[0].match(XMLNS_DECL_RE) ?? [] };
   }
 
   /**
@@ -63,14 +71,21 @@ export namespace fragment {
    * intrinsic box (its viewBox) is centered on `at`. Without a viewBox the
    * fragment's local origin lands on `at` — best effort for content whose
    * box isn't knowable pre-insert.
+   *
+   * Shell `xmlns:*` declarations ride on the wrapper `<g>` — namespaces,
+   * like position, are authored content here: once the shell is gone,
+   * `insert_fragment` has no way to recover a prefix's URI, so prefixed
+   * content (`inkscape:label`, `sodipodi:*`, …) would serialize
+   * namespace-invalid.
    */
   export function position(svg: string, at: { x: number; y: number }): string {
-    const { inner, viewbox } = strip_shell(svg);
+    const { inner, viewbox, xmlns } = strip_shell(svg);
     const cx = viewbox ? viewbox.min_x + viewbox.width / 2 : 0;
     const cy = viewbox ? viewbox.min_y + viewbox.height / 2 : 0;
     const tx = fmt(at.x - cx);
     const ty = fmt(at.y - cy);
-    return `<g transform="translate(${tx} ${ty})">${inner}</g>`;
+    const decls = xmlns.length > 0 ? ` ${xmlns.join(" ")}` : "";
+    return `<g${decls} transform="translate(${tx} ${ty})">${inner}</g>`;
   }
 
   /** Trim float noise so the authored transform stays readable. */

--- a/editor/app/(canvas)/svg/_components/fragment.ts
+++ b/editor/app/(canvas)/svg/_components/fragment.ts
@@ -1,0 +1,80 @@
+/**
+ * Consumer-side fragment authoring for `commands.insert_fragment`.
+ *
+ * `@grida/svg-editor` deliberately ships no placement opt — "position is
+ * authored content" (see the `insert_fragment` JSDoc). To land an asset at
+ * a document-space point, the position is authored INTO the markup before
+ * the single `insert_fragment` call: strip the asset's `<svg>` shell
+ * (keeping its inner markup byte-verbatim), read its viewBox for the
+ * intrinsic box, and wrap the content in a positioning
+ * `<g transform="translate(…)">`. The whole drop is then one undo step and
+ * round-trips as ordinary markup.
+ *
+ * String-level on purpose: no DOM parse, no re-serialization (a
+ * `XMLSerializer` pass would re-stamp `xmlns` on every child and destroy
+ * the verbatim-trivia property the editor preserves). The shell scan is
+ * demo-grade — it assumes the opening `<svg …>` tag contains no literal
+ * `>` inside attribute values, which holds for icon-set files.
+ */
+export namespace fragment {
+  export type ViewBox = {
+    min_x: number;
+    min_y: number;
+    width: number;
+    height: number;
+  };
+
+  const SVG_OPEN_RE = /<svg(?:\s[^>]*)?>/i;
+  const VIEWBOX_RE =
+    /viewBox\s*=\s*["']\s*([-\d.eE+]+)[\s,]+([-\d.eE+]+)[\s,]+([-\d.eE+]+)[\s,]+([-\d.eE+]+)\s*["']/;
+
+  /**
+   * Split a standalone SVG document into its inner markup (bytes between
+   * the root `<svg …>` open tag and the last `</svg>`) and its declared
+   * viewBox. A string with no `<svg>` shell is already a bare fragment —
+   * returned as-is with `viewbox: null`.
+   */
+  export function strip_shell(svg: string): {
+    inner: string;
+    viewbox: ViewBox | null;
+  } {
+    const open = SVG_OPEN_RE.exec(svg);
+    if (!open) return { inner: svg, viewbox: null };
+
+    const start = open.index + open[0].length;
+    const end = svg.lastIndexOf("</svg");
+    const inner = end > start ? svg.slice(start, end) : "";
+
+    const vb = VIEWBOX_RE.exec(open[0]);
+    const viewbox = vb
+      ? {
+          min_x: Number(vb[1]),
+          min_y: Number(vb[2]),
+          width: Number(vb[3]),
+          height: Number(vb[4]),
+        }
+      : null;
+
+    return { inner, viewbox };
+  }
+
+  /**
+   * Author a fragment positioned at a document-space point: the asset's
+   * intrinsic box (its viewBox) is centered on `at`. Without a viewBox the
+   * fragment's local origin lands on `at` — best effort for content whose
+   * box isn't knowable pre-insert.
+   */
+  export function position(svg: string, at: { x: number; y: number }): string {
+    const { inner, viewbox } = strip_shell(svg);
+    const cx = viewbox ? viewbox.min_x + viewbox.width / 2 : 0;
+    const cy = viewbox ? viewbox.min_y + viewbox.height / 2 : 0;
+    const tx = fmt(at.x - cx);
+    const ty = fmt(at.y - cy);
+    return `<g transform="translate(${tx} ${ty})">${inner}</g>`;
+  }
+
+  /** Trim float noise so the authored transform stays readable. */
+  function fmt(n: number): string {
+    return String(Math.round(n * 100) / 100);
+  }
+}

--- a/editor/app/(canvas)/svg/_components/library-window.tsx
+++ b/editor/app/(canvas)/svg/_components/library-window.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { memo, useCallback } from "react";
+import { Cross1Icon, PlusIcon } from "@radix-ui/react-icons";
+import {
+  FloatingWindowBody,
+  FloatingWindowClose,
+  FloatingWindowRoot,
+  FloatingWindowTitleBar,
+  FloatingWindowTrigger,
+  useFloatingWindowControls,
+} from "@/components/floating-window";
+import { Button } from "@app/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@app/ui/components/tooltip";
+import {
+  IconsBrowser,
+  type IconsBrowserItem,
+} from "@/grida-canvas-hosted/library/icons-browser";
+import { datatransfer } from "@/grida-canvas/data-transfer";
+
+/**
+ * "Library" — the icons.grida.co browser, floating-window edition for the
+ * SVG demo routes. Same browser component the main canvas playground
+ * mounts. Pure chrome: both insertion paths hand the host an asset URL —
+ * click via `onInsertSrc`, drag via the shared `x-grida-data-transfer`
+ * payload — and the host owns fetch, placement, and feedback.
+ *
+ * Memoized: the host page re-renders on every persisted edit; with a
+ * stable `onInsertSrc` the open window (virtualized icon grid included)
+ * skips those re-renders entirely.
+ */
+export const SvgLibraryWindow = memo(function SvgLibraryWindow({
+  onInsertSrc,
+}: {
+  /** Insert the asset at `src` into the document (click-to-insert path). */
+  onInsertSrc: (src: string) => void;
+}) {
+  const controls = useFloatingWindowControls({ defaultOpen: false });
+
+  const handleInsertIcon = useCallback(
+    (icon: IconsBrowserItem) => onInsertSrc(icon.download),
+    [onInsertSrc]
+  );
+
+  const handleIconDragStart = useCallback(
+    (icon: IconsBrowserItem, event: React.DragEvent<HTMLButtonElement>) => {
+      event.dataTransfer.setData(
+        datatransfer.key,
+        datatransfer.encode({
+          type: "svg",
+          name: icon.name,
+          src: icon.download,
+        })
+      );
+    },
+    []
+  );
+
+  return (
+    <>
+      <div className="absolute top-4 left-4 z-50">
+        <Tooltip>
+          <FloatingWindowTrigger
+            windowId="svg-library"
+            controls={controls}
+            asChild
+          >
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                className="size-8 rounded-full p-0"
+                aria-label="Open Library"
+              >
+                <PlusIcon className="size-4" aria-hidden />
+              </Button>
+            </TooltipTrigger>
+          </FloatingWindowTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            Open Library
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <FloatingWindowRoot
+        windowId="svg-library"
+        controls={controls}
+        initialX={64}
+        initialY={120}
+        width={360}
+        height={560}
+        className="z-[999] rounded-xl shadow-xl max-w-[calc(100vw-3rem)] max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden"
+        render={({ dragHandleProps, controls: c }) => (
+          <>
+            <FloatingWindowTitleBar
+              dragHandleProps={dragHandleProps}
+              className="bg-background"
+            >
+              <span className="font-medium text-sm">Library</span>
+              <FloatingWindowClose
+                windowId="svg-library"
+                controls={c}
+                className="ml-auto text-xs text-muted-foreground hover:text-foreground"
+              >
+                <Cross1Icon className="size-4" aria-hidden />
+                <span className="sr-only">Close</span>
+              </FloatingWindowClose>
+            </FloatingWindowTitleBar>
+            <FloatingWindowBody className="p-0 text-sm h-full flex flex-col overflow-hidden">
+              <IconsBrowser
+                onInsert={handleInsertIcon}
+                onDragStart={handleIconDragStart}
+              />
+            </FloatingWindowBody>
+          </>
+        )}
+      />
+    </>
+  );
+});

--- a/editor/app/(canvas)/svg/_components/svg-shell.tsx
+++ b/editor/app/(canvas)/svg/_components/svg-shell.tsx
@@ -57,6 +57,7 @@ export function SvgShell({
   onCameraReset,
   sidebarContent,
   inspectorActions,
+  canvasOverlay,
 }: {
   title: string;
   badge?: string;
@@ -77,6 +78,12 @@ export function SvgShell({
   sidebarContent?: React.ReactNode;
   /** Optional trailing actions in the Inspector header (e.g. Play). */
   inspectorActions?: React.ReactNode;
+  /**
+   * Floating chrome over the canvas area (e.g. a Library window), rendered
+   * as a SIBLING of `canvas` — outside its drop target and context-menu
+   * wrapper, so interactions on the overlay don't leak into the canvas.
+   */
+  canvasOverlay?: React.ReactNode;
 }) {
   const editor = useSvgEditor();
   const canUndo = useCanUndo();
@@ -178,6 +185,7 @@ export function SvgShell({
       {/* ─── Center: canvas ─────────────────────────────────────── */}
       <main className="flex-1 relative bg-muted overflow-hidden">
         <SvgCanvasContextMenu>{canvas}</SvgCanvasContextMenu>
+        {canvasOverlay}
       </main>
 
       {/* ─── Right sidebar: inspector ───────────────────────────── */}

--- a/editor/app/(canvas)/svg/examples/default/page.tsx
+++ b/editor/app/(canvas)/svg/examples/default/page.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
-import { SvgEditorCanvas, useEditorLoad } from "@grida/svg-editor/react";
+import { useCallback, useState, useSyncExternalStore } from "react";
+import {
+  SvgEditorCanvas,
+  useCommands,
+  useEditorLoad,
+} from "@grida/svg-editor/react";
 import type { DomSurfaceHandle } from "@grida/svg-editor/dom";
+import { toast } from "sonner";
+import { datatransfer } from "@/grida-canvas/data-transfer";
 import { SvgShell } from "../../_components/svg-shell";
 import { SvgToolbar } from "../../_components/svg-toolbar";
 import {
@@ -10,6 +16,8 @@ import {
   PathToolbarPosition,
 } from "../../_components/path-toolbar";
 import { DocsNav } from "../../_components/docs-nav";
+import { SvgLibraryWindow } from "../../_components/library-window";
+import { fragment } from "../../_components/fragment";
 import SAMPLE_SVG from "../../_fixtures/artwork";
 import { SvgRouteShell, useSvgDocStore } from "../../_storage";
 import { useSvgAgentHydrated } from "../../_ai/provider";
@@ -27,10 +35,11 @@ export default function SvgEditorDevPage() {
 function SvgEditorDevPageBody() {
   const store = useSvgDocStore();
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [dragging, setDragging] = useState(false);
+  const [dragging, setDragging] = useState<"file" | "library" | null>(null);
   const [sourceName, setSourceName] = useState<string | null>(null);
   const [handle, setHandle] = useState<DomSurfaceHandle | null>(null);
   const load = useEditorLoad();
+  const cmd = useCommands();
   const docs = useSyncExternalStore(
     store.subscribe,
     store.getDocs,
@@ -62,18 +71,68 @@ function SvgEditorDevPageBody() {
     reader.readAsText(file);
   };
 
+  // Fetch a library asset and insert it as ONE history step. With a target
+  // point, the position is authored into the markup — see
+  // `fragment.position`. Shared by click-to-insert and drop-at-point.
+  const insertFromSrc = useCallback(
+    (src: string, at: { x: number; y: number } | null) => {
+      const task = fetch(src, { cache: "no-store" })
+        .then((res) => {
+          if (!res.ok) throw new Error("Failed to fetch icon");
+          return res.text();
+        })
+        .then((svg) => {
+          cmd.insert_fragment(at ? fragment.position(svg, at) : svg);
+        });
+      toast.promise(task, {
+        loading: "Loading icon...",
+        success: "Icon inserted",
+        error: "Failed to insert icon",
+      });
+    },
+    [cmd]
+  );
+
+  // Library click-to-insert: land the icon at the viewport center.
+  const insertSrcAtViewportCenter = useCallback(
+    (src: string) => insertFromSrc(src, handle?.camera.center ?? null),
+    [insertFromSrc, handle]
+  );
+
+  const dragKind = (dt: DataTransfer | null): "file" | "library" | null => {
+    if (dt?.types?.includes(datatransfer.key)) return "library";
+    if (dt?.types?.includes("Files")) return "file";
+    return null;
+  };
+
   const onDragOver = (e: React.DragEvent) => {
-    if (!e.dataTransfer?.types?.includes("Files")) return;
+    const kind = dragKind(e.dataTransfer);
+    if (!kind) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
-    if (!dragging) setDragging(true);
+    if (dragging !== kind) setDragging(kind);
   };
   const onDragLeave = (e: React.DragEvent) => {
-    if (e.currentTarget === e.target) setDragging(false);
+    if (e.currentTarget === e.target) setDragging(null);
   };
   const onDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    setDragging(false);
+    setDragging(null);
+    const known = e.dataTransfer?.getData(datatransfer.key);
+    if (known) {
+      const data = datatransfer.decode(known);
+      if (data.type !== "svg") return;
+      // Drop point → world space, so the icon lands centered under the
+      // pointer. Same screen-space convention as the surface's gestures.
+      const cr = e.currentTarget.getBoundingClientRect();
+      const at =
+        handle?.camera.screen_to_world({
+          x: e.clientX - cr.left,
+          y: e.clientY - cr.top,
+        }) ?? null;
+      insertFromSrc(data.src, at);
+      return;
+    }
     const file = e.dataTransfer?.files?.[0];
     if (file) loadSvgFile(file);
   };
@@ -98,7 +157,7 @@ function SvgEditorDevPageBody() {
           onDragLeave={onDragLeave}
           onDrop={onDrop}
           className="absolute inset-0 bg-[radial-gradient(circle,theme(colors.border)_1px,transparent_1px)] [background-size:20px_20px] data-[dragging=true]:outline-2 data-[dragging=true]:outline-dashed data-[dragging=true]:outline-primary data-[dragging=true]:-outline-offset-2"
-          data-dragging={dragging}
+          data-dragging={dragging !== null}
         >
           <SvgEditorCanvas
             fit
@@ -112,10 +171,15 @@ function SvgEditorDevPageBody() {
           </PathToolbarPosition>
           {dragging && (
             <div className="absolute inset-0 flex items-center justify-center bg-primary/5 text-primary text-sm font-semibold pointer-events-none">
-              Drop SVG to load
+              {dragging === "file" ? "Drop SVG to load" : "Drop to insert"}
             </div>
           )}
         </div>
+      }
+      canvasOverlay={
+        // Sibling of the drop target on purpose — dropping an icon back
+        // onto the Library window must not insert it into the canvas.
+        <SvgLibraryWindow onInsertSrc={insertSrcAtViewportCenter} />
       }
     />
   );

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_examples.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   SvgEditorCanvas,
   SvgEditorProvider,
+  useCommands,
   useSvgEditor,
 } from "@grida/svg-editor/react";
 import type { Tool } from "@grida/svg-editor";
+import type { DomSurfaceHandle } from "@grida/svg-editor/dom";
 import {
   CSS,
   GROUP_TRANSFORM,
+  INSERT_FRAGMENT,
+  INSERT_FRAGMENT_ICONS,
   LINE,
   NESTED_SVG,
   PATH,
@@ -140,4 +144,113 @@ export function SymbolUseExample() {
 /** CSS-driven fill + transform via a document <style> block. */
 export function CssExample() {
   return <SvgStage svg={CSS} tool={{ type: "cursor" }} selectName="pill" />;
+}
+
+// ─── Fragment insertion — `commands.insert_fragment` ────────────────────────
+
+/** Drag payload type for the demo's icon chips — scoped to this card. */
+const FRAGMENT_MIME = "application/x-grida-svg-fragment-demo";
+
+/**
+ * The minimal `insert_fragment` consumer: click a chip to insert its icon,
+ * or drag it onto the stage to insert at the drop point. Both paths are a
+ * single `insert_fragment` call — position is authored content, so the
+ * drop point becomes a `<g transform="translate(…)">` wrapper around the
+ * fragment, and the whole insert is ONE undo step.
+ */
+export function InsertFragmentExample() {
+  return (
+    <SvgEditorProvider initialSvg={INSERT_FRAGMENT}>
+      <InsertFragmentBody />
+    </SvgEditorProvider>
+  );
+}
+
+function InsertFragmentBody() {
+  const cmd = useCommands();
+  const [handle, setHandle] = useState<DomSurfaceHandle | null>(null);
+  // Cascade repeated center-inserts so stamps don't hide each other.
+  const stamps = useRef(0);
+
+  const insert_at = (
+    icon: (typeof INSERT_FRAGMENT_ICONS)[number],
+    at: { x: number; y: number }
+  ) => {
+    // The whole recipe: author the position around the fragment, insert
+    // once. Rounded — the transform round-trips into the saved file.
+    const tx = Math.round((at.x - icon.size / 2) * 100) / 100;
+    const ty = Math.round((at.y - icon.size / 2) * 100) / 100;
+    cmd.insert_fragment(
+      `<g transform="translate(${tx} ${ty})">${icon.svg}</g>`
+    );
+  };
+
+  const insert_at_stage_center = (
+    icon: (typeof INSERT_FRAGMENT_ICONS)[number]
+  ) => {
+    const n = stamps.current++;
+    insert_at(icon, { x: 280 + (n % 5) * 28 - 56, y: 160 });
+  };
+
+  const onDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(FRAGMENT_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  };
+  const onDrop = (e: React.DragEvent) => {
+    const key = e.dataTransfer.getData(FRAGMENT_MIME);
+    const icon = INSERT_FRAGMENT_ICONS.find((i) => i.name === key);
+    if (!icon || !handle) return;
+    e.preventDefault();
+    // Drop point (container-local px) → world space via the camera.
+    const cr = e.currentTarget.getBoundingClientRect();
+    const at = handle.camera.screen_to_world({
+      x: e.clientX - cr.left,
+      y: e.clientY - cr.top,
+    });
+    insert_at(icon, at);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        {INSERT_FRAGMENT_ICONS.map((icon) => (
+          <button
+            key={icon.name}
+            type="button"
+            draggable
+            onClick={() => insert_at_stage_center(icon)}
+            onDragStart={(e) => {
+              e.dataTransfer.setData(FRAGMENT_MIME, icon.name);
+              e.dataTransfer.effectAllowed = "copy";
+            }}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-muted cursor-grab active:cursor-grabbing"
+            title={`Insert ${icon.name} — click, or drag onto the stage`}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              className="size-4"
+              aria-hidden
+              dangerouslySetInnerHTML={{ __html: icon.svg }}
+            />
+            {icon.name}
+          </button>
+        ))}
+        <span className="text-xs text-muted-foreground">
+          click to insert · drag to place
+        </span>
+      </div>
+      <div
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        className="relative aspect-video w-full overflow-hidden rounded-lg border bg-[radial-gradient(circle,theme(colors.border)_1px,transparent_1px)] [background-size:20px_20px]"
+      >
+        <SvgEditorCanvas
+          fit
+          onAttach={setHandle}
+          className="absolute inset-0 h-full w-full"
+        />
+      </div>
+    </div>
+  );
 }

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/_fixtures.ts
@@ -196,3 +196,39 @@ export const CSS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 240
   <circle class="ghost" cx="380" cy="130" r="64"/>
   <text class="brand" x="280" y="220" font-family="ui-monospace, monospace" font-size="18">fill + transform via style</text>
 </svg>`;
+
+// ─── Fragment insertion — `commands.insert_fragment` ────────────────────────
+// A mostly-empty pasteboard with one authored landmark, so an inserted icon is
+// obviously NEW content and its placement relative to existing markup is
+// legible. Paired with the icon fragments below: click inserts, drag inserts
+// at the drop point — both as ONE history step.
+export const INSERT_FRAGMENT = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 320" width="560" height="320">
+  <rect id="pasteboard" width="560" height="320" fill="#f8fafc"/>
+  <text id="hint" x="280" y="296" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" fill="#94a3b8">click an icon to insert — or drag it here</text>
+</svg>`;
+
+// Icon *fragments* — multi-element subtrees with no <svg> shell, the shape a
+// vendor icon or clipboard payload arrives in. 24×24 box each; the demo
+// authors the drop position around them (see the card in `_examples.tsx`).
+export const INSERT_FRAGMENT_ICONS: ReadonlyArray<{
+  name: string;
+  /** Intrinsic box — fragments carry no viewBox; the consumer knows it. */
+  size: number;
+  svg: string;
+}> = [
+  {
+    name: "star",
+    size: 24,
+    svg: `<g fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></g>`,
+  },
+  {
+    name: "heart",
+    size: 24,
+    svg: `<g fill="none" stroke="#ec4899" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></g>`,
+  },
+  {
+    name: "bolt",
+    size: 24,
+    svg: `<g fill="none" stroke="#6366f1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></g>`,
+  },
+];

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
@@ -3,6 +3,7 @@
 import {
   CssExample,
   GroupTransformExample,
+  InsertFragmentExample,
   LineExample,
   NestedSvgExample,
   PathExample,
@@ -45,6 +46,7 @@ const SECTIONS: { id: string; label: string }[] = [
   { id: "nested-svg", label: "Nested <svg>" },
   { id: "symbol-use", label: "Symbol & use" },
   { id: "css", label: "CSS cascade" },
+  { id: "insert-fragment", label: "Fragment insertion" },
 ];
 
 export default function SvgEditorPackagePage() {
@@ -308,6 +310,26 @@ export default function SvgEditorPackagePage() {
                 caption="Not yet decided: how the editor cooperates with the cascade. This card is the surface for choosing the behavior, not a finished feature."
               >
                 <CssExample />
+              </SpecCard>
+
+              <SpecCard
+                id="insert-fragment"
+                title="Fragment insertion — insert_fragment"
+                description={
+                  <>
+                    <code>commands.insert_fragment(svg)</code> inserts a
+                    pre-authored subtree — a vendor icon, a clipboard payload —
+                    as <strong>one</strong> history step. Click a chip to
+                    insert; drag it onto the stage to insert at the drop point.
+                    Position is authored content: the drop point becomes a{" "}
+                    <code>&lt;g transform&gt;</code> wrapper in the markup, so
+                    placement round-trips and a single undo removes the whole
+                    insert.
+                  </>
+                }
+                caption="The insertion-side primitive paste will compose. No placement opt by design — the caller authors position into the fragment."
+              >
+                <InsertFragmentExample />
               </SpecCard>
             </div>
           </section>

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -646,6 +646,15 @@ editor.commands.{
   // e.g. "path"); only the closed `InsertableTag` set gets a pointer-driven
   // draw gesture and default paint.
   insert(tag: string, attrs?: Readonly<Record<string, string>>): NodeId;
+  // markup-shaped sibling of `insert` — one or more sibling elements, or a
+  // full `<svg>` doc (the shell is discarded; its children are the content).
+  // Subtrees adopted verbatim; ONE history step; returns root ids in
+  // document order. Authored ids are NEVER rewritten (dedup is Tidy's job);
+  // undeclared `xlink:` / shell-declared prefixes are hoisted onto the root
+  // in the same step. Position is authored content: wrap the fragment in
+  // `<g transform="translate(x y)">` to land it at a point — same single
+  // undo step, no placement opt.
+  insert_fragment(svg: string, opts?: { parent?: NodeId; index?: number; select?: boolean }): NodeId[];
   insert_preview(tag: string, initial?: Readonly<Record<string, string>>): InsertPreviewSession;
 
   // content

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -278,6 +278,16 @@ reference handling, paste position, multi-document support.
 
 Current implementation notes:
 
+- **Insertion-side primitive shipped.** `commands.insert_fragment(svg, opts)`
+  is the markup-shaped atomic insert that paste composes: parses a bare
+  fragment or a full `<svg>` doc (shell discarded, children taken), adopts
+  subtrees verbatim (authored `id`s NEVER rewritten — dedup stays Tidy's
+  job), hoists resolvable undeclared `xmlns:*` prefixes onto the root, ONE
+  history step, roots returned in document order. Backed by
+  `SvgDocument.create_fragment` / `undeclared_ns_prefixes` /
+  `declare_xmlns` (`core/document.ts`). Remaining paste work is the list
+  below — clipboard wiring, copy-side defs dependency walking, command ids
+  and keymap bindings.
 - Not implemented. No `clipboard.copy` / `clipboard.cut` / `clipboard.paste`
   command id is registered (`commands/defaults.ts`) and no keymap binding
   exists for them (`keymap/defaults.ts`).

--- a/packages/grida-svg-editor/__tests__/insert-fragment.test.ts
+++ b/packages/grida-svg-editor/__tests__/insert-fragment.test.ts
@@ -1,0 +1,379 @@
+// Headless tests for `commands.insert_fragment` — atomic insertion of a
+// pre-authored SVG fragment / full-document string:
+//   - root ids returned in document order; contiguous landing.
+//   - ONE undo restores the exact pre-insert serialization; redo restores
+//     the post-insert one (byte-equal both ways).
+//   - full `<svg>` doc input → children only; the shell is discarded.
+//   - parent / index / select opts.
+//   - id-collision policy: authored ids inserted verbatim, never rewritten.
+//   - namespace hoisting: well-known `xlink` and shell-declared prefixes
+//     land on the root in the same history step; authored declarations win.
+//   - empty / invalid input behavior (no-op vs throw).
+//   - positioning is authored content: a transform-wrapped fragment lands
+//     positioned and undoes in one step.
+
+import { describe, expect, it } from "vitest";
+import { createSvgEditor } from "../src/index";
+
+const EMPTY = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"/>`;
+const WITH_RECT = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`;
+
+describe("commands.insert_fragment / multi-element fragments", () => {
+  it("returns the inserted root ids in document order", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<path d="M0 0H10"/><path d="M0 5H10"/>`
+    );
+    expect(ids).toHaveLength(2);
+    // Returned order is document order — the parent's element children
+    // end with the two roots in source order.
+    const children = editor.document.element_children_of(editor.document.root);
+    expect(children).toEqual(ids);
+    expect(editor.document.get_attr(ids[0], "d")).toBe("M0 0H10");
+    expect(editor.document.get_attr(ids[1], "d")).toBe("M0 5H10");
+  });
+
+  it("inserts the subtree verbatim into the serialized output", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    editor.commands.insert_fragment(`<path d="M0 0H10"/><path d="M0 5H10"/>`);
+    expect(editor.serialize()).toBe(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M0 0H10"/><path d="M0 5H10"/></svg>`
+    );
+  });
+
+  it("a `<g>`-wrapped fragment returns one root id with its children intact", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<g fill="red"><path d="M0 0H10"/><path d="M0 5H10"/></g>`
+    );
+    expect(ids).toHaveLength(1);
+    expect(editor.document.tag_of(ids[0])).toBe("g");
+    expect(editor.document.element_children_of(ids[0])).toHaveLength(2);
+  });
+
+  it("ONE undo restores the exact pre-insert serialization; redo restores the post-insert one", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+
+    editor.commands.insert_fragment(
+      `<g transform="translate(1 2)"><path d="M0 0H10"/><circle cx="5" cy="5" r="2"/></g><line x1="0" y1="0" x2="9" y2="9"/>`
+    );
+    const after = editor.serialize();
+    expect(after).not.toBe(baseline);
+
+    expect(editor.state.can_undo).toBe(true);
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    // The whole fragment was ONE step — nothing left to undo.
+    expect(editor.state.can_undo).toBe(false);
+
+    editor.commands.redo();
+    expect(editor.serialize()).toBe(after);
+  });
+
+  it("preserves the fragment's inner trivia verbatim (quotes, attr spacing, comments)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const fragment = `<g fill ='red' data-x="1"><!-- note --><path d="M0 0H5"/></g>`;
+    editor.commands.insert_fragment(fragment);
+    expect(editor.serialize()).toContain(fragment);
+  });
+
+  it("drops top-level non-element junk between roots (comments, stray text)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<!-- a --> <rect width="1" height="1"/> stray <circle r="2"/>`
+    );
+    expect(ids).toHaveLength(2);
+    expect(editor.document.tag_of(ids[0])).toBe("rect");
+    expect(editor.document.tag_of(ids[1])).toBe("circle");
+    const out = editor.serialize();
+    expect(out).not.toContain("<!-- a -->");
+    expect(out).not.toContain("stray");
+  });
+
+  it("selects the inserted roots by default; undo restores the previous selection", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const base = editor.document.element_children_of(editor.document.root)[0];
+    editor.commands.select(base);
+
+    const ids = editor.commands.insert_fragment(
+      `<path d="M0 0H10"/><path d="M0 5H10"/>`
+    );
+    expect(editor.state.selection).toEqual(ids);
+
+    editor.commands.undo();
+    expect(editor.state.selection).toEqual([base]);
+  });
+
+  it("doesn't touch selection when opts.select === false", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const before = editor.state.selection;
+    editor.commands.insert_fragment(`<path d="M0 0H10"/>`, { select: false });
+    expect(editor.state.selection).toEqual(before);
+  });
+});
+
+describe("commands.insert_fragment / full-document input", () => {
+  it("a full `<svg>` doc takes children only — the shell is discarded", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="12" r="10"/></svg>`
+    );
+    expect(ids).toHaveLength(1);
+    expect(editor.document.tag_of(ids[0])).toBe("circle");
+    const out = editor.serialize();
+    // No nested <svg>, and none of the shell's attrs leaked in.
+    expect(out.match(/<svg/g)).toHaveLength(1);
+    expect(out).not.toContain(`viewBox="0 0 24 24"`);
+  });
+
+  it("XML prolog / doctype on a full-doc input are discarded with the shell", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE svg>\n<svg xmlns="http://www.w3.org/2000/svg"><rect width="4" height="4"/></svg>`
+    );
+    expect(ids).toHaveLength(1);
+    expect(editor.document.tag_of(ids[0])).toBe("rect");
+    const out = editor.serialize();
+    expect(out).not.toContain("<?xml");
+    expect(out).not.toContain("DOCTYPE");
+  });
+
+  it("an `<svg>` among SEVERAL top-level elements is content, inserted as-is", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const ids = editor.commands.insert_fragment(
+      `<rect width="1" height="1"/><svg width="2" height="2"/>`
+    );
+    expect(ids).toHaveLength(2);
+    expect(editor.document.tag_of(ids[1])).toBe("svg");
+    expect(editor.serialize()).toContain(`<svg width="2" height="2"/>`);
+  });
+});
+
+describe("commands.insert_fragment / parent and index opts", () => {
+  it("opts.parent inserts into a non-root container", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg"><g id="layer"/></svg>`,
+    });
+    const layer = editor.document.element_children_of(editor.document.root)[0];
+    const ids = editor.commands.insert_fragment(`<path d="M0 0H10"/>`, {
+      parent: layer,
+    });
+    expect(editor.document.parent_of(ids[0])).toBe(layer);
+    expect(editor.serialize()).toContain(
+      `<g id="layer"><path d="M0 0H10"/></g>`
+    );
+  });
+
+  it("opts.index places the whole fragment contiguously at the element-children position", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const root = editor.document.root;
+    const base = editor.document.element_children_of(root)[0];
+    const ids = editor.commands.insert_fragment(
+      `<path d="M0 0H10"/><path d="M0 5H10"/>`,
+      { index: 0 }
+    );
+    expect(editor.document.element_children_of(root)).toEqual([
+      ids[0],
+      ids[1],
+      base,
+    ]);
+  });
+
+  it("an out-of-range index appends", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const root = editor.document.root;
+    const base = editor.document.element_children_of(root)[0];
+    const ids = editor.commands.insert_fragment(`<path d="M0 0H10"/>`, {
+      index: 99,
+    });
+    expect(editor.document.element_children_of(root)).toEqual([base, ids[0]]);
+  });
+
+  it("throws on a parent id that isn't a live element of the document", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    expect(() =>
+      editor.commands.insert_fragment(`<path d="M0 0H10"/>`, {
+        parent: "no-such-node",
+      })
+    ).toThrow(/parent/);
+
+    // A removed (detached, but still id-mapped for undo) node is not a
+    // live parent either.
+    const base = editor.document.element_children_of(editor.document.root)[0];
+    editor.commands.select(base);
+    editor.commands.remove();
+    expect(() =>
+      editor.commands.insert_fragment(`<path d="M0 0H10"/>`, { parent: base })
+    ).toThrow(/parent/);
+
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+  });
+});
+
+describe("commands.insert_fragment / id collisions", () => {
+  it("authored ids are inserted verbatim — never rewritten", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const base = editor.document.element_children_of(editor.document.root)[0];
+    const baseline = editor.serialize();
+
+    const ids = editor.commands.insert_fragment(
+      `<circle id="base" cx="5" cy="5" r="2"/>`
+    );
+    // Both elements carry the authored id; the pre-existing one is
+    // untouched and the fragment's was not renamed.
+    expect(editor.document.get_attr(base, "id")).toBe("base");
+    expect(editor.document.get_attr(ids[0], "id")).toBe("base");
+    expect(editor.serialize().match(/id="base"/g)).toHaveLength(2);
+
+    // The collision is still one clean undo step away.
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+  });
+
+  it("a fragment carrying defs + url(#…) references registers in the defs view", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    editor.commands.insert_fragment(
+      `<defs><linearGradient id="lg1"><stop offset="0" stop-color="red"/></linearGradient></defs><rect width="5" height="5" fill="url(#lg1)"/>`
+    );
+    const entries = editor.defs.gradients.list();
+    expect(entries.map((e) => e.id)).toContain("lg1");
+    expect(entries.find((e) => e.id === "lg1")?.ref_count).toBe(1);
+
+    editor.commands.undo();
+    expect(editor.defs.gradients.list()).toHaveLength(0);
+  });
+});
+
+describe("commands.insert_fragment / namespace hoisting", () => {
+  it("hoists xmlns:xlink onto the root when the fragment uses the prefix undeclared", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg"/>`,
+    });
+    const baseline = editor.serialize();
+
+    editor.commands.insert_fragment(`<use xlink:href="#x"/>`);
+    const after = editor.serialize();
+    expect(after).toBe(
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#x"/></svg>`
+    );
+
+    // The hoist rides the same single history step.
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+    editor.commands.redo();
+    expect(editor.serialize()).toBe(after);
+  });
+
+  it("doesn't duplicate a declaration the root already carries", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"/>`,
+    });
+    editor.commands.insert_fragment(`<use xlink:href="#x"/>`);
+    expect(editor.serialize().match(/xmlns:xlink/g)).toHaveLength(1);
+  });
+
+  it("a fragment declaring its own prefix needs no hoist", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg"/>`,
+    });
+    editor.commands.insert_fragment(
+      `<g xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#x"/></g>`
+    );
+    // The declaration stays where it was authored — not copied to root.
+    expect(editor.serialize().match(/xmlns:xlink/g)).toHaveLength(1);
+    expect(editor.serialize()).toContain(
+      `<g xmlns:xlink="http://www.w3.org/1999/xlink">`
+    );
+  });
+
+  it("hoists a custom prefix declared on a discarded `<svg>` shell, with the shell's URI", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg"/>`,
+    });
+    editor.commands.insert_fragment(
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:acme="https://acme.example/ns"><path acme:meta="x" d="M0 0H4"/></svg>`
+    );
+    const out = editor.serialize();
+    expect(out).toContain(`xmlns:acme="https://acme.example/ns"`);
+    expect(out).toContain(`acme:meta="x"`);
+  });
+
+  it("an authored root declaration wins over a hoist candidate — never rebound", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:acme="https://host.example/ns"/>`,
+    });
+    editor.commands.insert_fragment(
+      `<svg xmlns="http://www.w3.org/2000/svg" xmlns:acme="https://acme.example/ns"><path acme:meta="x" d="M0 0H4"/></svg>`
+    );
+    const out = editor.serialize();
+    expect(out).toContain(`xmlns:acme="https://host.example/ns"`);
+    expect(out).not.toContain(`https://acme.example/ns`);
+  });
+
+  it("a prefix with no discoverable URI is left as authored — no hoist", () => {
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg"/>`,
+    });
+    editor.commands.insert_fragment(`<path foo:bar="1" d="M0 0H4"/>`);
+    const out = editor.serialize();
+    expect(out).toContain(`foo:bar="1"`);
+    expect(out).not.toContain("xmlns:foo");
+  });
+});
+
+describe("commands.insert_fragment / empty and invalid input", () => {
+  it.each(["", "   \n  ", "<!-- nothing here -->"])(
+    "input with no top-level elements (%j) returns [] with NO history step",
+    (input) => {
+      const editor = createSvgEditor({ svg: WITH_RECT });
+      const baseline = editor.serialize();
+      expect(editor.commands.insert_fragment(input)).toEqual([]);
+      expect(editor.serialize()).toBe(baseline);
+      expect(editor.state.can_undo).toBe(false);
+    }
+  );
+
+  it("throws on malformed markup, leaving the document untouched", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    expect(() => editor.commands.insert_fragment(`<g><path></g>`)).toThrow(
+      /mismatched end tag/
+    );
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("throws TypeError on a non-string input", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(() =>
+      editor.commands.insert_fragment(undefined as unknown as string)
+    ).toThrow(TypeError);
+  });
+});
+
+describe("commands.insert_fragment / positioning is authored content", () => {
+  // The contract has no placement opt. Drop-at-point composes by authoring
+  // the position INTO the fragment — wrap in `<g transform="translate(x
+  // y)">` — so placement round-trips as ordinary markup and the whole
+  // drop is one undo step.
+  it("a transform-wrapped fragment lands positioned and undoes in ONE step", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const baseline = editor.serialize();
+
+    const ids = editor.commands.insert_fragment(
+      `<g transform="translate(40 50)"><path d="M0 0H10"/><path d="M0 5H10"/></g>`
+    );
+    expect(ids).toHaveLength(1);
+    expect(editor.document.get_attr(ids[0], "transform")).toBe(
+      "translate(40 50)"
+    );
+
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+});

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.16",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -19,6 +19,7 @@ import {
   type ParseResult,
   type PiNode,
   type TextNode,
+  SVG_NS,
   XLINK_NS,
   XMLNS_NS,
   XML_NS,
@@ -476,7 +477,8 @@ export class SvgDocument implements DocumentEvents {
       }
     }
     if (value !== null) {
-      const prefix = ns === XLINK_NS ? "xlink" : null;
+      const prefix =
+        ns === XLINK_NS ? "xlink" : ns === XMLNS_NS ? "xmlns" : null;
       n.attrs.push({
         raw_name: prefix ? `${prefix}:${name}` : name,
         prefix,
@@ -950,7 +952,7 @@ export class SvgDocument implements DocumentEvents {
     local: string,
     opts?: { prefix?: string | null; ns?: string | null }
   ): NodeId {
-    const id = `e${Math.random().toString(36).slice(2, 10)}`;
+    const id = this.fresh_node_id();
     const prefix = opts?.prefix ?? null;
     const ns = opts?.ns ?? null;
     const node: ElementNode = {
@@ -970,6 +972,181 @@ export class SvgDocument implements DocumentEvents {
     };
     this.nodes.set(id, node);
     return id;
+  }
+
+  /** Fresh internal NodeId, guaranteed unique within this document's node
+   *  map. Shared by `create_element` and fragment adoption — collisions
+   *  matter for the latter because the parser assigns sequential per-parse
+   *  ids that a second parse would repeat. */
+  private fresh_node_id(): NodeId {
+    let id: NodeId;
+    do {
+      id = `e${Math.random().toString(36).slice(2, 10)}`;
+    } while (this.nodes.has(id));
+    return id;
+  }
+
+  // ─── Fragment ingestion ──────────────────────────────────────────────────
+
+  /**
+   * Parse an SVG **fragment** string and adopt its element subtrees into
+   * this document's node store — registered like {@link create_element}
+   * but NOT inserted into the tree (no version bump, no emit). Callers
+   * attach the returned roots via {@link insert}; the editor's
+   * `commands.insert_fragment` is the history-bracketed consumer.
+   *
+   * Input shapes:
+   *   - A **bare fragment** — one or more sibling elements
+   *     (`<path …/><path …/>`, or a single `<g>…</g>`). The top-level
+   *     elements become the returned roots, in source order.
+   *   - A **full SVG document** — when the input's only top-level element
+   *     is an `<svg>`, that element is treated as a document SHELL, not
+   *     content: its element children become the roots and the shell
+   *     itself (viewBox, width/height, prolog, doctype) is discarded. Its
+   *     `xmlns:*` prefix declarations are harvested into `xmlns` so the
+   *     caller can re-declare prefixes the adopted content still uses.
+   *     An `<svg>` that appears as one of SEVERAL top-level elements (or
+   *     anywhere below the top level) is content, adopted as-is.
+   *
+   * Top-level non-element nodes (whitespace between roots, comments, PIs,
+   * doctype) are dropped — adoption takes elements, and the host
+   * document's own trivia stays untouched. WITHIN each adopted subtree
+   * every byte of source trivia survives verbatim (attribute order, quote
+   * styles, whitespace, comments), so the inserted markup serializes back
+   * exactly as authored — same rules as the initial parse.
+   *
+   * Authored `id=""` attributes are adopted verbatim — never rewritten,
+   * even when they collide with ids already in the document. Silent id
+   * renaming is exactly the proprietary noise this editor refuses (README
+   * "What clean means" §3); deduplication belongs to the explicit Tidy
+   * command. Internal NodeIds ARE freshly assigned (see
+   * {@link fresh_node_id}) so adopted nodes never collide in the id map.
+   *
+   * Throws `TypeError` on a non-string input and `Error` on markup the
+   * parser rejects (unclosed / mismatched tags, malformed attributes). An
+   * input with no top-level elements (empty string, whitespace, comments
+   * only) returns `{ roots: [], xmlns: [] }`.
+   */
+  create_fragment(markup: string): {
+    roots: NodeId[];
+    xmlns: ReadonlyArray<{ prefix: string; uri: string }>;
+  } {
+    if (typeof markup !== "string") {
+      throw new TypeError(
+        `create_fragment(markup) requires a string source, got ${markup === null ? "null" : typeof markup}`
+      );
+    }
+    // Wrap so multi-root fragments parse uniformly (the parser wants one
+    // root). The wrapper carries the two namespaces this package treats as
+    // well-known, so `xlink:`-prefixed attrs in a bare fragment resolve
+    // their `ns` the same way a host-document parse would. The wrapper is
+    // never adopted — only its children are.
+    const wrapped = `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}">${markup}</svg>`;
+    const parsed = parse_svg(wrapped);
+    const wrapper = parsed.nodes.get(parsed.root) as ElementNode;
+    const element_children = (n: ElementNode): ElementNode[] =>
+      n.children
+        .map((c) => parsed.nodes.get(c))
+        .filter((cn): cn is ElementNode => cn?.kind === "element");
+
+    let content = element_children(wrapper);
+    const xmlns: { prefix: string; uri: string }[] = [];
+    if (content.length === 1 && content[0].local === "svg") {
+      // Full-document input: the lone `<svg>` is a shell. Harvest its
+      // prefix declarations (NOT the default `xmlns=` — the host
+      // document's default namespace governs the adopted content).
+      const shell = content[0];
+      for (const a of shell.attrs) {
+        if (a.prefix === "xmlns") {
+          xmlns.push({ prefix: a.local, uri: a.value });
+        }
+      }
+      content = element_children(shell);
+    }
+
+    const roots: NodeId[] = [];
+    for (const node of content) {
+      roots.push(this.adopt_parsed_subtree(node, parsed.nodes, null));
+    }
+    return { roots, xmlns };
+  }
+
+  /**
+   * Register `node` and its whole subtree (from a foreign parse) into this
+   * document's node map under fresh NodeIds. The parser assigns sequential
+   * per-parse ids (`n0`, `n1`, …), so adopting without a remap would
+   * collide with this document's own nodes. Children links are rewritten;
+   * the subtree root arrives detached (`parent: null`), like
+   * `create_element`. Mutates the parsed nodes in place — a parse result
+   * is single-use.
+   */
+  private adopt_parsed_subtree(
+    node: AnyNode,
+    source: ReadonlyMap<NodeId, AnyNode>,
+    parent: NodeId | null
+  ): NodeId {
+    const id = this.fresh_node_id();
+    node.id = id;
+    node.parent = parent;
+    this.nodes.set(id, node);
+    if (node.kind === "element") {
+      const parsed_children = node.children;
+      node.children = [];
+      for (const c of parsed_children) {
+        const child = source.get(c);
+        if (!child) continue;
+        node.children.push(this.adopt_parsed_subtree(child, source, id));
+      }
+    }
+    return id;
+  }
+
+  /**
+   * Namespace prefixes USED within `id`'s subtree (element tags and
+   * attribute names) that are not DECLARED within the subtree itself —
+   * i.e. prefixes the subtree borrows from ancestor scope. `xml` and
+   * `xmlns` are excluded (bound by the XML spec, never declared).
+   * Declaration scoping is honored per use-site: a prefix declared on the
+   * using element or any of its ancestors up to (and including) the
+   * subtree root counts as declared.
+   *
+   * Structural fact only — the caller decides what an unbound prefix
+   * means (e.g. `commands.insert_fragment` hoists a resolvable
+   * declaration onto the document root).
+   */
+  undeclared_ns_prefixes(id: NodeId): ReadonlySet<string> {
+    const out = new Set<string>();
+    const walk = (nid: NodeId, declared: ReadonlySet<string>) => {
+      const n = this.nodes.get(nid);
+      if (!n || n.kind !== "element") return;
+      const scope = new Set(declared);
+      for (const a of n.attrs) {
+        if (a.prefix === "xmlns") scope.add(a.local);
+      }
+      const need = (p: string | null) => {
+        if (p === null || p === "xml" || p === "xmlns") return;
+        if (!scope.has(p)) out.add(p);
+      };
+      need(n.prefix);
+      for (const a of n.attrs) {
+        if (a.prefix !== "xmlns") need(a.prefix);
+      }
+      for (const c of n.children) walk(c, scope);
+    };
+    walk(id, new Set());
+    return out;
+  }
+
+  /**
+   * Declare a namespace prefix on the ROOT element: appends
+   * `xmlns:<prefix>="<uri>"` when the root doesn't already declare that
+   * prefix. An authored declaration always wins — this never rebinds.
+   * Policy wrapper over {@link set_attr} in the `XMLNS_NS` space; removal
+   * works through `set_attr(root, prefix, null, XMLNS_NS)` as usual.
+   */
+  declare_xmlns(prefix: string, uri: string): void {
+    if (this.get_attr(this.root, prefix, XMLNS_NS) !== null) return;
+    this.set_attr(this.root, prefix, uri, XMLNS_NS);
   }
 
   // ─── Serialization ───────────────────────────────────────────────────────

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -16,7 +16,7 @@ import { Keymap } from "../keymap/keymap";
 import { applyDefaultBindings } from "../keymap/defaults";
 import cmath from "@grida/cmath";
 import { create_defs } from "./defs";
-import { SvgDocument } from "./document";
+import { SvgDocument, XLINK_NS, XMLNS_NS } from "./document";
 import type { GeometryProvider } from "./geometry";
 import type { SurfaceBridge } from "./surface-bridge";
 import { group as group_policy } from "./group";
@@ -370,6 +370,62 @@ export type Commands = {
     attrs: Readonly<Record<string, string>>,
     opts?: { parent?: NodeId; index?: number; select?: boolean }
   ): NodeId;
+  /**
+   * Atomic insertion of a pre-authored SVG **fragment** — one or more
+   * sibling elements as markup (`"<g …><path …/></g>"`), or a full
+   * `<svg>` document whose element children are taken as the content
+   * (the `<svg>` shell — viewBox, width/height, prolog, doctype — is
+   * discarded; an `<svg>` that is one of several top-level elements is
+   * content and inserted as-is). The element subtrees are adopted
+   * verbatim — every byte of trivia inside each element survives
+   * (attribute order, quote styles, whitespace, comments) — inserted
+   * contiguously in source order at `opts.parent` / `opts.index`, and
+   * selected. ONE history step regardless of fragment size; a single
+   * `undo()` restores the exact pre-insert serialization. Returns the
+   * inserted top-level ids in document order.
+   *
+   * This is the markup-shaped sibling of {@link insert} — the primitive
+   * paste and asset-stamping flows compose. Use `insert` for a tag +
+   * attrs; use `insert_fragment` for markup.
+   *
+   * **Position is authored content.** There is deliberately no placement
+   * opt: to land a fragment at a document-space point, author the
+   * position into the markup before inserting — wrap it in
+   * `<g transform="translate(x y)">…</g>` or set the elements' own
+   * geometry attrs. Placement then round-trips as ordinary markup and
+   * the whole drop is the same single undo step.
+   *
+   * **`id` collisions:** authored `id=""` attributes are inserted
+   * verbatim, NEVER rewritten — silent id renaming is proprietary noise
+   * (P1; README "What clean means" §3). When a fragment id collides
+   * with an existing one, reference resolution (`url(#…)`, `href`)
+   * follows the document-order rules of the host renderer; resolving
+   * the duplication is the explicit Tidy command's job, not insertion's.
+   *
+   * **Namespaces:** when the fragment uses a prefix the document root
+   * doesn't declare, the declaration is hoisted onto the root as part
+   * of the same history step — `xlink` (well-known URI) and any prefix
+   * the discarded `<svg>` shell declared. A prefix whose URI is not
+   * discoverable is left as authored (the input was equally unbound as
+   * a standalone document). An authored root declaration always wins —
+   * never rebound.
+   *
+   * **Refusals:** an input with no top-level elements (empty /
+   * whitespace / comments-only) returns `[]` with NO history step.
+   * Throws on malformed markup (parser errors propagate), on a
+   * non-string input, and on an `opts.parent` that isn't a live element
+   * of the current document — a silent no-op there would hide consumer
+   * bugs (same stance as `serialize_node`).
+   *
+   * `opts.parent` defaults to root; `opts.index` (position in the
+   * parent's element-children list; the whole fragment lands
+   * contiguously at it) defaults to append; `opts.select` defaults to
+   * `true`.
+   */
+  insert_fragment(
+    svg: string,
+    opts?: { parent?: NodeId; index?: number; select?: boolean }
+  ): NodeId[];
   /**
    * Preview-bracketed insertion for drag-to-size gestures. Creates and
    * inserts the node immediately (so HUD selection chrome renders);
@@ -1744,6 +1800,20 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
    * win. `opts.parent` defaults to root; `opts.index` (insert-before
    * sibling index) defaults to append; `opts.select` defaults to `true`.
    */
+  /**
+   * Resolve an optional `index` (position in `parent`'s element-children
+   * list to insert AT — anything at or after it shifts; out-of-range or
+   * `undefined` appends) to an insert-before anchor. Shared by `insert`,
+   * `insert_fragment`, and `insert_preview`.
+   */
+  function resolve_insert_before(
+    parent: NodeId,
+    index: number | undefined
+  ): NodeId | null {
+    if (index === undefined) return null;
+    return doc.element_children_of(parent)[index] ?? null;
+  }
+
   function insert(
     tag: string,
     attrs: Readonly<Record<string, string>>,
@@ -1751,14 +1821,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   ): NodeId {
     const parent = opts?.parent ?? doc.root;
     const select_after = opts?.select !== false;
-    // Resolve insert-before from the optional `index`. `index` is the
-    // position in the parent's element-children list to insert AT —
-    // anything at or after that index gets shifted. `undefined` appends.
-    let insert_before: NodeId | null = null;
-    if (opts?.index !== undefined) {
-      const siblings = doc.element_children_of(parent);
-      insert_before = siblings[opts.index] ?? null;
-    }
+    const insert_before = resolve_insert_before(parent, opts?.index);
     const id = doc.create_element(tag);
     const merged_attrs: Record<string, string> = {
       ...default_paint_attrs_for(tag),
@@ -1783,6 +1846,76 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   }
 
   /**
+   * Atomic fragment insertion — contract in {@link Commands.insert_fragment}.
+   * Parses + adopts via `doc.create_fragment` (subtrees registered but
+   * detached, like `create_element` — history.redo finds them via
+   * closure), computes the namespace hoist plan, then brackets inserts +
+   * hoisted declarations + selection in ONE history step.
+   */
+  function insert_fragment(
+    svg: string,
+    opts?: { parent?: NodeId; index?: number; select?: boolean }
+  ): NodeId[] {
+    const parent = opts?.parent ?? doc.root;
+    if (!doc.is_element(parent) || !doc.contains(doc.root, parent)) {
+      throw new Error(
+        `insert_fragment: parent ${JSON.stringify(parent)} is not an element in the current document`
+      );
+    }
+    const select_after = opts?.select !== false;
+    const { roots, xmlns } = doc.create_fragment(svg);
+    if (roots.length === 0) return [];
+
+    // Namespace fidelity guard (same spirit as `retype_to_path`'s
+    // synthetic `fill="none"`). A fragment is not a standalone document —
+    // it may use prefixes whose declarations lived on a discarded
+    // ancestor. Inserting such content into a document whose root doesn't
+    // declare the prefix would serialize a namespace-ill-formed file that
+    // strict XML consumers reject wholesale. Hoist the declarations we
+    // can resolve: `xlink` (well-known URI) and anything the discarded
+    // `<svg>` shell declared. Their writes ride the same atomic step.
+    const known_uri = new Map<string, string>([["xlink", XLINK_NS]]);
+    for (const d of xmlns) known_uri.set(d.prefix, d.uri);
+    const hoist: Array<{ prefix: string; uri: string }> = [];
+    const considered = new Set<string>();
+    for (const id of roots) {
+      for (const prefix of doc.undeclared_ns_prefixes(id)) {
+        if (considered.has(prefix)) continue;
+        considered.add(prefix);
+        // An authored declaration on the root wins — never rebind.
+        if (doc.get_attr(doc.root, prefix, XMLNS_NS) !== null) continue;
+        const uri = known_uri.get(prefix);
+        // No discoverable URI → left as authored; the input was equally
+        // unbound as a standalone document.
+        if (uri === undefined) continue;
+        hoist.push({ prefix, uri });
+      }
+    }
+
+    const insert_before = resolve_insert_before(parent, opts?.index);
+    const previous_selection = selection;
+    const apply = () => {
+      for (const { prefix, uri } of hoist) doc.declare_xmlns(prefix, uri);
+      // Each root is inserted before the same anchor, in source order —
+      // the whole fragment lands contiguously, order preserved.
+      for (const id of roots) doc.insert(id, parent, insert_before);
+      if (select_after) set_selection(roots);
+    };
+    const revert = () => {
+      for (let i = roots.length - 1; i >= 0; i--) doc.remove(roots[i]);
+      for (const { prefix } of hoist) {
+        doc.set_attr(doc.root, prefix, null, XMLNS_NS);
+      }
+      if (select_after) set_selection(previous_selection);
+    };
+    apply();
+    history.atomic("insert fragment", (tx) => {
+      tx.push({ providerId: PROVIDER_ID, apply, revert });
+    });
+    return roots;
+  }
+
+  /**
    * Preview-bracketed insertion. Used by the pointer-driven drag gesture
    * in the DOM surface. Per-frame attr writes call `update(attrs)`; one
    * undo step on `commit()`; clean rollback on `discard()`.
@@ -1797,11 +1930,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     opts?: { parent?: NodeId; index?: number }
   ): InsertPreviewSession {
     const parent = opts?.parent ?? doc.root;
-    let insert_before: NodeId | null = null;
-    if (opts?.index !== undefined) {
-      const siblings = doc.element_children_of(parent);
-      insert_before = siblings[opts.index] ?? null;
-    }
+    const insert_before = resolve_insert_before(parent, opts?.index);
     const id = doc.create_element(tag);
     const previous_selection = selection;
 
@@ -2060,6 +2189,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     group,
     ungroup,
     insert,
+    insert_fragment,
     insert_preview,
     set_text,
     load_svg,


### PR DESCRIPTION
Closes #814.

## Producer — `@grida/svg-editor` 1.0.0-alpha.16

New command, the markup-shaped sibling of `insert` and the primitive clipboard paste will compose:

```ts
commands.insert_fragment(
  svg: string,
  opts?: { parent?: NodeId; index?: number; select?: boolean }
): NodeId[]
```

- Accepts a bare fragment (one or more sibling elements) or a full `<svg>` document — a lone top-level `<svg>` is a shell: its children become the content, the shell (viewBox, prolog, doctype) is discarded.
- Subtrees are adopted **byte-verbatim** (attribute order, quotes, whitespace, comments) and inserted contiguously as **one history step**; a single `undo()` restores the exact pre-insert serialization. Returns root ids in document order; selects them by default (consistent with `insert` / `insert_preview`).
- **Position is authored content** — deliberately no placement opt. A placement opt would force the editor to own an anchoring policy and a geometry dependency it can't honor headlessly. To land a fragment at a point, the caller authors `<g transform="translate(x y)">…</g>` around it and inserts once: exact placement, same single undo step, round-trips as ordinary markup.
- Authored `id`s are **never rewritten** (silent renaming is the noise this package refuses; dedup is the explicit Tidy command's charter). Resolvable undeclared namespace prefixes (`xlink`, shell-declared) are hoisted onto the root within the same step; authored root declarations are never rebound.
- Document layer: `SvgDocument.create_fragment` / `undeclared_ns_prefixes` / `declare_xmlns`; `set_attr`'s append path learned the `XMLNS_NS` prefix space.
- **29 new producer tests** (multi-element fragments, full-doc input, parent/index opts, id-collision policy, namespace hoisting, refusal behavior, positioning recipe) — package suite at 1158 green, typecheck clean. Version bumped to `1.0.0-alpha.16`.

## Consumer — SVG demos (dogfood)

- **`/svg/examples/default`** gains a **Library** floating window — the same icons.grida.co `IconsBrowser` the canvas playground mounts, with the same `x-grida-data-transfer` drag payload. Click inserts at the viewport center; dragging onto the canvas inserts centered at the drop point; both are a single undo step. The window is pure chrome: click and drag both hand the page an asset URL, and the page owns fetch, placement, and feedback.
- `fragment.ts` implements the positioning recipe consumer-side (string-level shell strip + viewBox-centered translate — string-level on purpose, so the asset's bytes survive verbatim), with colocated node tests.
- **`/packages/@grida/svg-editor`** gains a minimal **Fragment insertion** spec card: click-or-drag icon chips, the `<g transform>` recipe written out inline.
- `SvgShell` gains an optional `canvasOverlay` slot so floating chrome sits outside the canvas drop target.

## Verification

- Browser-verified on both pages: click-insert and drop-at-point land within 1px of target; one undo removes the whole insert; redo restores byte-identically.
- Stress-tested: 490+ scripted command sequences (insert/undo/redo/nudge/paint/group/rotate) comparing the rendered DOM against the serialized document after every op — no desync.
- `pnpm vitest run` (package): 1158/1158 · editor consumer tests green · oxfmt/oxlint clean.

## Follow-ups (out of scope, queued)

- Batch `doc.emit` in `insert_fragment`'s apply/revert (currently one emit per root/hoist, each triggering a gradient rescan on undo/redo) and reclaim adopted subtrees when their history entry is discarded.
- Pre-existing: `cleanup_text_edit` calls `render()` before clearing the render-skip flag (statically dead call; canvas heals on the next emit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click or drag-and-drop SVG fragment & icon insertion; visual library window for browsing/inserting icons; canvas overlay region to host the library.
  * Inserted fragments preserve authored markup, ids and positioning when placed.

* **Tests**
  * Extensive tests covering fragment parsing, positioning, insertion semantics, undo/redo and namespace handling.

* **Documentation**
  * Added public API command for fragment insertion.

* **Chores**
  * Bumped package version to 1.0.0-alpha.16
<!-- end of auto-generated comment: release notes by coderabbit.ai -->