### PR TITLE
@grida/svg-editor: make align idempotent — frame-correct deltas + flush-on-read geometry

### DIFF
--- a/packages/grida-svg-editor/__tests__/align-and-tree.test.ts
+++ b/packages/grida-svg-editor/__tests__/align-and-tree.test.ts
@@ -232,9 +232,11 @@ function op_mat(op: TransformOp): Mat {
         [1, 0, 0, 1, -op.cx, -op.cy]
       );
     }
-    default:
-      // skewX / skewY unused by these fixtures.
-      return MAT_IDENT;
+    case "skewX":
+    case "skewY":
+      // Unused by these fixtures — fail fast rather than silently model
+      // wrong geometry with an identity fallback.
+      throw new Error(`op_mat: unsupported transform op "${op.type}"`);
   }
 }
 

--- a/packages/grida-svg-editor/__tests__/align-and-tree.test.ts
+++ b/packages/grida-svg-editor/__tests__/align-and-tree.test.ts
@@ -6,7 +6,37 @@ import { describe, expect, it } from "vitest";
 import { createSvgEditor } from "../src/index";
 import type { SvgEditorInternal } from "../src/core/editor";
 import type { GeometryProvider } from "../src/core/geometry";
-import type { NodeId, Rect } from "../src/types";
+import { transform, type TransformOp } from "../src/core/transform";
+import type { NodeId, Rect, Vec2 } from "../src/types";
+
+/** Parse a `viewBox` attribute into a Rect (`null` when absent/malformed). */
+function viewbox_rect(vb: string | null): Rect | null {
+  if (!vb) return null;
+  const [x, y, w, h] = vb.split(/[\s,]+/).map(Number);
+  if (![x, y, w, h].every(Number.isFinite)) return null;
+  return { x, y, width: w, height: h };
+}
+
+/** AABB union — the shape the real DOM `getBBox` collapses to for a `<g>`. */
+function union_of_rects(rects: ReadonlyArray<Rect>): Rect {
+  const min_x = Math.min(...rects.map((r) => r.x));
+  const min_y = Math.min(...rects.map((r) => r.y));
+  const max_x = Math.max(...rects.map((r) => r.x + r.width));
+  const max_y = Math.max(...rects.map((r) => r.y + r.height));
+  return { x: min_x, y: min_y, width: max_x - min_x, height: max_y - min_y };
+}
+
+/** Internal NodeIds keyed by the authored `id` attribute. */
+function ids_by_attr(
+  editor: ReturnType<typeof createSvgEditor>
+): Map<string, NodeId> {
+  const out = new Map<string, NodeId>();
+  for (const [id] of editor.tree().nodes) {
+    const attr_id = editor.document.get_attr(id, "id");
+    if (attr_id) out.set(attr_id, id);
+  }
+  return out;
+}
 
 function install_rect_geometry(
   editor: ReturnType<typeof createSvgEditor>
@@ -31,36 +61,15 @@ function install_rect_geometry(
         };
       }
       if (tag === "svg") {
-        // Parse the viewBox so the root has a stable bbox for single-
-        // selection align tests.
-        const vb = doc.get_attr(id, "viewBox");
-        if (vb) {
-          const [x, y, w, h] = vb.split(/[\s,]+/).map(Number);
-          if ([x, y, w, h].every(Number.isFinite)) {
-            return { x, y, width: w, height: h };
-          }
-        }
-        return null;
+        // viewBox so the root has a stable bbox for single-selection align.
+        return viewbox_rect(doc.get_attr(id, "viewBox"));
       }
       if (tag === "g") {
-        // Union of element children — same shape the real DOM `getBBox`
-        // collapses to for a `<g>`.
         const kids = doc
           .element_children_of(id)
           .map((kid) => this.bounds_of(kid))
           .filter((b): b is Rect => b !== null);
-        if (kids.length === 0) return null;
-        let minX = Infinity;
-        let minY = Infinity;
-        let maxX = -Infinity;
-        let maxY = -Infinity;
-        for (const r of kids) {
-          if (r.x < minX) minX = r.x;
-          if (r.y < minY) minY = r.y;
-          if (r.x + r.width > maxX) maxX = r.x + r.width;
-          if (r.y + r.height > maxY) maxY = r.y + r.height;
-        }
-        return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+        return kids.length === 0 ? null : union_of_rects(kids);
       }
       return null;
     },
@@ -89,17 +98,8 @@ function rect_ids(editor: ReturnType<typeof createSvgEditor>): {
   B: NodeId;
   C: NodeId;
 } {
-  const tree = editor.tree();
-  const by_id_attr = new Map<string, NodeId>();
-  for (const [id] of tree.nodes) {
-    const attr_id = editor.document.get_attr(id, "id");
-    if (attr_id) by_id_attr.set(attr_id, id);
-  }
-  return {
-    A: by_id_attr.get("A")!,
-    B: by_id_attr.get("B")!,
-    C: by_id_attr.get("C")!,
-  };
+  const ids = ids_by_attr(editor);
+  return { A: ids.get("A")!, B: ids.get("B")!, C: ids.get("C")! };
 }
 
 // ─── align ───────────────────────────────────────────────────────────────────
