### PR TITLE
fix(svg): attr `=` trivia round-trip + strict attr grammar; docs(wg): rendering-hardening spec

### DIFF
--- a/docs/wg/feat-svg-editor/clipboard.md
+++ b/docs/wg/feat-svg-editor/clipboard.md
@@ -558,14 +558,11 @@ document markup in a privileged interpreter (mounting it into a live web
 page, where event-handler attributes and embedded foreign content can
 execute) has that exposure for _loaded_ documents already; paste changes
 the likelihood of hostile input — a keystroke now suffices where a file
-open was required — not the mechanism. **No rendering-surface hardening
-specification exists today; this paragraph is the tracking obligation.**
-Before clipboard ships in a surface that interprets markup in a
-privileged context, that surface's hardening posture must be specified
-and reviewed — inert rendering of execution-bearing constructs is a
-_projection_ choice, compatible with document fidelity (the model keeps
-the bytes; the surface declines to execute them), and is the expected
-shape of that work. A host that wants paste-time screening applies it on
+open was required — not the mechanism. **That surface's hardening
+posture is specified in
+[`rendering-hardening.md`](./rendering-hardening.md); the obligation
+remains open until that specification is reviewed and the surface
+enforces it.** A host that wants paste-time screening applies it on
 its side of the provider seam — made meaningful for _all_ paths by the
 native-transport opt-out (§ Transport) — where mutating text in transit
 is an explicit host choice rather than a silent editor behavior.

--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -81,6 +81,16 @@ preserving the author's source on round-trip.
   structural rewrite) and scopes the candidate identity schemes
   (positional path, `id` attribute, semantic anchor) against them. The
   `serialize_node` half of #775 shipped; this owns the reference half.
+- [`rendering-hardening.md`](./rendering-hardening.md) — specification
+  for rendering untrusted documents inertly. Hardening is a
+  _projection_ choice at the rendering surface — the model keeps the
+  bytes verbatim; the surface declines to execute them. Names the
+  execution-vector inventory, the editing obligations that rule out
+  structural isolation (image context, sandboxed frame) for the
+  editing surface, the inert-projection requirements, and the named
+  costs. Carries the clipboard FRD's trust-model tracking obligation —
+  open until the spec is reviewed and a surface enforces it. Proposed —
+  under review; no surface implements it yet.
 
 ### Glossary
 
@@ -112,6 +122,12 @@ package-internal docs. Those have moved to their canonical homes:
   [`research/usvg-tree-notes.md`](../research/usvg-tree-notes.md):
   what resvg's `usvg` IR normalises away and what an editor IR must
   refuse.
+- **Security research** —
+  [`research/untrusted-svg-rendering.md`](../research/untrusted-svg-rendering.md):
+  how the web platform and peer editors render untrusted SVG inertly
+  (script-vector inventory, sanitizers, secure static image mode,
+  sandboxed frames, CSP semantics). Input to
+  [`rendering-hardening.md`](./rendering-hardening.md).
 
 Additional pointers — the `@grida/svg-editor` package itself, the
 `/svg` demo wiring, the AI agent binding, package-internal

