### PR TITLE
chore(deps): lucide-react 1.x + icons package page sync

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@uidotdev/usehooks": "^2.4.1",
-    "lucide-react": "^0.511.0",
+    "lucide-react": "^1.17.0",
     "next": "^16",
     "pdfjs-dist": "4.8.69",
     "react": "^19",

--- a/editor/app/(dev)/ui/_sidebar.tsx
+++ b/editor/app/(dev)/ui/_sidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenuItem,
 } from "@app/ui/components/sidebar";
 import { uiNavGroups } from "./_nav";
+import { GridaLogo } from "@/components/grida-logo";
 
 export function UISidebar() {
   const pathname = usePathname();
@@ -23,8 +24,9 @@ export function UISidebar() {
       <SidebarHeader className="border-b">
         <Link
           href="/ui"
-          className="px-2 py-1.5 text-sm font-semibold tracking-tight"
+          className="flex items-center gap-2 px-2 py-1.5 text-sm font-semibold tracking-tight"
         >
+          <GridaLogo className="size-4" />
           UI Components
         </Link>
       </SidebarHeader>

--- a/editor/app/(dev)/ui/icons/page.tsx
+++ b/editor/app/(dev)/ui/icons/page.tsx
@@ -1,54 +1,11 @@
 import type { Metadata } from "next";
 import React from "react";
 
-// Logos (incl. the Grida brand mark) — the explicit /logos subpath.
-import {
-  GridaLogo,
-  AppleLogo,
-  BirdLogo,
-  GoogleLogo,
-  KakaoTalkLogo,
-  SupabaseLogo,
-  WhatsAppLogo,
-  StripeBadgeLogo,
-  StripeWordmarkLogo,
-  TossLogo,
-  PostgreSQLLogo,
-  WindowsLogo,
-  SlackLogo,
-  XLogo,
-  AnthropicLogo,
-  OpenAILogo,
-  LinuxLogo,
-  NpmLogo,
-  UnsplashLogo,
-  SalesforceLogo,
-  BlackForestLabsLogo,
-  ACMELogo,
-  LeviLogo,
-} from "@grida/react-icons/logos";
-
-// Core editor / graphics-design glyphs — the package root.
-import {
-  PlayFilledIcon,
-  PauseFilledRoundedIcon,
-  FeNoiseIcon,
-  FeBackdropBlurIcon,
-  FeLayerBlurIcon,
-  FeGlassIcon,
-  SolidPaintIcon,
-  LinearGradientPaintIcon,
-  RadialGradientPaintIcon,
-  SweepGradientPaintIcon,
-  DiamondGradientPaintIcon,
-  ImagePaintIcon,
-  BlendModeIcon,
-  RemoveBackgroundIcon,
-  UpscaleIcon,
-  MirroringAllIcon,
-  MirroringAngleIcon,
-  MirroringNoneIcon,
-} from "@grida/react-icons";
+// The whole package surface, enumerated as namespaces so this page can never
+// drift from what the package actually ships — a new export renders here
+// without touching this file.
+import * as icons from "@grida/react-icons";
+import * as logos from "@grida/react-icons/logos";
 
 // Not yet promoted — still editor-internal (couples @grida/cg + flex composites).
 import {
@@ -79,71 +36,75 @@ type IconEntry = {
   Comp: React.ComponentType<{ className?: string }>;
 };
 
-// ── Promoted to @grida/react-icons/logos (source paths dropped) ──────────────
+type IconNamespace = Record<string, IconEntry["Comp"]>;
 
-const BRAND: IconEntry[] = [{ name: "GridaLogo", Comp: GridaLogo }];
+const ICONS_NS = icons as unknown as IconNamespace;
+const LOGOS_NS = logos as unknown as IconNamespace;
 
-const LOGOS: IconEntry[] = [
-  { name: "AppleLogo", Comp: AppleLogo },
-  { name: "BirdLogo", Comp: BirdLogo },
-  { name: "GoogleLogo", Comp: GoogleLogo },
-  { name: "KakaoTalkLogo", Comp: KakaoTalkLogo },
-  { name: "SupabaseLogo", Comp: SupabaseLogo },
-  { name: "WhatsAppLogo", Comp: WhatsAppLogo },
-  { name: "StripeBadgeLogo", Comp: StripeBadgeLogo },
-  { name: "StripeWordmarkLogo", Comp: StripeWordmarkLogo },
-  { name: "TossLogo", Comp: TossLogo },
-  { name: "PostgreSQLLogo", Comp: PostgreSQLLogo },
-  { name: "WindowsLogo", Comp: WindowsLogo },
-  { name: "SlackLogo", Comp: SlackLogo },
-  { name: "XLogo", Comp: XLogo },
-  { name: "AnthropicLogo", Comp: AnthropicLogo },
-  { name: "OpenAILogo", Comp: OpenAILogo },
-  { name: "LinuxLogo", Comp: LinuxLogo },
-  { name: "NpmLogo", Comp: NpmLogo },
-  { name: "UnsplashLogo", Comp: UnsplashLogo },
-  { name: "SalesforceLogo", Comp: SalesforceLogo },
-  { name: "BlackForestLabsLogo", Comp: BlackForestLabsLogo },
-  { name: "ACMELogo", Comp: ACMELogo },
-  { name: "LeviLogo", Comp: LeviLogo },
-];
+// `default` guards against CJS-interop namespace quirks.
+const exportedNames = (ns: IconNamespace) =>
+  Object.keys(ns)
+    .filter((n) => n !== "default")
+    .sort();
+
+const entriesOf = (ns: IconNamespace, names: readonly string[]): IconEntry[] =>
+  names.map((name) => ({ name, Comp: ns[name] }));
+
+// ── Promoted to @grida/react-icons/logos — enumerated from the package, so a
+//    newly added logo shows up here automatically ─────────────────────────────
+
+const BRAND: IconEntry[] = entriesOf(LOGOS_NS, ["GridaLogo"]);
+
+const LOGOS: IconEntry[] = entriesOf(
+  LOGOS_NS,
+  exportedNames(LOGOS_NS).filter((n) => n !== "GridaLogo")
+);
 
 // ── Promoted to @grida/react-icons root — grouped by SEMANTIC role, not by the
-//    editor directory the source happened to live in ──────────────────────────
+//    editor directory the source happened to live in. Group membership is
+//    typechecked against the package; anything not grouped falls through to
+//    the automatic "Ungrouped" section below ──────────────────────────────────
 
-const MEDIA: IconEntry[] = [
-  { name: "PlayFilledIcon", Comp: PlayFilledIcon },
-  { name: "PauseFilledRoundedIcon", Comp: PauseFilledRoundedIcon },
-];
+const group = (names: readonly (keyof typeof icons)[]): IconEntry[] =>
+  entriesOf(ICONS_NS, names);
 
-const FILTER_FX: IconEntry[] = [
-  { name: "FeNoiseIcon", Comp: FeNoiseIcon },
-  { name: "FeBackdropBlurIcon", Comp: FeBackdropBlurIcon },
-  { name: "FeLayerBlurIcon", Comp: FeLayerBlurIcon },
-  { name: "FeGlassIcon", Comp: FeGlassIcon },
-];
+const MEDIA = group(["PlayFilledIcon", "PauseFilledRoundedIcon"]);
 
-const PAINT: IconEntry[] = [
-  { name: "SolidPaintIcon", Comp: SolidPaintIcon },
-  { name: "LinearGradientPaintIcon", Comp: LinearGradientPaintIcon },
-  { name: "RadialGradientPaintIcon", Comp: RadialGradientPaintIcon },
-  { name: "SweepGradientPaintIcon", Comp: SweepGradientPaintIcon },
-  { name: "DiamondGradientPaintIcon", Comp: DiamondGradientPaintIcon },
-  { name: "ImagePaintIcon", Comp: ImagePaintIcon },
-];
+const FILTER_FX = group([
+  "FeNoiseIcon",
+  "FeBackdropBlurIcon",
+  "FeLayerBlurIcon",
+  "FeGlassIcon",
+]);
 
-const BLEND: IconEntry[] = [{ name: "BlendModeIcon", Comp: BlendModeIcon }];
+const PAINT = group([
+  "SolidPaintIcon",
+  "LinearGradientPaintIcon",
+  "RadialGradientPaintIcon",
+  "SweepGradientPaintIcon",
+  "DiamondGradientPaintIcon",
+  "ImagePaintIcon",
+]);
 
-const IMAGE: IconEntry[] = [
-  { name: "RemoveBackgroundIcon", Comp: RemoveBackgroundIcon },
-  { name: "UpscaleIcon", Comp: UpscaleIcon },
-];
+const BLEND = group(["BlendModeIcon"]);
 
-const VECTOR: IconEntry[] = [
-  { name: "MirroringAllIcon", Comp: MirroringAllIcon },
-  { name: "MirroringAngleIcon", Comp: MirroringAngleIcon },
-  { name: "MirroringNoneIcon", Comp: MirroringNoneIcon },
-];
+const IMAGE = group(["RemoveBackgroundIcon", "UpscaleIcon"]);
+
+const VECTOR = group([
+  "MirroringAllIcon",
+  "MirroringAngleIcon",
+  "MirroringNoneIcon",
+]);
+
+// Root exports not placed in a semantic group above — rendered automatically
+// so nothing the package ships is missing from this page.
+const GROUPED = new Set(
+  [MEDIA, FILTER_FX, PAINT, BLEND, IMAGE, VECTOR].flat().map((e) => e.name)
+);
+const UNGROUPED: IconEntry[] = entriesOf(
+  ICONS_NS,
+  exportedNames(ICONS_NS).filter((n) => !GROUPED.has(n))
+);
 
 // ── Not yet promoted — editor-internal ───────────────────────────────────────
 
@@ -188,14 +149,7 @@ const STROKE_DECORATION: IconEntry[] = [
 ];
 
 const PROMOTED_COUNT =
-  BRAND.length +
-  LOGOS.length +
-  MEDIA.length +
-  FILTER_FX.length +
-  PAINT.length +
-  BLEND.length +
-  IMAGE.length +
-  VECTOR.length;
+  exportedNames(ICONS_NS).length + exportedNames(LOGOS_NS).length;
 
 function IconCell({
   name,
@@ -296,6 +250,29 @@ export default function UIIconsPage() {
         </p>
       </div>
 
+      <div className="rounded-md border p-4 text-sm">
+        <p className="font-medium">
+          Are you looking for{" "}
+          <a
+            href="https://icons.grida.co"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4"
+          >
+            icons.grida.co
+          </a>
+          ?
+        </p>
+        <p className="mt-1 leading-relaxed text-muted-foreground">
+          Grida Icons is our aggregated catalog of popular open-source icon sets
+          (Lucide, Heroicons, Phosphor, Octicons, Radix UI, SVGL) with a free
+          search API — that&apos;s a separate project. This page documents{" "}
+          <code className="font-mono">@grida/react-icons</code>: the
+          hand-authored React components for Grida&apos;s own editor-domain
+          glyphs and brand logos.
+        </p>
+      </div>
+
       <hr />
 
       <Section
@@ -367,6 +344,19 @@ export default function UIIconsPage() {
       >
         <IconGrid entries={VECTOR} />
       </Section>
+
+      {UNGROUPED.length > 0 ? (
+        <>
+          <hr />
+
+          <Section
+            title="Ungrouped"
+            description="Root exports not yet placed in a semantic group above — enumerated from the package automatically, so nothing it ships is missing from this page."
+          >
+            <IconGrid entries={UNGROUPED} />
+          </Section>
+        </>
+      ) : null}
 
       <hr />
 

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/hud/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/hud/page.tsx
@@ -33,7 +33,8 @@ import { Button } from "@app/ui/components/button";
 import { useScrollSpy } from "@/hooks/use-scroll-spy";
 import Footer from "@/www/footer";
 import Header from "@/www/header";
-import { ArrowRightIcon, GithubIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { useMemo } from "react";
 
@@ -189,7 +190,7 @@ export default function HudSpecPage() {
                     rel="noopener noreferrer"
                   >
                     <Button size="sm" variant="outline">
-                      <GithubIcon className="mr-1.5 size-3.5" />
+                      <GitHubLogoIcon className="mr-1.5 size-3.5" />
                       source
                     </Button>
                   </Link>

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/svg-editor/page.tsx
@@ -19,7 +19,8 @@ import { cn } from "@app/ui/lib/utils";
 import { useScrollSpy } from "@/hooks/use-scroll-spy";
 import Footer from "@/www/footer";
 import Header from "@/www/header";
-import { ArrowRightIcon, GithubIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { useMemo } from "react";
 import type * as React from "react";
@@ -95,7 +96,7 @@ export default function SvgEditorPackagePage() {
                   rel="noopener noreferrer"
                 >
                   <Button size="lg" variant="outline">
-                    <GithubIcon className="size-4 mr-2" />
+                    <GitHubLogoIcon className="size-4 mr-2" />
                     GitHub
                   </Button>
                 </Link>

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/tree-view/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/tree-view/page.tsx
@@ -37,7 +37,8 @@ import { CopyToClipboardInput } from "@/components/copy-to-clipboard-input";
 import { Resources } from "@/resources";
 import Footer from "@/www/footer";
 import Header from "@/www/header";
-import { ArrowRightIcon, GithubIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import Image from "next/image";
 import Link from "next/link";
 import type * as React from "react";
@@ -80,7 +81,7 @@ export default function TreeViewLandingPage() {
             </Link>
             <Link href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
               <Button size="lg" variant="outline">
-                <GithubIcon className="size-4 mr-2" />
+                <GitHubLogoIcon className="size-4 mr-2" />
                 GitHub
               </Button>
             </Link>

--- a/editor/app/(tools)/tools/page.tsx
+++ b/editor/app/(tools)/tools/page.tsx
@@ -11,11 +11,11 @@ import {
   BoxIcon,
   CodeIcon,
   EraserIcon,
-  FigmaIcon,
   FrameIcon,
   ImageIcon,
   KeyRoundIcon,
 } from "lucide-react";
+import { FigmaLogoIcon } from "@radix-ui/react-icons";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -86,7 +86,7 @@ const categories: { name: string; tools: Tool[] }[] = [
         title: ".fig Inspector",
         description: "Parse and inspect Figma .fig files and clipboard data",
         link: "/tools/fig",
-        icon: FigmaIcon,
+        icon: FigmaLogoIcon,
       },
       {
         title: "E.164 Phone Number Tool",

--- a/editor/app/(www)/(figma)/figma/assistant/page.tsx
+++ b/editor/app/(www)/(figma)/figma/assistant/page.tsx
@@ -1,7 +1,7 @@
 import Header from "@/www/header";
 import Footer from "@/www/footer";
 import React from "react";
-import { Github } from "lucide-react";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import { Button } from "@app/ui/components/button";
 import { Card, CardContent } from "@app/ui/components/card";
 import { ArrowRight } from "lucide-react";
@@ -63,7 +63,7 @@ function Hero() {
             rel="noopener noreferrer"
             className="flex items-center text-white gap-2"
           >
-            <Github className="size-5" />
+            <GitHubLogoIcon className="size-5" />
             <span>600 Stars</span>
           </a>
 

--- a/editor/app/(www)/(slides)/slides/_sections/import.tsx
+++ b/editor/app/(www)/(slides)/slides/_sections/import.tsx
@@ -1,7 +1,8 @@
 import { SectionHeader, SectionHeaderBadge } from "@/www/ui/section";
 import { Section } from "@/www/ui/section";
 import { Badge } from "@app/ui/components/badge";
-import { FigmaIcon, FileCode2Icon } from "lucide-react";
+import { FileCode2Icon } from "lucide-react";
+import { FigmaLogoIcon } from "@radix-ui/react-icons";
 import { BentoCard, BentoCardContent, BentoGrid } from "@/www/ui/bento-grid";
 
 export default function Import() {
@@ -21,7 +22,7 @@ export default function Import() {
         >
           <BentoCardContent
             name="Figma Slides"
-            Icon={FigmaIcon}
+            Icon={FigmaLogoIcon}
             description="Drop your .deck file and continue with editable layers and slide objects on the same canvas."
             className="group-hover:-translate-y-0"
           />

--- a/editor/components/resource-type-icon.tsx
+++ b/editor/components/resource-type-icon.tsx
@@ -31,7 +31,7 @@ import {
   BookUserIcon,
   GlobeIcon,
   PaletteIcon,
-  BoxSelectIcon,
+  ShapesIcon,
 } from "lucide-react";
 import { SupabaseLogo } from "@grida/react-icons/logos";
 
@@ -72,7 +72,7 @@ export type ResourceTypeIconName =
   | "v0_site"
   | "v0_canvas"
   | "palette"
-  | "vector-square"
+  | "shapes"
   | "v0_schema"
   | "v0_campaign_referral"
   | "slides";
@@ -138,8 +138,8 @@ export function ResourceTypeIcon({
       return <PenToolIcon {...props} />;
     case "palette":
       return <PaletteIcon {...props} />;
-    case "vector-square":
-      return <BoxSelectIcon {...props} />;
+    case "shapes":
+      return <ShapesIcon {...props} />;
     case "slides":
       return <PresentationIcon {...props} />;
     case "form-x-supabase":

--- a/editor/package.json
+++ b/editor/package.json
@@ -158,7 +158,7 @@
     "jose": "^6.1.3",
     "libphonenumber-js": "^1.12.6",
     "lowlight": "^3.3.0",
-    "lucide-react": "^0.511.0",
+    "lucide-react": "^1.17.0",
     "mapbox-gl": "^3.4.0",
     "masonic": "^4.1.0",
     "mdn-data": "^2.8.0",

--- a/editor/theme/templates/enterprise/west-referral/standard.tsx
+++ b/editor/theme/templates/enterprise/west-referral/standard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { cn } from "@app/ui/lib/utils";
-import { InstagramIcon } from "lucide-react";
+import { InstagramLogoIcon } from "@radix-ui/react-icons";
 import Image from "next/image";
 import Link from "next/link";
 import { Skeleton } from "@app/ui/components/skeleton";
@@ -201,7 +201,7 @@ export function FooterTemplate({
           </div>
         )}
         <div className="text-muted-foreground">
-          {instagram && <InstagramIcon className="size-4" />}
+          {instagram && <InstagramLogoIcon className="size-4" />}
         </div>
       </div>
       <div className="text-sm text-muted-foreground flex gap-2">

--- a/editor/theme/templates/formstart/default/page.tsx
+++ b/editor/theme/templates/formstart/default/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import React from "react";
 import { CalendarBoxIcon, LocationBoxIcon } from "../../kit/components/icons";
 import { TwitterLogoIcon } from "@radix-ui/react-icons";
-import { YoutubeIcon } from "lucide-react";
+import { YouTubeLogo } from "@grida/react-icons/logos";
 import grida from "@grida/schema";
 
 interface Props {
@@ -131,7 +131,7 @@ function Footer() {
     <footer className="container max-w-4xl mx-auto border-t px-4 py-8 text-muted-foreground">
       <aside className="flex gap-2">
         <TwitterLogoIcon className="size-4" />
-        <YoutubeIcon className="size-4" />
+        <YouTubeLogo className="size-4" />
       </aside>
     </footer>
   );

--- a/editor/www/data/sitemap.ts
+++ b/editor/www/data/sitemap.ts
@@ -115,7 +115,7 @@ export namespace sitemap {
       description: "Presentations on a real canvas",
     } satisfies Item,
     svg: {
-      icon: "vector-square",
+      icon: "shapes",
       title: "SVG",
       href: links.svg,
       description: "The clean SVG editor & SDK",

--- a/packages/grida-react-icons/README.md
+++ b/packages/grida-react-icons/README.md
@@ -1,5 +1,10 @@
 # @grida/react-icons
 
+> **Live:** [grida.co/ui/icons](https://grida.co/ui/icons) — every icon in
+> the package, rendered. _Looking for the open-source icon search & API
+> ([icons.grida.co](https://icons.grida.co))? That's a separate project —
+> [gridaco/icons](https://github.com/gridaco/icons)._
+
 Icons for building **expert editors and graphics-design tools** — the
 genuine missing pieces that general icon sets don't ship: paint &
 gradient types, blend modes, stroke endpoints/markers, vector-editing

--- a/packages/grida-react-icons/package.json
+++ b/packages/grida-react-icons/package.json
@@ -10,7 +10,7 @@
     "react",
     "svg"
   ],
-  "homepage": "https://grida.co",
+  "homepage": "https://grida.co/ui/icons",
   "license": "MIT",
   "author": "Grida",
   "repository": "https://github.com/gridaco/grida",

--- a/packages/grida-react-icons/src/logos/index.ts
+++ b/packages/grida-react-icons/src/logos/index.ts
@@ -21,3 +21,4 @@ export { default as UnsplashLogo } from "./unsplash";
 export { default as WhatsAppLogo } from "./whatsapp";
 export { default as WindowsLogo } from "./windows";
 export { default as XLogo } from "./x";
+export { default as YouTubeLogo } from "./youtube";

--- a/packages/grida-react-icons/src/logos/youtube.tsx
+++ b/packages/grida-react-icons/src/logos/youtube.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function YouTubeLogo({
+  className,
+  ...props
+}: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
     "cmdk": "^1.1.1",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
-    "lucide-react": "^0.511.0",
+    "lucide-react": "^1.17.0",
     "motion": "^12.33.0",
     "nanoid": "^3.3.11",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@react-three/drei':
         specifier: ^10.0.7
         version: 10.7.7(@react-three/fiber@9.1.2(@types/react@19.1.3)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0))(@types/react@19.1.3)(@types/three@0.170.0)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0)
@@ -231,8 +231,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
-        specifier: ^0.511.0
-        version: 0.511.0(react@19.2.5)
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.5)
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -462,7 +462,7 @@ importers:
         version: 16.2.6(@mdx-js/loader@3.1.1(acorn@8.16.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@number-flow/react':
         specifier: ^0.5.7
         version: 0.5.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -498,7 +498,7 @@ importers:
         version: 0.0.38(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^10.34.0
-        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)
+        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)
       '@stepperize/react':
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.5)
@@ -591,10 +591,10 @@ importers:
         version: 10.3.1(react@19.2.5)
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
+        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
       '@vercel/edge-config':
         specifier: ^1.2.1
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@vercel/functions':
         specifier: ^1.6.0
         version: 1.6.0
@@ -603,7 +603,7 @@ importers:
         version: 1.19.1
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
+        version: 1.3.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
       '@visx/responsive':
         specifier: ^3.10.2
         version: 3.12.0(react@19.2.5)
@@ -728,8 +728,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       lucide-react:
-        specifier: ^0.511.0
-        version: 0.511.0(react@19.2.5)
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.5)
       mapbox-gl:
         specifier: ^3.4.0
         version: 3.18.1
@@ -1621,8 +1621,8 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
-        specifier: ^0.511.0
-        version: 0.511.0(react@19.2.5)
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.5)
       motion:
         specifier: ^12.33.0
         version: 12.33.0(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -10977,8 +10977,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.511.0:
-    resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: 19.2.5
 
@@ -18272,7 +18272,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -20166,7 +20166,7 @@ snapshots:
 
   '@sentry/core@10.38.0': {}
 
-  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)':
+  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -21466,7 +21466,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.5
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
+  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -21475,7 +21475,7 @@ snapshots:
 
   '@vercel/edge-config-fs@0.1.0': {}
 
-  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
@@ -21496,7 +21496,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vercel/speed-insights@1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
+  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -25645,7 +25645,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.511.0(react@19.2.5):
+  lucide-react@1.17.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 


### PR DESCRIPTION
## What

- **Bump `lucide-react` `^0.511.0` → `^1.17.0`** in `editor`, `@app/ui`, and `viewer`.
- **Brand-icon fallout**: lucide 1.0 removed its deprecated brand icons (`GithubIcon`, `FigmaIcon`, `InstagramIcon`, `YoutubeIcon`, …). Affected call sites (8 files) now use the `@radix-ui/react-icons` logo equivalents already used across the repo — `GitHubLogoIcon`, `FigmaLogoIcon`, `InstagramLogoIcon`.
- **`YouTubeLogo` added to `@grida/react-icons/logos`** (official mark, `currentColor`, per the package contract) — Radix ships no YouTube logo; used by the formstart template footer.
- **www header**: the SVG menu item now renders lucide's `Shapes` icon — the `"vector-square"` resource-icon variant (→ `BoxSelectIcon`, a dashed marquee square) is renamed to `"shapes"` (→ `ShapesIcon`); the sitemap entry was its only consumer.
- **`/ui/icons` page** now enumerates the `@grida/react-icons` namespaces instead of hand-listing imports, so the page can't drift from what the package ships: logos render automatically (sorted), root glyphs keep their typechecked semantic groups, and an automatic "Ungrouped" section catches anything not yet grouped. Adds an "Are you looking for icons.grida.co?" callout distinguishing this package from the separate aggregated icon-search project ([gridaco/icons](https://github.com/gridaco/icons)).
- **Cross-links**: package README gets a `Live: grida.co/ui/icons` line + the icons.grida.co disambiguation; `package.json` `homepage` → `https://grida.co/ui/icons`. The `/ui` sidebar title now carries the Grida mark.

## Why

Routine dependency refresh; 1.x is lucide's first stable major. The brand-icon removal forced the call-site sweep, which surfaced that the icons showcase page was manually synced (the new `YouTubeLogo` would have silently missed it).

## Verification

- All 167 lucide icon names imported across the repo verified present in 1.17.0 (script sweep); no programmatic lucide API usage exists beyond named imports.
- `pnpm lint` 0 errors, `turbo typecheck` 49/49, `turbo test` (packages + editor) all green.
- Verified live in the dev server: `/tools` (lucide 1.x glyphs + Figma logo swap), `/ui/icons` (callout, auto-enumerated logos incl. `YouTubeLogo`, sidebar mark).

## Reviewer notes

- Radix logo icons sit on a 15×15 viewBox vs lucide's 24×24 — all swapped call sites size via Tailwind `size-*` classes, so rendered size is unchanged.
- The header Features dropdown (SVG → Shapes icon) resisted automated screenshotting (Radix hover-intent); worth a one-second manual hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YouTube logo icon to the icon library
  * Introduced new "shapes" resource type icon

* **Documentation**
  * Updated icon catalog with enhanced organization and live reference to the hosted icon search UI

* **Chores**
  * Upgraded lucide-react dependency to latest version across packages
  * Standardized icon implementations for consistency across the application
  * Updated package metadata for icon library homepage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->