@@ -184,6 +184,262 @@ describe("editor.commands.align", () => {
     editor.commands.select([A, B, C]);
     const before = editor.serialize();
     editor.commands.align("right");
+    expect(editor.serialize()).not.toBe(before);
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(before);
+  });
+});
+
+// ─── align under a transformed <g> ancestor (#795) ──────────────────────────
+//
+// The flat provider above reads raw attrs as world bounds, so `world ≡ own`
+// holds and the world→local projection gap is invisible. This provider is
+// faithful to the real DOM driver: `bounds_of` = own bbox × ancestor CTM
+// (`getBBox` + `getCTM`), and `world_delta_to_local` inverts the linear
+// part of the PARENT's CTM — the frame position attributes are written in.
+
+/** SVG 2×3 affine as the spec's `[a b c d e f]` column order:
+ *  point (x, y) ↦ (a·x + c·y + e, b·x + d·y + f). */
+type Mat = readonly [number, number, number, number, number, number];
+const MAT_IDENT: Mat = [1, 0, 0, 1, 0, 0];
+
+function mat_mul(m: Mat, n: Mat): Mat {
+  return [
+    m[0] * n[0] + m[2] * n[1],
+    m[1] * n[0] + m[3] * n[1],
+    m[0] * n[2] + m[2] * n[3],
+    m[1] * n[2] + m[3] * n[3],
+    m[0] * n[4] + m[2] * n[5] + m[4],
+    m[1] * n[4] + m[3] * n[5] + m[5],
+  ];
+}
+
+function op_mat(op: TransformOp): Mat {
+  switch (op.type) {
+    case "matrix":
+      return [op.a, op.b, op.c, op.d, op.e, op.f];
+    case "translate":
+      return [1, 0, 0, 1, op.tx, op.ty];
+    case "scale":
+      return [op.sx, 0, 0, op.sy, 0, 0];
+    case "rotate": {
+      // rotate(θ cx cy) ≡ translate(cx cy) rotate(θ) translate(-cx -cy)
+      const t = (op.angle * Math.PI) / 180;
+      const cos = Math.cos(t);
+      const sin = Math.sin(t);
+      return mat_mul(
+        mat_mul([1, 0, 0, 1, op.cx, op.cy], [cos, sin, -sin, cos, 0, 0]),
+        [1, 0, 0, 1, -op.cx, -op.cy]
+      );
+    }
+    default:
+      // skewX / skewY unused by these fixtures.
+      return MAT_IDENT;
+  }
+}
+
+/** AABB of `r`'s four corners under `m` — what `getBBox` × `getCTM`
+ *  collapses to. */
+function mat_project_rect(r: Rect, m: Mat): Rect {
+  const corners: ReadonlyArray<readonly [number, number]> = [
+    [r.x, r.y],
+    [r.x + r.width, r.y],
+    [r.x, r.y + r.height],
+    [r.x + r.width, r.y + r.height],
+  ];
+  const pts = corners.map(([x, y]) => [
+    m[0] * x + m[2] * y + m[4],
+    m[1] * x + m[3] * y + m[5],
+  ]);
+  const xs = pts.map((p) => p[0]);
+  const ys = pts.map((p) => p[1]);
+  const min_x = Math.min(...xs);
+  const min_y = Math.min(...ys);
+  return {
+    x: min_x,
+    y: min_y,
+    width: Math.max(...xs) - min_x,
+    height: Math.max(...ys) - min_y,
+  };
+}
+
+function install_ctm_geometry(
+  editor: ReturnType<typeof createSvgEditor>
+): void {
+  const internal = editor as SvgEditorInternal;
+  const doc = editor.document;
+  const num = (id: NodeId, name: string, fallback = 0) => {
+    const raw = doc.get_attr(id, name);
+    if (raw == null) return fallback;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) ? n : fallback;
+  };
+  // CTM from root user space down to `id`'s frame. `include_own` folds
+  // the node's own `transform` (bounds path); without it the result is
+  // the PARENT frame — the space `x`/`y` and a leading translate live in.
+  const ctm_of = (id: NodeId, include_own: boolean): Mat => {
+    const chain: NodeId[] = [];
+    let cur: NodeId | null = include_own ? id : doc.parent_of(id);
+    while (cur !== null) {
+      chain.unshift(cur);
+      cur = doc.parent_of(cur);
+    }
+    let m = MAT_IDENT;
+    for (const node of chain) {
+      const ops = transform.parse(doc.get_attr(node, "transform"));
+      if (!ops) continue;
+      for (const op of ops) m = mat_mul(m, op_mat(op));
+    }
+    return m;
+  };
+  const driver: GeometryProvider = {
+    bounds_of(id: NodeId): Rect | null {
+      const tag = doc.tag_of(id);
+      if (tag === "rect") {
+        const local = {
+          x: num(id, "x"),
+          y: num(id, "y"),
+          width: num(id, "width"),
+          height: num(id, "height"),
+        };
+        return mat_project_rect(local, ctm_of(id, true));
+      }
+      if (tag === "svg") {
+        return viewbox_rect(doc.get_attr(id, "viewBox"));
+      }
+      if (tag === "g") {
+        // Children's world bounds already fold the g's own transform.
+        const kids = doc
+          .element_children_of(id)
+          .map((kid) => this.bounds_of(kid))
+          .filter((b): b is Rect => b !== null);
+        return kids.length === 0 ? null : union_of_rects(kids);
+      }
+      return null;
+    },
+    bounds_of_many(ids) {
+      const out = new Map<NodeId, Rect>();
+      for (const id of ids) {
+        const r = this.bounds_of(id);
+        if (r) out.set(id, r);
+      }
+      return out;
+    },
+    nodes_in_rect: () => [],
+    node_at_point: () => null,
+    world_delta_to_local(id: NodeId, delta: Vec2): Vec2 {
+      const m = ctm_of(id, false);
+      const det = m[0] * m[3] - m[2] * m[1];
+      if (!Number.isFinite(det) || det === 0) return delta;
+      return {
+        x: (m[3] * delta.x - m[2] * delta.y) / det,
+        y: (-m[1] * delta.x + m[0] * delta.y) / det,
+      };
+    },
+  };
+  internal._internal.set_geometry(driver);
+}
+
+// The issue's minimal reproduction: two rects under <g transform="scale(2)">.
+// Pre-fix, align wrote world deltas into own-frame attrs — a 2× overshoot
+// the next align corrected in the opposite direction, forever.
+const SCALED_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+<g transform="scale(2)">
+<rect id="A" x="0"  y="0" width="10" height="10"/>
+<rect id="B" x="40" y="0" width="10" height="10"/>
+</g>
+</svg>`;
+
+describe("editor.commands.align — transformed <g> ancestor (#795)", () => {
+  it("scale(2) ancestor: lands exactly and the second align is a no-op", () => {
+    const editor = createSvgEditor({ svg: SCALED_SVG });
+    install_ctm_geometry(editor);
+    const ids = ids_by_attr(editor);
+    const A = ids.get("A")!;
+    const B = ids.get("B")!;
+    editor.commands.select([A, B]);
+
+    // World bboxes: A=(0,0,20,20), B=(80,0,20,20) → union center.x = 50.
+    // A needs +40 world = +20 local; B needs -40 world = -20 local.
+    expect(editor.commands.align("horizontal_centers")).toBe(true);
+    expect(editor.document.get_attr(A, "x")).toBe("20");
+    expect(editor.document.get_attr(B, "x")).toBe("20");
+
+    // Idempotent: every member is already at the target → zero deltas →
+    // align refuses. Pre-fix this oscillated A↔B forever.
+    const settled = editor.serialize();
+    expect(editor.commands.align("horizontal_centers")).toBe(false);
+    expect(editor.serialize()).toBe(settled);
+  });
+
+  it("scale(2) ancestor: align left converges in one step", () => {
+    const editor = createSvgEditor({ svg: SCALED_SVG });
+    install_ctm_geometry(editor);
+    const ids = ids_by_attr(editor);
+    const A = ids.get("A")!;
+    const B = ids.get("B")!;
+    editor.commands.select([A, B]);
+
+    // Union left edge is A's (world x=0). B moves -80 world = -40 local.
+    expect(editor.commands.align("left")).toBe(true);
+    expect(editor.document.get_attr(A, "x")).toBe("0");
+    expect(editor.document.get_attr(B, "x")).toBe("0");
+    expect(editor.commands.align("left")).toBe(false);
+  });
+
+  it("rotated ancestor: align settles instead of spiraling", () => {
+    // 90° rotation written as an exact integer matrix so the projected
+    // deltas stay bit-exact (rotate(θ) for θ ∤ 90 leaves float residue
+    // that would make the strict no-op assertion flaky).
+    const editor = createSvgEditor({
+      svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+<g transform="matrix(0 1 -1 0 0 0)">
+<rect id="A" x="0"  y="0" width="10" height="10"/>
+<rect id="B" x="40" y="0" width="10" height="10"/>
+</g>
+</svg>`,
+    });
+    install_ctm_geometry(editor);
+    const ids = ids_by_attr(editor);
+    const A = ids.get("A")!;
+    const B = ids.get("B")!;
+    editor.commands.select([A, B]);
+
+    // World bboxes: A=(-10,0,10,10), B=(-10,40,10,10) → union center.y=25.
+    // The world deltas are purely vertical (±20), but under the 90°
+    // ancestor they land on the members' local X axis: both x → 20.
+    // Pre-fix, writing the world dy into own-frame y moved the members
+    // horizontally in world space — never converging.
+    expect(editor.commands.align("vertical_centers")).toBe(true);
+    expect(editor.document.get_attr(A, "x")).toBe("20");
+    expect(editor.document.get_attr(B, "x")).toBe("20");
+
+    const settled = editor.serialize();
+    expect(editor.commands.align("vertical_centers")).toBe(false);
+    expect(editor.serialize()).toBe(settled);
+  });
+
+  it("single selection under a scaled <g>: aligns to the group, idempotent", () => {
+    const editor = createSvgEditor({ svg: SCALED_SVG });
+    install_ctm_geometry(editor);
+    const ids = ids_by_attr(editor);
+    const A = ids.get("A")!;
+    editor.commands.select(A);
+
+    // Parent <g> world bbox = (0,0,100,20). A's world right edge (20)
+    // → 100 needs +80 world = +40 local → x = 40.
+    expect(editor.commands.align("right")).toBe(true);
+    expect(editor.document.get_attr(A, "x")).toBe("40");
+    expect(editor.commands.align("right")).toBe(false);
+  });
+
+  it("undo restores byte-equal pre-align state under a scaled ancestor", () => {
+    const editor = createSvgEditor({ svg: SCALED_SVG });
+    install_ctm_geometry(editor);
+    const ids = ids_by_attr(editor);
+    editor.commands.select([ids.get("A")!, ids.get("B")!]);
+    const before = editor.serialize();
+    editor.commands.align("horizontal_centers");
     expect(editor.serialize()).not.toBe(before);
     editor.commands.undo();
     expect(editor.serialize()).toBe(before);

--- a/packages/grida-svg-editor/__tests__/geometry-stale-read.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/geometry-stale-read.browser.test.ts
@@ -1,0 +1,106 @@
+// Flush-on-read: live-DOM geometry reads must never observe (or cache) the
+// previous document's layout.
+//
+// The failure mode this pins (gridaco/grida#795, live-editor follow-up): the
+// geometry channel (`subscribe_geometry`) fires synchronously INSIDE a doc
+// mutation, before the surface's render listener projects the new attrs into
+// the live DOM. A subscriber that reads `editor.geometry.bounds_of(...)` from
+// that window — exactly what a `useSyncExternalStore` bounds hook does on its
+// snapshot check — used to read `getBBox()` off the stale DOM, and the
+// `MemoizedGeometryProvider` cached that rect as current. Every later
+// geometry consumer then planned against one-mutation-stale bounds: invoking
+// align repeatedly re-applied the PREVIOUS delta each time, so the element
+// marched/ping-ponged instead of settling. The fix: `SvgGeometryDriver`
+// flushes the pending render (`flush_dom`, revision-gated) before every
+// live-DOM read — the same model as CSS layout flushing on `offsetWidth`.
+//
+// Needs a real layout engine (`getBBox`); jsdom cannot observe this.
+
+import { describe, expect, it } from "vitest";
+import type { Rect } from "../src/types";
+import { attachSurface, nodeIdByName } from "./_browser-helpers";
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+<rect id="A" x="10" y="10" width="20" height="20"/>
+<rect id="B" x="50" y="40" width="20" height="20"/>
+</svg>`;
+
+/** Mirror of a React `useSyncExternalStore` bounds hook: reads bounds from
+ *  inside the geometry channel, where the store-changed check would run.
+ *  Returns the log of rects it observed. */
+function installPoisonReader(
+  editor: ReturnType<typeof attachSurface>["editor"],
+  id: string
+): Array<Rect | null> {
+  const seen: Array<Rect | null> = [];
+  editor.subscribe_geometry(() => {
+    seen.push(editor.geometry?.bounds_of(id) ?? null);
+  });
+  return seen;
+}
+
+describe("geometry flush-on-read — align stays idempotent under mid-mutation readers", () => {
+  it("single-selection align converges; repeat invocations are no-ops", () => {
+    const s = attachSurface(SVG);
+    try {
+      const A = nodeIdByName(s.editor, "A");
+      installPoisonReader(s.editor, A);
+      s.editor.commands.select(A);
+
+      // Parent is the root <svg> viewport (0 0 200 100); align right puts
+      // A's right edge at 200 → x = 180.
+      expect(s.editor.commands.align("right")).toBe(true);
+      expect(s.editor.document.get_attr(A, "x")).toBe("180");
+
+      // Pre-fix, the mid-mutation read cached A's PREVIOUS bounds, so this
+      // second call saw x=10, recomputed the same +170 delta, and marched
+      // the rect to x=350. It must refuse (zero delta) and change nothing.
+      const settled = s.editor.serialize();
+      expect(s.editor.commands.align("right")).toBe(false);
+      expect(s.editor.document.get_attr(A, "x")).toBe("180");
+      expect(s.editor.serialize()).toBe(settled);
+    } finally {
+      s.dispose();
+    }
+  });
+
+  it("multi-selection align settles instead of ping-ponging", () => {
+    const s = attachSurface(SVG);
+    try {
+      const A = nodeIdByName(s.editor, "A");
+      const B = nodeIdByName(s.editor, "B");
+      installPoisonReader(s.editor, A);
+      installPoisonReader(s.editor, B);
+      s.editor.commands.select([A, B]);
+
+      // Union x ∈ [10, 70], center 40. A (w=20) → x=30; B → x=30.
+      expect(s.editor.commands.align("horizontal_centers")).toBe(true);
+      expect(s.editor.document.get_attr(A, "x")).toBe("30");
+      expect(s.editor.document.get_attr(B, "x")).toBe("30");
+
+      const settled = s.editor.serialize();
+      expect(s.editor.commands.align("horizontal_centers")).toBe(false);
+      expect(s.editor.serialize()).toBe(settled);
+    } finally {
+      s.dispose();
+    }
+  });
+
+  it("a geometry-channel subscriber observes post-mutation bounds, not the previous layout", () => {
+    const s = attachSurface(SVG);
+    try {
+      const A = nodeIdByName(s.editor, "A");
+      const seen = installPoisonReader(s.editor, A);
+      s.editor.commands.select(A);
+      s.editor.commands.align("right");
+
+      // The reader fired from inside the mutation window. Flush-on-read
+      // means it must already see the post-align rect (x=180), never the
+      // pre-align x=10 layout.
+      expect(seen.length).toBeGreaterThan(0);
+      expect(seen[seen.length - 1]?.x).toBe(180);
+    } finally {
+      s.dispose();
+    }
+  });
+});

--- a/packages/grida-svg-editor/docs/geometry.md
+++ b/packages/grida-svg-editor/docs/geometry.md
@@ -46,6 +46,7 @@ interface GeometryProvider {
   bounds_of_many(ids: ReadonlyArray<NodeId>): Map<NodeId, Rect>;
   nodes_in_rect(rect: Rect): NodeId[];
   node_at_point(p: Vec2): NodeId | null;
+  world_delta_to_local?(id: NodeId, delta: Vec2): Vec2;
 }
 ```
 
@@ -70,7 +71,12 @@ the driver room to batch.
 | ------------------- | --------------------------------------------------------------------------------------------------- |
 | `structure_version` | tree shape changes, `id` writes, `set_text`                                                         |
 | `geometry_version`  | tree shape changes, `set_text`, writes to attributes in `GEOMETRY_ATTRS`, and DOM font-load settle† |
-| `doc_version`       | every mutation (including presentation writes)                                                      |
+| `revision`          | every mutation (including presentation writes)                                                      |
+
+All three live on `SvgDocument`. `revision` is the total order —
+surfaced as `EditorState.content_version`, it derives `dirty`, keys the
+typed-read memo caches, and gates the DOM surface's render flush (see
+§Flush-on-read below).
 
 `GEOMETRY_ATTRS` is the closed set of attribute names whose writes can
 shift bounds — `x`, `y`, `width`, `d`, `transform`, `font-size`, etc.
@@ -80,31 +86,55 @@ See [`src/core/document.ts`](../src/core/document.ts) for the full list.
 font-load settle (`document.fonts` `loadingdone`). The DOM surface drives
 it through `editor._internal.bump_geometry()` →
 `SvgDocument.bump_geometry()`, which advances `geometry_version` only — it
-does **not** bump `structure_version` / `doc_version`, mark the doc dirty,
+does **not** bump `structure_version` / `revision`, mark the doc dirty,
 or touch undo (a reflow is not an edit). See §Limitations "Text bbox
 depends on font".
 
 The `MemoizedGeometryProvider` subscribes to both `structure_version`
 and `geometry_version` and clears its cache on either. It does **not**
-subscribe to `doc_version` — a fill-color change does not invalidate
+subscribe to `revision` — a fill-color change does not invalidate
 bounds.
 
 ## Why caching is load-bearing
 
-The DOM surface re-renders the entire `<svg>` root on every editor
-tick (it calls `editor.serialize()` and `replaceWith`s the result).
-That means every editor tick replaces the DOM elements that
-`getBBox`/`getCTM` would read from.
+The DOM surface re-renders the entire `<svg>` root whenever the doc
+changed (it calls `editor.serialize()` and `replaceWith`s the result;
+the rebuild is gated on `revision`, so emits that carry no doc change
+— selection, tool — skip it). Every re-render replaces the DOM
+elements that `getBBox`/`getCTM` would read from.
 
-For idle editing this is fine — `render()` only fires on doc mutation.
-But during a drag, snap queries 50+ candidate node bounds per
-pointermove against a freshly-mounted tree, and without caching each
-call forces a synchronous layout flush. The memoizer makes the first
-read of a frame pay the layout cost; subsequent reads in the same
-frame are O(1).
+For idle editing this is fine — the rebuild only happens on doc
+mutation. But during a drag, snap queries 50+ candidate node bounds
+per pointermove against a freshly-mounted tree, and without caching
+each call forces a synchronous layout flush. The memoizer makes the
+first read of a frame pay the layout cost; subsequent reads in the
+same frame are O(1).
 
 The cache is keyed on `NodeId`, not on DOM element references —
-elements are replaced every tick, but ids persist.
+elements are replaced on every re-render, but ids persist.
+
+## Flush-on-read — reads never observe a stale render
+
+Doc listeners (`subscribe_geometry`, `editor.subscribe`) fire
+synchronously inside the mutation — before the surface's render
+listener has projected the new attrs into the live DOM. A geometry
+read issued from such a listener (a React `useSyncExternalStore`
+bounds hook, say) would otherwise read the PREVIOUS document's
+layout — and because the memoizer caches whatever the driver
+returns, that one stale read poisons every later consumer until the
+next invalidation: repeated `align` re-applies the previous delta
+and the selection oscillates instead of settling.
+
+So the driver flushes before every live-DOM read: each
+`SvgGeometryDriver` method (and the `getComputedStyle`-backed
+computed resolver) first calls the surface's `flush_dom()`, which
+re-renders iff `revision` is ahead of the last-rendered revision.
+Same model as CSS layout — reading `offsetWidth` flushes pending
+layout; reading `bounds_of` flushes the pending render. The contract
+is stated on the `GeometryProvider` interface (any future driver
+backed by a lazily-synced projection must honor it); the regression
+suite is
+[`geometry-stale-read.browser.test.ts`](../__tests__/geometry-stale-read.browser.test.ts).
 
 ## Show/hide uses `visibility`, not `display`
 

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -204,6 +204,8 @@ export class SvgDocument implements DocumentEvents {
    * stays the same and React skips the re-render of the whole tree.
    */
   private _structure_version = 0;
+  /** Total listener-visible mutation count. See the `revision` getter. */
+  private _revision = 0;
   /** Bumps on writes that can shift world-space bounds (`GEOMETRY_ATTRS`,
    *  `set_text`, `insert`, `remove`). Cache key for `GeometryProvider`;
    *  see ../../docs/geometry.md. */
@@ -270,6 +272,21 @@ export class SvgDocument implements DocumentEvents {
     return this._structure_version;
   }
 
+  /**
+   * Total mutation counter — advances on EVERY listener-visible mutation
+   * (attribute, style, text, topology, load/reset), unlike the selective
+   * `structure_version` / `geometry_version` channels. The single
+   * edit-version source: anything derived from this document — the
+   * editor's `content_version` / `dirty`, memoized reads, a rendered
+   * projection — answers "am I current?" by comparing values, with no
+   * event-ordering dependence. Advances BEFORE listeners fire, so a
+   * read issued from inside a change listener already sees the new
+   * value.
+   */
+  get revision(): number {
+    return this._revision;
+  }
+
   /** See `_geometry_version` for what this counter signals. */
   get geometry_version(): number {
     return this._geometry_version;
@@ -287,16 +304,16 @@ export class SvgDocument implements DocumentEvents {
    * settled glyph metrics. See ../../docs/geometry.md §Limitations.
    *
    * Deliberately does NOT call `emit()`: this is not a document edit, so
-   * it must not bump `doc_version` / mark the doc dirty / touch undo
-   * (the editor's `on_change` handler does all three). The editor's
-   * `_internal.bump_geometry` advances `geometry_version` here and fans
-   * out the geometry listeners itself.
+   * `revision` must not advance — no dirty flag, no undo, no render
+   * flush. The editor's `_internal.bump_geometry` advances
+   * `geometry_version` here and fans out the geometry listeners itself.
    */
   bump_geometry(): void {
     this._geometry_version++;
   }
 
   private emit() {
+    this._revision++;
     for (const fn of this.listeners) fn();
   }
 

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -49,6 +49,7 @@ import type {
   ReorderDirection,
   Tool,
   Unsubscribe,
+  Vec2,
 } from "../types";
 import { DEFAULT_STYLE, TOOL_CURSOR } from "../types";
 import { array_shallow_equal } from "../util/equal";
@@ -481,10 +482,11 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   let mode: Mode = "select";
   let tool: Tool = TOOL_CURSOR;
   let version = 0;
-  /** Document-edit counter — only bumps on actual mutations, not selection. */
-  let doc_version = 0;
-  /** doc_version at the last load()/serialize(); compared to derive `dirty`. */
-  let baseline_doc_version = 0;
+  /** `doc.revision` at the last load()/reset(); compared to derive `dirty`.
+   *  The doc's own total mutation counter is the single edit-version
+   *  source — `content_version`, `dirty`, and the typed-read memo caches
+   *  all derive from it (no editor-side shadow counter to drift). */
+  let baseline_revision = doc.revision;
   /**
    * Bumps once per `editor.load(svg)` call. The constructor's initial parse
    * does NOT count — it's the "factory" state. Hosts subscribe via
@@ -513,11 +515,11 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       scope,
       mode,
       tool,
-      dirty: doc_version !== baseline_doc_version,
+      dirty: doc.revision !== baseline_revision,
       can_undo: history.stack.canUndo,
       can_redo: history.stack.canRedo,
       version,
-      content_version: doc_version,
+      content_version: doc.revision,
       structure_version: doc.structure_version,
       geometry_version: doc.geometry_version,
       load_version,
@@ -558,11 +560,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   }
 
   doc.on_change(() => {
-    // Every doc mutation bumps doc_version; load()/serialize() snapshots it
-    // as the baseline for `dirty`.
-    doc_version++;
     // Fire the geometry channel only when the doc's geometry_version
     // advanced — pure presentation writes don't reach the geometry cache.
+    // (Edit counting lives on the doc itself: `doc.revision`.)
     fire_geometry_listeners_if_advanced();
   });
 
@@ -676,7 +676,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   // ─── Properties API ──────────────────────────────────────────────────────
   //
   // `node_paint` and `node_properties` return reference-stable snapshots:
-  // repeated reads at the same `doc_version` are O(1) cache hits; reads
+  // repeated reads at the same `doc.revision` are O(1) cache hits; reads
   // across mutations rebuild and structurally diff against the last
   // snapshot, returning the prior reference when the underlying values
   // didn't change.
@@ -686,15 +686,15 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
 
   const paint_cache = new Map<
     string,
-    { doc_version: number; value: PaintValue }
+    { revision: number; value: PaintValue }
   >();
   const property_cache = new Map<
     string,
-    { doc_version: number; value: ReadProperty }
+    { revision: number; value: ReadProperty }
   >();
   const properties_cache = new Map<
     string,
-    { doc_version: number; value: PropertyMap }
+    { revision: number; value: PropertyMap }
   >();
 
   // Tree snapshot cache — invalidated by `structure_version` only.
@@ -762,13 +762,13 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   function node_property_cached(id: NodeId, name: string): ReadProperty {
     const key = `${id} ${name}`;
     const cached = property_cache.get(key);
-    if (cached && cached.doc_version === doc_version) return cached.value;
+    if (cached && cached.revision === doc.revision) return cached.value;
     const next = properties.read(doc, id, name);
     if (cached && properties.value_equals(cached.value, next)) {
-      cached.doc_version = doc_version;
+      cached.revision = doc.revision;
       return cached.value;
     }
-    property_cache.set(key, { doc_version, value: next });
+    property_cache.set(key, { revision: doc.revision, value: next });
     return next;
   }
 
@@ -778,7 +778,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   ): PropertyMap {
     const key = `${id} ${names.join("")}`;
     const cached = properties_cache.get(key);
-    if (cached && cached.doc_version === doc_version) return cached.value;
+    if (cached && cached.revision === doc.revision) return cached.value;
     // Build via the per-(id,name) cache so the inner values are reference
     // stable too, not just the outer object.
     const next: { [name: string]: ReadProperty } = {};
@@ -789,18 +789,18 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       if (cached && cached.value[name] !== v) changed = true;
     }
     if (cached && !changed) {
-      cached.doc_version = doc_version;
+      cached.revision = doc.revision;
       return cached.value;
     }
     const frozen = Object.freeze(next) as PropertyMap;
-    properties_cache.set(key, { doc_version, value: frozen });
+    properties_cache.set(key, { revision: doc.revision, value: frozen });
     return frozen;
   }
 
   function node_paint(id: NodeId, channel: "fill" | "stroke"): PaintValue {
     const key = `${id} ${channel}`;
     const cached = paint_cache.get(key);
-    if (cached && cached.doc_version === doc_version) return cached.value;
+    if (cached && cached.revision === doc.revision) return cached.value;
     const { declared, provenance } = properties.resolve_declared(
       doc,
       id,
@@ -809,10 +809,10 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     const computed = paint.parse(declared);
     const next: PaintValue = { declared, computed, provenance };
     if (cached && paint.value_equals(cached.value, next)) {
-      cached.doc_version = doc_version;
+      cached.revision = doc.revision;
       return cached.value;
     }
-    paint_cache.set(key, { doc_version, value: next });
+    paint_cache.set(key, { revision: doc.revision, value: next });
     return next;
   }
 
@@ -927,6 +927,15 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     return { gradient_id };
   }
 
+  /** World→local delta projection shared by every one-shot translate
+   *  writer (translate / nudge via `prepare_rpc`, align). Re-expresses a
+   *  world-space delta in the frame the target's position attributes are
+   *  written in — nested-viewport / transformed-ancestor correctness.
+   *  Identity for flat docs and DOM-less hosts (no provider, or a
+   *  provider without a layout engine). */
+  const project_world_delta: translate_pipeline.DeltaProjector = (id, d) =>
+    geometry_provider?.world_delta_to_local?.(id, d) ?? d;
+
   /** Shared one-shot translate runner. `stages` selects semantics — see
    *  `core/translate-pipeline/README.md`'s "Stage lists per entry point". */
   function do_translate_oneshot(
@@ -949,10 +958,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       },
       emit,
       stages,
-      // Nested-viewport / transformed-ancestor correctness: write the delta
-      // in each mover's local frame. Identity for flat docs and DOM-less
-      // hosts (no provider, or a provider without a layout engine).
-      project: (id, d) => geometry_provider?.world_delta_to_local?.(id, d) ?? d,
+      project: project_world_delta,
     });
     apply();
     history.atomic(label, (tx) => {
@@ -1445,7 +1451,10 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
    * center of a reference rect. Same mechanics as `resize_to`: per-member
    * translate baselines (so `<g>`, transformed, and natively-attributed
    * nodes all write the cleanest in-place representation), one atomic
-   * history step.
+   * history step. Deltas are computed in world space and re-expressed in
+   * each member's local frame before writing (`world_delta_to_local`),
+   * so members under scaled/rotated ancestors land exactly and a repeat
+   * invocation is a no-op.
    *
    * Reference rect is selection-size dependent:
    *   - multi-selection: union of member bboxes
@@ -1495,8 +1504,18 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
 
     // `compute_align_deltas` omits zero-deltas — every entry in `deltas`
     // is a member that actually moves. No need to filter again.
-    const deltas = compute_align_deltas(members, target, direction);
-    if (deltas.size === 0) return false;
+    const world_deltas = compute_align_deltas(members, target, direction);
+    if (world_deltas.size === 0) return false;
+
+    // Deltas are world-space but `intent.apply` writes own-frame attrs —
+    // unprojected, a scaled/rotated ancestor turns every delta into an
+    // over/undershoot and repeated aligns oscillate instead of settling.
+    // Projected eagerly, not inside the closures, so redo replays the
+    // exact deltas even after the surface detaches.
+    const deltas = new Map<NodeId, Vec2>();
+    for (const [id, d] of world_deltas) {
+      deltas.set(id, project_world_delta(id, d));
+    }
 
     const apply = () => {
       for (const m of members) {
@@ -2143,7 +2162,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     mode = "select";
     tool = TOOL_CURSOR;
     history.clear();
-    baseline_doc_version = doc_version;
+    baseline_revision = doc.revision;
     load_version++;
     emit();
   }
@@ -2219,7 +2238,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     scope = null;
     mode = "select";
     tool = TOOL_CURSOR;
-    baseline_doc_version = doc_version;
+    baseline_revision = doc.revision;
     emit();
   }
 
@@ -2498,7 +2517,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
         // A surface-observed reflow the IR can't see (web font settled
         // after the font-* write). Advance ONLY the geometry channel:
         // `doc.bump_geometry()` advances `geometry_version` without
-        // emitting, so `doc_version` / `structure_version` / dirty / undo
+        // emitting, so `doc.revision` / `structure_version` / dirty / undo
         // stay put (a reflow is not an edit); then fan out the geometry
         // listeners so the MemoizedGeometryProvider cache clears.
         doc.bump_geometry();

--- a/packages/grida-svg-editor/src/core/geometry.ts
+++ b/packages/grida-svg-editor/src/core/geometry.ts
@@ -19,6 +19,19 @@ import type { NodeId, Rect, Unsubscribe, Vec2 } from "../types";
  * will query dozens of nodes per pointermove. The driver wraps SVG
  * `getBBox` + `getCTM`; the memoizer caches per-`NodeId` to survive
  * the surface re-rendering the SVG tree every editor tick.
+ *
+ * **Freshness contract.** Every read MUST reflect the CURRENT document
+ * — including when issued synchronously from inside a doc-change
+ * listener (`subscribe_geometry` fires mid-mutation, before any
+ * render). An implementation backed by a lazily-synced projection
+ * (e.g. a rendered DOM tree) must flush that projection before
+ * reading; compare `SvgDocument.revision` against the projection's
+ * last-rendered revision. Returning the previous document's geometry
+ * is not a transient glitch: the `MemoizedGeometryProvider` wrapper
+ * caches whatever the driver returns, so one stale read poisons every
+ * later consumer until the next invalidation (align/resize then plan
+ * against one-mutation-old bounds and oscillate — see
+ * `__tests__/geometry-stale-read.browser.test.ts`).
  */
 export interface GeometryProvider {
   /**

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -53,7 +53,7 @@ export interface SurfaceBridge {
    *  `font-size` write. Advances `geometry_version` by exactly 1 and fires
    *  `subscribe_geometry` listeners (clearing the `MemoizedGeometryProvider`
    *  cache) WITHOUT marking the doc dirty, advancing `structure_version` /
-   *  `doc_version`, or touching undo — a reflow is not an edit. The DOM
+   *  `revision`, or touching undo — a reflow is not an edit. The DOM
    *  surface drives this from a `document.fonts` `loadingdone` listener;
    *  see `src/dom.ts` and ../../docs/geometry.md §Limitations. */
   bump_geometry(): void;

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -310,6 +310,14 @@ class DomSurface implements Surface {
   private hud: HUDSurface;
   private teardown: Array<() => void> = [];
   private element_index = new Map<NodeId, SVGElement>();
+  /** `doc.revision` at the last completed `render()`. `-1` = never
+   *  rendered. Compared against the live revision by `flush_dom()` to
+   *  decide whether the rendered tree is a current projection of the IR —
+   *  pull-based on purpose: an event-driven dirty flag would depend on
+   *  listener registration order (the editor's own `doc.on_change` handler
+   *  fans out geometry listeners BEFORE any surface subscription would
+   *  run, and those listeners can re-enter reads). */
+  private rendered_doc_revision = -1;
   /** Last pointer position in container-local CSS px. Tracked separately from
    *  HUD hover so the measurement HUD can run its own hit-test that allows
    *  the `<svg>` root (which `hit_test` excludes for selection purposes).
@@ -803,7 +811,10 @@ class DomSurface implements Surface {
       this.hud.setVectorBendMode(
         this.current_tool.type === "bend" ? "always" : "auto"
       );
-      this.render();
+      // Revision-gated: a no-op when a flush-on-read (geometry driver /
+      // computed resolver) already projected this mutation, or when the
+      // emit carried no doc change (selection, tool, mode).
+      this.flush_dom();
       this.sync_surface_selection();
       // Sync pixel grid enabled state BEFORE sync_canvas_size — that call
       // re-paints the HUD internally and must see the latest flag. Cheap
@@ -935,13 +946,19 @@ class DomSurface implements Surface {
     // matching, `var()`, and inheritance — the cases the headless cascade
     // engine doesn't cover at v1.
     internal.set_computed_resolver({
+      // `flush_dom()` first: like the geometry driver, these read the live
+      // DOM as a proxy for document state, and a query from inside a doc-
+      // change listener would otherwise resolve against the pre-mutation
+      // cascade. See the staleness contract on `flush_dom`.
       computed_property: (id, name) => {
+        this.flush_dom();
         const el = this.element_index.get(id);
         if (!el) return null;
         const value = getComputedStyle(el).getPropertyValue(name);
         return value === "" ? null : value;
       },
       computed_paint: (id, channel) => {
+        this.flush_dom();
         const el = this.element_index.get(id);
         if (!el) return null;
         const computed = getComputedStyle(el).getPropertyValue(channel);
@@ -961,6 +978,7 @@ class DomSurface implements Surface {
       camera: () => this.camera,
       container: () => this.container,
       pick_at_world: (p, allow_root) => this._pick_node_at_world(p, allow_root),
+      flush: () => this.flush_dom(),
     });
     const geometry = new MemoizedGeometryProvider(driver, {
       subscribe_structure: (cb) =>
@@ -1221,10 +1239,34 @@ class DomSurface implements Surface {
 
   // ─── Render ──────────────────────────────────────────────────────────────
 
+  /**
+   * Bring the live DOM up to date with the doc IR iff it is stale.
+   *
+   * Staleness contract: anything that reads the LIVE DOM as a proxy for
+   * document state — the geometry driver (`getBBox` / `getCTM`), the
+   * computed-style resolver — MUST call this first. Doc listeners (the
+   * geometry channel, editor `subscribe`) fire synchronously inside the
+   * mutation, BEFORE the surface's render listener has projected the new
+   * attrs into the DOM; a read in that window returns the PREVIOUS
+   * geometry, and through `MemoizedGeometryProvider` it would be cached as
+   * if current — every later consumer (align, resize_to, snap) then plans
+   * against one-mutation-stale bounds. Same model as CSS layout: reading
+   * `offsetWidth` flushes pending layout; reading `bounds_of` flushes the
+   * pending render.
+   */
+  private flush_dom(): void {
+    if (this.rendered_doc_revision === this.editor._internal.doc.revision) {
+      return;
+    }
+    this.render();
+  }
+
   private render() {
     // During an active text-edit session the text element and its caret /
     // selection rect overlays are managed live by `SvgTextSurface`. Replacing
     // the SVG would yank them out. Skip the re-render until commit/cancel.
+    // (`rendered_doc_revision` is deliberately NOT stamped on this early
+    // return — the next `flush_dom()` after the session ends re-renders.)
     if (this.text_edit) return;
     const owner_doc = this.container.ownerDocument;
     const doc = this.editor._internal.doc;
@@ -1269,6 +1311,7 @@ class DomSurface implements Surface {
       }
     };
     tag_walk(new_svg);
+    this.rendered_doc_revision = doc.revision;
   }
 
   private sync_canvas_size() {
@@ -4700,12 +4743,23 @@ type GeometryAccessors = {
    *  fallback through one shared implementation. `allow_root` mirrors
    *  the surface-internal `pick_at` flag — see comment there. */
   pick_at_world(p: Vec2, allow_root: boolean): NodeId | null;
+  /** Re-render the live DOM from the doc IR iff it has unprojected
+   *  mutations (`DomSurface.flush_dom`). The driver calls this before
+   *  every live-DOM read so a query issued inside a doc-change listener —
+   *  i.e. after the IR mutated but before the surface's render listener
+   *  ran — cannot observe (and, via the memoizer, cache) the previous
+   *  document's layout. */
+  flush(): void;
 };
 
 class SvgGeometryDriver implements GeometryProvider {
   constructor(private readonly accessors: GeometryAccessors) {}
 
   bounds_of(id: NodeId): Rect | null {
+    // Before `element_for`: a pending render also replaces the element
+    // index, so resolving the element against a stale tree would hand
+    // back a detached node.
+    this.accessors.flush();
     const el = this.accessors.element_for(id);
     if (!el) return null;
 
@@ -4770,6 +4824,7 @@ class SvgGeometryDriver implements GeometryProvider {
   }
 
   nodes_in_rect(rect: Rect): NodeId[] {
+    this.accessors.flush();
     const root = this.accessors.root();
     if (!root) return [];
     const hits: NodeId[] = [];
@@ -4784,6 +4839,7 @@ class SvgGeometryDriver implements GeometryProvider {
   }
 
   node_at_point(p: Vec2): NodeId | null {
+    this.accessors.flush();
     return this.accessors.pick_at_world(p, true);
   }
 
@@ -4800,6 +4856,7 @@ class SvgGeometryDriver implements GeometryProvider {
    *  the local delta. Identity (→ delta unchanged) for flat frames,
    *  top-level nodes, and any degenerate / unavailable matrix. */
   world_delta_to_local(id: NodeId, delta: Vec2): Vec2 {
+    this.accessors.flush();
     const el = this.accessors.element_for(id);
     const parent = el?.parentNode;
     const root = this.accessors.root();


### PR DESCRIPTION
Fixes #795.

Repeated align invocations oscillated / looped instead of settling. Investigating against the live editor showed **two independent root causes sharing this one presentation** — the transformed-ancestor frame bug documented in the issue, and a geometry-cache staleness race that reproduces even in flat documents (this is what the `/svg/examples/default` repro actually hits). Both are fixed here, each at its own depth.

## Root cause 1 — world deltas written own-frame (the issue's etiology)

`align()` read world-space bboxes, computed world-space deltas, then handed them to the own-frame `translate_pipeline.intent.apply` — bypassing the `world_delta_to_local` projection the drag and nudge/RPC paths already use. Under a `<g transform="scale(2)">` ancestor every delta overshoots 2×, and successive aligns ping-pong forever.

**Ladder rung: call-site defect.** The contract (`DeltaProjector`) already existed; align ignored it. Fixed by projecting per-member deltas through a shared `project_world_delta` (typed as the pipeline's `DeltaProjector`) before `intent.apply` — projected eagerly so redo replays exact deltas even after the surface detaches.

## Root cause 2 — stale-read poisoning of the geometry cache

`subscribe_geometry` fires synchronously **inside** the doc mutation, before the surface's render listener projects the new attrs into the live DOM. A subscriber that reads `bounds_of` from that window (exactly what a React `useSyncExternalStore` bounds hook does on its snapshot check) read the *previous* document's layout off `getBBox()`, and `MemoizedGeometryProvider` cached it as current. Every later command then planned against one-mutation-stale bounds: each align re-applied the previous click's delta — move, phantom move, or endless ping-pong when alternating directions.

**Ladder rung: API-contract defect at the notify/flush seam** — any subscriber could poison the shared cache; fixing align alone would leave the class of bug. Fixed at the seam with **flush-on-read**, the same model as CSS layout flushing on an `offsetWidth` read:

- `SvgDocument` gains a `revision` counter (total mutation order, advances before listeners fire),
- the DOM surface gains a revision-gated `flush_dom()`,
- every live-DOM read (`SvgGeometryDriver` methods, the `getComputedStyle` resolver) flushes first.

Deliberately pull-based — an event-driven dirty flag would depend on listener registration order, which is the disease this fixes.

## SDK hygiene (review findings applied)

- The editor's shadow `doc_version` counter is **deleted**; `content_version`, `dirty`, and the typed-read memo caches all derive from `doc.revision` — one counter, two internal consumers, which is what earns it a public slot.
- The freshness contract ("reads must reflect the current document, even from inside a doc-change listener") is stated on the public `GeometryProvider` interface so future drivers inherit the rule.
- `docs/geometry.md` updated: `revision` in the version-bump table, a new *Flush-on-read* section, render-gating mechanics corrected.

## Coverage (all fail on the unfixed code)

- `align-and-tree.test.ts` — transformed-ancestor regression block over a CTM-faithful synthetic provider (deliberately independent matrix math so a shared bug can't cancel out): scale(2) convergence, exact-integer 90° rotation settling, single-selection align-to-parent, byte-equal undo.
- `geometry-stale-read.browser.test.ts` — real-Chromium suite installing a mid-mutation reader via public API: single- and multi-selection align idempotency, and the reader itself observing post-mutation bounds.

Full package suite (1163 headless + 13 browser) and repo typecheck (incl. the editor app consumer) are green. Verified in the live demo: align right ×4 and center-align ×2 settle after the first click.

## Out of scope

`commit_resize` (the `resize_to` path) writes its world-space group translate through the same projector-less `intent.apply` — the same bug family. Deliberately not bundled; tracked as a separate task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment/idempotency when elements live inside transformed ancestor groups (scaled/rotated); undo now restores pre-align state.

* **Documentation**
  * Clarified geometry provider contract, freshness guarantees, and document revision/versioning behavior.

* **Tests**
  * Added tests validating geometry flush-on-read behavior and alignment stability under mid-mutation readers and transformed ancestors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->