### PR TITLE
docs(readme): packages table, SVG section, drift fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 <div align="center">
   <h1>Grida</h1>
   <p>
-    <strong>Grida is an open-source canvas editor & rendering engine (Rust + Skia + WASM) — plus Database/CMS and Forms.</strong>
+    <strong>Grida is an open-source canvas editor & rendering engine (Rust + Skia + WASM) — plus an SVG editor, Database/CMS and Forms.</strong>
   </p>
   <p>
     <a href="https://grida.co/canvas">Canvas demo</a> •
+    <a href="https://grida.co/svg">SVG editor</a> •
     <a href="https://grida.co/docs/packages/@grida/refig">Refig</a> •
     <a href="https://grida.co/downloads">Downloads</a> •
     <a href="https://grida.co">Website</a> •
@@ -43,6 +44,7 @@ If Grida is useful, consider starring this repo — it helps a lot.
 ## Demo
 
 - **Canvas (Skia/WASM)**: [grida.co/canvas](https://grida.co/canvas)
+- **SVG editor**: [grida.co/svg](https://grida.co/svg)
 
 ---
 
@@ -59,10 +61,14 @@ Core engine is written in Rust (Skia) and is exposed to web/Node via `@grida/can
 - [x] Infinite canvas + fast pan/zoom
 - [x] `.grida` document format (FlatBuffers)
 - [x] Render backends: DOM + Skia/WASM (WebGL2 + raster)
-- [x] Import: Figma (`@grida/io-figma`)
-- [x] SVG tooling (`@grida/io-svg`) (subset)
+- [x] Import: Figma (`@grida/io-figma`), SVG
+- [x] SVG tooling (`@grida/svg`)
+- [x] Canvas-native rich text editing
+- [x] History — time-bucketed undo/redo with preview
+- [x] Markdown & HTML/CSS embeds (in-house Chromium-aligned renderer)
+- [x] Multi-page PDF export
 - [x] Bitmap editor (TP)
-- [x] SVG editor (TP)
+- [x] SVG editor — see [SVG](#svg)
 - [x] Vector network model (paths, holes, compound shapes)
 - [x] Headless rendering: `@grida/refig` (Node + browser)
 - [ ] Component / instance model
@@ -115,6 +121,21 @@ main();
 ```
 
 Docs: [@grida/refig](https://grida.co/docs/packages/@grida/refig)
+
+---
+
+<br/>
+<br/>
+
+## SVG
+
+**The clean SVG editor.** Open an SVG, change one thing, save — and the diff shows exactly that. Nothing else moves. A round-trip-faithful editor and headless SDK, built for the era when people and AI edit the same files — AI chat built in.
+
+- **Try it**: [grida.co/svg](https://grida.co/svg)
+- **SDK**: [`@grida/svg-editor`](https://www.npmjs.com/package/@grida/svg-editor) — headless core + React bindings (alpha), backed by [`@grida/svg`](https://www.npmjs.com/package/@grida/svg) for path data and trivia-preserving parsing
+- **The file is the source of truth** — byte-equal round trip when nothing changed; the editor leaves no fingerprints of its own
+
+On the rendering side, Grida Canvas ships an in-house SVG renderer — **Rust + Skia → WASM**, a Chromium-shaped pipeline within the same in-tree engine that renders HTML/CSS (Stylo + Taffy + Skia), validated against Chromium-rendered oracles (resvg-test-suite corpus, WPT-style harness).
 
 ---
 
@@ -180,7 +201,7 @@ Docs: [@grida/refig](https://grida.co/docs/packages/@grida/refig)
 
 ## Quickstart (monorepo)
 
-**Requirements:** Node.js **24+**, pnpm **10+**
+**Requirements:** Node.js **24+**, pnpm **11+**
 
 ```bash
 pnpm install
@@ -204,11 +225,28 @@ pnpm test
 
 ## Packages
 
-Selected packages you can use independently:
+Published packages you can use independently:
 
-- **`@grida/refig`**: headless Figma renderer (Node + browser) + CLI
-- **`@grida/canvas-wasm`**: Skia renderer via WASM (WebGL + headless raster)
-- **`@grida/ruler`**, **`@grida/pixel-grid`**, **`@grida/transparency-grid`**: infinite-canvas UI primitives
+| Package                                                                                | Description                                                                                             | Demo                                                                                                 |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [`@grida/canvas-wasm`](https://www.npmjs.com/package/@grida/canvas-wasm)               | Grida Canvas rendering engine (Rust + Skia) as WASM — WebGL2 in the browser, headless raster in Node.js |                                                                                                      |
+| [`@grida/refig`](https://www.npmjs.com/package/@grida/refig)                           | Headless Figma renderer — render `.fig` / REST JSON to PNG/JPEG/WebP/PDF/SVG, with CLI                  | [demo](https://grida.co/packages/@grida/refig) · [docs](https://grida.co/docs/packages/@grida/refig) |
+| [`@grida/svg-editor`](https://www.npmjs.com/package/@grida/svg-editor)                 | Headless, round-trip-faithful SVG editor SDK with React bindings (alpha)                                | [demo](https://grida.co/packages/@grida/svg-editor)                                                  |
+| [`@grida/svg`](https://www.npmjs.com/package/@grida/svg)                               | SVG tooling — path data, attribute parsing, trivia-preserving round-trip parser                         |                                                                                                      |
+| [`@grida/hud`](https://www.npmjs.com/package/@grida/hud)                               | Canvas-based heads-up display (overlays, handles) for editor viewports                                  | [demo](https://grida.co/packages/@grida/hud)                                                         |
+| [`@grida/tree-view`](https://www.npmjs.com/package/@grida/tree-view)                   | Headless, agnostic tree-view controller (layer panels)                                                  | [demo](https://grida.co/packages/@grida/tree-view)                                                   |
+| [`@grida/text-editor`](https://www.npmjs.com/package/@grida/text-editor)               | Backend-agnostic text editor engine (experimental)                                                      |                                                                                                      |
+| [`@grida/history`](https://www.npmjs.com/package/@grida/history)                       | Dependency-free transaction & undo/redo engine                                                          |                                                                                                      |
+| [`@grida/keybinding`](https://www.npmjs.com/package/@grida/keybinding)                 | Declarative keybinding primitives — modifiers, platform resolution, event matching                      |                                                                                                      |
+| [`@grida/cmath`](https://www.npmjs.com/package/@grida/cmath)                           | Unopinionated canvas math — vectors, rects, transforms, snapping                                        |                                                                                                      |
+| [`@grida/vn`](https://www.npmjs.com/package/@grida/vn)                                 | Vector network model (paths, holes, compound shapes)                                                    |                                                                                                      |
+| [`@grida/color`](https://www.npmjs.com/package/@grida/color)                           | Core graphics color library                                                                             |                                                                                                      |
+| [`@grida/ruler`](https://www.npmjs.com/package/@grida/ruler)                           | Zero-dependency canvas ruler for infinite canvas                                                        | [demo](https://grida.co/packages/@grida/ruler)                                                       |
+| [`@grida/pixel-grid`](https://www.npmjs.com/package/@grida/pixel-grid)                 | Pixel-perfect grid component for infinite canvas                                                        | [demo](https://grida.co/packages/@grida/pixel-grid)                                                  |
+| [`@grida/transparency-grid`](https://www.npmjs.com/package/@grida/transparency-grid)   | Transparency (checkerboard) grid for infinite canvas                                                    | [demo](https://grida.co/packages/@grida/transparency-grid)                                           |
+| [`@grida/tailwindcss-colors`](https://www.npmjs.com/package/@grida/tailwindcss-colors) | Tailwind CSS color data (RGBA/HEX/OKLCH) for programmatic use                                           |                                                                                                      |
+
+Interactive demos: [grida.co/packages](https://grida.co/packages)
 
 ---
 

--- a/packages/grida-canvas-pixelgrid/package.json
+++ b/packages/grida-canvas-pixelgrid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grida/pixel-grid",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "description": "Pixel Grid component for Infinite Canvas",
   "keywords": [
     "canvas",


### PR DESCRIPTION
## What

Regular README refresh — the last content rewrite was 2026-02-18, ~270 merged PRs ago. This brings the top-level story up to date with what shipped since.

- **Packages section → formal table.** All 16 published (`private: false`) packages, with npm links, live demo links (`grida.co/packages/@grida/*`), and refig docs. Replaces the stale 3-bullet list.
- **New `## SVG` section** (after Canvas). Editor-led framing: the clean, round-trip-faithful SVG editor ([grida.co/svg](https://grida.co/svg), `@grida/svg-editor`, AI chat built in) is the headline; the in-house Chromium-shaped SVG renderer (Rust + Skia → WASM, validated against Chromium-rendered oracles) is the supporting credibility layer rather than a section of its own. The htmlcss engine is mentioned in one line there + one Canvas checklist bullet — deliberately not sold standalone (no published conformance scoreboard yet).
- **Canvas checklist refresh.** Adds shipped items: canvas-native rich text editing, time-bucketed history with preview, Markdown & HTML/CSS embeds, multi-page PDF export, SVG import. Fixes a stale package reference: `@grida/io-svg` → `@grida/svg` (io-svg never existed as published).
- **Small fact fixes.** Hero strapline / nav / Demo section now mention the SVG editor; pnpm requirement corrected 10+ → 11+ to match root `engines`.
- **`@grida/pixel-grid`: `private: true` → `false`.** Drift fix — the package is published on npm (0.0.0) and featured with a live demo on /packages; the flag excluded it from the "all private:false packages" listing rule.

## Why

The README still described the February state: no SVG editor product, 3 ad-hoc package bullets vs 16 published packages, and stale facts (`@grida/io-svg`, pnpm 10+). Goal: sell the right items in the right framing.

## Reviewer notes

- **Claims discipline on the renderer**: copy intentionally says "Chromium-shaped pipeline" / "Chromium-rendered oracles" and cites no pass-rate numbers — there's no published scoreboard yet, so we avoid claims that invite "show me the numbers".
- **Deliberately deferred** (follow-up passes): Desktop section (no visuals yet, active development) and the full AI/agent story (daemon, BYOK, model catalogs) — only the SVG editor's "AI chat built in" line ships now.
- All linked routes verified live against a running dev server (200s for 7 package demos, /svg, /packages, /canvas, refig docs); npm publish status of every table row verified via `npm view`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with expanded feature descriptions including SVG editor capabilities, database/CMS/Forms support, and Canvas tooling
  * Revised system requirements (pnpm 10+ → 11+)
  * Enhanced packages section with improved descriptions and interactive demos

* **Chores**
  * Made pixel-grid package publicly available for publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->