--- a/docs/wg/feat-svg-editor/rendering-hardening.md
+++ b/docs/wg/feat-svg-editor/rendering-hardening.md
@@ -1,0 +1,317 @@
+---
+title: "Rendering hardening — the inert projection"
+description: "Specification for rendering untrusted SVG documents inertly in the SVG editor: hardening is a projection choice at the rendering surface, never a mutation of the document model. Names the execution-vector inventory the projection must neutralize, the surface obligations that constrain the strategy, the inert-projection requirements, the named costs, and the residual risks left to the host."
+keywords:
+  - svg
+  - svg-editor
+  - security
+  - hardening
+  - xss
+  - rendering
+  - projection
+tags:
+  - internal
+  - svg
+  - wg
+format: md
+---
+
+# Rendering hardening — the inert projection
+
+**Status:** Proposed — under review. No rendering surface implements
+this specification yet: the live-page surface today mounts document
+markup with full execution semantics, which is precisely the exposure
+this document exists to close. Hardening behavior must not land
+before this specification is reviewed. This document carries the
+tracking obligation recorded in the clipboard FRD's trust model
+([`clipboard.md`](./clipboard.md) § Trust model); that obligation
+remains open — it is discharged when this specification is reviewed
+and a surface enforces it, not by the specification existing.
+
+## Thesis: the model keeps the bytes; the surface declines to execute
+
+The editor's foundational stance is that the file is sovereign: the
+bytes are the source of truth, round-trip is byte-exact, and the
+editor never silently rewrites user content. That stance has a
+security corollary that this document makes explicit:
+
+> **Hardening is a projection choice. The document model is never the
+> place to neutralize hostile content; the rendering surface is.**
+
+A document containing a script element, an event-handler attribute,
+or an embedded HTML island is a _valid document_. The model parses
+it, preserves it, round-trips it, and copies it to the clipboard
+verbatim — all of that is fidelity, none of it is execution. Danger
+arises at exactly one place: a surface that hands the markup to a
+privileged interpreter (a live web page, where the document's author
+gains the embedding origin's authority). So the obligation lands
+there: **the projection from model to rendered output must be inert
+— author script must not execute in the embedding context — while
+the model underneath stays verbatim.**
+
+Sanitize-on-load and sanitize-on-paste are rejected throughout this
+design family (see the clipboard FRD's trust model): mutating content
+on the way _in_ destroys fidelity and still misses documents that
+arrive by other doors. Neutralizing on the way _out to the renderer_
+costs fidelity nothing — the projection is already a derived,
+regenerable artifact — and covers every door at once, because every
+document, however it arrived, renders through the same projection.
+
+## Threat model
+
+**The attacker is the document author; the victim is the embedding
+origin.** An SVG document is active content, not an image: mounted
+into a live page it can execute script through a half-dozen distinct
+vectors (inventoried below). The author of a hostile document may be
+an upstream of any ingestion path — a file the user opens, markup the
+user pastes, an asset fetched from a library, a document produced by
+another tool or an AI agent. Clipboard support changed the
+_likelihood_ (a keystroke now suffices where a file open was
+required), not the mechanism; the exposure is a property of rendering
+untrusted markup at all.
+
+What the attacker gains without hardening is the embedding origin's
+authority: the host application's session, storage, DOM, and whatever
+APIs the page exposes. For an editor SDK this is a _transitive_
+promise — every application that embeds the surface inherits the
+exposure — which is why the posture must be the package's default,
+not a host afterthought.
+
+Two trust boundaries are explicitly **not** this document's subject:
+the document model (it polices nothing, by design), and the host
+application's own input screening (a host that wants paste-time or
+load-time scanning applies it on its side of the seams the editor
+already provides). This document owns the third boundary: what the
+surface mounts.
+
+## What the surface owes the editor
+
+The strategy space is constrained by what the editing surface must
+be able to do. These obligations are why the platform's structural
+isolation primitives — rendering the document as an image, or inside
+a sandboxed frame — cannot carry the _editing_ surface, and they are
+requirements on whatever hardening shape is chosen:
+
+- **Per-node geometry.** The editor reads rendered geometry (bounding
+  boxes, transforms-as-rendered) for selection, snapping, and
+  measurement. The rendered tree must be measurable node-by-node.
+- **Rendered-cascade resolution.** The editor resolves effective
+  styling through the host renderer's computed values. The rendered
+  tree must be queryable per node.
+- **Hit-testing.** Pointer interaction resolves through the rendered
+  tree.
+- **In-place content editing.** Text editing mounts on the rendered
+  node itself.
+
+Each of these requires the document to be **live in the same
+rendering context as the surface's chrome** — which is exactly the
+privileged mounting that creates the exposure. The conclusion is not
+"accept the exposure" but "neutralize within the live mounting":
+hardening must operate on _what is mounted_, not on _where it is
+mounted_.
+
+A survey of how the platform and peer editors solve this —
+allowlist sanitization, the spec-mandated secure static image mode,
+sandboxed frames, and parse-into-model architectures — is maintained
+separately as
+[`research/untrusted-svg-rendering.md`](../research/untrusted-svg-rendering.md).
+Its conclusion in this document's terms: neutralizing the live
+projection is the only strategy that keeps both the verbatim model
+and the obligations above. The per-strategy verdicts are argued in
+§ Rejected alternatives.
+
+## The execution inventory
+
+The contract is an enumeration. The inert projection must neutralize
+**every** class below; a projection that misses one is not compliant.
+The classes are defined by construct kind — element kind, attribute
+name family, URI scheme, content namespace — never by pattern-matching
+serialized text.
+
+| #   | Class                       | Constructs                                                                                                                                                                                  |
+| --- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| V1  | Script elements             | `script`                                                                                                                                                                                    |
+| V2  | Event-handler attributes    | the `on*` attribute name family, including the animation-timeline hooks (`onbegin`, `onend`, `onrepeat`)                                                                                    |
+| V3  | Script-scheme URIs          | URI-bearing attribute values whose scheme is a script scheme (`javascript:`), after entity decoding and whitespace normalization                                                            |
+| V4  | Declarative animation       | the animation element family (`animate`, `set`, `animateTransform`, `animateMotion`, `discard`) — both for its event hooks and for its ability to retarget URI-bearing attributes over time |
+| V5  | Foreign content             | `foreignObject` and any subtree outside the SVG namespace — the embedded-HTML escape hatch to the full HTML execution surface                                                               |
+| V6  | Document-pulling references | `use` (and equivalents) whose target is not a same-document fragment — importing a subtree that may itself carry V1–V5                                                                      |
+| V7  | Style-borne vectors         | `@import` and non-local `url()` in style content; legacy script-bearing style constructs                                                                                                    |
+
+Two cross-cutting hazards qualify the inventory:
+
+- **Reparse mutation (mXSS).** Any scheme that sanitizes a _string_
+  and then mounts that string through a different parser inherits the
+  parser-differential bypass class. The requirements below address
+  this structurally (R3) rather than by allowlist vigilance.
+- **Network-bearing references that do not execute** — an external
+  raster image reference is a fetch (a tracking beacon, an IP leak),
+  not an execution. These are a privacy residual, named in
+  § Residuals, governed by the host's content policy rather than by
+  this projection. v1 draws the line at execution.
+
+## Requirements
+
+**R1 — The model is never mutated.** Hardening reads the model and
+shapes the projection; nothing is written back. Load → serialize
+remains byte-exact for any document, however hostile. The hardened
+projection is never the source for file serialization, clipboard
+payloads, or any export — those carry the verbatim bytes, always.
+
+**R2 — Inert by default.** Every rendering surface that interprets
+markup in a privileged context ships with the inert projection
+**on**. Disabling it is a host decision, explicit, named, and scoped
+(a host embedding only first-party content it already trusts at
+script level may opt out); the package never defaults to executing
+author content.
+
+**R3 — Neutralize from the model, not through a second parse.** The
+projection is computed from the parsed model the editor already
+holds — neutralization keys on the model's own token classes
+(element kind, attribute name, decoded URI scheme, namespace) — and
+is emitted with the same disciplined encoding as every other
+serialization. There is no separate sanitizer parse whose
+disagreement with the mount parse could be exploited; the one
+remaining parse (the host renderer reading the emitted projection)
+is fed only output the emitter constructed. The residual — the host
+parser reading emitted text differently than the emitter intended —
+is bounded by the emitter's quoting/encoding discipline and is a
+named review obligation on the implementation, with the inventory's
+known mutation tricks as test vectors.
+
+**R4 — Strict ingestion is load-bearing.** The editor refuses input
+its parser cannot tokenize (it throws rather than guesses). This
+property is part of the security design and must be preserved:
+nothing reaches the projection that the model did not fully
+tokenize, so there is no "content the sanitizer never saw."
+Loosening the parser toward error-recovery is a change to this
+specification, not a parser detail. The model's named fidelity
+tolerances (entity-spelling canonicalization, value re-encoding) are
+not loosenings of this property: they normalize values the tokenizer
+fully consumed, never admit untokenized content.
+
+**R5 — Appearance is preserved outside the named costs.** Beyond the
+enumerated neutralizations (§ Named costs), the inert projection must
+not alter the document's static rendered appearance. Hardening
+suppresses _behavior_; it does not restyle, reflow, or reorder.
+
+**R6 — The editing obligations survive.** Per-node geometry,
+rendered-cascade resolution, hit-testing, and in-place editing work
+identically under the inert projection. In particular, whatever
+structural correspondence the surface maintains between model nodes
+and rendered nodes must be preserved by neutralization — neutralize
+in place rather than dropping nodes where the distinction matters.
+
+**R7 — Neutralization is observable.** The surface can report that a
+document contains neutralized content and which classes were present
+(at minimum: a per-class count). Hosts surface this however they
+like ("this document contains scripts — inactive"); silence about
+suppressed content is not acceptable for an editor whose users
+reason about their own files.
+
+**R8 — Defense in depth is documented, never load-bearing.** Host
+integration guidance recommends a strict content-security posture
+(no inline-script allowances) as a second layer, with the explicit
+statement of what it does and does not cover — notably that
+declarative animation is not script and no script policy gates it.
+The projection must be complete on its own with the host policy
+absent.
+
+## Named costs
+
+The inert projection deliberately suppresses behavior; these are the
+visible consequences, taken with eyes open:
+
+- **Foreign content does not render.** A document whose visible
+  appearance depends on embedded HTML loses that region (a visual
+  loss, not a structural one — the model retains the subtree, and
+  serialization is unaffected). This is the standing trade of every
+  surveyed sanitizer.
+- **Declarative animation does not play in the editing surface.**
+  v1 neutralizes the whole animation family (V4): the retargeting
+  vector means animation elements can rewrite URI attributes, and a
+  per-target-attribute refinement (allowing purely geometric
+  animation) is a future relaxation requiring its own review. An
+  editing surface freezing animation at authoring time is an
+  acceptable interim posture — and arguably desirable while
+  measuring geometry.
+- **Script-scheme links are dead.** They are dead in every editor
+  surface surveyed; no loss in practice.
+- **Non-fragment `use` targets do not resolve.** Cross-document
+  composition does not render in the editing surface (v1).
+
+None of these costs touch the file: open + save remains byte-exact,
+and a copied selection carries the verbatim content, suppressed
+regions included.
+
+## Residuals and non-goals
+
+- **Network fetches that do not execute** (external raster images,
+  fonts) are a privacy channel, not an execution channel. v1 leaves
+  them to the host's content policy; tightening them into the
+  projection (e.g. a no-external-fetch mode) is a named future
+  option, not a v1 requirement.
+- **The host page's own security posture** — its CSP, its session
+  model, what it does with documents outside the editor — is the
+  host's.
+- **Non-browser surfaces** (a native renderer, a headless geometry
+  backend) have different interpreters and different exposures; each
+  surface class owes its own hardening statement. This document
+  binds surfaces that mount markup into a live web page.
+- **Denial-of-service via pathological documents** (billion-laughs
+  expansion, filter bombs, extreme node counts) is a robustness
+  concern tracked separately; it is not an execution vector and not
+  in this document's scope.
+
+## Registration
+
+This boundary follows the repository's prevented-vulnerability
+registry convention —
+[`GRIDA-SEC`](https://github.com/gridaco/grida/blob/main/SECURITY.md),
+which owns the registration procedure. This specification is the
+design half of that record; the registry entry is created when
+enforcement ships, not before, and enforcement must not ship without
+creating it.
+
+## Rejected alternatives
+
+- **Sanitize on ingestion (load or paste).** Argued and rejected in
+  § Thesis and the clipboard FRD's trust model.
+- **Image-context rendering for the editing surface.** The platform's
+  secure static mode is the strongest guarantee available and costs
+  nothing to adopt — but it forfeits the editing obligations
+  (§ What the surface owes the editor) wholesale. It is the
+  _right_ projection for non-interactive contexts (thumbnails,
+  read-only previews, list assets), and host guidance should say so;
+  it cannot carry the editing surface.
+- **Sandboxed-frame isolation for the editing surface.** Structural
+  for script, but the frame boundary severs the same obligations
+  from the host side. Running the
+  _entire editor_ inside the frame moves the boundary rather than
+  solving it — the host application then needs its own bridge for
+  every integration seam. Available to hosts as a deployment choice;
+  not the package's projection.
+- **A third-party sanitizer over the serialized string.** Imports
+  the parser-differential (mXSS) bypass class this design
+  structurally avoids (R3), adds an allowlist whose maintenance
+  cadence the package does not control, and operates on a string
+  when the editor already holds the parsed tree. The surveyed
+  precedent confirms the allowlist _content_ is reusable knowledge;
+  the _architecture_ (string in, string out, second parse) is the
+  part to decline.
+- **CSP as the primary control.** The embedding page's policy is not
+  the package's to guarantee, and hosts legitimately relax it for
+  unrelated reasons; what it does and does not cover is R8's subject.
+  A second layer, never the first.
+
+## Relationship to other documents
+
+- [`clipboard.md`](./clipboard.md) — the trust model that created
+  this document's obligation: paste is load-equivalent in trust, the
+  model does not police content, and the honest boundary is the
+  rendering surface. This specification is that boundary's contract.
+- [`research/untrusted-svg-rendering.md`](../research/untrusted-svg-rendering.md)
+  — the upstream survey (platform guarantees, peer sanitizers, CSP
+  semantics) this specification draws on.
+- [`element-ir.md`](./element-ir.md) — the model-side architecture;
+  its round-trip invariants are the fidelity guarantees R1 protects.

--- a/docs/wg/research/untrusted-svg-rendering.md
+++ b/docs/wg/research/untrusted-svg-rendering.md
@@ -1,0 +1,248 @@
+---
+title: "Untrusted SVG rendering — isolation strategies"
+description: "Survey of how the web platform and peer editors render untrusted SVG without executing author script: the script-execution vector inventory, allowlist sanitization (DOMPurify, tldraw), the secure static image mode, iframe sandboxing, parse-into-model editors (Figma, Penpot, Excalidraw), and what a host CSP does and does not neutralize."
+keywords:
+  - svg
+  - security
+  - xss
+  - sanitization
+  - mxss
+  - csp
+tags:
+  - internal
+  - wg
+  - research
+  - svg
+format: md
+---
+
+# Untrusted SVG rendering — isolation strategies
+
+An SVG document is active content, not an image. Mounted into a live
+web page it executes script in the embedding origin through several
+distinct vectors; referenced as an image it executes nothing, by spec
+mandate. This survey inventories the execution vectors, then examines
+the four strategies the platform and peer editors use to render
+untrusted SVG inertly, and closes with what a Content Security Policy
+adds as a layer.
+
+## The script-execution surface of SVG
+
+Every strategy below is judged against this inventory. A scheme that
+misses one row is not a hardening scheme.
+
+- **`script` elements.** SVG is XML and supports `script` directly —
+  the root cause of the recurring stored-XSS advisory class in apps
+  that echo uploaded SVG (PentesterLab, OWASP).
+- **Event-handler attributes** — `onload`, `onerror`, `onclick`,
+  `onmouseover`, and the SMIL-specific `onbegin` / `onend` /
+  `onrepeat`. PortSwigger's no-interaction payload:
+  `<svg><animate onbegin=alert(1) attributeName=x dur=1s>` — fires
+  when the animation timeline begins.
+- **`javascript:` in URI-bearing attributes** — `href` /
+  `xlink:href` on `a` and other linking elements.
+- **Declarative animation retargeting an href.** An `animate` with
+  `attributeName=href` and a `values` list can rewrite a sibling
+  `a` / `use` href to a `javascript:` URL over time. SMIL is
+  declarative animation, not script — no script-blocking control
+  stops the animation itself (PortSwigger, "SVG animate XSS vector").
+  The family is `animate`, `set`, `animateTransform`,
+  `animateMotion`, plus SVG 2's timed-removal `discard`.
+- **`foreignObject`** — embeds arbitrary HTML inside SVG (an
+  `iframe` with a `javascript:` source, an `img` with `onerror`),
+  opening the entire HTML XSS surface. Sanitizers must switch to
+  HTML-mode or strip at this boundary.
+- **`use` pulling another document** — a non-fragment `use` target
+  (external or `data:` document) imports a subtree that itself
+  carries any of the above.
+- **Style-borne vectors** — `@import`, external `url()` in style
+  content, and the legacy script-bearing CSS constructs
+  (`expression()`, `-moz-binding`, `behavior:`).
+- **Reparse mutation (mXSS).** Not an SVG construct but the failure
+  class of string-level sanitization: serializing a sanitized tree
+  and re-parsing it at mount time can mutate the tree back into
+  executable form, typically via HTML/SVG/MathML namespace
+  confusion. This is the documented bypass mechanism against
+  DOMPurify (below).
+
+Sources: <https://portswigger.net/web-security/cross-site-scripting/cheat-sheet>,
+<https://portswigger.net/research/svg-animate-xss-vector>,
+<https://www.w3.org/wiki/SVG_Security>,
+<https://pentesterlab.com/glossary/svg-xss>.
+
+## Strategy I — allowlist sanitization at the markup layer
+
+### DOMPurify's SVG profile
+
+- `USE_PROFILES: { svg: true, svgFilters: true }` is an allowlist:
+  only elements and attributes in the SVG + SVG-filter tables
+  survive; HTML and MathML do not.
+- The default `svgDisallowed` set strips `script`, `foreignobject`,
+  `use`, and the whole SMIL family (`animate`, `set`, `discard`, …).
+  `foreignobject` is also in `FORBID_CONTENTS`, so its subtree is
+  removed with it; re-enabling it requires explicit `ADD_TAGS` +
+  `HTML_INTEGRATION_POINTS` configuration (a recurring friction
+  point — issues #1002, #1088, hit by mermaid and Grafana).
+- Event-handler attributes are stripped; URI attributes pass an
+  allowlist of schemes (`http`, `https`, `mailto`, `tel`, …) —
+  `javascript:` never survives.
+- The bypass history is the central caution. **CVE-2020-26870**:
+  serialize→parse is not idempotent; namespace confusion moving from
+  SVG/MathML foreign content back to HTML let payloads survive
+  sanitization. **CVE-2024-45801** (fixed 2.5.4 / 3.1.3):
+  nesting-based mXSS evaded the depth-checking hardening added after
+  the first round. The pattern: the sanitizer's parse and the mount
+  parse disagree, and the disagreement is exploitable.
+- Maintenance posture is strong (Cure53 since 2014, Trusted Types
+  support), but the guarantee is operational, not structural — it
+  requires staying current with releases.
+
+Sources: <https://github.com/cure53/DOMPurify>,
+<https://www.sentinelone.com/vulnerability-database/cve-2020-26870/>,
+<https://www.wiz.io/vulnerability-database/cve/cve-2024-45801>,
+<https://flatt.tech/research/posts/bypassing-dompurify-with-good-old-xml/>.
+
+### tldraw's sanitizer
+
+- Until early 2026 tldraw mounted pasted/dropped SVG unsanitized;
+  issue #7876 ("Sanitize SVG content in the SDK to prevent XSS")
+  tracked the exposure, and PR #7896 (merged 2026-02-23) shipped the
+  fix: a custom ~643-line allowlist sanitizer with tag/attribute
+  tables derived from DOMPurify's (MIT), chosen over DOMPurify
+  itself ("wider scope than needed"), manual stripping
+  ("error-prone"), and CSP alone ("insufficient SDK-level
+  protection").
+- The sanitizer walks the parsed tree and switches between SVG-mode
+  and HTML-mode at `foreignObject` boundaries; documents whose root
+  is not `svg` are rejected outright.
+- URI hardening: `image` accepts only raster `data:` URLs; `use`
+  permits only fragment (`#id`) references; `a` allows only `http:` /
+  `https:` / `mailto:`. Animation elements that target `href` or
+  carry event hooks are removed — directly closing the
+  animate-retargets-href vector.
+- CSS filtering strips `@import`, `expression()`, `-moz-binding`,
+  `behavior:`, and external `url()` while preserving local
+  `url(#id)` references.
+- It runs at every ingestion point (paste, drop, file replace,
+  custom asset creation) and is exported as a public
+  `sanitizeSvg(svgText)` for SDK consumers. Notably, tldraw renders
+  the sanitized SVG inline — which is exactly why an allowlist
+  sanitizer was required; the image-context guarantee (Strategy II)
+  was not available to a surface that needs the markup live.
+
+Sources: <https://github.com/tldraw/tldraw/issues/7876>,
+<https://github.com/tldraw/tldraw/pull/7896>.
+
+## Strategy II — image-context isolation (secure static mode)
+
+- When an SVG is referenced by `img`, by CSS
+  (`background-image`, `list-style-image`, `content`), by SVG's own
+  `image` / `feImage`, or drawn via `canvas.drawImage()`, the
+  browser uses the _static image_ referencing mode, which mandates
+  the **secure static processing mode** (SVG Integration spec):
+  scripts must not execute, no resources may be fetched (scripts,
+  stylesheets, images — anything not inlined as `data:`), animations
+  do not run, and per the W3C SVG Security wiki, event listeners and
+  hit testing are disabled at all times.
+- The guarantee is **structural** — enforced by the rendering mode,
+  independent of document content. It holds for any payload,
+  including ones a sanitizer would miss.
+- The costs are the flip side of the same mandate: the rendered tree
+  is opaque to the host document (no DOM access, no per-node hit
+  testing or geometry reads, no text editing), and any external
+  reference the document legitimately depends on (fonts, images not
+  inlined) silently fails to render.
+- The restrictions apply only to _image_ contexts. The same document
+  viewed directly or embedded via `iframe` / `object` / `embed` is a
+  full document context and executes normally (MDN, "SVG as an
+  image").
+
+Sources: <https://svgwg.org/specs/integration/>,
+<https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image>,
+<https://www.w3.org/wiki/SVG_Security>,
+<https://bugzilla.mozilla.org/show_bug.cgi?id=628747>.
+
+## Strategy III — frame isolation (iframe sandbox)
+
+- An empty `sandbox=""` attribute applies every restriction: script
+  execution disabled, forms / popups / downloads / top-navigation
+  blocked, and the content treated as a unique opaque origin that
+  always fails same-origin checks.
+- For untrusted content, `allow-scripts` is never granted —
+  and the documented hard rule is that `allow-scripts` +
+  `allow-same-origin` together let same-origin framed content remove
+  its own sandbox, nullifying the mechanism (MDN).
+- Unlike the image context, a sandboxed frame is a _document_
+  context: SMIL and CSS animation run, the document is fully laid
+  out, interactivity inside the frame works. Script vectors are dead
+  because script is dead.
+- The cost is the boundary itself: the host document cannot attach
+  listeners to, hit-test, measure, or read computed style from nodes
+  inside a cross-origin/opaque frame. Any interaction requires a
+  `postMessage` bridge; an in-place editing model does not survive
+  the boundary.
+
+Source: <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe>.
+
+## Strategy IV — parse into a native model
+
+- **Figma** parses imported/pasted SVG into native vector nodes
+  (vector networks) — source markup is never mounted. Constructs
+  with no projection target in the model (script, events,
+  `foreignObject`, SMIL) are simply dropped; projection _is_ the
+  sanitization.
+- **Penpot** converts imported SVG elements into its own shape
+  records, with a residual `svg-raw` shape type for unmapped content
+  (a partial exception worth noting in any threat model of that
+  approach).
+- **Excalidraw** treats imported SVG as an opaque image asset (a
+  `data:` URL rendered through the image path) — i.e. it delegates
+  to Strategy II rather than parsing the markup into shapes.
+- The shared principle: parse → project onto a known schema →
+  re-emit from the model. Nothing the model does not understand
+  survives, so the security guarantee is structural and requires no
+  per-CVE upkeep. The cost is fidelity: the projection is lossy by
+  construction — unknown elements, exact byte layout, and
+  unsupported features are gone, which rules the strategy out
+  wherever byte-exact round-trip of the source is a requirement.
+
+Sources: <https://www.figma.com/plugin-docs/api/VectorNode/>,
+<https://help.figma.com/hc/en-us/articles/360040450213-Vector-networks>,
+<https://help.penpot.app/technical-guide/developer/data-model/>,
+<https://deepwiki.com/excalidraw/excalidraw/6.3-file-and-image-management>.
+
+## What a host CSP adds
+
+- A `script-src` (or `default-src`) directive blocks inline `script`
+  elements in mounted SVG, blocks inline event-handler attributes
+  (re-opened only by `'unsafe-inline'` / `'unsafe-hashes'` — hashes
+  do not cover event handlers), and blocks `javascript:` URLs with
+  no nonce/hash workaround.
+- CSP does **not** stop SMIL: declarative animation is not script,
+  so no `script-src` directive applies. An animate-retargets-href
+  chain is stopped only at the final `javascript:` navigation, while
+  the animation itself runs freely. CSP also offers no defense
+  against mXSS — the mutation happens in the parser, before any
+  policy applies.
+- Practical conclusion: a strict CSP (`script-src 'self'`, no
+  `'unsafe-inline'` / `'unsafe-hashes'`) is a strong second layer
+  for inline-mounted SVG, but it is the _embedding page's_ policy —
+  a library cannot guarantee it, and a host that needs
+  `'unsafe-inline'` for unrelated reasons silently loses the layer.
+
+Sources: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src>,
+<https://content-security-policy.com/script-src/>,
+<https://github.com/w3c/webappsec-csp/issues/13>.
+
+## Comparison
+
+| Strategy                      | Script neutralization                                                                 | Fidelity loss                                                                          | Live interactivity (hit-test / computed style / in-place edit) | Cost                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------- |
+| Allowlist sanitization        | Operational — complete while the allowlist is correct; documented mXSS bypass history | Low — markup mostly preserved; script / foreign content / SMIL / external refs dropped | Full — output is live host-DOM SVG                             | Allowlist + URI/CSS scrubbing + mode-switching upkeep |
+| Image context (secure static) | Structural — spec-mandated, content-independent                                       | Medium — non-inlined external refs silently dropped; no animation                      | None — opaque surface                                          | Trivial                                               |
+| Sandboxed frame               | Structural for script; document context otherwise                                     | Low — full layout, animation runs                                                      | None across the boundary without bridging                      | Frame plumbing + `postMessage` bridge                 |
+| Parse into model              | Structural — markup never mounted                                                     | High — lossy projection by construction                                                | Full, in the editor's own terms                                | Large up-front model investment; no per-CVE upkeep    |
+
+The strategies compose: several shipping tools use one for the live
+surface and another for previews (sanitize-inline + image-context
+thumbnails), and a strict host CSP layers under any of them.

--- a/docs/wg/research/untrusted-svg-rendering.md
+++ b/docs/wg/research/untrusted-svg-rendering.md
@@ -65,10 +65,10 @@ misses one row is not a hardening scheme.
   confusion. This is the documented bypass mechanism against
   DOMPurify (below).
 
-Sources: <https://portswigger.net/web-security/cross-site-scripting/cheat-sheet>,
-<https://portswigger.net/research/svg-animate-xss-vector>,
-<https://www.w3.org/wiki/SVG_Security>,
-<https://pentesterlab.com/glossary/svg-xss>.
+Sources: https://portswigger.net/web-security/cross-site-scripting/cheat-sheet,
+https://portswigger.net/research/svg-animate-xss-vector,
+https://www.w3.org/wiki/SVG_Security,
+https://pentesterlab.com/glossary/svg-xss.
 
 ## Strategy I — allowlist sanitization at the markup layer
 
@@ -97,10 +97,10 @@ Sources: <https://portswigger.net/web-security/cross-site-scripting/cheat-sheet>
   support), but the guarantee is operational, not structural — it
   requires staying current with releases.
 
-Sources: <https://github.com/cure53/DOMPurify>,
-<https://www.sentinelone.com/vulnerability-database/cve-2020-26870/>,
-<https://www.wiz.io/vulnerability-database/cve/cve-2024-45801>,
-<https://flatt.tech/research/posts/bypassing-dompurify-with-good-old-xml/>.
+Sources: https://github.com/cure53/DOMPurify,
+https://www.sentinelone.com/vulnerability-database/cve-2020-26870/,
+https://www.wiz.io/vulnerability-database/cve/cve-2024-45801,
+https://flatt.tech/research/posts/bypassing-dompurify-with-good-old-xml/.
 
 ### tldraw's sanitizer
 
@@ -130,8 +130,8 @@ Sources: <https://github.com/cure53/DOMPurify>,
   sanitizer was required; the image-context guarantee (Strategy II)
   was not available to a surface that needs the markup live.
 
-Sources: <https://github.com/tldraw/tldraw/issues/7876>,
-<https://github.com/tldraw/tldraw/pull/7896>.
+Sources: https://github.com/tldraw/tldraw/issues/7876,
+https://github.com/tldraw/tldraw/pull/7896.
 
 ## Strategy II — image-context isolation (secure static mode)
 
@@ -157,10 +157,10 @@ Sources: <https://github.com/tldraw/tldraw/issues/7876>,
   full document context and executes normally (MDN, "SVG as an
   image").
 
-Sources: <https://svgwg.org/specs/integration/>,
-<https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image>,
-<https://www.w3.org/wiki/SVG_Security>,
-<https://bugzilla.mozilla.org/show_bug.cgi?id=628747>.
+Sources: https://svgwg.org/specs/integration/,
+https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image,
+https://www.w3.org/wiki/SVG_Security,
+https://bugzilla.mozilla.org/show_bug.cgi?id=628747.
 
 ## Strategy III — frame isolation (iframe sandbox)
 
@@ -182,7 +182,7 @@ Sources: <https://svgwg.org/specs/integration/>,
   `postMessage` bridge; an in-place editing model does not survive
   the boundary.
 
-Source: <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe>.
+Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe.
 
 ## Strategy IV — parse into a native model
 
@@ -206,10 +206,10 @@ Source: <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/if
   unsupported features are gone, which rules the strategy out
   wherever byte-exact round-trip of the source is a requirement.
 
-Sources: <https://www.figma.com/plugin-docs/api/VectorNode/>,
-<https://help.figma.com/hc/en-us/articles/360040450213-Vector-networks>,
-<https://help.penpot.app/technical-guide/developer/data-model/>,
-<https://deepwiki.com/excalidraw/excalidraw/6.3-file-and-image-management>.
+Sources: https://www.figma.com/plugin-docs/api/VectorNode/,
+https://help.figma.com/hc/en-us/articles/360040450213-Vector-networks,
+https://help.penpot.app/technical-guide/developer/data-model/,
+https://deepwiki.com/excalidraw/excalidraw/6.3-file-and-image-management.
 
 ## What a host CSP adds
 
@@ -230,9 +230,9 @@ Sources: <https://www.figma.com/plugin-docs/api/VectorNode/>,
   a library cannot guarantee it, and a host that needs
   `'unsafe-inline'` for unrelated reasons silently loses the layer.
 
-Sources: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src>,
-<https://content-security-policy.com/script-src/>,
-<https://github.com/w3c/webappsec-csp/issues/13>.
+Sources: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src,
+https://content-security-policy.com/script-src/,
+https://github.com/w3c/webappsec-csp/issues/13.
 
 ## Comparison
 

--- a/packages/grida-svg-editor/__tests__/roundtrip.test.ts
+++ b/packages/grida-svg-editor/__tests__/roundtrip.test.ts
@@ -56,6 +56,20 @@ describe("round-trip fidelity (P1)", () => {
     expect(roundtrip(src)).toBe(src);
   });
 
+  it("preserves whitespace around an attribute's `=`", () => {
+    // Trivia on both sides of `=` must survive: before-`=` rides the attr
+    // token's eq_trivia, after-`=` rides eq_trailing.
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect fill = "red" width ="10" height= "10"/></svg>`;
+    expect(roundtrip(src)).toBe(src);
+  });
+
+  it("preserves multi-space and newline trivia after `=`", () => {
+    const a = `<svg xmlns="http://www.w3.org/2000/svg"><rect fill =  'red'/></svg>`;
+    const b = `<svg xmlns="http://www.w3.org/2000/svg"><rect fill =\n"red"/></svg>`;
+    expect(roundtrip(a)).toBe(a);
+    expect(roundtrip(b)).toBe(b);
+  });
+
   it("preserves the byte-position of edited attributes (one diff per change)", () => {
     const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect x="10" y="20" width="100" height="50" fill="red"/></svg>`;
     const editor = createSvgEditor({ svg: src });

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -182,6 +182,16 @@ export const GEOMETRY_ATTRS: ReadonlySet<string> = new Set([
 /** `transform:` CSS property at the start of a declaration list or after `;`. */
 const CSS_TRANSFORM_PROPERTY = /(?:^|;)\s*transform\s*:/i;
 
+/** Trivia shape for editor-synthesized attribute tokens — parser-authored
+ *  tokens carry their source trivia verbatim; tokens the editor appends get
+ *  this one canonical shape (` name="value"`). */
+const SYNTH_ATTR_TRIVIA = {
+  pre: " ",
+  eq_trivia: "",
+  eq_trailing: "",
+  quote: '"',
+} as const;
+
 export class SvgDocument implements DocumentEvents {
   private nodes: Map<NodeId, AnyNode>;
   private prolog: AnyNode[];
@@ -502,9 +512,7 @@ export class SvgDocument implements DocumentEvents {
         local: name,
         ns,
         value,
-        pre: " ",
-        eq_trivia: "",
-        quote: '"',
+        ...SYNTH_ATTR_TRIVIA,
       });
       if (structural) this._structure_version++;
       if (geometry) this._geometry_version++;
@@ -770,9 +778,7 @@ export class SvgDocument implements DocumentEvents {
       local: "d",
       ns: null,
       value: d,
-      pre: " ",
-      eq_trivia: "",
-      quote: '"',
+      ...SYNTH_ATTR_TRIVIA,
     });
 
     // Fidelity guard for `<line>`: a line has no fill region, so its fill
@@ -795,9 +801,7 @@ export class SvgDocument implements DocumentEvents {
         local: "fill",
         ns: null,
         value: "none",
-        pre: " ",
-        eq_trivia: "",
-        quote: '"',
+        ...SYNTH_ATTR_TRIVIA,
       });
       added_fill_none = true;
     }
@@ -1252,7 +1256,7 @@ export class SvgDocument implements DocumentEvents {
   }
 
   private emit_attr(a: AttrToken): string {
-    return `${a.pre}${a.raw_name}${a.eq_trivia}=${a.quote}${encode_attr_value(
+    return `${a.pre}${a.raw_name}${a.eq_trivia}=${a.eq_trailing}${a.quote}${encode_attr_value(
       a.value,
       a.quote
     )}${a.quote}`;

--- a/packages/grida-svg/package.json
+++ b/packages/grida-svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": false,
   "description": "Grida-owned SVG tooling for parsing, transforming, and authoring SVG data.",
   "keywords": [

--- a/packages/grida-svg/src/parser/__tests__/attr-token-trivia.test.ts
+++ b/packages/grida-svg/src/parser/__tests__/attr-token-trivia.test.ts
@@ -1,0 +1,105 @@
+// Tokenizer-level coverage for attribute trivia capture and the strict
+// attribute grammar. The byte-exact round-trip half lives with the
+// serializer (the SVG editor package); these tests pin the parse half so
+// this package can prove its own contract — a serializer rewrite upstream
+// must not be the only thing standing between a tokenizer regression and
+// a green suite here.
+
+import { describe, expect, it } from "vitest";
+import { parse_svg } from "../parser";
+
+function attrs_of_rect(src: string) {
+  const result = parse_svg(src);
+  for (const node of result.nodes.values()) {
+    if (node.kind === "element" && node.local === "rect") return node.attrs;
+  }
+  throw new Error("no <rect> in fixture");
+}
+
+describe("attribute trivia capture", () => {
+  it("captures whitespace around `=` into eq_trivia / eq_trailing", () => {
+    const [fill] = attrs_of_rect(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect fill = "red"/></svg>`
+    );
+    expect(fill.raw_name).toBe("fill");
+    expect(fill.eq_trivia).toBe(" ");
+    expect(fill.eq_trailing).toBe(" ");
+    expect(fill.value).toBe("red");
+  });
+
+  it("captures multi-space and newline trivia after `=`", () => {
+    const [a] = attrs_of_rect(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect fill =  'red'/></svg>`
+    );
+    expect(a.eq_trailing).toBe("  ");
+    expect(a.quote).toBe("'");
+    const [b] = attrs_of_rect(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect fill =\n"red"/></svg>`
+    );
+    expect(b.eq_trailing).toBe("\n");
+  });
+
+  it("captures empty trivia for the common tight form", () => {
+    const [fill] = attrs_of_rect(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect fill="red"/></svg>`
+    );
+    expect(fill.eq_trivia).toBe("");
+    expect(fill.eq_trailing).toBe("");
+  });
+});
+
+describe("strict attribute grammar", () => {
+  it("throws on a valueless (boolean) attribute", () => {
+    // Not well-formed XML; the old treat-as-empty tolerance serialized
+    // corrupted markup (`name =""` fused into the next attribute).
+    expect(() =>
+      parse_svg(`<svg xmlns="http://www.w3.org/2000/svg"><rect hidden/></svg>`)
+    ).toThrow(/expected '='/);
+    expect(() =>
+      parse_svg(
+        `<svg xmlns="http://www.w3.org/2000/svg"><rect hidden fill="red"/></svg>`
+      )
+    ).toThrow(/expected '='/);
+  });
+
+  it("throws a controlled Error on malformed character references", () => {
+    // The reference must denote a legal XML Char (XML 1.0 §2.2 via §4.1):
+    // beyond-Unicode, surrogates, NUL, and C0 controls are all malformed —
+    // and must surface as the parser's Error shape, not a raw RangeError
+    // escaping String.fromCodePoint (or raw control bytes on re-emit).
+    for (const ref of ["&#x110000;", "&#xD800;", "&#0;", "&#8;", "&#xFFFE;"]) {
+      expect(() =>
+        parse_svg(
+          `<svg xmlns="http://www.w3.org/2000/svg"><rect fill="${ref}"/></svg>`
+        )
+      ).toThrow(/invalid character reference/);
+    }
+    // TAB/LF/CR references are legal Chars and must keep decoding.
+    expect(() =>
+      parse_svg(
+        `<svg xmlns="http://www.w3.org/2000/svg"><rect fill="a&#10;b"/></svg>`
+      )
+    ).not.toThrow();
+  });
+
+  it("throws on an empty attribute name", () => {
+    expect(() =>
+      parse_svg(`<svg xmlns="http://www.w3.org/2000/svg"><rect ="red"/></svg>`)
+    ).toThrow(/expected attribute name/);
+    // Missing inter-attribute separator must not tokenize as a nameless attr.
+    expect(() =>
+      parse_svg(
+        `<svg xmlns="http://www.w3.org/2000/svg"><rect fill="a"="b"/></svg>`
+      )
+    ).toThrow(/expected attribute name/);
+  });
+
+  it("diagnoses truncation as unterminated, not as a missing '='", () => {
+    expect(() =>
+      parse_svg(`<svg xmlns="http://www.w3.org/2000/svg"><rect fill`)
+    ).toThrow(/unterminated start tag/);
+    expect(() =>
+      parse_svg(`<svg xmlns="http://www.w3.org/2000/svg"><rect fill   `)
+    ).toThrow(/unterminated start tag/);
+  });
+});

--- a/packages/grida-svg/src/parser/parser.ts
+++ b/packages/grida-svg/src/parser/parser.ts
@@ -8,6 +8,21 @@
 // This is *not* a conforming XML parser. It is good enough to round-trip the
 // kind of SVG humans and tooling actually write. Where it fails the test
 // suite, the failure should be visible and small.
+//
+// Known, deliberate fidelity tolerances (each trades spec conformance
+// against byte fidelity; see also the `AttrToken.value` doc):
+//   - Entity spellings normalize on re-emit (`&#x72;` → the literal char;
+//     unknown named entities like `&nbsp;` re-emit as `&amp;nbsp;`).
+//   - Bare `&` / `<` inside attribute values are accepted (invalid XML)
+//     and re-emit escaped (`&amp;` / `&lt;`).
+//   - Line ends are NOT normalized (XML 1.0 §2.11 would fold `\r\n` to
+//     `\n`); kept verbatim on purpose for byte-exact round-trip.
+//
+// Strictness is load-bearing downstream: the SVG editor's rendering-
+// hardening design (docs/wg/feat-svg-editor/rendering-hardening.md, R4)
+// relies on this parser THROWING on input it cannot tokenize. Loosening
+// toward error-recovery is a contract change for that consumer, not a
+// local implementation detail.
 
 /**
  * Opaque-by-convention identifier for a node in a parsed SVG tree.
@@ -27,12 +42,19 @@ export type AttrToken = {
   local: string;
   /** Resolved namespace URI, or null if unprefixed and no default ns. */
   ns: string | null;
-  /** Raw attribute value string (entity-decoded). */
+  /** Attribute value, entity-decoded. Known fidelity tolerance: entity
+   *  SPELLINGS do not survive — `&#x72;ed` decodes to `red` and re-encodes
+   *  canonically. Not always meaning-preserving for conforming consumers:
+   *  whitespace references (`&#10;`) re-emit as raw control characters
+   *  (which XML attribute-value normalization folds to spaces), and
+   *  unrecognized named entities (`&nbsp;`) re-emit ampersand-escaped. */
   value: string;
   /** Trivia before the attribute name (whitespace, usually `" "`). */
   pre: string;
-  /** Trivia between `=` and the value (usually empty). */
+  /** Trivia between the attribute name and `=` (usually empty). */
   eq_trivia: string;
+  /** Trivia between `=` and the opening quote (usually empty). */
+  eq_trailing: string;
   /** Quote character (`"` or `'`). */
   quote: '"' | "'";
 };
@@ -383,31 +405,30 @@ function parse_attrs(
     const name_start = i;
     while (i < n && !/[\s=/>]/.test(src[i])) i++;
     const raw_name = src.slice(name_start, i);
-    // Skip whitespace before '='.
-    let eq_trivia = "";
-    while (i < n && /\s/.test(src[i])) {
-      eq_trivia += src[i];
-      i++;
+    if (raw_name === "") {
+      // A zero-length match means the next char is `=` (e.g. `<rect ="x"/>`
+      // or a missing inter-attribute separator like `a="1"="2"`). Nameless
+      // tokens would enter the model and collide with local-keyed lookups.
+      throw new Error("expected attribute name at " + i);
     }
+    // Capture whitespace before '=' (round-trips via eq_trivia).
+    const eq_start = i;
+    while (i < n && /\s/.test(src[i])) i++;
+    const eq_trivia = src.slice(eq_start, i);
+    if (i >= n) throw new Error("unterminated start tag");
     if (src[i] !== "=") {
-      // Boolean attr without value (rare in SVG) — treat as empty.
-      const [prefix, local] = split_qname(raw_name);
-      attrs.push({
-        raw_name,
-        prefix,
-        local,
-        ns: null,
-        value: "",
-        pre,
-        eq_trivia,
-        quote: '"',
-      });
-      pre = "";
-      continue;
+      // Valueless ("boolean") attributes are not well-formed XML. The old
+      // treat-as-empty tolerance was accept-then-corrupt: the token had no
+      // value-presence flag, so serialization fabricated `=""` and fused
+      // the trailing separator into the next attribute. Strict beats
+      // corrupt — refuse at the door like every other malformed shape.
+      throw new Error("expected '=' after attribute name at " + i);
     }
     i++; // consume '='
-    // Skip whitespace after '='.
+    // Capture whitespace after '=' (round-trips via eq_trailing).
+    const tw_start = i;
     while (i < n && /\s/.test(src[i])) i++;
+    const eq_trailing = src.slice(tw_start, i);
     const quote = src[i];
     if (quote !== '"' && quote !== "'") {
       throw new Error("expected attribute quote at " + i);
@@ -427,6 +448,7 @@ function parse_attrs(
       value: decode_entities(raw_value),
       pre,
       eq_trivia,
+      eq_trailing,
       quote: quote as '"' | "'",
     });
     pre = "";
@@ -442,15 +464,38 @@ const NAMED_ENTITIES: Record<string, string> = {
   apos: "'",
 };
 
+function decode_code_point(cp: number): string {
+  // XML 1.0 §4.1: a character reference must denote a character matching
+  // the §2.2 Char production — TAB/LF/CR, then the BMP minus surrogates
+  // and FFFE/FFFF, then the supplementary planes. NUL and other C0
+  // controls are NOT legal XML even as references; decoding them would
+  // re-emit raw control bytes no conforming parser accepts. Validating
+  // here also keeps the parser's controlled Error shape (fromCodePoint
+  // would escape a raw RangeError and silently mint lone surrogates).
+  const legal =
+    cp === 0x9 ||
+    cp === 0xa ||
+    cp === 0xd ||
+    (cp >= 0x20 && cp <= 0xd7ff) ||
+    (cp >= 0xe000 && cp <= 0xfffd) ||
+    (cp >= 0x10000 && cp <= 0x10ffff);
+  if (!legal) {
+    throw new Error("invalid character reference: " + cp);
+  }
+  return String.fromCodePoint(cp);
+}
+
 function decode_entities(s: string): string {
+  // Note: the regex matches only lowercase `#x` — uppercase `&#X..;` is
+  // not a valid XML CharRef and passes through as literal text.
   return s.replace(
     /&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/g,
     (_, ent) => {
-      if (ent.startsWith("#x") || ent.startsWith("#X")) {
-        return String.fromCodePoint(parseInt(ent.slice(2), 16));
+      if (ent.startsWith("#x")) {
+        return decode_code_point(parseInt(ent.slice(2), 16));
       }
       if (ent.startsWith("#")) {
-        return String.fromCodePoint(parseInt(ent.slice(1), 10));
+        return decode_code_point(parseInt(ent.slice(1), 10));
       }
       return NAMED_ENTITIES[ent] ?? `&${ent};`;
     }


### PR DESCRIPTION
## Summary

Two work items, one PR:

### 1. Parser fidelity: trivia after `=` survives; the attr grammar is now reject-or-preserve

The trivia-preserving parser dropped whitespace between an attribute's `=` and its value quote — `fill = "red"` re-emitted as `fill ="red"`, violating P1 (open + save → byte-equal). `AttrToken` gains a required `eq_trailing` field captured at parse and emitted by the serializer; the `eq_trivia` doc comment (which wrongly claimed to hold post-`=` trivia) is corrected; editor-synthesized tokens share one `SYNTH_ATTR_TRIVIA` shape.

Review of the same function (`parse_attrs`) surfaced **accept-then-corrupt** paths, all converted to strict rejections (each verified by execution before fixing):

- valueless (boolean) attrs serialized as malformed markup (`disabled =""foo=…`) → **throw**
- character references escaped raw `RangeError`s, minted lone surrogates, and re-emitted NUL/C0 controls → validated against the **XML 1.0 Char production** with the parser's controlled `Error`
- empty attribute names (`<rect ="x"/>`, missing inter-attr separators) entered the model as nameless tokens → **throw**
- truncated input at EOF after an attr name misdiagnosed as a missing `=` → reports `unterminated start tag`

A tolerance ledger in the parser header pins the deliberate fidelity trade-offs (entity respelling, bare `&`/`<` canonicalization, no line-end normalization) and records that the rendering-hardening design treats throw-on-untokenizable as load-bearing downstream.

**Versions:** `@grida/svg` 0.1.1 → **0.2.0** (required field on the exported `AttrToken` type — breaking under 0.x; must publish with/before the editor package). `@grida/svg-editor` alpha.16 → **alpha.17**.

### 2. WG docs: rendering-surface hardening spec + research survey

Discharges the *spec half* of the clipboard FRD's trust-model tracking obligation (#818's `clipboard.md` § Trust model):

- **`docs/wg/feat-svg-editor/rendering-hardening.md`** — hardening is a *projection* choice: the model keeps the bytes verbatim (save/clipboard/export never harden); the surface declines to execute. V1–V7 execution-vector inventory, the editing obligations that rule out image-context / sandboxed-frame isolation for the editing surface, requirements R1–R8 (R3: neutralize from the model's own tokens, no second sanitizer parse — structurally avoiding the mXSS class), named costs, residuals, rejected alternatives. **Status: Proposed** — the obligation remains open until reviewed and enforced; *no rendering behavior changes in this PR*.
- **`docs/wg/research/untrusted-svg-rendering.md`** — doctrine-compliant upstream survey (tldraw's sanitizer, DOMPurify SVG profile + mXSS CVE history, secure-static image mode, iframe sandbox, parse-into-model editors, CSP limits), cited by the spec so it stays at domain altitude.
- `clipboard.md` / `index.md` cross-refs keep the reviewed-and-enforced gate explicit.

## Review process

`/simplify` (4 angles) and `/code-review` at xhigh effort (9 finder angles + adversarial sweep) ran over this diff; all confirmed findings fixed here or tracked: undo-path attr-trivia restore and PI-separator/doctype-case fidelity gaps are deferred as scoped follow-up tasks (pre-existing, verified, out of this diff's scope).

## Testing

- `@grida/svg`: **368 passed** — incl. new tokenizer-level `attr-token-trivia.test.ts` (trivia capture + strict grammar + char-ref validation), per the core-first doctrine
- `@grida/svg-editor`: **1218 passed** — incl. new P1 round-trip regressions (`fill = "red"`, multi-space, newline after `=`)
- `tsc --noEmit` clean in both packages; both dists rebuilt (no skew)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVG Editor now preserves attribute formatting and whitespace during serialization for exact round-trip fidelity.
  * Stricter XML/SVG parsing with enhanced validation of attribute syntax and character references.

* **Documentation**
  * Added comprehensive SVG rendering hardening specification and untrusted content handling strategies.
  * Updated clipboard trust model to reference rendering hardening requirements.

* **Tests**
  * Added attribute formatting preservation tests and parser validation test suite.

* **Chores**
  * Version updates: `@grida/svg-editor` (1.0.0-alpha.17) and `@grida/svg` (0.2.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->