### PR TITLE
feat(svg-editor): clipboard copy/cut/paste — the payload is a standalone SVG document

### DIFF
--- a/docs/wg/feat-svg-editor/clipboard.md
+++ b/docs/wg/feat-svg-editor/clipboard.md
@@ -19,10 +19,13 @@ format: md
 
 # Clipboard — copy, cut, paste
 
-**Status:** Draft — pre-implementation. Revised after pedantic review
-(three independent passes: logical probes, bedrock verification, design
-probes); the review's blocking findings are folded in below as explicit
-policy rather than left implicit.
+**Status:** Implemented — the TypeScript SVG editor SDK ships this
+contract (commands, payload codec, native-event transport, provider
+seam). Revised after pedantic review (three independent passes: logical
+probes, bedrock verification, design probes) before implementation; the
+review's blocking findings are folded in below as explicit policy
+rather than left implicit. The named deferrals (§ Out of scope) remain
+open.
 
 This document specifies clipboard support for the SVG editor: what a
 copied selection becomes, what pasting accepts, how the payload moves

--- a/docs/wg/feat-svg-editor/clipboard.md
+++ b/docs/wg/feat-svg-editor/clipboard.md
@@ -1,0 +1,612 @@
+---
+title: "Clipboard — copy, cut, paste"
+description: "FRD for clipboard support in the SVG editor: the payload is a standalone SVG document, not a private format. Specifies the two extraction operations (standalone payload vs in-document clone), the five kinds of context a lifted subtree leaves behind and the policy for each, command and history semantics, placement, transport ownership, and the paste-is-load trust model."
+keywords:
+  - svg
+  - svg-editor
+  - clipboard
+  - copy
+  - paste
+  - cut
+  - fragment
+  - interop
+tags:
+  - internal
+  - svg
+  - wg
+format: md
+---
+
+# Clipboard — copy, cut, paste
+
+**Status:** Draft — pre-implementation. Revised after pedantic review
+(three independent passes: logical probes, bedrock verification, design
+probes); the review's blocking findings are folded in below as explicit
+policy rather than left implicit.
+
+This document specifies clipboard support for the SVG editor: what a
+copied selection becomes, what pasting accepts, how the payload moves
+between the editor and its host, and which guarantees survive the trip.
+It is written so a second implementer could honor the contract without
+reading the current implementation; where the contract deliberately
+leaves something open, the openness is named.
+
+## Thesis: the payload is the file format
+
+The editor's foundational stance is that the SVG file is sovereign — the
+bytes are the source of truth, and the editor maintains no private model
+the file is projected from. The clipboard inherits that stance directly:
+
+> **A clipboard payload is a standalone SVG document.**
+
+Not a JSON envelope, not a base64-encoded internal snapshot, not a
+versioned proprietary schema. The markup the user copies is the same kind
+of artifact as the file they are editing.
+
+This single decision does most of the design's work:
+
+- **No format to maintain.** A private envelope needs versioning,
+  migration, and documentation forever. SVG already has all three.
+- **Interop through the one channel peers actually share.** Plain SVG
+  markup as clipboard text is the only vector-interchange channel any
+  web-reachable peer reads. Concretely: Figma accepts pasted SVG markup
+  as editable vectors (with documented import losses — `marker` and
+  `pattern` are dropped) and emits markup via its explicit "Copy as
+  SVG" action; Inkscape reads SVG text from the clipboard. Acceptance
+  is not universal — Illustrator's clipboard interchange is PDF/AICB
+  and it does not ingest plain-text SVG — and almost no tool emits
+  markup on its _ordinary_ copy gesture. The honest claim is therefore:
+  this is the channel several peers read and the only one any of them
+  read; pasting our payload into a code editor always yields readable
+  source; pasting a peer's SVG export into us is indistinguishable from
+  pasting our own payload.
+- **Self-describing.** Any consumer that understands SVG understands the
+  payload — including consumers that do not exist yet, and including
+  machine authors (AI agents) for whom SVG markup is a native dialect.
+- **Honest fidelity.** For an editor whose in-memory model _is_ the
+  parsed file, markup-as-payload is lossless by construction. Editors
+  with private scene graphs cannot make this choice cheaply; this one
+  can, and not making it would quietly betray the editor's thesis.
+
+The cost of the decision is borne where it belongs: extraction. A subtree
+lifted out of a document leaves context behind, and the copy operation —
+not the payload format — must account for that. That contract is the
+heart of this document.
+
+## Vocabulary
+
+- **Payload** — the standalone SVG document produced by copy. Parses as
+  a complete, namespace-well-formed document in any SVG consumer.
+- **Fragment** — one or more sibling element subtrees expressed as
+  markup. A payload's content is a fragment; the payload adds the shell
+  that makes the fragment standalone.
+- **Context** — everything outside a subtree that affects its rendered
+  meaning. This document identifies five kinds (§ Extraction) plus one
+  inbound direction; the enumeration is the policy surface.
+- **Closure** — the set of elements, outside the copied subtrees, that
+  the subtrees reference and that the payload carries so it renders
+  standalone.
+- **Transport** — a channel that moves payload text between the editor
+  and the host or operating system clipboard. Transport moves text; it
+  never inspects or transforms it.
+- **In-place** — a paste placement policy where content lands at its
+  authored coordinates, unmodified.
+
+## Two extraction operations, not one
+
+Review surfaced that "the extraction contract" is two contracts wearing
+one name. This document names both and specifies the first:
+
+- **Payload extraction** — selection → standalone document. Carries the
+  closure and the namespace shell, because the destination is unknown
+  and must be assumed to share nothing with the source. This is what
+  copy produces. Specified here.
+- **Subtree clone** — selection → sibling subtrees within the _same_
+  document. Carries **no** closure and no shell: the destination is the
+  source, every reference still resolves, and carrying definitions
+  would deposit duplicates. This is what duplicate and clone-drag
+  gestures consume. Out of scope here; to be specified with those
+  gestures. The two operations share selection normalization and
+  verbatim subtree serialization — nothing else.
+
+Copy cannot know its destination, so it always performs payload
+extraction. The consequence — a payload pasted back into its own source
+document re-imports a closure the document already has — is specified,
+not hidden, in § Command semantics.
+
+## Requirements
+
+- **R1 — Copy always succeeds, with a defined floor.** Any non-empty
+  selection can be copied. There is no refusal path: unlike structural
+  operations (e.g. ungrouping a group that carries visual state), where
+  refusal is the honest answer, the copy gesture's contract with the
+  user is unconditional. "Succeeds" means, normatively: the payload is
+  assembled and written to the editor's internal buffer — that write
+  cannot fail. Delivery to external channels (native event data, the
+  host provider) is attempted per § Transport and MAY fail; such
+  failures are reportable to the host but do not constitute copy
+  failure. Where context cannot be carried faithfully, copy degrades by
+  the documented policies of § Extraction rather than refusing.
+- **R2 — Paste accepts markup, not just our markup.** Paste consumes any
+  parseable SVG input — a bare fragment or a full document. The editor's
+  own payloads are an ordinary case of this rule, not a privileged one.
+  There is no sniffing step that treats "our" content differently, and
+  therefore no paste-side behavior that depends on recognizing the
+  payload's origin.
+- **R3 — Same-document round-trip is exact, with a stated delta.**
+  Copying a selection and pasting it back into the same document
+  reproduces each selected subtree **byte-equal**. Trivia _within each
+  copied subtree_ — whitespace, attribute order, quoting, comments —
+  survives, because subtrees are serialized under the editor's
+  round-trip rules. Two things are deliberately outside this guarantee
+  and are stated rather than implied: (a) trivia _between_ selected
+  roots (a comment between two copied siblings) belongs to no selected
+  subtree and is not part of the selection; (b) the post-paste document
+  delta is the subtrees **plus the payload's carried closure block**,
+  and the insertion point follows § Placement — paste-back is byte-exact
+  per subtree, not diff-silent for the document.
+- **R4 — Authored ids are never rewritten.** Pasting content whose `id`
+  attributes collide with existing ones inserts them verbatim.
+  Duplicate ids are non-conforming SVG/XML, but their resolution is
+  well-defined and universal in practice: references resolve to the
+  first matching element in document order, in every host renderer.
+  Deduplication is the explicit cleanup command's job (Tidy), never a
+  silent side effect of paste. This extends the rule already
+  established for fragment insertion.
+- **R5 — History discipline.** Each user gesture is one undo step. Copy
+  touches no history. Cut's mutation is one step. Paste's insertion is
+  one step. Undo after cut restores the document; the clipboard is not
+  history-managed state and is unaffected by undo.
+- **R6 — Headless completeness and determinism.** Everything except
+  external transport delivery works without a rendering surface:
+  extraction, payload assembly, paste parsing, history. The payload is
+  a **pure function of (document, selection)** — the same selection
+  yields the same bytes headless or surface-attached. The clipboard's
+  correctness must be demonstrable in a unit test with no host
+  environment.
+- **R7 — The clipboard transport is a host seam; the payload is not.**
+  How payload text reaches the operating system clipboard is the
+  embedding product's concern, customizable by provider. What the
+  payload _is_ — its content, its assembly rules — is core: the editor
+  offers no payload-shaping configuration, because shaping options are
+  exactly the surface through which round-trip fidelity erodes. This is
+  a statement about the editor's option surface, not a tamper
+  guarantee: a host provider can mutate text in transit, and doing so
+  is the host's explicit act, outside the editor's guarantees
+  (§ Trust model).
+
+## Extraction: what leaks when a subtree leaves its document
+
+A subtree's rendered meaning depends on five kinds of context, plus one
+inbound direction. Each has a stated policy; "we didn't think about it"
+is the only wrong answer. Policies 1–2 carry context; 3–5 deliberately
+do not, by argument; the inbound direction cannot be carried at all.
+
+### 1. Referenced resources — carried, by a closed carrier list
+
+SVG externalizes paint servers, filters, clips, masks, and markers into
+referenced definitions (`url(#…)` in presentation values; `href` on
+referencing elements). A copied subtree that references a gradient
+renders unfilled without it.
+
+**Policy: copy includes the closure of referenced definitions, walked
+from a closed, enumerated carrier list.** The carriers walked in v1:
+
+- Presentation values carrying `url(#…)`: the paint channels (`fill`,
+  `stroke`), `filter`, `clip-path`, `mask`, and the marker properties
+  (`marker-start`, `marker-mid`, `marker-end`, and the `marker`
+  shorthand) — whether authored as a presentation attribute or as an
+  inline `style` declaration on the element.
+- Element references: `href` / `xlink:href` on referencing elements
+  (`use`, `textPath`, `mpath`, `feImage`, `pattern`, the gradient
+  elements' inheritance chains, and their kin).
+
+The walk is recursive (a gradient may reference another gradient; a
+filter may reference an image), resolves targets within the source
+document, and **excludes targets that already lie within the copied
+forest** — a referenced element that is itself a copied root or a
+descendant of one is already content, and carrying it again would
+duplicate it. The resulting set, deduplicated, is emitted verbatim into
+a single `defs` element in the payload. References that do not resolve
+in the source document are left as authored — the payload is no more
+broken than the source was.
+
+**Not walked in v1, named as documented degradations:** references
+carried inside `style` _elements_ (stylesheet rules within the copied
+subtree — walking them requires CSS parsing, which is the deliberately
+deferred cascade capability of policy 4, and entangling a solid layer
+with a deferred one is exactly what this document refuses to do); SMIL
+timing and value references (`begin="other.click"`, animated values
+naming `url(#…)`); `cursor`; SVG 2 text-layout properties
+(`shape-inside`, `shape-subtract`). A copied subtree depending on one of
+these carries the reference verbatim but not its target. The list of
+non-walked carriers is part of the contract: extending it is a spec
+change, not a bug fix.
+
+**The id-collision consequence, named.** When a carried definition's id
+collides with an id already present in the destination, document order
+decides which definition _all_ references — pasted and pre-existing —
+resolve to (R4). Under v1 placement (append at document top level,
+§ Placement), the destination's definition precedes the carried one and
+wins: the pasted content adopts the destination's same-named definition,
+and the carried copy is inert markup. This is accepted; Tidy is the
+recovery. A future placement that inserts _before_ existing content
+would invert the consequence (the carried definition would capture the
+destination's existing references) — any such placement design must
+re-confront this, by name.
+
+### 2. Namespace declarations — carried, including a deliberate repair
+
+Fragment serialization is honest about namespaces: a subtree using a
+prefixed attribute (`xlink:href`) does not invent the declaration its
+ancestor held. A standalone payload, however, must parse on its own —
+and an undeclared prefix is a namespace well-formedness _error_, not a
+degradation: leaving it unbound would break the payload's defining
+property.
+
+**Policy: the payload shell declares what the fragment uses.** For each
+copied root, prefixes used but not declared within the subtree are
+resolved against the source document's in-scope declarations, and — when
+the source itself never declared the prefix — against the well-known
+prefix table (`xlink` and kin). The latter is a **deliberate repair**:
+the payload can be _more_ well-formed than a broken source, because
+standalone parseability is constitutive of the payload where it is not
+constitutive of the source. Consequences, named: pasting such a payload
+back into its broken source document hoists the repaired declaration
+onto the destination root — a root-level diff produced by a content
+gesture; and pasting into a destination that binds the same prefix to a
+_different_ namespace leaves the destination's binding in authority
+(authored declarations are never rebound), silently re-meaning the
+pasted prefixed content. Both are edges of honest behavior, not bugs.
+
+This is the inverse of the hoisting that fragment insertion performs on
+paste — declarations harvested from a discarded shell are hoisted onto
+the destination root — so the two sides form a designed round-trip.
+
+### 3. Ancestor transforms — not carried, by argument
+
+A subtree under a scaled or rotated ancestor group has a world
+appearance its own markup does not encode. Two candidate policies:
+
+- **Verbatim:** copy the subtree as authored. Exactly right whenever
+  the paste destination supplies equivalent context — pasting back
+  under the same ancestor. Note honestly: v1 placement inserts at the
+  document top level, so v1's own same-document paste supplies
+  equivalent context only when the source already sat at top level; a
+  nested-context copy pasted in the same document _does_ shift
+  visually under v1.
+- **Materialize:** wrap the fragment in a synthesized group carrying
+  the accumulated ancestor transform. Correct for cross-context paste;
+  **double-applies** the moment content is pasted back under its
+  original ancestor (the flow a future scoped paste serves); and it
+  fabricates markup the user never authored.
+
+**Policy: verbatim — the lesser evil, not a free win.** Materialization
+breaks the paste-under-same-ancestor flow irreparably and violates the
+no-synthesized-noise principle; verbatim mis-places only the
+nested-source case and is exactly recoverable by the user (the content
+is selected after paste; a nudge or drag corrects it).
+Materialization remains a candidate _option_ for a future scoped-paste
+design, where the destination context is known and the correction is
+computable; it must not become a silent default.
+
+### 4. Inherited presentation and cascade — not carried, by argument
+
+A child of a group declaring `fill="red"` copied alone loses its red; an
+element styled by a stylesheet rule in the document loses the rule.
+Candidate policies mirror the transform case: verbatim, or materialize
+the inherited values onto the payload.
+
+**Policy: verbatim, with materialization as a designed future
+enhancement.** The same-context argument applies with equal force:
+pasting back under the same ancestor must not find inherited values
+duplicated onto the child, where they would shadow future edits to the
+ancestor. Materialization is _derivable_ when designed: the editor's
+property model reports, per property, whether the winning value was
+inherited rather than authored on the element — and at a copied root,
+"inherited" necessarily means "from outside the copied subtree," which
+is exactly the predicate a materializing copy needs. Stylesheet-derived
+values are **not** covered by that derivation (the cascade engine
+deliberately defers stylesheet matching), which is one reason
+materialization is out of v1 rather than in it.
+
+### 5. The viewport — not carried
+
+Percentage lengths (`width="50%"`), and anything else that resolves
+against the nearest SVG viewport, take their meaning from a context that
+is none of the above: the viewport established by the ancestor `svg`
+element's `viewBox` and sizing. **Policy: not carried.** The payload
+shell declares no viewport in v1 (see § Payload), so viewport-relative
+values in a pasted fragment resolve against the _destination's_
+viewport — same-document paste preserves meaning exactly; cross-document
+paste re-resolves, which is the nature of relative units. A
+viewport-bearing shell is a named enhancement (§ Placement names its
+sibling), and any future design must confront that a synthesized
+`viewBox` _changes_ viewport-relative meaning rather than preserving it.
+
+### Inbound references — cannot be carried
+
+The closure walk is outbound: it follows references _from_ the copied
+subtrees. References pointing _into_ the selection from outside — most
+concretely a SMIL animation element elsewhere in the document targeting
+a copied node by id — are not part of the copied subtrees, not carried,
+and the pasted copy is therefore inert with respect to them. This is a
+documented degradation, not an oversight: carrying inbound referents
+would drag arbitrary unrelated document content into the payload.
+
+## The payload, normatively
+
+A payload is assembled as follows. The assembly is deterministic (R6):
+no step consults the rendering surface, geometry, or the environment.
+
+1. **Normalize the selection.** If a selected node is a descendant of
+   another selected node, the ancestor's subtree subsumes it (the same
+   rule deletion uses). Roots are emitted in **document order**,
+   regardless of selection order — sibling order is paint order, and
+   paint order is meaning.
+2. **Serialize each root subtree verbatim** under the editor's
+   trivia-preserving serialization rules.
+3. **Collect the closure** (§ Extraction 1) and emit it, deduplicated
+   and verbatim, in one `defs` element preceding the content. If the
+   closure is empty, no `defs` element is emitted.
+4. **Assemble the shell:** a root `svg` element declaring the SVG
+   namespace and every resolved prefix the fragment requires
+   (§ Extraction 2), and nothing else — no viewport, no sizing, no
+   editor metadata. Roots are emitted contiguously in document order;
+   any byte sequence between them is insignificant (a consuming parser
+   treats top-level inter-element trivia as outside every subtree, and
+   the editor's own paste drops it).
+
+The result parses as a complete, namespace-well-formed SVG document in
+any conforming consumer. Pasting it back through the editor discards the
+shell, harvests its namespace declarations, and adopts the content — by
+the already-specified contract of fragment insertion.
+
+## Command semantics
+
+Three commands, with the identifiers the keybinding surface already
+reserves: `clipboard.copy`, `clipboard.cut`, `clipboard.paste`.
+
+- **Copy** — pure read. Assembles the payload from the current selection
+  and hands it to transport (§ Transport). No document mutation, no
+  history entry. A no-op (not an error) on empty selection. Success per
+  R1: the buffer write is the unconditional floor; external delivery is
+  best-effort and reportable.
+- **Cut** — copy, then delete. The deletion is the existing removal
+  semantics (ancestor-subsumption, exact restoration on undo) recorded
+  as one history step attributed to the cut gesture. The deletion
+  proceeds once the payload is secured in the internal buffer — which
+  cannot fail — so a failed _external_ write never strands the user
+  with deleted content and no copy: the buffer holds it, undo restores
+  it, and the failure is reportable. The clipboard write is not part of
+  the history step: undoing a cut restores the document and leaves the
+  clipboard holding the payload — the universal convention, and the
+  reason "cut, undo, paste" works as a move idiom.
+- **Paste** — a **synchronous** command over delivered text. The core
+  command takes payload text as input; _acquisition_ of that text —
+  from native event data, from an awaited provider read, or from the
+  internal buffer — is the invoking channel's job and completes before
+  the command runs. The core never holds in-flight transport state;
+  concurrency of acquisition is the invoking channel's concern. The
+  command parses and inserts as one atomic fragment insertion: one
+  history step, roots adopted verbatim, namespace hoisting included.
+  The inserted roots become the new selection — the user's next gesture
+  (nudge, drag, delete) targets what they just pasted.
+
+  **Paste's refusal table is its own, not fragment insertion's.**
+  Fragment insertion is an API whose caller authored the input —
+  malformed markup there is a caller bug and throws. Paste's input is
+  _environment-supplied_: prose, URLs, and JSON are what clipboards
+  hold most of the day. Normatively: input with no parseable top-level
+  element is a **no-op refusal** — no mutation, no history, observable
+  to the host as a refusal, never a thrown error — matching the
+  editor's command doctrine that commands which can't apply are no-ops.
+  Text explicitly delivered through the programmatic API keeps error
+  semantics, because there the caller authored the call.
+
+### Same-document paste: the carried closure, named
+
+Because copy performs payload extraction (it cannot know its
+destination) and paste adopts content verbatim (R2/R4 forbid recognizing
+or rewriting "our" payloads), pasting a def-referencing selection back
+into its source document **re-imports the closure**: the document gains
+a `defs` block duplicating definitions it already has, with colliding
+ids, of which the pre-existing one wins (§ Extraction 1). Cut-then-paste
+— the move idiom — does the same when the cut content referenced
+definitions that were not themselves selected. This is the accepted cost
+of one uniform paste rule and an unconditional copy; the alternatives
+were each worse, and are recorded in § Rejected alternatives. Tidy is
+the recovery: deduplicating defs is precisely its mandate. The
+in-document gestures that _should not_ pay this cost — duplicate,
+clone-drag — are exactly the consumers of the subtree-clone operation,
+which carries no closure (§ Two extraction operations).
+
+### Placement: in-place, appended (v1)
+
+Pasted content lands at its authored coordinates, inserted **at the
+document top level, appended after existing content, contiguously, in
+payload order**. The insertion point is normative because two
+consequences hang on it: which colliding definition wins (§ Extraction
+1), and paint order. In-place is exact in _coordinates_; in _paint
+order_, appended content renders on top — copying the bottom-most shape
+of an overlapping stack and pasting in place produces a byte-equal
+subtree at the same coordinates that now paints last. This is the
+behavior of every append-on-paste editor, and it is named here rather
+than absorbed into "exact."
+
+In-place is the only placement policy that is simultaneously: noise-free
+(no synthesized wrapper or rewritten coordinates), geometry-independent
+(works headless, R6), and coordinate-exact for the same-document
+round-trip (R3). Selection of the pasted roots makes the landing site
+visible even when it coincides with the source.
+
+Named enhancements, each requiring its own design pass: paste at pointer
+position and scoped paste (into the active isolation scope) — both must
+confront that landing content at a point requires either a synthesized
+wrapper group or rewritten coordinates, the two noises v1's policy
+exists to avoid; _which noise is acceptable is the open design
+question_, and "compose insertion with a position adjustment in one
+history step" is the mechanism, not the answer. Likewise collision
+offset for repeated paste, and a viewport-bearing shell (§ Extraction
+5). Nothing in the v1 contract forecloses any of them; none of them is
+implied to be free.
+
+## Transport
+
+Ownership is the contract here; the review found the draft left it
+ambiguous, so it is stated as a table:
+
+- **Core owns:** payload assembly (R7), the **internal buffer**, and
+  the **precedence rule** below. These are not customizable.
+- **The rendering surface owns:** wiring the host environment's native
+  clipboard events, and the gating discipline for them (below).
+- **The host owns:** the optional provider — an async text read and an
+  async text write, the seam the construction options already reserve —
+  and everything behind it (permission models, gesture-window
+  constraints, platform quirks).
+- **Channels are dumb pipes** (Vocabulary): no channel inspects or
+  transforms payload text. Precedence and fallback are core policy
+  _about_ channels, decided in exactly one place.
+
+**Write rule (copy/cut):** the internal buffer is always written. In
+addition, exactly **one** external channel is written per gesture: the
+native event's data transfer when the gesture arrived as a native
+clipboard event, else the provider when one is configured, else nothing.
+"Available" means exactly that order. (Dual-writing event data _and_ an
+async provider would race the OS clipboard against itself outside the
+gesture window; one gesture, one external write.)
+
+**Read rule (paste):** explicitly delivered text first (native event
+data, or a programmatic argument), else the provider when configured,
+else the internal buffer. **The buffer can be stale** relative to the OS
+clipboard: a host with no provider whose user copies in the editor, then
+copies elsewhere in the OS, then invokes paste from a menu (no native
+event) receives the editor's older buffer content, not the OS clipboard.
+This divergence is the documented cost of having no provider; hosts that
+expose menu-driven paste SHOULD configure one. The keystroke path is
+immune (the native event always delivers fresh text).
+
+**The native event path, with its real engine floor.** In a browser
+host, the user's copy/cut/paste keystrokes dispatch clipboard events in
+which the gesture itself is the permission — no prompts in any engine.
+Whether the events _fire at all_ over a canvas with no text selection is
+engine-dependent bedrock, checked: Chromium fires them against the
+focused element regardless of selection; Firefox has dispatched them
+unconditionally on the keystroke since ~2017 (Mozilla bug 846674, via
+1208217); WebKit derived copy from the text selection and fired nothing
+without one until **January 2025** (WebKit bug 156529, fixed) — the
+installed Safari base below that fix does not deliver copy/cut events to
+a selectionless canvas. The surface therefore treats the event path as
+primary _where it fires_ and MUST NOT treat it as the sole path; the
+provider and buffer are not conveniences but the working channel on
+older WebKit. (Implementations may also ensure a focusable element
+inside the surface holds focus, the established mitigation in canvas
+editors.)
+
+**Gating the native events.** Clipboard events are gated by a stricter
+predicate than the keyboard attention gate, because the cost asymmetry
+is different: a wrongly claimed keystroke costs a scroll; a wrongly
+claimed clipboard gesture destroys what the user believed they copied,
+or routes a paste meant for a host text field into the document.
+Normatively: the surface claims **copy/cut** only when focus is inside
+its container subtree AND no host text input is active AND the host
+document's text selection is empty; it claims **paste** only when focus
+is inside its container subtree AND the active element is not editable.
+Pointer-over-canvas alone — sufficient for the keyboard gate — does
+**not** claim clipboard gestures: a user with text selected in a sibling
+panel and the pointer idly over the canvas must get their text copy.
+While the editor's inline text editing is active, all three are inert
+(the text session owns the clipboard).
+
+**Host control over the native path.** Because native-event wiring is
+surface-owned, a host cannot interpose on it the way it can on the
+provider. The surface therefore exposes an option to **disable native
+clipboard transport**, routing all clipboard traffic through the
+provider seam — the configuration under which a host's paste-time
+screening (§ Trust model) governs every path, not just the secondary
+one.
+
+**Deliberate non-adoptions (v1).** A dedicated SVG media type on the
+asynchronous clipboard channel — single-engine support today
+(Chromium-line, since 124), and that engine sanitizes the channel,
+making it _lossy_ for a fidelity-first editor. An HTML-carrier envelope
+embedding an opaque payload — unnecessary where plain text is already
+lossless; that technique exists to smuggle private formats, which this
+design has none of. Pickled web-custom clipboard formats — single-engine
+and invisible to unmodified native applications. Each has a clean
+adoption path later if a concrete need arrives; none is load-bearing
+now.
+
+## Trust model
+
+**Paste is load-equivalent in trust, not in fidelity.** Pasting markup
+admits exactly what loading a file admits: the editor parses into its
+own model and preserves element content verbatim; nothing is executed by
+parsing. (The fidelity scope differs — load preserves a whole document
+including top-level prolog, comments, and processing instructions, while
+paste adopts top-level _elements_ only — but the _trust_ surface is
+identical.) The editor does not sanitize on paste — silently deleting or
+rewriting user content on the way in is a fidelity violation, and the
+clipboard is not a trust boundary the _document model_ can meaningfully
+police.
+
+The honest boundary is the rendering surface: a surface that interprets
+document markup in a privileged interpreter (mounting it into a live web
+page, where event-handler attributes and embedded foreign content can
+execute) has that exposure for _loaded_ documents already; paste changes
+the likelihood of hostile input — a keystroke now suffices where a file
+open was required — not the mechanism. **No rendering-surface hardening
+specification exists today; this paragraph is the tracking obligation.**
+Before clipboard ships in a surface that interprets markup in a
+privileged context, that surface's hardening posture must be specified
+and reviewed — inert rendering of execution-bearing constructs is a
+_projection_ choice, compatible with document fidelity (the model keeps
+the bytes; the surface declines to execute them), and is the expected
+shape of that work. A host that wants paste-time screening applies it on
+its side of the provider seam — made meaningful for _all_ paths by the
+native-transport opt-out (§ Transport) — where mutating text in transit
+is an explicit host choice rather than a silent editor behavior.
+
+## Rejected alternatives
+
+- **A private envelope format** (structured payload embedded in a rich
+  clipboard type, with markup as a downgraded fallback) — the standard
+  design for editors with private scene graphs. Rejected: this editor
+  has no private model to preserve, so the envelope would carry nothing
+  the markup doesn't, while costing a format contract, version
+  migrations, and the self-describing property.
+- **Id rewriting on paste** — rejected by R4. Collision-freedom is not
+  the editor's invariant to enforce silently; duplicate-id resolution
+  is well-defined in every host renderer, and explicit cleanup exists
+  for users who want uniqueness.
+- **Paste-side closure deduplication** (skipping carried definitions
+  whose id already resolves in the destination) — rejected: it is
+  content-sensitive mutation on ingest, requires recognizing "our"
+  payloads or second-guessing everyone's (violating R2's uniformity),
+  and silently drops elements the payload author shipped. The
+  duplicated-defs cost of § Command semantics is taken with eyes open
+  instead.
+- **Sanitize-on-paste as default** — rejected by the trust model.
+  Fidelity-preserving and silently-content-mutating are not
+  simultaneously satisfiable.
+- **Refusal on context loss** (refusing to copy selections whose
+  appearance depends on uncarried context) — rejected by R1. Refusal is
+  the right shape for operations that would otherwise _corrupt the
+  document_ (ungrouping a stateful group); copy corrupts nothing — its
+  degraded cases mis-render the _payload_, and the residual
+  destination-side costs (closure duplication, paint-order change) are
+  named in § Command semantics and § Placement rather than refused
+  away.
+
+## Out of scope (v1)
+
+Adjacent work this design deliberately enables but does not include: the
+**subtree-clone operation** and its consumers — duplicate and clone-drag
+gestures (§ Two extraction operations; they must not pay the closure
+cost, which is why they are a different operation, not a clipboard
+client); ingestion of peer tools' proprietary clipboard formats; pasting
+non-SVG content (plain text as a new text element, raster images);
+additional system-clipboard representations beyond plain text; the
+materializing variants of extraction policies 3 and 4; the
+viewport-bearing shell of policy 5; pointer-relative, scoped, and
+offset placement.

--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -65,6 +65,15 @@ preserving the author's source on round-trip.
   (byte-equal until the first re-typing edit), a single `<path>` target,
   and a cubic-Bézier conic representation, with the round-trip invariants
   that keep the conversion honest.
+- [`clipboard.md`](./clipboard.md) — FRD for copy/cut/paste. The
+  payload is a standalone SVG document, not a private format. Names two
+  extraction operations (standalone payload vs in-document clone) and
+  the five kinds of context a lifted subtree leaves behind (references
+  and namespaces carried; transforms, cascade, and viewport verbatim by
+  argument), with the same-document closure-duplication cost stated
+  rather than hidden. Also: command/history semantics, in-place
+  appended placement, transport ownership and the engine floor for
+  native clipboard events, and the paste-is-load trust model.
 - [`durable-node-identity.md`](./durable-node-identity.md) — the open
   problem behind #775: `NodeId` is parse-ephemeral, so no reference
   survives a `load()`, let alone an external rewrite of the file. Frames

--- a/editor/app/(canvas)/svg/_components/svg-menu.tsx
+++ b/editor/app/(canvas)/svg/_components/svg-menu.tsx
@@ -32,19 +32,28 @@ import { toggleInspectorDebug, useInspectorDebug } from "./use-inspector-debug";
 export function SvgMenuContent({
   canUndo,
   canRedo,
+  canCopy,
   onOpenFile,
   onSaveFile,
   onReset,
   onUndo,
   onRedo,
+  onCopy,
+  onCut,
+  onPaste,
 }: {
   canUndo: boolean;
   canRedo: boolean;
+  /** Selection non-empty — gates Cut / Copy (Paste reads the clipboard). */
+  canCopy: boolean;
   onOpenFile: () => void;
   onSaveFile: () => void;
   onReset: () => void;
   onUndo: () => void;
   onRedo: () => void;
+  onCopy: () => void;
+  onCut: () => void;
+  onPaste: () => void;
 }) {
   const debug = useInspectorDebug();
   return (
@@ -89,6 +98,27 @@ export function SvgMenuContent({
           >
             Redo
             <DropdownMenuShortcut>⇧⌘Z</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={onCut}
+            disabled={!canCopy}
+            className="text-xs"
+          >
+            Cut
+            <DropdownMenuShortcut>⌘X</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={onCopy}
+            disabled={!canCopy}
+            className="text-xs"
+          >
+            Copy
+            <DropdownMenuShortcut>⌘C</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onPaste} className="text-xs">
+            Paste
+            <DropdownMenuShortcut>⌘V</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuSubContent>
       </DropdownMenuSub>

--- a/editor/app/(canvas)/svg/_components/svg-shell.tsx
+++ b/editor/app/(canvas)/svg/_components/svg-shell.tsx
@@ -8,6 +8,7 @@ import {
   useCanUndo,
   useCommands,
   useEditorSerialize,
+  useEditorState,
   useSvgEditor,
 } from "@grida/svg-editor/react";
 import type { SvgEditor } from "@grida/svg-editor";
@@ -88,6 +89,7 @@ export function SvgShell({
   const editor = useSvgEditor();
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();
+  const hasSelection = useEditorState((s) => s.selection.length > 0);
   const cmd = useCommands();
   const serialize = useEditorSerialize();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -149,11 +151,20 @@ export function SvgShell({
             <SvgMenuContent
               canUndo={canUndo}
               canRedo={canRedo}
+              canCopy={hasSelection}
               onOpenFile={() => fileInputRef.current?.click()}
               onSaveFile={saveSvg}
               onReset={onReset}
               onUndo={() => cmd.undo()}
               onRedo={() => cmd.redo()}
+              // Menu items route through the command REGISTRY (not the
+              // bare commands) — this is the provider/RPC acquisition
+              // path the keystroke flow never exercises: copy/cut write
+              // navigator.clipboard via the route's ClipboardProvider,
+              // paste reads it (see route-shell.tsx).
+              onCopy={() => cmd.invoke("clipboard.copy")}
+              onCut={() => cmd.invoke("clipboard.cut")}
+              onPaste={() => cmd.invoke("clipboard.paste")}
             />
           </DropdownMenu>
           <span className="font-bold text-xs">{title}</span>

--- a/editor/app/(canvas)/svg/_storage/route-shell.tsx
+++ b/editor/app/(canvas)/svg/_storage/route-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useSyncExternalStore, type PropsWithChildren } from "react";
 import { SvgEditorProvider } from "@grida/svg-editor/react";
+import type { Providers } from "@grida/svg-editor";
 import {
   FloatingWindowBounds,
   FloatingWindowHost,
@@ -48,6 +49,21 @@ export function SvgRouteShell({
   );
 }
 
+/**
+ * `navigator.clipboard`-backed ClipboardProvider — the host-owned
+ * transport seam (P2) for menu / RPC-invoked clipboard commands
+ * (`clipboard.copy` / `cut` / `paste` via the command registry). The
+ * keystroke path never touches this: ⌘C/⌘X/⌘V reach the editor as native
+ * ClipboardEvents wired by the DOM surface. A denied read resolves to
+ * `null` (the command treats it as an empty clipboard, not an error).
+ */
+const demo_providers: Providers = {
+  clipboard: {
+    write: (text) => navigator.clipboard.writeText(text),
+    read: () => navigator.clipboard.readText().catch(() => null),
+  },
+};
+
 function ActiveDocMount({ children }: PropsWithChildren) {
   const store = useSvgDocStore();
   const activeId = useSyncExternalStore(
@@ -58,7 +74,11 @@ function ActiveDocMount({ children }: PropsWithChildren) {
   const initialSvg = store.getActiveSvg();
 
   return (
-    <SvgEditorProvider key={activeId ?? "__pending__"} initialSvg={initialSvg}>
+    <SvgEditorProvider
+      key={activeId ?? "__pending__"}
+      initialSvg={initialSvg}
+      providers={demo_providers}
+    >
       <EditorBindingEffect />
       {children}
     </SvgEditorProvider>

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -642,6 +642,25 @@ editor.commands.{
                                       // groups with visual state — see TODO §10)
   remove(): void;
 
+  // clipboard — the payload is a STANDALONE SVG DOCUMENT, not a private
+  // format (the file is the IR, so the clipboard is the file format).
+  // Copy carries the outbound url(#…)/href reference closure in one
+  // <defs> block and declares borrowed xmlns prefixes on the payload
+  // shell; ancestor transforms / inherited presentation / viewport are
+  // deliberately NOT carried (verbatim policy). Cut = copy + remove as
+  // ONE history step labeled "cut"; undo restores the document and the
+  // clipboard keeps the payload (cut → undo → paste = move). Paste is
+  // synchronous over delivered text (`text ?? internal buffer`) and has
+  // a gesture-grade refusal table: non-parseable environment input is a
+  // no-op `[]`, never a throw (insert_fragment keeps strict semantics).
+  // System-clipboard wiring is the DOM surface's native ClipboardEvent
+  // transport (text/plain = the markup itself) plus the optional
+  // ClipboardProvider seam. Full contract:
+  // https://grida.co/docs/wg/feat-svg-editor/clipboard
+  copy(): string | null;              // payload | null on empty selection; no history
+  cut(): string | null;               // one undoable step; buffer secured before delete
+  paste(text?: string): NodeId[];     // inserted roots (selected); [] = refusal
+
   // insertion — `tag` is an open string (so paste / RPC can create any element,
   // e.g. "path"); only the closed `InsertableTag` set gets a pointer-driven
   // draw gesture and default paint.

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -307,7 +307,8 @@ Still open (deferred by the FRD, tracked here):
 - **Subtree clone** — the closure-free in-document extraction operation
   that duplicate (`⌘D`, §5 alt-drag clone) consumes. A different
   contract from payload extraction (carrying the closure in-document
-  would deposit duplicate defs); needs its own spec pass.
+  would deposit duplicate defs); needs its own spec pass. Tracked:
+  [#817](https://github.com/gridaco/grida/issues/817).
 - **Paste placement enhancements** — paste-at-pointer, collision
   offset, scoped paste (each must confront wrapper-vs-rewrite noise).
 - **Materializing extraction variants** — ancestor-transform bake and
@@ -323,9 +324,13 @@ Still open (deferred by the FRD, tracked here):
 
 ### 5. Alt-drag (translate with clone)
 
+Tracked: [#817](https://github.com/gridaco/grida/issues/817).
+
 Hold Alt during a translate gesture to clone the selected nodes and move
 the clone. Interaction with history (one undo step for clone + move?),
-group semantics, defs duplication.
+group semantics, defs duplication — note the clipboard FRD's verdict:
+this consumes the **subtree-clone** operation (no defs closure), not
+the clipboard's payload extraction.
 
 Current implementation notes:
 

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -273,41 +273,53 @@ Open:
 
 ### 4. Copy / paste
 
-Document-internal copy of selected elements. Clipboard format, defs
-reference handling, paste position, multi-document support.
+**Shipped.** Spec: [`docs/wg/feat-svg-editor/clipboard.md`](../../docs/wg/feat-svg-editor/clipboard.md)
+(FRD — payload = standalone SVG document; extraction policies for the
+five context kinds; command/refusal semantics; transport ownership;
+trust model).
 
-Current implementation notes:
+What shipped:
 
-- **Insertion-side primitive shipped.** `commands.insert_fragment(svg, opts)`
-  is the markup-shaped atomic insert that paste composes: parses a bare
-  fragment or a full `<svg>` doc (shell discarded, children taken), adopts
-  subtrees verbatim (authored `id`s NEVER rewritten — dedup stays Tidy's
-  job), hoists resolvable undeclared `xmlns:*` prefixes onto the root, ONE
-  history step, roots returned in document order. Backed by
-  `SvgDocument.create_fragment` / `undeclared_ns_prefixes` /
-  `declare_xmlns` (`core/document.ts`). Remaining paste work is the list
-  below — clipboard wiring, copy-side defs dependency walking, command ids
-  and keymap bindings.
-- Not implemented. No `clipboard.copy` / `clipboard.cut` / `clipboard.paste`
-  command id is registered (`commands/defaults.ts`) and no keymap binding
-  exists for them (`keymap/defaults.ts`).
-- A `ClipboardProvider` interface is declared in `types.ts` with
-  `read(): Promise<string | null>` / `write(text: string): Promise<void>`
-  and surfaced via `Providers.clipboard` on `CreateSvgEditorOptions.providers`,
-  but no editor code reads `providers.clipboard` today — it's just a
-  reserved slot.
-- No ID-regeneration helper exists. `parser.ts:fresh_id` generates IDs at
-  parse time only; `doc.create_element` (used by `selection.group`) makes
-  a new `data-grida-id`, not a new SVG `id` attribute.
-- No `<defs>` dependency walker. `defs` registry in `core/defs.ts` only
-  tracks gradients (`upsert`); no traversal of `url(#…)` / `href` refs in
-  a copied subtree.
-- `docs/keybindings.md` lists Cut/Copy/Paste/Duplicate as `[~]` "command doesn't
-  exist yet" and pins the clipboard model as TBD.
-- Entry points to add: a new `commands/clipboard.ts` (or extend
-  `commands/defaults.ts`), bindings in `keymap/defaults.ts`, and a
-  subtree-clone helper in `core/document.ts` (no equivalent exists today
-  beyond `create_element` + per-attr copy).
+- **Core codec** — `core/clipboard.ts:extract_payload` (selection →
+  standalone document: normalization, closed-carrier-list reference
+  closure with cycle guard + forest exclusion, xmlns shell with
+  well-known repair, deterministic, headless).
+- **Commands** — `commands.copy()` / `cut()` / `paste(text?)` on the
+  public surface; internal buffer as the transport floor; provider
+  write-through; cut as one history step labeled `"cut"`; paste's
+  gesture-grade refusal table (junk environment input → `[]`, never a
+  throw).
+- **Registry ids** — `clipboard.copy` / `cut` / `paste` registered
+  (`commands/defaults.ts`), `select`-mode gated; deliberately NO keymap
+  rows (native ClipboardEvents are the binding — a keymap claim would
+  `preventDefault` the keystroke and suppress the event's generation).
+- **DOM surface transport** — `copy`/`cut`/`paste` listeners on the
+  owner document behind a focus-only clipboard gate
+  (`claims_clipboard`, stricter than keyboard attention); container
+  focus management (`tabIndex = -1`, focus on pointerdown); the
+  `DomSurfaceOptions.clipboard: false` native-transport opt-out.
+- Tests: `__tests__/clipboard-extract.test.ts`,
+  `clipboard-commands.test.ts`, `clipboard.browser.test.ts`; manual TC
+  `test/svg-editor-clipboard.md`.
+
+Still open (deferred by the FRD, tracked here):
+
+- **Subtree clone** — the closure-free in-document extraction operation
+  that duplicate (`⌘D`, §5 alt-drag clone) consumes. A different
+  contract from payload extraction (carrying the closure in-document
+  would deposit duplicate defs); needs its own spec pass.
+- **Paste placement enhancements** — paste-at-pointer, collision
+  offset, scoped paste (each must confront wrapper-vs-rewrite noise).
+- **Materializing extraction variants** — ancestor-transform bake and
+  inherited-presentation capture (provenance-driven).
+- **Non-walked carriers** — `<style>` element rules (blocked on the
+  cascade engine's stylesheet matching), SMIL timing/value refs,
+  `cursor`, SVG 2 text-layout properties.
+- **Peer-format ingestion** (e.g. Figma's binary clipboard) and
+  non-SVG paste (plain text → `<text>`, raster images).
+- **Rendering-surface hardening** — the FRD trust-model's tracking
+  obligation; the `innerHTML` mount executes `on*` attrs for loaded
+  AND pasted content alike. Separate, security-reviewed work item.
 
 ### 5. Alt-drag (translate with clone)
 

--- a/packages/grida-svg-editor/__tests__/_browser-helpers.ts
+++ b/packages/grida-svg-editor/__tests__/_browser-helpers.ts
@@ -31,7 +31,10 @@ export type AttachedSurface = {
  * This is the gesture path's real entry point: the surface installs pointer
  * handlers, so {@link dragByClient} drives the actual translate/snap pipeline.
  */
-export function attachSurface(svgText: string): AttachedSurface {
+export function attachSurface(
+  svgText: string,
+  opts?: { clipboard?: boolean }
+): AttachedSurface {
   const container = document.createElement("div");
   // Pin to the top-left of the viewport with a concrete size so client
   // coordinates equal world coordinates under the identity camera.
@@ -52,6 +55,7 @@ export function attachSurface(svgText: string): AttachedSurface {
     container,
     gestures: true,
     fit: false,
+    clipboard: opts?.clipboard,
   });
 
   const elementByName = (name: string): SVGGraphicsElement => {

--- a/packages/grida-svg-editor/__tests__/clipboard-commands.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard-commands.test.ts
@@ -273,6 +273,20 @@ describe("clipboard.* registry handlers", () => {
     expect(editor.serialize()).toContain(`<circle r="3"/>`);
   });
 
+  it("paste handler prefers explicitly delivered args.text over the provider", async () => {
+    const { provider } = fake_provider({ read: `<rect width="9"/>` });
+    const editor = createSvgEditor({
+      svg: WITH_RECT,
+      providers: { clipboard: provider },
+    });
+    expect(
+      editor.commands.invoke("clipboard.paste", { text: `<circle r="7"/>` })
+    ).toBe(true);
+    expect(editor.serialize()).toContain(`<circle r="7"/>`);
+    await tick();
+    expect(provider.read).not.toHaveBeenCalled();
+  });
+
   it("paste handler falls back to the buffer with honest chain semantics", () => {
     const editor = createSvgEditor({ svg: WITH_RECT });
     // Empty buffer → false (chain may keep going).

--- a/packages/grida-svg-editor/__tests__/clipboard-commands.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard-commands.test.ts
@@ -1,0 +1,285 @@
+// Headless tests for `commands.copy` / `commands.cut` / `commands.paste`
+// and the `clipboard.*` registry handlers. Contract:
+// docs/wg/feat-svg-editor/clipboard.md §Command semantics / §Transport.
+//
+//   - copy: pure read (no history, no content_version bump); buffer is the
+//     unconditional success floor; provider delivery is best-effort.
+//   - cut: ONE history step labeled "cut"; undo restores byte-equal; the
+//     buffer survives undo (cut → undo → paste = move idiom).
+//   - paste: sync over delivered text (arg wins over buffer); gesture-
+//     grade refusal table — junk / malformed input is a no-op `[]`, never
+//     a throw; non-string arg throws TypeError; same-document round-trip
+//     is byte-equal per subtree PLUS the carried closure (the accepted
+//     cost, asserted rather than hidden); ids verbatim; appended last;
+//     pasted roots selected; ONE undo removes the whole paste including
+//     hoisted xmlns.
+//   - registry: ids registered; `select`-mode gate; paste routing
+//     (provider-async when configured, buffer-sync otherwise).
+
+import { describe, expect, it, vi } from "vitest";
+import { createSvgEditor } from "../src/index";
+import { createSvgEditorWithInternals, first_rect } from "./_helpers";
+import type { ClipboardProvider } from "../src/types";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const WITH_RECT = `<svg xmlns="${SVG_NS}" viewBox="0 0 100 100"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`;
+const WITH_GRADIENT =
+  `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs>` +
+  `<rect id="base" fill="url(#g1)"/></svg>`;
+
+function fake_provider(opts?: { read?: string | null; fail_write?: boolean }) {
+  const written: string[] = [];
+  const provider: ClipboardProvider = {
+    write: vi.fn<(text: string) => Promise<void>>(async (text) => {
+      if (opts?.fail_write) throw new Error("denied");
+      written.push(text);
+    }),
+    read: vi.fn<() => Promise<string | null>>(async () => opts?.read ?? null),
+  };
+  return { provider, written };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("commands.copy", () => {
+  it("returns the payload and writes the buffer (paste() round-trips it)", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    const payload = editor.commands.copy();
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`
+    );
+    const pasted = editor.commands.paste();
+    expect(pasted).toHaveLength(1);
+    // Byte-equal subtree round-trip (FRD R3).
+    expect(editor.serialize_node(pasted[0])).toBe(
+      editor.serialize_node(first_rect(editor))
+    );
+  });
+
+  it("is a pure read — no history entry, no content_version bump", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    const before = editor.state.content_version;
+    editor.commands.copy();
+    expect(editor.state.can_undo).toBe(false);
+    expect(editor.state.content_version).toBe(before);
+    expect(editor.state.dirty).toBe(false);
+  });
+
+  it("returns null on empty selection and leaves the buffer untouched", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(editor.commands.copy()).toBeNull();
+    expect(editor.commands.paste()).toEqual([]);
+  });
+
+  it("delivers to the provider exactly once (write-through)", async () => {
+    const { provider, written } = fake_provider();
+    const editor = createSvgEditor({
+      svg: WITH_RECT,
+      providers: { clipboard: provider },
+    });
+    editor.commands.select(first_rect(editor));
+    const payload = editor.commands.copy();
+    await tick();
+    expect(written).toEqual([payload]);
+    expect(provider.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("a rejected provider write is not a copy failure — the buffer floor holds", async () => {
+    const { provider } = fake_provider({ fail_write: true });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const editor = createSvgEditor({
+        svg: WITH_RECT,
+        providers: { clipboard: provider },
+      });
+      editor.commands.select(first_rect(editor));
+      const payload = editor.commands.copy();
+      expect(payload).not.toBeNull();
+      await tick();
+      // Buffer path still works after the failed external write.
+      expect(editor.commands.paste()).toHaveLength(1);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("commands.cut", () => {
+  it("removes the selection; ONE undo restores byte-equal", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    editor.commands.select(first_rect(editor));
+    const payload = editor.commands.cut();
+    expect(payload).not.toBeNull();
+    expect(editor.serialize()).not.toContain("<rect");
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("records the history step as 'cut', not 'remove'", () => {
+    const editor = createSvgEditorWithInternals({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.cut();
+    expect(editor._internal.history.undo_label()).toBe("cut");
+  });
+
+  it("the buffer survives undo — cut → undo → paste is the move idiom", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.cut();
+    editor.commands.undo();
+    const pasted = editor.commands.paste();
+    expect(pasted).toHaveLength(1);
+    // Original restored + pasted copy.
+    expect(editor.serialize().match(/<rect/g)).toHaveLength(2);
+  });
+
+  it("is a no-op on empty selection — no mutation, no history", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    expect(editor.commands.cut()).toBeNull();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+});
+
+describe("commands.paste", () => {
+  it("pastes explicit text, selects the roots, appends last", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const ids = editor.commands.paste(`<circle cx="5" cy="5" r="2"/>`);
+    expect(ids).toHaveLength(1);
+    expect(editor.state.selection).toEqual(ids);
+    const children = editor.document.element_children_of(editor.document.root);
+    expect(children[children.length - 1]).toBe(ids[0]);
+  });
+
+  it("explicit text wins over the buffer", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.copy();
+    const ids = editor.commands.paste(`<circle r="1"/>`);
+    expect(editor.document.tag_of(ids[0])).toBe("circle");
+  });
+
+  it("returns [] when there is no text and no buffer", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(editor.commands.paste()).toEqual([]);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("junk prose is a no-op refusal — [], no mutation, no history", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    expect(editor.commands.paste("hello, clipboard")).toEqual([]);
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("malformed markup is a no-op refusal, NOT a throw (gesture-grade table)", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    expect(editor.commands.paste(`<rect width="10`)).toEqual([]);
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("a non-string argument throws TypeError — caller bug, not environment input", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(() => editor.commands.paste(123 as unknown as string)).toThrow(
+      TypeError
+    );
+    expect(() => editor.commands.paste(null as unknown as string)).toThrow(
+      TypeError
+    );
+  });
+
+  it("same-document copy → paste: subtree byte-equal AND the carried closure lands (the accepted cost)", () => {
+    const editor = createSvgEditor({ svg: WITH_GRADIENT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.copy();
+    const pasted = editor.commands.paste();
+    // The payload's carried <defs> block is itself an adopted root — paste
+    // returns [defs, rect] in document order.
+    expect(pasted).toHaveLength(2);
+    expect(editor.document.tag_of(pasted[0])).toBe("defs");
+    expect(editor.serialize_node(pasted[1])).toBe(
+      editor.serialize_node(first_rect(editor))
+    );
+    // The payload's <defs> clone is adopted verbatim (R2/R4 forbid
+    // recognizing or rewriting it) — the document now holds the gradient
+    // twice. Documented, not hidden; Tidy is the recovery.
+    expect(editor.serialize().match(/<linearGradient/g)).toHaveLength(2);
+  });
+
+  it("colliding ids are inserted verbatim — never rewritten", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.copy();
+    editor.commands.paste();
+    expect(editor.serialize().match(/id="base"/g)).toHaveLength(2);
+  });
+
+  it("ONE undo removes the whole paste including hoisted xmlns", () => {
+    const editor = createSvgEditorWithInternals({ svg: WITH_RECT });
+    const baseline = editor.serialize();
+    const ids = editor.commands.paste(
+      `<svg xmlns="${SVG_NS}" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#base"/></svg>`
+    );
+    expect(ids).toHaveLength(1);
+    expect(editor.serialize()).toContain(`xmlns:xlink`);
+    expect(editor._internal.history.undo_label()).toBe("paste");
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+});
+
+describe("clipboard.* registry handlers", () => {
+  it("registers all three command ids", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(editor.commands.has("clipboard.copy")).toBe(true);
+    expect(editor.commands.has("clipboard.cut")).toBe(true);
+    expect(editor.commands.has("clipboard.paste")).toBe(true);
+  });
+
+  it("gates on select mode — refuses during content edit", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    editor.commands.select(first_rect(editor));
+    editor.commands.set_mode("edit-content");
+    expect(editor.commands.invoke("clipboard.copy")).toBe(false);
+    expect(editor.commands.invoke("clipboard.cut")).toBe(false);
+    expect(editor.commands.invoke("clipboard.paste")).toBe(false);
+  });
+
+  it("copy / cut handlers guard on empty selection", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    expect(editor.commands.invoke("clipboard.copy")).toBe(false);
+    expect(editor.commands.invoke("clipboard.cut")).toBe(false);
+  });
+
+  it("paste handler routes through the provider when configured", async () => {
+    const { provider } = fake_provider({ read: `<circle r="3"/>` });
+    const editor = createSvgEditor({
+      svg: WITH_RECT,
+      providers: { clipboard: provider },
+    });
+    expect(editor.commands.invoke("clipboard.paste")).toBe(true);
+    await tick();
+    expect(provider.read).toHaveBeenCalledTimes(1);
+    expect(editor.serialize()).toContain(`<circle r="3"/>`);
+  });
+
+  it("paste handler falls back to the buffer with honest chain semantics", () => {
+    const editor = createSvgEditor({ svg: WITH_RECT });
+    // Empty buffer → false (chain may keep going).
+    expect(editor.commands.invoke("clipboard.paste")).toBe(false);
+    editor.commands.select(first_rect(editor));
+    expect(editor.commands.invoke("clipboard.copy")).toBe(true);
+    expect(editor.commands.invoke("clipboard.paste")).toBe(true);
+    expect(editor.serialize().match(/<rect/g)).toHaveLength(2);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/clipboard-extract.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard-extract.test.ts
@@ -85,6 +85,18 @@ describe("clipboard.extract_payload / reference closure", () => {
     );
   });
 
+  it("carries targets from DUPLICATE inline declarations — the CSS winner included", () => {
+    // Last declaration wins in CSS; scanning only one declaration would
+    // risk carrying the loser and dropping the resource that renders.
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="old"/><linearGradient id="new"/></defs>` +
+        `<rect style="fill: url(#old); fill: url(#new)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(payload).toContain(`id="new"`);
+    expect(payload).toContain(`id="old"`);
+  });
+
   it("carries an inline-style url(#…) target", () => {
     const doc = new SvgDocument(
       `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs><rect style="fill: url(#g1)"/></svg>`
@@ -286,6 +298,22 @@ describe("clipboard.extract_payload / namespaces", () => {
     expect(payload).toBe(
       `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}"><use xlink:href="#nope"/></svg>`
     );
+  });
+
+  it("escapes special characters in a resolved namespace URI on the shell", () => {
+    // The resolved URI is the PARSED value (entities decoded) — the shell
+    // must re-escape it like any serialized attribute, or a quote-bearing
+    // URI breaks the payload's well-formedness.
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}" xmlns:weird="urn:&quot;x&amp;y">` +
+        `<g><rect weird:flag="1"/></g></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(payload).toContain(`xmlns:weird="urn:&quot;x&amp;y"`);
+    // Round-trip: the payload parses, and from the payload root the
+    // shell's declaration covers every prefix the content uses.
+    const reparsed = new SvgDocument(payload);
+    expect(reparsed.undeclared_ns_prefixes(reparsed.root).size).toBe(0);
   });
 
   it("leaves an unknown undeclared prefix unbound — the source was equally unbound", () => {

--- a/packages/grida-svg-editor/__tests__/clipboard-extract.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard-extract.test.ts
@@ -1,0 +1,331 @@
+// Headless tests for `core/clipboard.ts` — payload extraction
+// (selection → standalone SVG document). Contract:
+// docs/wg/feat-svg-editor/clipboard.md §The payload, normatively.
+//
+//   - normalization: ancestor subsumes descendant; document order
+//     regardless of selection order; stale ids skipped; empty → null.
+//   - closure: the CLOSED carrier list (presentation attrs + inline
+//     style; href tag set), recursive, cycle-guarded, forest-excluded,
+//     subtree-aware dedup, unresolved-left-as-authored, first-in-doc-
+//     order duplicate-id resolution. `<style>` rules / `<a href>` are
+//     deliberately NOT walked.
+//   - namespaces: borrowed prefixes declared on the shell (nearest
+//     ancestor declaration wins; well-known `xlink` repair; unknown
+//     prefixes left unbound).
+//   - shell: no `<defs>` when the closure is empty; no viewBox / sizing;
+//     deterministic bytes; per-subtree trivia byte-preserved.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import { clipboard } from "../src/core/clipboard";
+import type { NodeId } from "../src/types";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const XLINK_NS = "http://www.w3.org/1999/xlink";
+
+function el(doc: SvgDocument, tag: string, nth = 0): NodeId {
+  const found = doc.all_elements().filter((id) => doc.tag_of(id) === tag);
+  if (nth >= found.length) {
+    throw new Error(`no <${tag}>[${nth}] in document`);
+  }
+  return found[nth];
+}
+
+describe("clipboard.extract_payload / normalization", () => {
+  it("ancestor subsumes a selected descendant — the subtree is emitted once", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><g id="grp"><rect id="r" width="10" height="10"/></g></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [
+      el(doc, "rect"),
+      el(doc, "g"),
+    ]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><g id="grp"><rect id="r" width="10" height="10"/></g></svg>`
+    );
+  });
+
+  it("roots are emitted in DOCUMENT order regardless of selection order", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><rect id="a"/><rect id="b"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [
+      el(doc, "rect", 1),
+      el(doc, "rect", 0),
+    ]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><rect id="a"/><rect id="b"/></svg>`
+    );
+  });
+
+  it("stale / unknown ids are skipped, not thrown (copy has no refusal path)", () => {
+    const doc = new SvgDocument(`<svg xmlns="${SVG_NS}"><rect id="a"/></svg>`);
+    const payload = clipboard.extract_payload(doc, [
+      "zzz-not-a-node" as NodeId,
+      el(doc, "rect"),
+    ]);
+    expect(payload).toBe(`<svg xmlns="${SVG_NS}"><rect id="a"/></svg>`);
+  });
+
+  it("returns null on empty selection and on all-stale selection", () => {
+    const doc = new SvgDocument(`<svg xmlns="${SVG_NS}"><rect/></svg>`);
+    expect(clipboard.extract_payload(doc, [])).toBeNull();
+    expect(clipboard.extract_payload(doc, ["nope" as NodeId])).toBeNull();
+  });
+});
+
+describe("clipboard.extract_payload / reference closure", () => {
+  it("carries a fill url(#…) target (presentation attribute)", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs><rect id="r" fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs><rect id="r" fill="url(#g1)"/></svg>`
+    );
+  });
+
+  it("carries an inline-style url(#…) target", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs><rect style="fill: url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toContain(`<defs><linearGradient id="g1"/></defs>`);
+  });
+
+  it("carries marker-* and the marker shorthand", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><marker id="m1"/><marker id="m2"/></defs>` +
+        `<line x2="5" marker-end="url(#m1)"/><path d="M0 0" marker="url(#m2)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [
+      el(doc, "line"),
+      el(doc, "path"),
+    ]);
+    expect(payload).toContain(`<marker id="m1"/>`);
+    expect(payload).toContain(`<marker id="m2"/>`);
+  });
+
+  it("collects MULTIPLE url(#…) references from one value", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><filter id="f1"/><filter id="f2"/></defs>` +
+        `<rect style="filter: url(#f1) url(#f2)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toContain(`<filter id="f1"/>`);
+    expect(payload).toContain(`<filter id="f2"/>`);
+  });
+
+  it("walks recursively — a gradient href chain comes along whole", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs>` +
+        `<linearGradient id="g1" href="#g2"/><linearGradient id="g2" href="#g3"/><linearGradient id="g3"/>` +
+        `</defs><rect fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toContain(`id="g1"`);
+    expect(payload).toContain(`id="g2"`);
+    expect(payload).toContain(`id="g3"`);
+  });
+
+  it("terminates on a reference cycle, each member emitted once", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs>` +
+        `<linearGradient id="g1" href="#g2"/><linearGradient id="g2" href="#g1"/>` +
+        `</defs><rect fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(payload.match(/id="g1"/g)).toHaveLength(1);
+    expect(payload.match(/id="g2"/g)).toHaveLength(1);
+  });
+
+  it("a definition shared by two copied roots is emitted once", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs>` +
+        `<rect fill="url(#g1)"/><circle r="1" fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [
+      el(doc, "rect"),
+      el(doc, "circle"),
+    ])!;
+    // Self-closing — exactly one serialization of the shared gradient.
+    expect(payload.match(/<linearGradient/g)).toHaveLength(1);
+  });
+
+  it("a collected element nested inside another collected element is not double-emitted", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs>` +
+        `<pattern id="p"><linearGradient id="g1"/></pattern>` +
+        `</defs><rect fill="url(#p)" stroke="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    // g1 rides inside p — exactly one serialization of it.
+    expect(payload.match(/id="g1"/g)).toHaveLength(1);
+    expect(payload).toContain(
+      `<defs><pattern id="p"><linearGradient id="g1"/></pattern></defs>`
+    );
+  });
+
+  it("excludes targets inside the copied forest (use → copied sibling)", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><rect id="shape"/><use href="#shape"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [
+      el(doc, "rect"),
+      el(doc, "use"),
+    ]);
+    // Both roots are content; nothing to carry — no <defs>.
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><rect id="shape"/><use href="#shape"/></svg>`
+    );
+  });
+
+  it("leaves unresolved references as authored — no defs, no error", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><rect fill="url(#nope)"/></svg>`
+    );
+    expect(clipboard.extract_payload(doc, [el(doc, "rect")])).toBe(
+      `<svg xmlns="${SVG_NS}"><rect fill="url(#nope)"/></svg>`
+    );
+  });
+
+  it("does NOT walk <style> element rules (documented v1 degradation)", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><style>.a { fill: url(#g1); }</style>` +
+        `<defs><linearGradient id="g1"/></defs><rect class="a"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toBe(`<svg xmlns="${SVG_NS}"><rect class="a"/></svg>`);
+  });
+
+  it("does NOT walk <a href> (navigation, not a resource reference)", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><rect id="target"/><a href="#target"><circle r="1"/></a></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "a")]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><a href="#target"><circle r="1"/></a></svg>`
+    );
+  });
+
+  it("duplicate source ids resolve to the FIRST in document order", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs>` +
+        `<linearGradient id="g1" data-which="first"/><linearGradient id="g1" data-which="second"/>` +
+        `</defs><rect fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(payload).toContain(`data-which="first"`);
+    expect(payload).not.toContain(`data-which="second"`);
+  });
+
+  it("collect_reference_closure returns closure ids in document order", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><filter id="f"/><linearGradient id="g"/></defs>` +
+        `<rect fill="url(#g)" style="filter: url(#f)"/></svg>`
+    );
+    const closure = clipboard.collect_reference_closure(doc, [el(doc, "rect")]);
+    expect(closure.map((id) => doc.tag_of(id))).toEqual([
+      "filter",
+      "linearGradient",
+    ]);
+  });
+});
+
+describe("clipboard.extract_payload / namespaces", () => {
+  it("declares a prefix the content borrows from the source root", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}"><rect id="r"/><use xlink:href="#r"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "use")]);
+    // The use's target rides as closure; the borrowed xlink prefix lands
+    // on the shell.
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}"><defs><rect id="r"/></defs><use xlink:href="#r"/></svg>`
+    );
+  });
+
+  it("a closure member's borrowed prefix alone triggers the shell declaration", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}"><defs>` +
+        `<linearGradient id="g1" xlink:href="#g2"/><linearGradient id="g2"/>` +
+        `</defs><rect fill="url(#g1)"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(
+      payload.startsWith(`<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}">`)
+    ).toBe(true);
+  });
+
+  it("nearest ancestor declaration wins for a custom prefix", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}" xmlns:custom="uri-outer">` +
+        `<g xmlns:custom="uri-inner"><rect custom:flag="1"/></g></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")])!;
+    expect(payload).toContain(`xmlns:custom="uri-inner"`);
+    expect(payload).not.toContain(`uri-outer`);
+  });
+
+  it("a prefix the copied subtree declares itself is not re-declared on the shell", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><g xmlns:foo="uri-foo" foo:flag="1"><rect/></g></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "g")]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><g xmlns:foo="uri-foo" foo:flag="1"><rect/></g></svg>`
+    );
+  });
+
+  it("repairs an undeclared xlink from the well-known table (payload must be well-formed)", () => {
+    // Source never declares xlink — broken source, parser tolerates it.
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><use xlink:href="#nope"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "use")]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}" xmlns:xlink="${XLINK_NS}"><use xlink:href="#nope"/></svg>`
+    );
+  });
+
+  it("leaves an unknown undeclared prefix unbound — the source was equally unbound", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><rect weird:flag="1"/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toBe(`<svg xmlns="${SVG_NS}"><rect weird:flag="1"/></svg>`);
+  });
+});
+
+describe("clipboard.extract_payload / shell", () => {
+  it("emits no <defs> when the closure is empty, and no viewBox / sizing ever", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}" viewBox="0 0 100 100" width="100" height="100"><rect/></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(payload).toBe(`<svg xmlns="${SVG_NS}"><rect/></svg>`);
+  });
+
+  it("is deterministic — same (document, selection) → identical bytes", () => {
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><defs><linearGradient id="g1"/></defs><rect fill="url(#g1)"/></svg>`
+    );
+    const a = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    const b = clipboard.extract_payload(doc, [el(doc, "rect")]);
+    expect(a).toBe(b);
+  });
+
+  it("preserves trivia WITHIN each copied subtree byte-exact", () => {
+    // Attribute spacing, quote styles, name-side `=` trivia, comments —
+    // everything the parser models survives. (Space AFTER `=` is a known
+    // parser-level round-trip gap, present in `serialize()` too — not a
+    // clipboard concern.)
+    const doc = new SvgDocument(
+      `<svg xmlns="${SVG_NS}"><g><!-- keep --><rect   id='r' fill ="red"/></g></svg>`
+    );
+    const payload = clipboard.extract_payload(doc, [el(doc, "g")]);
+    expect(payload).toBe(
+      `<svg xmlns="${SVG_NS}"><g><!-- keep --><rect   id='r' fill ="red"/></g></svg>`
+    );
+  });
+});

--- a/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
@@ -9,7 +9,11 @@
 // is the manual TC (test/svg-editor-clipboard.md).
 
 import { afterEach, describe, expect, it } from "vitest";
-import { attachSurface, type AttachedSurface } from "./_browser-helpers";
+import {
+  attachSurface,
+  nodeIdByName,
+  type AttachedSurface,
+} from "./_browser-helpers";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 const DOC = `<svg xmlns="${SVG_NS}" viewBox="0 0 100 100"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`;
@@ -33,13 +37,9 @@ afterEach(() => {
 });
 
 function select_rect(s: AttachedSurface) {
-  for (const [node_id, n] of s.editor.tree().nodes) {
-    if (n.tag === "rect") {
-      s.editor.commands.select(node_id);
-      return node_id;
-    }
-  }
-  throw new Error("no rect");
+  const id = nodeIdByName(s.editor, "base");
+  s.editor.commands.select(id);
+  return id;
 }
 
 function dispatch_clipboard(

--- a/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
@@ -1,0 +1,178 @@
+// Browser-mode tests (real Chromium) for the DOM surface's native
+// clipboard transport — focus management, the clipboard gate, and the
+// copy/cut/paste ClipboardEvent handlers. Contract:
+// docs/wg/feat-svg-editor/clipboard.md §Transport.
+//
+// Events are SYNTHETIC (`new ClipboardEvent(..., { clipboardData })` —
+// Chromium honors the init member); they exercise the surface's listeners
+// and gates, not the OS clipboard. The real-keystroke / OS-clipboard flow
+// is the manual TC (test/svg-editor-clipboard.md).
+
+import { afterEach, describe, expect, it } from "vitest";
+import { attachSurface, type AttachedSurface } from "./_browser-helpers";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const DOC = `<svg xmlns="${SVG_NS}" viewBox="0 0 100 100"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`;
+
+let surfaces: AttachedSurface[] = [];
+let extra_nodes: Element[] = [];
+
+function mount(svg = DOC, opts?: { clipboard?: boolean }) {
+  const s = attachSurface(svg, opts);
+  surfaces.push(s);
+  return s;
+}
+
+afterEach(() => {
+  for (const s of surfaces) s.dispose();
+  surfaces = [];
+  for (const n of extra_nodes) n.remove();
+  extra_nodes = [];
+  document.getSelection()?.removeAllRanges();
+  (document.activeElement as HTMLElement | null)?.blur?.();
+});
+
+function select_rect(s: AttachedSurface) {
+  for (const [node_id, n] of s.editor.tree().nodes) {
+    if (n.tag === "rect") {
+      s.editor.commands.select(node_id);
+      return node_id;
+    }
+  }
+  throw new Error("no rect");
+}
+
+function dispatch_clipboard(
+  target: EventTarget,
+  kind: "copy" | "cut" | "paste",
+  dt = new DataTransfer()
+) {
+  const e = new ClipboardEvent(kind, {
+    clipboardData: dt,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(e);
+  return { e, dt };
+}
+
+describe("focus management", () => {
+  it("pointerdown focuses the container (programmatically focusable, not tab-reachable)", () => {
+    const s = mount();
+    expect(s.container.tabIndex).toBe(-1);
+    s.container.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: 50,
+        clientY: 50,
+        button: 0,
+      })
+    );
+    expect(document.activeElement).toBe(s.container);
+  });
+});
+
+describe("copy / cut over the focused canvas", () => {
+  it("copy writes the payload to the event DataTransfer and claims the gesture", () => {
+    const s = mount();
+    select_rect(s);
+    s.container.focus();
+    const { e, dt } = dispatch_clipboard(s.container, "copy");
+    expect(e.defaultPrevented).toBe(true);
+    expect(dt.getData("text/plain")).toBe(
+      `<svg xmlns="${SVG_NS}"><rect id="base" x="0" y="0" width="10" height="10"/></svg>`
+    );
+  });
+
+  it("copy with empty selection leaves the gesture unclaimed (act-then-claim)", () => {
+    const s = mount();
+    s.container.focus();
+    const { e, dt } = dispatch_clipboard(s.container, "copy");
+    expect(e.defaultPrevented).toBe(false);
+    expect(dt.getData("text/plain")).toBe("");
+  });
+
+  it("cut removes the selection, delivers the payload, and one undo restores", () => {
+    const s = mount();
+    const baseline = s.editor.serialize();
+    select_rect(s);
+    s.container.focus();
+    const { e, dt } = dispatch_clipboard(s.container, "cut");
+    expect(e.defaultPrevented).toBe(true);
+    expect(dt.getData("text/plain")).toContain(`<rect id="base"`);
+    expect(s.editor.serialize()).not.toContain("<rect");
+    s.editor.commands.undo();
+    expect(s.editor.serialize()).toBe(baseline);
+  });
+});
+
+describe("the clipboard gate", () => {
+  it("does not claim when focus is outside the container — pointer-over is not enough", () => {
+    const s = mount();
+    select_rect(s);
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    document.body.focus();
+    const { e } = dispatch_clipboard(document, "copy");
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("a non-collapsed host text selection wins over copy", () => {
+    const s = mount();
+    select_rect(s);
+    const sibling = document.createElement("div");
+    sibling.textContent = "the user's prose";
+    document.body.appendChild(sibling);
+    extra_nodes.push(sibling);
+    s.container.focus();
+    document.getSelection()?.selectAllChildren(sibling);
+    const { e } = dispatch_clipboard(s.container, "copy");
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("a focused host text input wins over paste", () => {
+    const s = mount();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    extra_nodes.push(input);
+    input.focus();
+    const dt = new DataTransfer();
+    dt.setData("text/plain", `<circle r="1"/>`);
+    const { e } = dispatch_clipboard(input, "paste", dt);
+    expect(e.defaultPrevented).toBe(false);
+    expect(s.editor.serialize()).not.toContain("circle");
+  });
+
+  it("clipboard: false opts out of native transport entirely", () => {
+    const s = mount(DOC, { clipboard: false });
+    select_rect(s);
+    s.container.focus();
+    const { e, dt } = dispatch_clipboard(s.container, "copy");
+    expect(e.defaultPrevented).toBe(false);
+    expect(dt.getData("text/plain")).toBe("");
+  });
+});
+
+describe("paste over the focused canvas", () => {
+  it("inserts the delivered markup and selects the roots (claim-then-act)", () => {
+    const s = mount();
+    s.container.focus();
+    const dt = new DataTransfer();
+    dt.setData("text/plain", `<circle cx="5" cy="5" r="2"/>`);
+    const { e } = dispatch_clipboard(s.container, "paste", dt);
+    expect(e.defaultPrevented).toBe(true);
+    expect(s.editor.serialize()).toContain(`<circle cx="5" cy="5" r="2"/>`);
+    expect(s.editor.state.selection).toHaveLength(1);
+  });
+
+  it("junk text still claims but mutates nothing (gesture-grade refusal)", () => {
+    const s = mount();
+    const baseline = s.editor.serialize();
+    s.container.focus();
+    const dt = new DataTransfer();
+    dt.setData("text/plain", "not svg at all");
+    const { e } = dispatch_clipboard(s.container, "paste", dt);
+    expect(e.defaultPrevented).toBe(true);
+    expect(s.editor.serialize()).toBe(baseline);
+    expect(s.editor.state.can_undo).toBe(false);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -22,7 +22,11 @@ type Internal = {
     set_text: (id: string, text: string) => void;
     all_elements: () => string[];
   };
-  history: { preview: (label: string) => unknown };
+  history: {
+    preview: (label: string) => unknown;
+    undo_label: () => string | null;
+  };
+  clipboard: { copy: () => string | null; cut: () => string | null };
   insert_text_preview: (
     initial: Readonly<Record<string, string>>,
     opts?: { parent?: string }
@@ -49,6 +53,7 @@ describe("editor._internal contract", () => {
     const internal = internalOf(editor);
     expect(Object.keys(internal).sort()).toEqual(
       [
+        "clipboard",
         "doc",
         "emit",
         "bump_geometry",
@@ -65,6 +70,9 @@ describe("editor._internal contract", () => {
       ].sort()
     );
     expect(typeof internal.history.preview).toBe("function");
+    expect(typeof internal.history.undo_label).toBe("function");
+    expect(typeof internal.clipboard.copy).toBe("function");
+    expect(typeof internal.clipboard.cut).toBe("function");
     expect(typeof internal.emit).toBe("function");
     expect(typeof internal.subscribe_translate_commit).toBe("function");
     expect(typeof internal.notify_translate_commit).toBe("function");

--- a/packages/grida-svg-editor/docs/keybindings.md
+++ b/packages/grida-svg-editor/docs/keybindings.md
@@ -60,18 +60,18 @@ source of truth for what svg-editor ships out of the box.
 
 ## Editing
 
-| Action      | macOS                   | Windows/Linux               | Status | Command               | Notes                                      |
-| ----------- | ----------------------- | --------------------------- | ------ | --------------------- | ------------------------------------------ |
-| Undo        | `⌘ + Z`                 | `Ctrl + Z`                  | [x]    | `history.undo`        | shipped                                    |
-| Redo        | `⌘ + ⇧ + Z`             | `Ctrl + ⇧ + Z`              | [x]    | `history.redo`        | shipped                                    |
-| Redo (alt)  | `⌘ + Y`                 | `Ctrl + Y`                  | [x]    | `history.redo`        | shipped (alias)                            |
-| Cut         | `⌘ + X`                 | `Ctrl + X`                  | [~]    | `clipboard.cut`       | clipboard model TBD                        |
-| Copy        | `⌘ + C`                 | `Ctrl + C`                  | [~]    | `clipboard.copy`      | clipboard model TBD                        |
-| Copy as PNG | `⌘ + ⇧ + C`             | `Ctrl + ⇧ + C`              | [-]    | —                     | host-owned (rasterizer)                    |
-| Paste       | `⌘ + V`                 | `Ctrl + V`                  | [~]    | `clipboard.paste`     | clipboard model TBD                        |
-| Duplicate   | `⌘ + D`                 | `Ctrl + D`                  | [~]    | `selection.duplicate` | command doesn't exist yet                  |
-| Delete      | `Delete` or `Backspace` | `Delete` or `Backspace`     | [x]    | `selection.remove`    | shipped; future routing inside the handler |
-| Flatten     | `⌘ + E` or `⌥ + ⇧ + F`  | `Ctrl + E` or `Alt + ⇧ + F` | [-]    | —                     | no flatten command yet                     |
+| Action      | macOS                   | Windows/Linux               | Status | Command               | Notes                                                                                                                                                                                                                                          |
+| ----------- | ----------------------- | --------------------------- | ------ | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Undo        | `⌘ + Z`                 | `Ctrl + Z`                  | [x]    | `history.undo`        | shipped                                                                                                                                                                                                                                        |
+| Redo        | `⌘ + ⇧ + Z`             | `Ctrl + ⇧ + Z`              | [x]    | `history.redo`        | shipped                                                                                                                                                                                                                                        |
+| Redo (alt)  | `⌘ + Y`                 | `Ctrl + Y`                  | [x]    | `history.redo`        | shipped (alias)                                                                                                                                                                                                                                |
+| Cut         | `⌘ + X`                 | `Ctrl + X`                  | [x]    | `clipboard.cut`       | shipped — via native clipboard events, deliberately NO keymap row (a keymap claim would `preventDefault` the keystroke and suppress the native event); command id serves menu/RPC hosts. See `docs/wg/feat-svg-editor/clipboard.md` §Transport |
+| Copy        | `⌘ + C`                 | `Ctrl + C`                  | [x]    | `clipboard.copy`      | shipped — same native-event routing as Cut                                                                                                                                                                                                     |
+| Copy as PNG | `⌘ + ⇧ + C`             | `Ctrl + ⇧ + C`              | [-]    | —                     | host-owned (rasterizer)                                                                                                                                                                                                                        |
+| Paste       | `⌘ + V`                 | `Ctrl + V`                  | [x]    | `clipboard.paste`     | shipped — same native-event routing; command id reads the provider (else internal buffer)                                                                                                                                                      |
+| Duplicate   | `⌘ + D`                 | `Ctrl + D`                  | [~]    | `selection.duplicate` | command doesn't exist yet                                                                                                                                                                                                                      |
+| Delete      | `Delete` or `Backspace` | `Delete` or `Backspace`     | [x]    | `selection.remove`    | shipped; future routing inside the handler                                                                                                                                                                                                     |
+| Flatten     | `⌘ + E` or `⌥ + ⇧ + F`  | `Ctrl + E` or `Alt + ⇧ + F` | [-]    | —                     | no flatten command yet                                                                                                                                                                                                                         |
 
 ## Transformation
 

--- a/packages/grida-svg-editor/src/commands/defaults.ts
+++ b/packages/grida-svg-editor/src/commands/defaults.ts
@@ -174,6 +174,52 @@ export function registerDefaultCommands(
     return editor.commands.align(args as AlignDirection);
   });
 
+  // ─── clipboard ────────────────────────────────────────────────────────────
+  // Contract: docs/wg/feat-svg-editor/clipboard.md. No keymap rows bind
+  // these — Cmd+C/X/V reach the editor as native ClipboardEvents wired by
+  // the DOM surface (a keymap claim would preventDefault the keystroke and
+  // suppress the native event's generation). These ids exist for menu /
+  // RPC / palette hosts.
+  //
+  // All three gate on `select` mode — one step beyond the FRD's named
+  // text-edit inertness: cut/paste during vector content-edit would mutate
+  // structure under an open edit session (same hazard `selection.group`
+  // guards). Copy is a pure read but gates too, for symmetry.
+
+  reg.register("clipboard.copy", () => {
+    if (editor.state.mode !== "select") return false;
+    if (editor.state.selection.length === 0) return false;
+    return editor.commands.copy() !== null;
+  });
+
+  reg.register("clipboard.cut", () => {
+    if (editor.state.mode !== "select") return false;
+    if (editor.state.selection.length === 0) return false;
+    return editor.commands.cut() !== null;
+  });
+
+  // Paste acquisition is the invoking channel's job (FRD §Command
+  // semantics); for this programmatic channel that means the provider
+  // when configured (async read, fire-and-forget — the refusal
+  // observability of the async leg is inherently weaker), else the
+  // editor's internal buffer (sync, honest chain semantics).
+  reg.register("clipboard.paste", () => {
+    if (editor.state.mode !== "select") return false;
+    const provider = editor.providers.clipboard;
+    if (provider) {
+      void provider
+        .read()
+        .then((text) => {
+          if (text) editor.commands.paste(text);
+        })
+        .catch((err) => {
+          console.warn("[svg-editor] clipboard provider read failed:", err);
+        });
+      return true;
+    }
+    return editor.commands.paste().length > 0;
+  });
+
   // ─── content edit ─────────────────────────────────────────────────────────
   // Enter — enter content-edit (text edit / vector edit) on the single
   // selected node. Mirrors the double-click → `enter_content_edit` intent

--- a/packages/grida-svg-editor/src/commands/defaults.ts
+++ b/packages/grida-svg-editor/src/commands/defaults.ts
@@ -199,12 +199,18 @@ export function registerDefaultCommands(
   });
 
   // Paste acquisition is the invoking channel's job (FRD §Command
-  // semantics); for this programmatic channel that means the provider
-  // when configured (async read, fire-and-forget — the refusal
-  // observability of the async leg is inherently weaker), else the
-  // editor's internal buffer (sync, honest chain semantics).
-  reg.register("clipboard.paste", () => {
+  // semantics). Precedence here mirrors the FRD read rule: explicitly
+  // delivered text first (`args.text` — an RPC/host caller that already
+  // holds the markup), else the provider when configured (async read,
+  // fire-and-forget — the refusal observability of the async leg is
+  // inherently weaker), else the editor's internal buffer (sync, honest
+  // chain semantics).
+  reg.register("clipboard.paste", (args) => {
     if (editor.state.mode !== "select") return false;
+    const text = (args as { text?: string } | undefined)?.text;
+    if (typeof text === "string") {
+      return editor.commands.paste(text).length > 0;
+    }
     const provider = editor.providers.clipboard;
     if (provider) {
       void provider

--- a/packages/grida-svg-editor/src/core/clipboard.ts
+++ b/packages/grida-svg-editor/src/core/clipboard.ts
@@ -28,6 +28,7 @@
  * and does not live here.
  */
 
+import { encode_attr_value } from "@grida/svg/parser";
 import type { NodeId } from "../types";
 import type { SvgDocument } from "./document";
 import { SVG_NS, WELL_KNOWN_NS_PREFIXES, XMLNS_NS } from "./document";
@@ -54,6 +55,10 @@ export namespace clipboard {
     "marker-end",
     "marker",
   ] as const;
+
+  /** Set view of {@link URL_REF_PROPS} for membership tests over parsed
+   *  style declarations. */
+  const URL_REF_PROP_SET: ReadonlySet<string> = new Set(URL_REF_PROPS);
 
   /**
    * Elements whose `href` / `xlink:href` is a same-document resource
@@ -129,7 +134,10 @@ export namespace clipboard {
 
     let shell = `<svg xmlns="${SVG_NS}"`;
     for (const [prefix, uri] of shell_ns) {
-      shell += ` xmlns:${prefix}="${uri}"`;
+      // `uri` is the PARSED value (entities decoded) — re-escape it the
+      // same way the serializer escapes any attribute, or a URI carrying
+      // a literal quote would break the shell's well-formedness.
+      shell += ` xmlns:${prefix}="${encode_attr_value(uri, '"')}"`;
     }
     shell += ">";
 
@@ -236,18 +244,20 @@ export namespace clipboard {
    *  carrier list. */
   function refs_of(doc: SvgDocument, id: NodeId): string[] {
     const out: string[] = [];
-    // One parse of the inline style per element (`get_style` re-parses the
-    // whole attribute per property); first declaration wins, matching
-    // `get_style`'s semantics.
-    const styles = new Map<string, string>();
-    for (const { property, value } of doc.get_all_styles(id)) {
-      if (!styles.has(property)) styles.set(property, value);
-    }
     for (const prop of URL_REF_PROPS) {
-      for (const value of [doc.get_attr(id, prop), styles.get(prop)]) {
-        if (!value) continue;
-        for (const m of value.matchAll(URL_REF_RE)) out.push(m[1]);
-      }
+      const value = doc.get_attr(id, prop);
+      if (!value) continue;
+      for (const m of value.matchAll(URL_REF_RE)) out.push(m[1]);
+    }
+    // EVERY inline declaration is scanned (one parse per element —
+    // `get_style` would re-parse the attribute per property). Duplicate
+    // declarations of one property are legal; the LAST wins in CSS, so
+    // picking any single one risks dropping the reference that actually
+    // renders. Carrying every declared reference is faithful: the winner
+    // comes along, and a carried loser is harmless extra defs.
+    for (const { property, value } of doc.get_all_styles(id)) {
+      if (!URL_REF_PROP_SET.has(property)) continue;
+      for (const m of value.matchAll(URL_REF_RE)) out.push(m[1]);
     }
     if (HREF_TAGS.has(doc.tag_of(id))) {
       // ns=null matches any namespace — covers `href` and `xlink:href`.

--- a/packages/grida-svg-editor/src/core/clipboard.ts
+++ b/packages/grida-svg-editor/src/core/clipboard.ts
@@ -1,0 +1,276 @@
+/**
+ * Clipboard payload extraction — selection → standalone SVG document.
+ *
+ * Implements the copy side of the clipboard FRD
+ * ([docs/wg/feat-svg-editor/clipboard.md](../../../../docs/wg/feat-svg-editor/clipboard.md)):
+ * the payload is a standalone, namespace-well-formed SVG document — not a
+ * private envelope. Assembly is a pure function of (document, selection):
+ * no geometry, no environment, no randomness (FRD R6 — the same selection
+ * yields the same bytes headless or surface-attached).
+ *
+ * What the payload carries, and what it deliberately does not
+ * (FRD §Extraction — five context kinds):
+ *
+ *   1. Referenced resources — CARRIED. The outbound `url(#…)` / `href`
+ *      closure is walked from the closed carrier list below and emitted
+ *      verbatim in one `<defs>` block.
+ *   2. Namespace declarations — CARRIED. Prefixes a subtree borrows from
+ *      ancestor scope are declared on the payload shell (an undeclared
+ *      prefix is a well-formedness error, so this includes the deliberate
+ *      well-known-table repair for e.g. `xlink`).
+ *   3. Ancestor transforms — NOT carried (verbatim policy).
+ *   4. Inherited presentation / cascade — NOT carried (verbatim policy).
+ *   5. Viewport — NOT carried (no `viewBox`, no sizing on the shell).
+ *
+ * This module is the **payload extraction** operation only. The sibling
+ * operation the FRD names — in-document subtree CLONE (duplicate /
+ * clone-drag), which must NOT carry the closure — is a different contract
+ * and does not live here.
+ */
+
+import type { NodeId } from "../types";
+import type { SvgDocument } from "./document";
+import { SVG_NS, XLINK_NS, XMLNS_NS } from "./document";
+
+export namespace clipboard {
+  /**
+   * Presentation carriers that may hold `url(#…)` references, read both as
+   * a presentation attribute and as an inline `style=""` declaration.
+   *
+   * CLOSED LIST — extending it is a spec change to the FRD's §Extraction 1
+   * carrier list, not a bug fix. Deliberately NOT walked in v1 (documented
+   * degradations): `<style>` element rules (CSS parsing is the deferred
+   * cascade capability), SMIL timing/value references, `cursor`, SVG 2
+   * text-layout properties.
+   */
+  const URL_REF_PROPS = [
+    "fill",
+    "stroke",
+    "filter",
+    "clip-path",
+    "mask",
+    "marker-start",
+    "marker-mid",
+    "marker-end",
+    "marker",
+  ] as const;
+
+  /**
+   * Elements whose `href` / `xlink:href` is a same-document resource
+   * reference the closure follows. CLOSED LIST — `<a href>` is navigation,
+   * `<image href>` is content, SMIL `href` is an animation target; none of
+   * them are walked.
+   */
+  const HREF_TAGS = new Set([
+    "use",
+    "textPath",
+    "mpath",
+    "feImage",
+    "pattern",
+    "linearGradient",
+    "radialGradient",
+    "filter",
+  ]);
+
+  /**
+   * `url(#id)` extractor. Global — a single value can carry several
+   * references (`filter: url(#a) blur(2px) url(#b)` is a legal filter
+   * function list). Same quoting tolerance as the defs registry's
+   * ref-counting pattern.
+   */
+  const URL_REF_RE = /url\(\s*["']?#([^"')\s]+)["']?\s*\)/g;
+
+  /** Prefixes resolvable without a source declaration — the same
+   *  well-known table the paste-side hoist uses. */
+  const WELL_KNOWN_PREFIXES: ReadonlyMap<string, string> = new Map([
+    ["xlink", XLINK_NS],
+  ]);
+
+  /**
+   * Extract a standalone SVG document from the selection.
+   *
+   * Pipeline (FRD §The payload, normatively):
+   *   1. Normalize — ancestor subtrees subsume selected descendants (the
+   *      same rule deletion uses); stale / non-element / detached ids are
+   *      skipped, never thrown (R1: copy has no refusal path); roots are
+   *      emitted in DOCUMENT order regardless of selection order (sibling
+   *      order is paint order, and paint order is meaning).
+   *   2. Closure — {@link collect_reference_closure} over the roots,
+   *      emitted verbatim in one `<defs>` element (omitted when empty).
+   *   3. Shell — `<svg>` declaring the SVG namespace plus every resolved
+   *      prefix the fragment requires, and nothing else.
+   *
+   * Returns `null` when nothing serializable is selected — the caller's
+   * no-op, not an error.
+   */
+  export function extract_payload(
+    doc: SvgDocument,
+    selection: ReadonlyArray<NodeId>
+  ): string | null {
+    const roots = normalize_selection(doc, selection);
+    if (roots.length === 0) return null;
+
+    const closure = collect_reference_closure(doc, roots);
+
+    // Shell namespace declarations: every payload member (roots AND
+    // closure — `<linearGradient xlink:href>` living in `<defs>` is the
+    // common real case) contributes the prefixes its subtree borrows from
+    // ancestor scope. Members are processed in document order, first
+    // declaration wins — the FRD is silent on conflicting prefix URIs
+    // across members; first-in-document-order is deterministic and honest.
+    const shell_ns = new Map<string, string>();
+    for (const member of [...closure, ...roots].sort(by_document_order(doc))) {
+      for (const prefix of doc.undeclared_ns_prefixes(member)) {
+        if (shell_ns.has(prefix)) continue;
+        const uri = resolve_prefix(doc, member, prefix);
+        if (uri !== null) shell_ns.set(prefix, uri);
+        // Unresolvable unknown prefix: left unbound — the source was
+        // equally unbound, and inventing a URI would be fabrication.
+      }
+    }
+
+    let shell = `<svg xmlns="${SVG_NS}"`;
+    for (const [prefix, uri] of shell_ns) {
+      shell += ` xmlns:${prefix}="${uri}"`;
+    }
+    shell += ">";
+
+    const defs_block =
+      closure.length > 0
+        ? `<defs>${closure.map((id) => doc.serialize_node(id)).join("")}</defs>`
+        : "";
+    const content = roots.map((id) => doc.serialize_node(id)).join("");
+
+    return `${shell}${defs_block}${content}</svg>`;
+  }
+
+  /**
+   * Outbound reference closure of the copied forest (FRD §Extraction 1).
+   *
+   * Walks the closed carrier list over every element of every root's
+   * subtree; resolves `#id` targets within the source document
+   * (first-in-document-order wins, matching host-renderer duplicate-id
+   * resolution); recurses into collected targets (gradient `href` chains,
+   * filter → `feImage`); guards against reference cycles.
+   *
+   * Excluded: targets already inside the copied forest (they are content —
+   * carrying them again would duplicate them), and unresolved references
+   * (left as authored; the payload is no more broken than the source).
+   *
+   * Returns closure members deduplicated subtree-aware (a collected
+   * element nested inside another collected element is dropped) in
+   * document order.
+   *
+   * Exported for isolated testing (P5); not part of the public package
+   * surface.
+   */
+  export function collect_reference_closure(
+    doc: SvgDocument,
+    roots: ReadonlyArray<NodeId>
+  ): NodeId[] {
+    // Doc-order first-wins id map — built once per walk.
+    const id_map = new Map<string, NodeId>();
+    for (const el of doc.all_elements()) {
+      const id_attr = doc.get_attr(el, "id");
+      if (id_attr !== null && !id_map.has(id_attr)) id_map.set(id_attr, el);
+    }
+
+    const in_forest = (target: NodeId): boolean =>
+      roots.some((r) => doc.contains(r, target));
+
+    const collected = new Set<NodeId>();
+    const pending: NodeId[] = [...roots];
+
+    while (pending.length > 0) {
+      const subtree = pending.pop()!;
+      for (const el of elements_of_subtree(doc, subtree)) {
+        for (const ref of refs_of(doc, el)) {
+          const target = id_map.get(ref);
+          if (target === undefined) continue; // unresolved — left as authored
+          if (in_forest(target)) continue; // already content
+          if (collected.has(target)) continue; // cycle / shared-def guard
+          collected.add(target);
+          pending.push(target);
+        }
+      }
+    }
+
+    // Subtree-aware dedup (a collected gradient inside a collected
+    // pattern would otherwise serialize twice), then document order.
+    return doc.prune_nested_nodes([...collected]).sort(by_document_order(doc));
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────
+
+  function normalize_selection(
+    doc: SvgDocument,
+    selection: ReadonlyArray<NodeId>
+  ): NodeId[] {
+    const live = [...new Set(selection)].filter(
+      (id) => doc.is_element(id) && doc.contains(doc.root, id)
+    );
+    return doc.prune_nested_nodes(live).sort(by_document_order(doc));
+  }
+
+  function by_document_order(
+    doc: SvgDocument
+  ): (a: NodeId, b: NodeId) => number {
+    const index = new Map<NodeId, number>();
+    let i = 0;
+    for (const id of doc.all_nodes()) index.set(id, i++);
+    return (a, b) => (index.get(a) ?? 0) - (index.get(b) ?? 0);
+  }
+
+  /** Preorder element walk of `root`'s subtree, root included. */
+  function elements_of_subtree(doc: SvgDocument, root: NodeId): NodeId[] {
+    const out: NodeId[] = [];
+    const walk = (id: NodeId) => {
+      if (!doc.is_element(id)) return;
+      out.push(id);
+      for (const c of doc.children_of(id)) walk(c);
+    };
+    walk(root);
+    return out;
+  }
+
+  /** Same-document reference ids carried by one element, per the closed
+   *  carrier list. */
+  function refs_of(doc: SvgDocument, id: NodeId): string[] {
+    const out: string[] = [];
+    for (const prop of URL_REF_PROPS) {
+      for (const value of [doc.get_attr(id, prop), doc.get_style(id, prop)]) {
+        if (!value) continue;
+        for (const m of value.matchAll(URL_REF_RE)) out.push(m[1]);
+      }
+    }
+    if (HREF_TAGS.has(doc.tag_of(id))) {
+      // ns=null matches any namespace — covers `href` and `xlink:href`.
+      const href = doc.get_attr(id, "href");
+      if (href !== null && href.startsWith("#") && href.length > 1) {
+        out.push(href.slice(1));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Resolve a prefix a member's subtree borrows from ancestor scope:
+   * nearest ancestor `xmlns:<prefix>` declaration wins (correct XML
+   * scoping), falling back to the well-known table — the deliberate
+   * repair that keeps the payload namespace-well-formed even when the
+   * source never declared the prefix (FRD §Extraction 2).
+   */
+  function resolve_prefix(
+    doc: SvgDocument,
+    member: NodeId,
+    prefix: string
+  ): string | null {
+    let cur: NodeId | null = doc.parent_of(member);
+    while (cur !== null) {
+      const uri = doc.get_attr(cur, prefix, XMLNS_NS);
+      if (uri !== null) return uri;
+      cur = doc.parent_of(cur);
+    }
+    return WELL_KNOWN_PREFIXES.get(prefix) ?? null;
+  }
+}

--- a/packages/grida-svg-editor/src/core/clipboard.ts
+++ b/packages/grida-svg-editor/src/core/clipboard.ts
@@ -30,7 +30,7 @@
 
 import type { NodeId } from "../types";
 import type { SvgDocument } from "./document";
-import { SVG_NS, XLINK_NS, XMLNS_NS } from "./document";
+import { SVG_NS, WELL_KNOWN_NS_PREFIXES, XMLNS_NS } from "./document";
 
 export namespace clipboard {
   /**
@@ -80,12 +80,6 @@ export namespace clipboard {
    */
   const URL_REF_RE = /url\(\s*["']?#([^"')\s]+)["']?\s*\)/g;
 
-  /** Prefixes resolvable without a source declaration — the same
-   *  well-known table the paste-side hoist uses. */
-  const WELL_KNOWN_PREFIXES: ReadonlyMap<string, string> = new Map([
-    ["xlink", XLINK_NS],
-  ]);
-
   /**
    * Extract a standalone SVG document from the selection.
    *
@@ -107,7 +101,11 @@ export namespace clipboard {
     doc: SvgDocument,
     selection: ReadonlyArray<NodeId>
   ): string | null {
-    const roots = normalize_selection(doc, selection);
+    // One doc-order comparator per extraction (each build walks the whole
+    // node tree); collect_reference_closure keeps its own — it is an
+    // independently exported test entry point.
+    const order = by_document_order(doc);
+    const roots = normalize_selection(doc, selection, order);
     if (roots.length === 0) return null;
 
     const closure = collect_reference_closure(doc, roots);
@@ -119,7 +117,7 @@ export namespace clipboard {
     // declaration wins — the FRD is silent on conflicting prefix URIs
     // across members; first-in-document-order is deterministic and honest.
     const shell_ns = new Map<string, string>();
-    for (const member of [...closure, ...roots].sort(by_document_order(doc))) {
+    for (const member of [...closure, ...roots].sort(order)) {
       for (const prefix of doc.undeclared_ns_prefixes(member)) {
         if (shell_ns.has(prefix)) continue;
         const uri = resolve_prefix(doc, member, prefix);
@@ -204,12 +202,13 @@ export namespace clipboard {
 
   function normalize_selection(
     doc: SvgDocument,
-    selection: ReadonlyArray<NodeId>
+    selection: ReadonlyArray<NodeId>,
+    order: (a: NodeId, b: NodeId) => number
   ): NodeId[] {
     const live = [...new Set(selection)].filter(
       (id) => doc.is_element(id) && doc.contains(doc.root, id)
     );
-    return doc.prune_nested_nodes(live).sort(by_document_order(doc));
+    return doc.prune_nested_nodes(live).sort(order);
   }
 
   function by_document_order(
@@ -237,8 +236,15 @@ export namespace clipboard {
    *  carrier list. */
   function refs_of(doc: SvgDocument, id: NodeId): string[] {
     const out: string[] = [];
+    // One parse of the inline style per element (`get_style` re-parses the
+    // whole attribute per property); first declaration wins, matching
+    // `get_style`'s semantics.
+    const styles = new Map<string, string>();
+    for (const { property, value } of doc.get_all_styles(id)) {
+      if (!styles.has(property)) styles.set(property, value);
+    }
     for (const prop of URL_REF_PROPS) {
-      for (const value of [doc.get_attr(id, prop), doc.get_style(id, prop)]) {
+      for (const value of [doc.get_attr(id, prop), styles.get(prop)]) {
         if (!value) continue;
         for (const m of value.matchAll(URL_REF_RE)) out.push(m[1]);
       }
@@ -271,6 +277,6 @@ export namespace clipboard {
       if (uri !== null) return uri;
       cur = doc.parent_of(cur);
     }
-    return WELL_KNOWN_PREFIXES.get(prefix) ?? null;
+    return WELL_KNOWN_NS_PREFIXES.get(prefix) ?? null;
   }
 }

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -1278,4 +1278,4 @@ function parse_inline_style(
   return out;
 }
 
-export { XLINK_NS, XML_NS, XMLNS_NS };
+export { SVG_NS, XLINK_NS, XML_NS, XMLNS_NS };

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -1278,4 +1278,15 @@ function parse_inline_style(
   return out;
 }
 
+/**
+ * Namespace prefixes resolvable without a source declaration. ONE table,
+ * shared by the paste-side hoist (`insert_fragment`'s xmlns plan) and the
+ * copy-side shell repair (clipboard payload extraction) — the two sides
+ * form a round-trip and must agree: a prefix only one side knows would
+ * produce payloads the other can't honor.
+ */
+export const WELL_KNOWN_NS_PREFIXES: ReadonlyMap<string, string> = new Map([
+  ["xlink", XLINK_NS],
+]);
+
 export { SVG_NS, XLINK_NS, XML_NS, XMLNS_NS };

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -17,7 +17,7 @@ import { applyDefaultBindings } from "../keymap/defaults";
 import cmath from "@grida/cmath";
 import { create_defs } from "./defs";
 import { clipboard as clipboard_codec } from "./clipboard";
-import { SvgDocument, XLINK_NS, XMLNS_NS } from "./document";
+import { SvgDocument, WELL_KNOWN_NS_PREFIXES, XMLNS_NS } from "./document";
 import type { GeometryProvider } from "./geometry";
 import type { SurfaceBridge } from "./surface-bridge";
 import { group as group_policy } from "./group";
@@ -1979,7 +1979,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     // strict XML consumers reject wholesale. Hoist the declarations we
     // can resolve: `xlink` (well-known URI) and anything the discarded
     // `<svg>` shell declared. Their writes ride the same atomic step.
-    const known_uri = new Map<string, string>([["xlink", XLINK_NS]]);
+    const known_uri = new Map(WELL_KNOWN_NS_PREFIXES);
     for (const d of xmlns) known_uri.set(d.prefix, d.uri);
     const hoist: Array<{ prefix: string; uri: string }> = [];
     const considered = new Set<string>();

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -16,6 +16,7 @@ import { Keymap } from "../keymap/keymap";
 import { applyDefaultBindings } from "../keymap/defaults";
 import cmath from "@grida/cmath";
 import { create_defs } from "./defs";
+import { clipboard as clipboard_codec } from "./clipboard";
 import { SvgDocument, XLINK_NS, XMLNS_NS } from "./document";
 import type { GeometryProvider } from "./geometry";
 import type { SurfaceBridge } from "./surface-bridge";
@@ -326,6 +327,61 @@ export type Commands = {
   // structure
   reorder(direction: ReorderDirection): void;
   remove(): void;
+  // clipboard — contract: docs/wg/feat-svg-editor/clipboard.md
+  /**
+   * Copy the selection as a **standalone SVG document** (the payload is
+   * the file format — no private envelope). The payload carries the
+   * outbound `url(#…)` / `href` reference closure in one `<defs>` block
+   * and declares every namespace prefix the fragment borrows from
+   * ancestor scope; ancestor transforms, inherited presentation, and the
+   * viewport are deliberately NOT carried (verbatim policy — see the FRD).
+   *
+   * Pure read: no document mutation, no history entry. The payload is
+   * always written to the editor's internal clipboard buffer (the
+   * transport floor — cannot fail) and, when a `ClipboardProvider` is
+   * configured, delivered to it best-effort (a failed provider write is
+   * dev-warned, never a copy failure).
+   *
+   * Returns the payload string, or `null` on empty / non-live selection
+   * (a no-op, not an error — copy has no refusal path).
+   */
+  copy(): string | null;
+  /**
+   * Copy, then delete the selection — ONE history step labeled `"cut"`
+   * with {@link remove}'s exact capture/revert semantics. The payload is
+   * secured in the internal buffer BEFORE the deletion commits, so a
+   * failed external write never strands the user with deleted content
+   * and no copy. The clipboard write is not part of the history step:
+   * undo restores the document and leaves the buffer holding the payload
+   * (cut → undo → paste works as a move idiom).
+   *
+   * Returns the payload string, or `null` on empty selection (no
+   * mutation, no history).
+   */
+  cut(): string | null;
+  /**
+   * Paste SVG markup — `text` when given, else the internal clipboard
+   * buffer. Synchronous over delivered text: acquisition from a native
+   * clipboard event or an async provider read is the invoking channel's
+   * job and completes before this command runs.
+   *
+   * Accepts anything {@link insert_fragment} parses (bare fragment or
+   * full document — the editor's own payloads are an ordinary case, not
+   * a privileged one) and inserts it with the same atomic semantics:
+   * one history step, subtrees adopted verbatim, ids never rewritten,
+   * namespace declarations hoisted, appended at the document top level,
+   * inserted roots selected.
+   *
+   * **Gesture-grade refusal table** (deliberately weaker than
+   * `insert_fragment`'s): paste's input is environment-supplied — prose,
+   * URLs, and JSON are what clipboards hold most of the day — so
+   * non-parseable input is a **no-op refusal** (`[]`, no mutation, no
+   * history), never a thrown error. A non-string argument still throws
+   * `TypeError` (caller bug — no acquisition channel produces one).
+   * Empty selection→buffer misses (`undefined` text, empty buffer) also
+   * return `[]`.
+   */
+  paste(text?: string): NodeId[];
   /**
    * Wrap the current selection in a new plain `<g>`. Returns `true` if
    * the wrap was performed (a history step was pushed and the new group
@@ -496,6 +552,13 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   let load_version = 0;
   let style: EditorStyle = { ...DEFAULT_STYLE, ...opts.style };
   const providers = opts.providers ?? {};
+  /**
+   * In-memory clipboard buffer — the transport floor (FRD R1: the buffer
+   * write cannot fail; external channels are best-effort on top). NOT part
+   * of `EditorState` and NOT history-managed: it survives `load()` /
+   * `reset()` / undo, like the OS clipboard it mirrors.
+   */
+  let clipboard_buffer: string | null = null;
   const listeners = new Set<(state: EditorState) => void>();
   let attached_surface: Surface | null = null;
   /**
@@ -1625,6 +1688,16 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   }
 
   function remove() {
+    remove_selection("remove");
+  }
+
+  /**
+   * Shared deletion body for `remove` and `cut` — identical
+   * capture/revert semantics, differing only in the history label
+   * (`verb`), so undo attribution names the gesture that caused the
+   * deletion.
+   */
+  function remove_selection(verb: string) {
     if (selection.length === 0) return;
 
     // Compact selection to subtree roots first — `doc.remove` detaches
@@ -1675,7 +1748,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     };
     apply();
     history.atomic(
-      captures.length === 1 ? "remove" : `remove ${captures.length}`,
+      captures.length === 1 ? verb : `${verb} ${captures.length}`,
       (tx) => {
         tx.push({ providerId: PROVIDER_ID, apply, revert });
       }
@@ -1875,6 +1948,19 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     svg: string,
     opts?: { parent?: NodeId; index?: number; select?: boolean }
   ): NodeId[] {
+    return insert_fragment_impl(svg, opts, "insert fragment");
+  }
+
+  /**
+   * Label-bearing body shared by `insert_fragment` and `paste` — same
+   * atomic insertion, differing only in history attribution (undo for a
+   * paste gesture should read "paste", not "insert fragment").
+   */
+  function insert_fragment_impl(
+    svg: string,
+    opts: { parent?: NodeId; index?: number; select?: boolean } | undefined,
+    label: string
+  ): NodeId[] {
     const parent = opts?.parent ?? doc.root;
     if (!doc.is_element(parent) || !doc.contains(doc.root, parent)) {
       throw new Error(
@@ -1928,10 +2014,75 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       if (select_after) set_selection(previous_selection);
     };
     apply();
-    history.atomic("insert fragment", (tx) => {
+    history.atomic(label, (tx) => {
       tx.push({ providerId: PROVIDER_ID, apply, revert });
     });
     return roots;
+  }
+
+  // ─── Clipboard ───────────────────────────────────────────────────────────
+  // Contract: docs/wg/feat-svg-editor/clipboard.md. Payload assembly is
+  // core/clipboard.ts (pure); these commands own the buffer + transport
+  // write-through. `deliver_external` implements the one-external-channel
+  // rule: the public commands deliver to the provider; the surface's
+  // native-event path calls `_internal.clipboard.*` (deliver=false) and
+  // writes the event's DataTransfer instead — one gesture, one external
+  // write.
+
+  function copy_impl(deliver_external: boolean): string | null {
+    const payload = clipboard_codec.extract_payload(doc, selection);
+    if (payload === null) return null;
+    clipboard_buffer = payload;
+    if (deliver_external && providers.clipboard) {
+      void providers.clipboard.write(payload).catch((err) => {
+        // Best-effort external delivery (FRD R1): the buffer is the
+        // success floor; a failed provider write is reportable, never a
+        // copy failure.
+        console.warn("[svg-editor] clipboard provider write failed:", err);
+      });
+    }
+    return payload;
+  }
+
+  function copy(): string | null {
+    return copy_impl(true);
+  }
+
+  function cut_impl(deliver_external: boolean): string | null {
+    // Extract BEFORE removing — `serialize_node` throws on detached
+    // nodes, and the FRD requires the payload secured in the buffer
+    // before the deletion commits.
+    const payload = copy_impl(deliver_external);
+    if (payload === null) return null;
+    remove_selection("cut");
+    return payload;
+  }
+
+  function cut(): string | null {
+    return cut_impl(true);
+  }
+
+  function paste(text?: string): NodeId[] {
+    if (text !== undefined && typeof text !== "string") {
+      throw new TypeError(
+        `paste(text) requires a string when provided, got ${text === null ? "null" : typeof text}`
+      );
+    }
+    const source = text ?? clipboard_buffer;
+    if (source === null) return [];
+    try {
+      return insert_fragment_impl(source, undefined, "paste");
+    } catch (err) {
+      if (err instanceof TypeError) throw err;
+      // Gesture-grade refusal (FRD §Command semantics): paste's input is
+      // environment-supplied — prose, URLs, JSON are what clipboards hold
+      // most of the day — so non-parseable input is a no-op, never a
+      // throw. Mutation-safe to catch here: `create_fragment` parses the
+      // whole input before adopting anything, so a parse error precedes
+      // any document-visible change. `insert_fragment` (whose caller
+      // authored its input) keeps strict error semantics.
+      return [];
+    }
   }
 
   /**
@@ -2205,6 +2356,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     align,
     reorder,
     remove,
+    copy,
+    cut,
+    paste,
     group,
     ungroup,
     insert,
@@ -2482,6 +2636,11 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       doc,
       history: {
         preview: (label: string) => history.preview(label),
+        undo_label: () => history.stack.undoLabel,
+      },
+      clipboard: {
+        copy: () => copy_impl(false),
+        cut: () => cut_impl(false),
       },
       insert_text_preview,
       emit,

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -25,9 +25,24 @@ export interface SurfaceBridge {
   readonly doc: SvgDocument;
 
   /** History bracket factory. Surfaces open one per gesture and
-   *  `set / commit / discard` it across frames. */
+   *  `set / commit / discard` it across frames. `undo_label` reads the
+   *  label of the step `undo()` would revert — gesture attribution
+   *  (e.g. asserting a cut recorded as "cut", not "remove"). */
   readonly history: {
     preview(label: string): Preview;
+    undo_label(): string | null;
+  };
+
+  /** surface → editor: buffer-only clipboard operations for the native
+   *  ClipboardEvent path. Same semantics as `commands.copy` / `commands.cut`
+   *  EXCEPT no provider delivery — the surface writes the event's
+   *  DataTransfer instead, honoring the one-external-channel rule
+   *  (docs/wg/feat-svg-editor/clipboard.md §Transport: one gesture, one
+   *  external write). Paste has no row here — the surface hands the
+   *  event's text to the public `commands.paste(text)`. */
+  readonly clipboard: {
+    copy(): string | null;
+    cut(): string | null;
   };
 
   /** Text-creation bracket for the click-to-place text tool. Creates an

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -553,6 +553,7 @@ class DomSurface implements Surface {
     this.container = options.container;
     const container = this.container;
     this.fit_on_attach = options.fit === true;
+    this.clipboard_enabled = options.clipboard !== false;
     this.attention = create_attention_tracker(container);
     this.teardown.push(() => this.attention.dispose());
     // The container is exclusively owned by the surface — interactive
@@ -594,7 +595,8 @@ class DomSurface implements Surface {
     // copy/cut event target from focus fire at all over a selectionless
     // canvas (the pre-2025 WebKit floor; FRD §Transport). The focus ring
     // is suppressed — the HUD's selection chrome is the focus signal here.
-    this.clipboard_enabled = options.clipboard !== false;
+    // Unconditional: focus management is a general canvas mitigation, not
+    // gated by `clipboard_enabled`.
     container.tabIndex = -1;
     container.style.outline = "none";
 

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -104,6 +104,7 @@ import type {
 } from "./types";
 import { TOOL_CURSOR } from "./types";
 import { array_shallow_equal } from "./util/equal";
+import { is_text_input_focused } from "./util/dom";
 
 // Re-exports of surface-scoped types that don't belong on the headless
 // entry. Anything DOM-coupled (Camera, Gestures, MemoizedGeometryProvider,
@@ -226,6 +227,18 @@ export type DomSurfaceOptions = {
    */
   gestures?: boolean;
   /**
+   * Wire native ClipboardEvent transport — `copy` / `cut` / `paste`
+   * listeners on the owner document, gated by the clipboard attention
+   * discipline. Default `true`. Pass `false` to route ALL clipboard
+   * traffic through the `ClipboardProvider` seam instead (the
+   * configuration under which a host's paste-time screening governs
+   * every path) — see docs/wg/feat-svg-editor/clipboard.md §Transport
+   * "Host control over the native path". Focus management (the container
+   * focusing on pointerdown) stays either way — it is a general canvas
+   * mitigation, not a clipboard feature.
+   */
+  clipboard?: boolean;
+  /**
    * Auto-fit the document into the viewport on initial attach. Default
    * `false`. Mirrors Excalidraw's `initialData.scrollToContent`.
    * Subsequent `editor.load()` calls do NOT re-fit — call
@@ -344,6 +357,9 @@ class DomSurface implements Surface {
   readonly gestures: Gestures;
   /** One-shot: cleared after the post-mount RAF honors `options.fit`. */
   private fit_on_attach: boolean;
+  /** Native ClipboardEvent transport wired (`options.clipboard !== false`).
+   *  See `DomSurfaceOptions.clipboard`. */
+  private readonly clipboard_enabled: boolean;
   /** Container element (cached from options). */
   private readonly container: HTMLElement;
   /** Pointer/focus-attention tracker — gates the doc/window-level keydown
@@ -571,6 +587,16 @@ class DomSurface implements Surface {
     (
       container.style as CSSStyleDeclaration & { webkitUserSelect?: string }
     ).webkitUserSelect = "none";
+    // Programmatically focusable, not tab-reachable. The surface focuses
+    // the container on pointerdown so (a) native clipboard events target
+    // the canvas (and the clipboard gate's focus-within arm can claim
+    // them — see `claims_clipboard`), and (b) engines that derive the
+    // copy/cut event target from focus fire at all over a selectionless
+    // canvas (the pre-2025 WebKit floor; FRD §Transport). The focus ring
+    // is suppressed — the HUD's selection chrome is the focus signal here.
+    this.clipboard_enabled = options.clipboard !== false;
+    container.tabIndex = -1;
+    container.style.outline = "none";
 
     // Derive pipeline options from current style. Shared by the
     // orchestrator (drag gestures) and the nudge-dwell watcher (after-
@@ -2091,6 +2117,82 @@ class DomSurface implements Surface {
 
     // Prevent context menu inside container (we don't have right-click UI yet).
     on(this.container, "contextmenu", (e: MouseEvent) => e.preventDefault());
+
+    // Native clipboard transport — the primary channel (the keystroke is
+    // the permission; no prompts in any engine). Wired on `owner_doc` for
+    // symmetry with keydown; gated per-event by `claims_clipboard`. See
+    // docs/wg/feat-svg-editor/clipboard.md §Transport.
+    if (this.clipboard_enabled) {
+      on(owner_doc, "copy", (e: ClipboardEvent) =>
+        this.on_copy_or_cut(e, "copy")
+      );
+      on(owner_doc, "cut", (e: ClipboardEvent) =>
+        this.on_copy_or_cut(e, "cut")
+      );
+      on(owner_doc, "paste", (e: ClipboardEvent) => this.on_paste(e));
+    }
+  }
+
+  /**
+   * Gate for claiming a native clipboard gesture. Deliberately STRICTER
+   * than the keyboard attention gate: focus-based only — pointer-over is
+   * a sufficient signal for a keystroke (worst case: a stolen scroll) but
+   * not for clipboard (worst case: destroying what the user believed they
+   * copied, or routing a paste meant for a host text field into the
+   * document). A user with text selected in a sibling panel and the
+   * pointer idly over the canvas must get their text copy.
+   */
+  private claims_clipboard(kind: "copy" | "cut" | "paste"): boolean {
+    // The inline text session owns the clipboard while active.
+    if (this.text_edit) return false;
+    // Structural mutation under an open content-edit session is the same
+    // hazard the `clipboard.*` registry handlers gate (vector edit).
+    if (this.editor.state.mode !== "select") return false;
+    if (!this.attention.is_focus_within()) return false;
+    // A focused host text input always wins, for paste especially.
+    if (is_text_input_focused()) return false;
+    if (kind !== "paste") {
+      // A non-collapsed host text selection is the natural target of a
+      // copy/cut gesture — never claim over it.
+      const sel = this.container.ownerDocument.getSelection();
+      if (sel && !sel.isCollapsed) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Act-then-claim: an empty selection returns without `preventDefault()`,
+   * leaving the browser default (and the OS clipboard) untouched. The
+   * buffer-only `_internal.clipboard` variants are used here — the event's
+   * DataTransfer is this gesture's ONE external channel (the public
+   * commands would additionally write the provider; one gesture, one
+   * external write — FRD §Transport).
+   */
+  private on_copy_or_cut(e: ClipboardEvent, kind: "copy" | "cut"): void {
+    if (!this.claims_clipboard(kind)) return;
+    // No DataTransfer = no usable event channel — leave the gesture
+    // unclaimed rather than half-execute (a cut would delete without
+    // delivering anywhere external).
+    if (!e.clipboardData) return;
+    const internal = this.editor_internal();
+    const payload =
+      kind === "copy" ? internal.clipboard.copy() : internal.clipboard.cut();
+    if (payload === null) return;
+    e.clipboardData.setData("text/plain", payload);
+    e.preventDefault();
+  }
+
+  /**
+   * Claim-then-act (mirrors the keydown claim doctrine: swallow when the
+   * gesture is aimed at the editor, not just when a handler consumed):
+   * a refused paste — junk text — still claims; the suppressed default is
+   * a no-op on a div anyway.
+   */
+  private on_paste(e: ClipboardEvent): void {
+    if (!this.claims_clipboard("paste")) return;
+    e.preventDefault();
+    const text = e.clipboardData?.getData("text/plain");
+    if (text) this.editor.commands.paste(text);
   }
 
   /**
@@ -2180,6 +2282,13 @@ class DomSurface implements Surface {
         this.text_edit.pointerUp();
       }
       return;
+    }
+    // Take focus on press (text-edit case returned above — stealing focus
+    // there would blur the hidden input and force a deferred commit).
+    // Focus-within is what arms the clipboard gate and what makes engines
+    // that target copy/cut at the focused element fire over the canvas.
+    if (kind === "pointer_down") {
+      this.container.focus({ preventScroll: true });
     }
 
     const cr = this.container.getBoundingClientRect();

--- a/packages/grida-svg-editor/src/react.tsx
+++ b/packages/grida-svg-editor/src/react.tsx
@@ -101,6 +101,12 @@ export type SvgEditorCanvasProps = {
    * `DomSurfaceOptions.fit`.
    */
   fit?: boolean;
+  /**
+   * Wire native ClipboardEvent transport (copy/cut/paste). Default `true`.
+   * Pass `false` to route all clipboard traffic through the
+   * `ClipboardProvider` seam. See `DomSurfaceOptions.clipboard`.
+   */
+  clipboard?: boolean;
   /** Initial camera transform. Default identity. */
   initial_camera?: cmath.Transform;
   /**
@@ -125,6 +131,7 @@ export function SvgEditorCanvas({
   style,
   gestures,
   fit,
+  clipboard,
   initial_camera,
   onAttach,
 }: SvgEditorCanvasProps) {
@@ -143,6 +150,7 @@ export function SvgEditorCanvas({
       container,
       gestures,
       fit,
+      clipboard,
       initial_camera: initial_camera_ref.current,
     });
     on_attach_ref.current?.(handle);
@@ -150,7 +158,7 @@ export function SvgEditorCanvas({
       on_attach_ref.current?.(null);
       handle.detach();
     };
-  }, [editor, gestures, fit]);
+  }, [editor, gestures, fit, clipboard]);
   return <div ref={ref} className={className} style={style} />;
 }
 

--- a/packages/grida-svg-editor/src/util/attention.ts
+++ b/packages/grida-svg-editor/src/util/attention.ts
@@ -47,6 +47,18 @@ export interface AttentionTracker {
    * Pure read; no DOM mutation. Cheap enough to call once per keydown.
    */
   is_attended(): boolean;
+  /**
+   * `true` iff focus is inside `container`'s subtree — the focus arm of
+   * {@link is_attended} alone, WITHOUT the pointer-over arm.
+   *
+   * Exists for the native clipboard gate (`dom.ts`): pointer-over is a
+   * sufficient signal to claim a keystroke (worst case: a stolen scroll)
+   * but NOT a copy/cut/paste gesture (worst case: destroying what the
+   * user believed they copied, or routing a paste meant for a host text
+   * field into the document). See docs/wg/feat-svg-editor/clipboard.md
+   * §Transport "Gating the native events".
+   */
+  is_focus_within(): boolean;
   /** Detach the internal pointer-tracking listeners. */
   dispose(): void;
 }
@@ -72,20 +84,22 @@ export function create_attention_tracker(
   container.addEventListener("pointerenter", on_enter);
   container.addEventListener("pointerleave", on_leave);
 
-  const is_attended = (): boolean => {
+  const is_focus_within = (): boolean => {
     const owner = container.ownerDocument;
-    if (!owner) return pointer_over;
+    if (!owner) return false;
     const active = owner.activeElement;
     // Focus inside the surface's subtree counts. `contains(self)` is true,
     // so this also covers "the container itself is focused" (e.g. tabindex).
-    if (active && active !== owner.body && container.contains(active)) {
-      return true;
-    }
-    return pointer_over;
+    return !!active && active !== owner.body && container.contains(active);
+  };
+
+  const is_attended = (): boolean => {
+    return is_focus_within() || pointer_over;
   };
 
   return {
     is_attended,
+    is_focus_within,
     dispose: () => {
       container.removeEventListener("pointerenter", on_enter);
       container.removeEventListener("pointerleave", on_leave);

--- a/test/svg-editor-clipboard.md
+++ b/test/svg-editor-clipboard.md
@@ -4,7 +4,7 @@ title: Copy/cut/paste round-trips through the OS clipboard as plain SVG markup
 module: svg-editor
 area: clipboard
 tags: [clipboard, copy, paste, cut, interop, history, undo]
-status: untested
+status: verified
 severity: high
 date: 2026-06-10
 updated: 2026-06-10
@@ -75,6 +75,10 @@ events; the OS clipboard and real keystrokes are only exercised here):
 
 ## Notes
 
+- 2026-06-10: manually verified on the v1 implementation —
+  cross-window copy-paste (two editor windows) and repeated multi-paste
+  both work as specified. Translate-with-clone (Alt+drag) is a separate
+  deferred feature (TODO §5), not part of this TC.
 - Spec: `docs/wg/feat-svg-editor/clipboard.md`. Same-document paste of
   a defs-referencing shape intentionally duplicates the `<defs>` block
   (documented cost; Tidy is the planned recovery) — not a bug.

--- a/test/svg-editor-clipboard.md
+++ b/test/svg-editor-clipboard.md
@@ -1,0 +1,86 @@
+---
+id: TC-SVGEDITOR-CLIPBOARD-001
+title: Copy/cut/paste round-trips through the OS clipboard as plain SVG markup
+module: svg-editor
+area: clipboard
+tags: [clipboard, copy, paste, cut, interop, history, undo]
+status: untested
+severity: high
+date: 2026-06-10
+updated: 2026-06-10
+automatable: false
+covered_by:
+  - packages/grida-svg-editor/__tests__/clipboard-extract.test.ts
+  - packages/grida-svg-editor/__tests__/clipboard-commands.test.ts
+  - packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
+---
+
+## Behavior
+
+The clipboard payload is a **standalone SVG document** written to the OS
+clipboard as plain text — not a private format (spec:
+`docs/wg/feat-svg-editor/clipboard.md`). Consequences a manual pass must
+verify that automation cannot (the automated suites use synthetic
+events; the OS clipboard and real keystrokes are only exercised here):
+
+- ⌘C over the canvas puts SVG markup on the **system** clipboard —
+  pasting into a code editor yields readable source; pasting into
+  another SVG consumer (e.g. Figma) creates vectors.
+- Copy carries referenced `<defs>` (gradients etc.) so the payload
+  renders standalone; ids are never rewritten; pasted content lands at
+  its authored coordinates (in-place), appended on top, selected.
+- ⌘X is one undoable step; undo restores the document while the
+  clipboard keeps the payload (cut → undo → paste = move idiom).
+- The editor claims the gesture **only when the canvas has focus** — a
+  text selection in the surrounding page, or focus in any text input,
+  always wins. Pointer-over alone never claims clipboard.
+- Non-SVG clipboard text pasted over the canvas is a silent no-op (no
+  error, no mutation, no undo entry).
+
+## Steps
+
+1. Open the SVG editor demo at `http://localhost:3000/svg/`.
+2. **Copy → external.** Click a shape (canvas takes focus), press
+   `⌘/Ctrl+C`. Paste into a plain-text editor.
+   - Expected: a single-line standalone SVG document
+     (`<svg xmlns="…">…</svg>`); if the shape used a gradient, its
+     `<defs>` ride along.
+3. **Copy → paste in place.** Back on the canvas, press `⌘/Ctrl+V`.
+   - Expected: the copy lands exactly over the original (same
+     coordinates, painted on top) and is selected; one `⌘Z` removes it
+     entirely.
+4. **Cut as move.** Select a shape, `⌘/Ctrl+X` (it disappears), `⌘Z`
+   (it returns), `⌘/Ctrl+V`.
+   - Expected: after the paste, both the restored original and the
+     pasted copy exist; the cut and the paste were one undo step each.
+5. **External → paste.** Copy SVG markup from a code editor (e.g.
+   `<circle cx="50" cy="50" r="20" fill="tomato"/>`), focus the canvas
+   (click once), `⌘/Ctrl+V`.
+   - Expected: the circle appears and is selected.
+6. **Figma interop (both directions, if available).** Paste the step-2
+   payload into Figma — expected: editable vectors. In Figma, "Copy as
+   SVG" a small shape and paste over the canvas — expected: it appears.
+7. **The gate: host text wins.** Select some text in the page outside
+   the canvas (e.g. in the assistant panel or address bar dropdown),
+   with the pointer hovering over the canvas, press `⌘/Ctrl+C`, paste
+   into a text editor.
+   - Expected: the SELECTED TEXT was copied, not SVG markup.
+8. **The gate: text inputs win.** Focus any text input, press
+   `⌘/Ctrl+V` with the pointer over the canvas.
+   - Expected: the input receives the paste; the canvas does not.
+9. **Junk paste is a no-op.** Copy a prose sentence, focus the canvas,
+   `⌘/Ctrl+V`.
+   - Expected: nothing happens — no error toast, no insertion, and
+     `⌘Z` undoes the _previous_ edit, not a phantom paste.
+
+## Notes
+
+- Spec: `docs/wg/feat-svg-editor/clipboard.md`. Same-document paste of
+  a defs-referencing shape intentionally duplicates the `<defs>` block
+  (documented cost; Tidy is the planned recovery) — not a bug.
+- Safari floor: versions before the 2025 WebKit fix (bug 156529) do not
+  fire copy/cut events over a selectionless canvas; on such versions
+  steps 2–4 are expected to fail on the keystroke path. The menu /
+  provider path is the fallback there.
+- Step 6 export side: Figma drops `marker`/`pattern` on SVG import —
+  losses there are Figma's, not ours.


### PR DESCRIPTION
## What

Clipboard support for `@grida/svg-editor`: `commands.copy()` / `cut()` / `paste(text?)`, native ClipboardEvent transport on the DOM surface, the `ClipboardProvider` seam (first consumer), and /svg demo integration (provider + Edit-menu items).

**The design decision that shapes everything:** the clipboard payload is a **standalone SVG document**, not a private envelope. For an editor whose in-memory model *is* the parsed file, markup-as-payload is lossless by construction — and interop falls out: copy → paste into Figma creates vectors; Figma "Copy as SVG" / VS Code → paste into us just works. Spec: [`docs/wg/feat-svg-editor/clipboard.md`](https://github.com/gridaco/grida/blob/feat/svg-editor-clipboard/docs/wg/feat-svg-editor/clipboard.md) (FRD, first commit of this PR; survived a 3-pass pedantic review before implementation).

## How

- **Core codec** (`core/clipboard.ts`, pure & headless): selection → standalone document. Ancestor-subsumption normalization in document order; the closed-carrier-list `url(#…)`/`href` **defs closure** (recursive, cycle-guarded, copied-forest-excluded, subtree-aware dedup); xmlns shell with nearest-ancestor resolution + the well-known `xlink` repair; no viewBox/sizing — deterministic function of (document, selection).
- **Commands**: internal buffer = the transport floor (copy cannot fail; provider delivery is best-effort + dev-warn). Cut secures the buffer **before** deleting, ONE history step labeled `"cut"`. Paste is synchronous over delivered text (`text ?? buffer`), reuses `insert_fragment`'s atomic body, and has a **gesture-grade refusal table**: junk environment input → `[]`, no history, never a throw.
- **Transport**: native `copy`/`cut`/`paste` events are the keystroke binding — deliberately **no keymap rows** (a keymap claim would `preventDefault` the keystroke and suppress the event's generation). The surface gate is **focus-only**, stricter than keyboard attention: a host text selection or focused input always wins; pointer-over never claims clipboard. Container focus management (`tabIndex=-1`, focus on pointerdown, guarded against the inline text-edit input) also covers the pre-2025 WebKit floor (copy events not firing over a selectionless canvas — WebKit bug 156529). `DomSurfaceOptions.clipboard: false` opts out of native transport entirely (routes everything through the provider).
- **One-external-channel rule**: per gesture, exactly one external write — the event's DataTransfer on the keystroke path (via buffer-only `_internal.clipboard` variants), the provider on the command/menu path.

## Reviewer notes

- **Same-document paste duplicates carried `<defs>` intentionally** — copy can't know its destination, paste adopts verbatim (ids NEVER rewritten; dedup stays Tidy's job). Asserted in tests, documented in the FRD §Same-document paste; not a bug.
- `remove()` → `remove_selection(verb)` and `insert_fragment` → `insert_fragment_impl(label)` are label-threading refactors only — capture/revert semantics byte-identical.
- The `satisfies SurfaceBridge` seam gained `clipboard.{copy,cut}` + `history.undo_label()` (the latter for label-attribution tests — kept deliberately, see the /simplify commit message for the trade).
- Last commit applies a 4-angle cleanup review; one behavior-adjacent fix there: the `clipboard.paste` registry handler now honors `args.text` ahead of the provider (the FRD read rule's first leg).

## Testing

- **1214 node tests** (60 new: codec, commands, registry) + **23 browser-mode tests** (chromium: focus, gates, synthetic ClipboardEvents, opt-out) — all green; package build + typecheck, editor-app typecheck, oxlint clean.
- **Manually verified** ([`test/svg-editor-clipboard.md`](https://github.com/gridaco/grida/blob/feat/svg-editor-clipboard/test/svg-editor-clipboard.md) → `verified`): cross-window copy-paste and repeated multi-paste in the live /svg demo, plus the registry/provider path via the demo's Edit menu — including the designed R1 degradation (denied provider write → dev-warn, copy still succeeds via buffer).

## Deferred (tracked)

- Translate-with-clone (Alt+drag) + ⌘D duplicate → #817 (the **subtree-clone** operation — closure-free, a different contract from payload extraction).
- Paste placement enhancements, materializing extraction variants, peer-format ingestion, non-SVG paste, `<style>`-rule carriers → FRD §Out of scope / TODO §4.
- Rendering-surface hardening → the FRD trust-model's tracking obligation (pre-existing exposure, applies to `load()` as much as paste).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Copy/Cut/Paste support with native OS clipboard integration, menu items, and in-place paste/selection behavior
  * Cut is atomic (copy+remove) with its own undo step; paste refuses invalid input as a no-op

* **Documentation**
  * Added detailed clipboard design spec and updated API/commands and keybindings

* **Tests**
  * Added headless and browser tests verifying clipboard semantics and native-clipboard gating

* **Other**
  * Canvas/embed API exposes a clipboard toggle for host integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->