### PR TITLE
feat(desktop): integrated human Terminal pane (xterm.js + node-pty), ctrl+` toggle

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -507,6 +507,27 @@ the secret-dir guard below) does not exist yet and is the deferred hardening.
   judgment is the classifier/watchdog layer, named and deferred. `auto` is
   opt-in; the default `accept-edits` keeps a read-only-only shell.
 
+**Human terminal (deliberate contrast to the agent shell).** The
+workbench's Terminal pane (`bridge.terminal.*`) is a real, **unsandboxed**
+login PTY — arbitrary code execution by design, accepted under the same
+trust model as VSCode's integrated terminal: the human runs commands as
+themselves, on their own machine, with their own privileges (no
+escalation). It is deliberately NOT wrapped in `srt` and deliberately NOT
+part of the agent's tool surface — the agent's `run_command` stays
+confined behind the sandbox gates above, and no code path hands the agent
+a handle to a human terminal. What makes the surface acceptable is that
+only the legitimate desktop renderer can reach it: the four terminal IPC
+channels are registered through the same sender-frame `guarded()` wrapper
+as every other native capability (editor origin + `/desktop/*` path), the
+preload exposes them only on desktop routes, and the PTY host
+(`desktop/src/main/terminal-host.ts`) additionally (a) resolves the spawn
+cwd from a workspace **id** through the sidecar registry — the renderer
+never passes a raw path, (b) binds each terminal to the WebContents that
+created it so one window cannot drive another window's shell, (c) caps
+PTYs per window, and (d) kills every PTY on window close and app quit.
+A contract test (`desktop/src/main/terminal-host.test.ts`) fails if a
+terminal channel is ever registered outside `guarded()`.
+
 **No hosted auth in V1.** Desktop V1 ships no `/auth/*` route group, no
 PKCE handoff, no cloud session refresh, and no entitlement polling. Future
 hosted-provider work must re-register its callback and hosted-model files in
@@ -556,6 +577,8 @@ Today:
 - [editor/lib/desktop/bridge.ts](editor/lib/desktop/bridge.ts) — typed client of `window.grida` + SSR-safe presence detector (`useDesktopBridge`).
 - [desktop/src/main/host-apps.ts](desktop/src/main/host-apps.ts) — private desktop UX registry for “Open in…” app detection/opening.
 - [desktop/src/main/workspace-files.ts](desktop/src/main/workspace-files.ts) — move-to-trash for a workspace entry (file or folder); re-validates that `relPath` resolves inside the workspace root, and isn't the root itself, before `shell.trashItem`.
+- [desktop/src/main/terminal-host.ts](desktop/src/main/terminal-host.ts) — human-terminal PTY host: workspace-id-resolved cwd, per-WebContents terminal ownership, per-window PTY cap, kill-on-close; the unsandboxed-by-design surface described under "Human terminal" above.
+- [editor/scaffolds/desktop/workbench/terminal-pane.tsx](editor/scaffolds/desktop/workbench/terminal-pane.tsx) — xterm.js view over the `terminal` bridge namespace; renderer side of the human terminal.
 - `desktop/src/main.ts` — Electron main entry; acquires the single-instance lock (deferred to `ready` so a secondary instance can forward a macOS `open-file` path via `additionalData` before quitting — before any sidecar/window/IPC is created, preserving the one-sidecar invariant); routes `open-file`/`open-url`/`second-instance` opens.
 - [desktop/src/main/open-handoff.ts](desktop/src/main/open-handoff.ts) — pure codec for the secondary→primary "open" forward; tolerant `decode` so a foreign or legacy `second-instance` payload is never mistaken for an open.
 

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -12,6 +12,7 @@ import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import * as dotenv from "dotenv";
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 // cli flags
@@ -118,9 +119,11 @@ const config: ForgeConfig = {
     ignore: packageIgnore,
     // @anthropic-ai/sandbox-runtime ships executable vendored binaries
     // (vendor/seccomp/*/apply-seccomp) that cannot run from inside an asar —
-    // unpack it so they land on a real filesystem.
+    // unpack it so they land on a real filesystem. node-pty likewise: its
+    // native `pty.node` addon and `spawn-helper` executable cannot load/run
+    // from inside an asar.
     asar: {
-      unpack: "**/node_modules/@anthropic-ai/sandbox-runtime/**",
+      unpack: "**/node_modules/{@anthropic-ai/sandbox-runtime,node-pty}/**",
     },
     appBundleId: appBundleId,
     icon: icon,
@@ -138,8 +141,38 @@ const config: ForgeConfig = {
     extendInfo: "./Info.plist",
     appCategoryType: "public.app-category.developer-tools",
   },
-  rebuildConfig: {},
+  // node-pty is the only native dependency. Upstream ships N-API prebuilt
+  // binaries for darwin/win32 (its loader falls back to prebuilds/<platform>-
+  // <arch>), so rebuilding there is pure waste — and would force every dev
+  // machine to carry a C++ toolchain. Linux has no upstream prebuilds, so it
+  // is the one platform where @electron/rebuild must compile from source
+  // (requires the distro toolchain; GitHub's ubuntu runners ship it).
+  // node-abi is overridden in pnpm-workspace.yaml so the rebuild recognizes
+  // current Electron versions.
+  rebuildConfig: {
+    ignoreModules: process.platform === "linux" ? [] : ["node-pty"],
+  },
   hooks: {
+    // node-pty's npm tarball ships the darwin prebuilt `spawn-helper`
+    // with mode 0644 (no exec bit) and never chmods it, so PTY spawn
+    // fails with `posix_spawnp failed`. Fix the bit BEFORE asar packing:
+    // the installed app can be mounted read-only (macOS app
+    // translocation), so a runtime chmod can't be the only fix. asar
+    // preserves the mode into app.asar.unpacked. The dev tree is handled
+    // at runtime by terminal-host.ts `ensureSpawnHelperExecutable`.
+    packageAfterPrune: async (_forgeConfig, buildPath) => {
+      const prebuilds = path.join(
+        buildPath,
+        "node_modules",
+        "node-pty",
+        "prebuilds"
+      );
+      if (!fs.existsSync(prebuilds)) return;
+      for (const dir of fs.readdirSync(prebuilds)) {
+        const helper = path.join(prebuilds, dir, "spawn-helper");
+        if (fs.existsSync(helper)) fs.chmodSync(helper, 0o755);
+      }
+    },
     // GRIDA-DESKTOP-BUILD-GUARD — after packaging, verify every externalized
     // require (and its full transitive closure) actually resolves in the
     // packaged app. A missing dependency fails the build HERE instead of

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -27,6 +27,7 @@
     "@anthropic-ai/sandbox-runtime": "^0.0.52",
     "@hono/node-server": "^1.13.7",
     "hono": "^4.6.14",
+    "node-pty": "^1.1.0",
     "undici": "^7.24.4"
   },
   "devDependencies": {

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  node-abi: ^4.31.0
   '@grida/agent': link:../packages/grida-ai-agent
   '@grida/desktop-bridge': link:../packages/grida-desktop-bridge
   '@grida/ai-models': link:../packages/grida-ai-models
@@ -23,6 +24,9 @@ importers:
       hono:
         specifier: ^4.6.14
         version: 4.12.23
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       undici:
         specifier: ^7.24.4
         version: 7.25.0
@@ -582,36 +586,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -688,24 +698,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1832,24 +1846,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2057,9 +2075,12 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
-  node-abi@3.75.0:
-    resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
-    engines: {node: '>=10'}
+  node-abi@4.31.0:
+    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
+    engines: {node: '>=22.12.0'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -2076,6 +2097,9 @@ packages:
   node-forge@1.4.0:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3344,7 +3368,7 @@ snapshots:
       detect-libc: 2.0.4
       fs-extra: 10.1.0
       got: 11.8.6
-      node-abi: 3.75.0
+      node-abi: 4.31.0
       node-api-version: 0.2.1
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
@@ -5186,9 +5210,11 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  node-abi@3.75.0:
+  node-abi@4.31.0:
     dependencies:
       semver: 7.7.2
+
+  node-addon-api@7.1.1: {}
 
   node-api-version@0.2.1:
     dependencies:
@@ -5201,6 +5227,10 @@ snapshots:
       encoding: 0.1.13
 
   node-forge@1.4.0: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.37: {}
 

--- a/desktop/pnpm-workspace.yaml
+++ b/desktop/pnpm-workspace.yaml
@@ -9,12 +9,29 @@ nodeLinker: hoisted
 # strictDepBuilds: false keeps all other (unlisted) build scripts as warnings,
 # matching the pnpm 10 onlyBuiltDependencies whitelist behavior.
 strictDepBuilds: false
+# pnpm 11 blocks git/tarball-resolved subdependencies by default. The electron
+# tooling we already ship pins one: @electron/rebuild -> @electron/node-gyp is
+# a git-hosted dependency (upstream's choice, commit-pinned in our lockfile).
+# Any re-resolution of the graph (e.g. adding a dependency) would fail on it,
+# so the block is disabled here — reviewed: the only exotic subdep in the
+# lockfile is that commit-pinned @electron/node-gyp.
+blockExoticSubdeps: false
 allowBuilds:
   electron: true
   electron-winstaller: true
   fs-xattr: true
   macos-alias: true
+  # Skipped: node-pty ships prebuilt N-API binaries its loader falls back
+  # to (prebuilds/<platform>-<arch>/), so the node-gyp install script is
+  # unnecessary on darwin/win32; Linux packaging goes through forge's
+  # native-module rebuild instead.
+  node-pty: false
 overrides:
+  # @electron/rebuild pins an old node-abi that throws "Could not detect abi"
+  # for current Electron releases. Only the Linux packaging path actually
+  # rebuilds (see forge.config.ts rebuildConfig), but the lookup must succeed
+  # there. Keep this current when bumping Electron majors.
+  node-abi: "^4.31.0"
   "@grida/agent": "link:../packages/grida-ai-agent"
   "@grida/desktop-bridge": "link:../packages/grida-desktop-bridge"
   "@grida/ai-models": "link:../packages/grida-ai-models"

--- a/desktop/scripts/verify-packaged-bundle.mjs
+++ b/desktop/scripts/verify-packaged-bundle.mjs
@@ -79,8 +79,10 @@ function isExternalSpecifier(id) {
 function extractExternals(jsFile) {
   const code = fs.readFileSync(jsFile, "utf8");
   const found = new Set();
-  // matches require("x"), require('x'), require(`x`)
-  const re = /require\(\s*[`"']([^`"']+)[`"']\s*\)/g;
+  // matches require("x") and dynamic import("x") — Rollup keeps external
+  // dynamic imports as `import(...)` even in CJS output (dynamicImportInCjs),
+  // so lazily-loaded externals like node-pty never appear as require().
+  const re = /(?:require|import)\(\s*[`"']([^`"']+)[`"']\s*\)/g;
   let m;
   while ((m = re.exec(code))) {
     if (isExternalSpecifier(m[1])) found.add(m[1]);

--- a/desktop/src/bridge/contract.ts
+++ b/desktop/src/bridge/contract.ts
@@ -17,6 +17,8 @@ export type {
   OpenDialogOptions,
   RecentEntry,
   SaveDialogOptions,
+  TerminalCreateOptions,
+  TerminalHandlers,
   Workspace,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
@@ -43,6 +45,13 @@ export const IPC_CHANNELS = {
   SHELL_SHOW_ITEM_IN_FOLDER: "grida:shell:show-item-in-folder",
   HOST_APPS_RESOLVE_PREFERRED: "grida:host-apps:resolve-preferred",
   HOST_APPS_OPEN_WORKSPACE: "grida:host-apps:open-workspace",
+  TERMINAL_CREATE: "grida:terminal:create",
+  TERMINAL_WRITE: "grida:terminal:write",
+  TERMINAL_RESIZE: "grida:terminal:resize",
+  TERMINAL_KILL: "grida:terminal:kill",
+  // main → renderer push channels (no invoke response)
+  TERMINAL_DATA: "grida:terminal:data",
+  TERMINAL_EXIT: "grida:terminal:exit",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -16,6 +16,7 @@ import {
   type AgentSidecarInfo,
 } from "./main/agent-sidecar-supervisor";
 import { registerIpcHandlers } from "./main/ipc-handlers";
+import { disposeAllTerminals } from "./main/terminal-host";
 import { agentSidecarClient } from "./main/agent-sidecar-client";
 import { startAgentNotifications } from "./main/agent-notifications";
 import { routeDeepLink } from "./main/protocol-router";
@@ -353,6 +354,8 @@ app.on("activate", () => {
 });
 
 app.on("before-quit", () => {
-  // Belt-and-suspenders — supervisor also listens for this event.
+  // Belt-and-suspenders — supervisor also listens for this event, and
+  // terminal PTYs are also killed per-window on webContents teardown.
   stopAgentSidecar();
+  disposeAllTerminals();
 });

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -27,6 +27,12 @@ import {
   resolvePreferredHostApps,
   type HostAppId,
 } from "./host-apps";
+import {
+  createTerminal,
+  killTerminal,
+  resizeTerminal,
+  writeTerminal,
+} from "./terminal-host";
 import { trashWorkspaceEntry } from "./workspace-files";
 
 // `new URL(EDITOR_BASE_URL).origin` is needed per IPC invoke; parse the
@@ -243,6 +249,45 @@ export function registerIpcHandlers() {
       await trashWorkspaceEntry(workspace, opts.rel_path);
     }
   );
+
+  // GRIDA-SEC-004: human-interactive terminal. The PTY spawn cwd is the
+  // workspace root resolved from the sidecar registry — the renderer
+  // only ever names a workspace id, never a raw path. The PTY host
+  // additionally binds each terminal to its creating WebContents (see
+  // terminal-host.ts), so these guarded channels are the only way in.
+  guarded(
+    IPC_CHANNELS.TERMINAL_CREATE,
+    async (
+      event,
+      opts: { id: string; workspace_id: string; cols: number; rows: number }
+    ) => {
+      const workspace = await findWorkspaceOrThrow(opts.workspace_id);
+      await createTerminal(event.sender, {
+        id: opts.id,
+        cwd: workspace.root,
+        cols: opts.cols,
+        rows: opts.rows,
+      });
+    }
+  );
+
+  guarded(
+    IPC_CHANNELS.TERMINAL_WRITE,
+    (event, opts: { id: string; data: string }) => {
+      writeTerminal(event.sender, opts.id, opts.data);
+    }
+  );
+
+  guarded(
+    IPC_CHANNELS.TERMINAL_RESIZE,
+    (event, opts: { id: string; cols: number; rows: number }) => {
+      resizeTerminal(event.sender, opts.id, opts.cols, opts.rows);
+    }
+  );
+
+  guarded(IPC_CHANNELS.TERMINAL_KILL, (event, id: string) => {
+    killTerminal(event.sender, id);
+  });
 }
 
 async function findWorkspaceOrThrow(workspaceId: string) {

--- a/desktop/src/main/terminal-host.test.ts
+++ b/desktop/src/main/terminal-host.test.ts
@@ -4,6 +4,7 @@ import {
   clampGridSize,
   isValidTerminalId,
   resolveDefaultShell,
+  TerminalRegistry,
 } from "./terminal-host";
 
 describe("resolveDefaultShell", () => {
@@ -61,6 +62,73 @@ describe("isValidTerminalId", () => {
     expect(isValidTerminalId("a".repeat(65))).toBe(false);
     expect(isValidTerminalId("../etc/passwd")).toBe(false);
     expect(isValidTerminalId(42)).toBe(false);
+  });
+});
+
+/**
+ * The reservation protocol — regression coverage for the TOCTOU where
+ * concurrent `terminal.create` calls passed the duplicate/cap checks
+ * together before any of them reached the async spawn, and for
+ * exit-vs-recycled-id teardown.
+ */
+describe("TerminalRegistry", () => {
+  const owner = { id: 1 };
+  const other = { id: 2 };
+
+  it("a pending reservation already claims the id (concurrent create race)", () => {
+    const reg = new TerminalRegistry<object, string>(8);
+    reg.reserve("a", owner);
+    // second create for the same id arrives before the first spawn lands
+    expect(() => reg.reserve("a", owner)).toThrow(/already exists/);
+  });
+
+  it("pending reservations count against the per-owner cap", () => {
+    const reg = new TerminalRegistry<object, string>(2);
+    reg.reserve("a", owner);
+    reg.reserve("b", owner); // neither committed yet
+    expect(() => reg.reserve("c", owner)).toThrow(/too many terminals/);
+    // a different window is unaffected
+    reg.reserve("c", other);
+  });
+
+  it("commit fails after a mid-spawn kill, so the caller destroys the PTY", () => {
+    const reg = new TerminalRegistry<object, string>(8);
+    reg.reserve("a", owner);
+    expect(reg.take("a", owner)).toBeNull(); // kill during spawn: nothing live yet
+    expect(reg.commit("a", owner, "pty-1")).toBe(false);
+    expect(() => reg.get("a", owner)).toThrow(/not found/);
+  });
+
+  it("commit fails after a mid-spawn window close (takeAllFor)", () => {
+    const reg = new TerminalRegistry<object, string>(8);
+    reg.reserve("a", owner);
+    reg.reserve("b", owner);
+    expect(reg.commit("b", owner, "pty-b")).toBe(true);
+    expect(reg.takeAllFor(owner)).toEqual(["pty-b"]); // only live PTYs returned
+    expect(reg.commit("a", owner, "pty-a")).toBe(false);
+  });
+
+  it("a stale exit cannot tear down a recycled id", () => {
+    const reg = new TerminalRegistry<object, string>(8);
+    reg.reserve("a", owner);
+    reg.commit("a", owner, "pty-1");
+    reg.take("a", owner); // killed
+    reg.reserve("a", owner); // id recycled by a fresh create
+    reg.commit("a", owner, "pty-2");
+    expect(reg.releaseExited("a", "pty-1")).toBe(false); // old PTY's exit: no-op
+    expect(reg.get("a", owner)).toBe("pty-2");
+    expect(reg.releaseExited("a", "pty-2")).toBe(true);
+  });
+
+  it("ownership: another window can neither get nor take, and pending is not gettable", () => {
+    const reg = new TerminalRegistry<object, string>(8);
+    reg.reserve("a", owner);
+    expect(() => reg.get("a", owner)).toThrow(/not found/); // pending
+    reg.commit("a", owner, "pty-1");
+    expect(() => reg.get("a", other)).toThrow(/not found/);
+    expect(() => reg.take("a", other)).toThrow(/not found/);
+    expect(reg.take("bogus", owner)).toBeNull(); // idempotent kill
+    expect(reg.take("a", owner)).toBe("pty-1");
   });
 });
 

--- a/desktop/src/main/terminal-host.test.ts
+++ b/desktop/src/main/terminal-host.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  clampGridSize,
+  isValidTerminalId,
+  resolveDefaultShell,
+} from "./terminal-host";
+
+describe("resolveDefaultShell", () => {
+  it("uses $SHELL as a login shell on macOS", () => {
+    expect(resolveDefaultShell("darwin", { SHELL: "/opt/fish" })).toEqual({
+      command: "/opt/fish",
+      args: ["-l"],
+    });
+    expect(resolveDefaultShell("darwin", {})).toEqual({
+      command: "/bin/zsh",
+      args: ["-l"],
+    });
+  });
+
+  it("uses $SHELL as-is on linux", () => {
+    expect(resolveDefaultShell("linux", { SHELL: "/usr/bin/zsh" })).toEqual({
+      command: "/usr/bin/zsh",
+      args: [],
+    });
+    expect(resolveDefaultShell("linux", {})).toEqual({
+      command: "/bin/bash",
+      args: [],
+    });
+  });
+
+  it("defaults to powershell on windows", () => {
+    expect(resolveDefaultShell("win32", { SHELL: "/bin/bash" })).toEqual({
+      command: "powershell.exe",
+      args: [],
+    });
+  });
+});
+
+describe("clampGridSize", () => {
+  it("floors and clamps to [1, 1000]", () => {
+    expect(clampGridSize(80.7, 24)).toBe(80);
+    expect(clampGridSize(0, 24)).toBe(1);
+    expect(clampGridSize(-3, 24)).toBe(1);
+    expect(clampGridSize(99999, 24)).toBe(1000);
+  });
+
+  it("falls back on non-numeric input", () => {
+    expect(clampGridSize("80", 24)).toBe(24);
+    expect(clampGridSize(NaN, 24)).toBe(24);
+    expect(clampGridSize(undefined, 80)).toBe(80);
+  });
+});
+
+describe("isValidTerminalId", () => {
+  it("accepts UUID-shaped tokens and rejects everything else", () => {
+    expect(isValidTerminalId("0b8d7c2e-91c4-4b6e-a9f4-2f6a4a9d1c0e")).toBe(
+      true
+    );
+    expect(isValidTerminalId("")).toBe(false);
+    expect(isValidTerminalId("a".repeat(65))).toBe(false);
+    expect(isValidTerminalId("../etc/passwd")).toBe(false);
+    expect(isValidTerminalId(42)).toBe(false);
+  });
+});
+
+// GRIDA-SEC-004 anti-drift: every terminal IPC channel must be
+// registered through `guarded(` — the sender-frame gate that keeps the
+// RCE-by-design surface reachable only from editor-origin `/desktop/*`
+// frames. A bare `ipcMain.handle(IPC_CHANNELS.TERMINAL_...` ships the
+// surface without the gate.
+describe("terminal IPC registration", () => {
+  it("registers every terminal invoke channel via guarded()", () => {
+    const source = fs.readFileSync(
+      new URL("./ipc-handlers.ts", import.meta.url),
+      "utf8"
+    );
+    for (const channel of [
+      "TERMINAL_CREATE",
+      "TERMINAL_WRITE",
+      "TERMINAL_RESIZE",
+      "TERMINAL_KILL",
+    ]) {
+      expect(source).toMatch(
+        new RegExp(`guarded\\(\\s*IPC_CHANNELS.${channel}`)
+      );
+      expect(source).not.toMatch(
+        new RegExp(`ipcMain.handle\\(\\s*IPC_CHANNELS.${channel}`)
+      );
+    }
+  });
+});

--- a/desktop/src/main/terminal-host.ts
+++ b/desktop/src/main/terminal-host.ts
@@ -1,0 +1,239 @@
+/**
+ * GRIDA-SEC-004 — human-interactive terminal PTY host.
+ *
+ * Owns every PTY the desktop spawns for the renderer's Terminal pane
+ * (`bridge.terminal.*`). This is RCE-by-design surfaced to the
+ * renderer, accepted under the VSCode trust model: the human runs
+ * commands as themselves, with their own privileges — deliberately NOT
+ * under the agent's `srt` sandbox, and never wired into the agent's
+ * tool surface. What keeps the surface safe is that only the desktop's
+ * privileged renderer can reach it:
+ *
+ *  - every IPC channel is registered through `guarded()` in
+ *    `ipc-handlers.ts` (sender frame must be editor-origin `/desktop/*`),
+ *  - the spawn cwd is a workspace root resolved host-side from the
+ *    sidecar registry — the renderer never passes a raw path,
+ *  - write/resize/kill verify the calling WebContents owns the
+ *    terminal, so one window cannot drive another window's shell.
+ *
+ * Terminal ids are minted by the preload (UUID) so the renderer's data
+ * handler is registered before the PTY emits its first frame — same
+ * caller-mints-id pattern as `sessions.enqueue`.
+ *
+ * See /SECURITY.md `GRIDA-SEC-004`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { WebContents } from "electron";
+import type { IPty } from "node-pty";
+import { IPC_CHANNELS } from "../bridge/contract";
+
+/** Renderer-minted handle: UUID-sized opaque token, nothing fancier. */
+const TERMINAL_ID_RE = /^[0-9a-zA-Z-]{1,64}$/;
+
+/** A runaway renderer loop must not fork-bomb the host. The UI spawns
+ * one shell per workbench window; 8 leaves headroom for future tabs. */
+const MAX_TERMINALS_PER_WEBCONTENTS = 8;
+
+type TerminalRecord = { pty: IPty; wc: WebContents };
+
+const terminals = new Map<string, TerminalRecord>();
+/** WebContents ids that already have a kill-on-destroy hook. */
+const hookedWebContents = new Set<number>();
+
+// node-pty is a native module, loaded lazily so importing this module
+// (e.g. from tests exercising the pure helpers below) never touches
+// the addon. The vite main bundle leaves it external; see
+// vite.main.config.ts + the packaging recipe in forge.config.ts.
+let ptyModule: typeof import("node-pty") | null = null;
+async function loadPty(): Promise<typeof import("node-pty")> {
+  if (!ptyModule) {
+    await ensureSpawnHelperExecutable();
+    ptyModule = await import("node-pty");
+  }
+  return ptyModule;
+}
+
+/**
+ * node-pty@1.1.0 ships its darwin prebuilt `spawn-helper` without the
+ * executable bit — the npm tarball itself carries mode 0644 and nothing
+ * in the package ever chmods it — so the first PTY spawn fails with
+ * `posix_spawnp failed`. The packaged app fixes the bit at build time
+ * (forge.config.ts `packageAfterPrune`), because the installed bundle
+ * can be mounted read-only (macOS app translocation). This runtime pass
+ * covers the dev tree, and no-ops once the bit is present.
+ *
+ * The helper is anchored at `app.getAppPath()` (the directory holding
+ * package.json in dev; app.asar when packaged) rather than
+ * `import.meta.url` — Vite's CJS main build compiles `import.meta` to
+ * `{}`, which silently breaks `createRequire`-based resolution.
+ * Electron is imported lazily so this module stays importable in plain
+ * Node tests.
+ */
+async function ensureSpawnHelperExecutable(): Promise<void> {
+  if (process.platform === "win32") return;
+  try {
+    const { app } = await import("electron");
+    const helper = path
+      .join(
+        app.getAppPath(),
+        "node_modules",
+        "node-pty",
+        "prebuilds",
+        `${process.platform}-${process.arch}`,
+        "spawn-helper"
+      )
+      // Same rewrite node-pty's own loader applies — the helper must
+      // run from the real filesystem, not inside the asar.
+      .replace("app.asar", "app.asar.unpacked");
+    const mode = fs.statSync(helper).mode;
+    if (mode & 0o111) return;
+    fs.chmodSync(helper, mode | 0o755);
+  } catch {
+    // No prebuilt helper (source build) or unwritable tree — let the
+    // actual spawn surface any real failure.
+  }
+}
+
+/**
+ * The user's default interactive shell. macOS spawns it as a login
+ * shell (`-l`) so PATH and profile match Terminal.app; Linux trusts
+ * `$SHELL` as-is; Windows defaults to PowerShell (shipped with the OS
+ * since Windows 7), matching VSCode's default.
+ */
+export function resolveDefaultShell(
+  platform: NodeJS.Platform,
+  env: Record<string, string | undefined>
+): { command: string; args: string[] } {
+  if (platform === "win32") {
+    return { command: "powershell.exe", args: [] };
+  }
+  if (platform === "darwin") {
+    return { command: env.SHELL || "/bin/zsh", args: ["-l"] };
+  }
+  return { command: env.SHELL || "/bin/bash", args: [] };
+}
+
+/** Clamp a renderer-supplied grid dimension to something a PTY accepts. */
+export function clampGridSize(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(1000, Math.max(1, Math.floor(value)));
+}
+
+export function isValidTerminalId(id: unknown): id is string {
+  return typeof id === "string" && TERMINAL_ID_RE.test(id);
+}
+
+export async function createTerminal(
+  wc: WebContents,
+  opts: { id: string; cwd: string; cols: number; rows: number }
+): Promise<void> {
+  const { id } = opts;
+  if (!isValidTerminalId(id)) {
+    throw new Error("invalid terminal id");
+  }
+  if (terminals.has(id)) {
+    throw new Error(`terminal already exists: ${id}`);
+  }
+  let owned = 0;
+  for (const record of terminals.values()) {
+    if (record.wc === wc) owned += 1;
+  }
+  if (owned >= MAX_TERMINALS_PER_WEBCONTENTS) {
+    throw new Error("too many terminals for this window");
+  }
+
+  const pty = await loadPty();
+  const shell = resolveDefaultShell(process.platform, process.env);
+  const proc = pty.spawn(shell.command, shell.args, {
+    name: "xterm-256color",
+    cwd: opts.cwd,
+    cols: clampGridSize(opts.cols, 80),
+    rows: clampGridSize(opts.rows, 24),
+    env: {
+      ...(process.env as Record<string, string>),
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+    },
+  });
+
+  terminals.set(id, { pty: proc, wc });
+
+  proc.onData((data) => {
+    if (!wc.isDestroyed()) {
+      wc.send(IPC_CHANNELS.TERMINAL_DATA, { id, data });
+    }
+  });
+  proc.onExit(({ exitCode }) => {
+    terminals.delete(id);
+    if (!wc.isDestroyed()) {
+      wc.send(IPC_CHANNELS.TERMINAL_EXIT, { id, exit_code: exitCode });
+    }
+  });
+
+  // Kill on window close — no reattach in v1. `destroyed` also fires on
+  // app quit, so this covers both; `disposeAllTerminals` below is the
+  // belt-and-suspenders for quit paths that skip webContents teardown.
+  if (!hookedWebContents.has(wc.id)) {
+    hookedWebContents.add(wc.id);
+    wc.once("destroyed", () => {
+      hookedWebContents.delete(wc.id);
+      for (const [id, record] of terminals) {
+        if (record.wc === wc) {
+          terminals.delete(id);
+          record.pty.kill();
+        }
+      }
+    });
+  }
+}
+
+/** Look up a terminal, enforcing that `wc` is the WebContents that
+ * created it — one window cannot drive another window's shell. */
+function ownedTerminal(wc: WebContents, id: unknown): TerminalRecord {
+  const record = isValidTerminalId(id) ? terminals.get(id) : undefined;
+  if (!record || record.wc !== wc) {
+    throw new Error("terminal not found");
+  }
+  return record;
+}
+
+export function writeTerminal(wc: WebContents, id: unknown, data: unknown) {
+  if (typeof data !== "string") throw new Error("invalid terminal data");
+  ownedTerminal(wc, id).pty.write(data);
+}
+
+export function resizeTerminal(
+  wc: WebContents,
+  id: unknown,
+  cols: unknown,
+  rows: unknown
+) {
+  ownedTerminal(wc, id).pty.resize(
+    clampGridSize(cols, 80),
+    clampGridSize(rows, 24)
+  );
+}
+
+/**
+ * Idempotent on a missing id: the renderer's unmount cleanup races the
+ * host's own exit cleanup (a shell `exit` deletes the record before the
+ * pane unmounts), so "already gone" is a normal outcome — not an error.
+ * A live terminal still requires ownership, like write/resize.
+ */
+export function killTerminal(wc: WebContents, id: unknown) {
+  if (!isValidTerminalId(id)) return;
+  const record = terminals.get(id);
+  if (!record) return;
+  if (record.wc !== wc) throw new Error("terminal not found");
+  terminals.delete(id);
+  record.pty.kill();
+}
+
+export function disposeAllTerminals() {
+  for (const record of terminals.values()) {
+    record.pty.kill();
+  }
+  terminals.clear();
+}

--- a/desktop/src/main/terminal-host.ts
+++ b/desktop/src/main/terminal-host.ts
@@ -36,9 +36,118 @@ const TERMINAL_ID_RE = /^[0-9a-zA-Z-]{1,64}$/;
  * one shell per workbench window; 8 leaves headroom for future tabs. */
 const MAX_TERMINALS_PER_WEBCONTENTS = 8;
 
-type TerminalRecord = { pty: IPty; wc: WebContents };
+/**
+ * Bookkeeping for live AND in-flight terminals, with a reservation
+ * protocol that closes the TOCTOU between validation and the async
+ * native load + spawn: `reserve()` claims the id and counts against
+ * the per-owner cap synchronously BEFORE the first `await`, so
+ * concurrent `terminal.create` calls cannot pass the duplicate/cap
+ * checks together. `commit()` binds the spawned PTY only if the
+ * reservation is still live — a kill or window close that lands
+ * mid-spawn makes it return false and the caller destroys the fresh
+ * PTY instead of resurrecting the record. `releaseExited()` compares
+ * the PTY identity so a stale exit can never tear down a session that
+ * reused the id.
+ *
+ * Generic over owner/PTY so the protocol is unit-testable without
+ * Electron or node-pty (terminal-host.test.ts).
+ */
+export class TerminalRegistry<TOwner extends object, TPty> {
+  private readonly records = new Map<
+    string,
+    { owner: TOwner; pty: TPty | null }
+  >();
 
-const terminals = new Map<string, TerminalRecord>();
+  constructor(private readonly maxPerOwner: number) {}
+
+  /** Claim `id` for `owner` before any async work. Throws on an
+   * invalid or already-claimed id, or when the owner is at cap
+   * (pending reservations count — that's the point). */
+  reserve(id: unknown, owner: TOwner): void {
+    if (!isValidTerminalId(id)) {
+      throw new Error("invalid terminal id");
+    }
+    if (this.records.has(id)) {
+      throw new Error(`terminal already exists: ${id}`);
+    }
+    let owned = 0;
+    for (const record of this.records.values()) {
+      if (record.owner === owner) owned += 1;
+    }
+    if (owned >= this.maxPerOwner) {
+      throw new Error("too many terminals for this window");
+    }
+    this.records.set(id, { owner, pty: null });
+  }
+
+  /** Bind the spawned PTY to its reservation. Returns false when the
+   * reservation is gone (killed / window closed during spawn) — the
+   * caller must destroy `pty` itself. */
+  commit(id: string, owner: TOwner, pty: TPty): boolean {
+    const record = this.records.get(id);
+    if (!record || record.owner !== owner || record.pty !== null) return false;
+    record.pty = pty;
+    return true;
+  }
+
+  /** The owner's live terminal, or throw. Pending reservations and
+   * other owners' terminals are equally "not found" — one window can
+   * never address another window's shell. */
+  get(id: unknown, owner: TOwner): TPty {
+    const record = isValidTerminalId(id) ? this.records.get(id) : undefined;
+    if (!record || record.owner !== owner || record.pty === null) {
+      throw new Error("terminal not found");
+    }
+    return record.pty;
+  }
+
+  /** Remove the record for a kill. Missing id → null (idempotent — the
+   * renderer's unmount cleanup races the host's own exit cleanup);
+   * foreign owner → throw; pending reservation → removed, null (the
+   * in-flight create's `commit` then fails and destroys the PTY). */
+  take(id: unknown, owner: TOwner): TPty | null {
+    const record = isValidTerminalId(id) ? this.records.get(id) : undefined;
+    if (!record) return null;
+    if (record.owner !== owner) throw new Error("terminal not found");
+    this.records.delete(id as string);
+    return record.pty;
+  }
+
+  /** Exit-path removal: only if `pty` is still the record's PTY, so a
+   * stale exit can't delete a record whose id was since recycled. */
+  releaseExited(id: string, pty: TPty): boolean {
+    const record = this.records.get(id);
+    if (!record || record.pty !== pty) return false;
+    this.records.delete(id);
+    return true;
+  }
+
+  /** Remove every record of `owner` (window closed); returns the live
+   * PTYs to kill. Pending creates notice via failed `commit`. */
+  takeAllFor(owner: TOwner): TPty[] {
+    const live: TPty[] = [];
+    for (const [id, record] of this.records) {
+      if (record.owner !== owner) continue;
+      this.records.delete(id);
+      if (record.pty !== null) live.push(record.pty);
+    }
+    return live;
+  }
+
+  /** Remove everything (app quit); returns the live PTYs to kill. */
+  drainAll(): TPty[] {
+    const live: TPty[] = [];
+    for (const record of this.records.values()) {
+      if (record.pty !== null) live.push(record.pty);
+    }
+    this.records.clear();
+    return live;
+  }
+}
+
+const terminals = new TerminalRegistry<WebContents, IPty>(
+  MAX_TERMINALS_PER_WEBCONTENTS
+);
 /** WebContents ids that already have a kill-on-destroy hook. */
 const hookedWebContents = new Set<number>();
 
@@ -130,35 +239,34 @@ export async function createTerminal(
   opts: { id: string; cwd: string; cols: number; rows: number }
 ): Promise<void> {
   const { id } = opts;
-  if (!isValidTerminalId(id)) {
-    throw new Error("invalid terminal id");
-  }
-  if (terminals.has(id)) {
-    throw new Error(`terminal already exists: ${id}`);
-  }
-  let owned = 0;
-  for (const record of terminals.values()) {
-    if (record.wc === wc) owned += 1;
-  }
-  if (owned >= MAX_TERMINALS_PER_WEBCONTENTS) {
-    throw new Error("too many terminals for this window");
+  // Synchronous reservation BEFORE the await below — see TerminalRegistry.
+  terminals.reserve(id, wc);
+
+  let proc: IPty;
+  try {
+    const pty = await loadPty();
+    const shell = resolveDefaultShell(process.platform, process.env);
+    proc = pty.spawn(shell.command, shell.args, {
+      name: "xterm-256color",
+      cwd: opts.cwd,
+      cols: clampGridSize(opts.cols, 80),
+      rows: clampGridSize(opts.rows, 24),
+      env: {
+        ...(process.env as Record<string, string>),
+        TERM: "xterm-256color",
+        COLORTERM: "truecolor",
+      },
+    });
+  } catch (err) {
+    terminals.take(id, wc); // free the reservation
+    throw err;
   }
 
-  const pty = await loadPty();
-  const shell = resolveDefaultShell(process.platform, process.env);
-  const proc = pty.spawn(shell.command, shell.args, {
-    name: "xterm-256color",
-    cwd: opts.cwd,
-    cols: clampGridSize(opts.cols, 80),
-    rows: clampGridSize(opts.rows, 24),
-    env: {
-      ...(process.env as Record<string, string>),
-      TERM: "xterm-256color",
-      COLORTERM: "truecolor",
-    },
-  });
-
-  terminals.set(id, { pty: proc, wc });
+  if (!terminals.commit(id, wc, proc)) {
+    // Killed (or window closed) while the spawn was in flight.
+    proc.kill();
+    return;
+  }
 
   proc.onData((data) => {
     if (!wc.isDestroyed()) {
@@ -166,8 +274,9 @@ export async function createTerminal(
     }
   });
   proc.onExit(({ exitCode }) => {
-    terminals.delete(id);
-    if (!wc.isDestroyed()) {
+    // Identity-checked: a kill already removed the record, and an id
+    // recycled after this PTY's death must not be torn down by it.
+    if (terminals.releaseExited(id, proc) && !wc.isDestroyed()) {
       wc.send(IPC_CHANNELS.TERMINAL_EXIT, { id, exit_code: exitCode });
     }
   });
@@ -179,29 +288,16 @@ export async function createTerminal(
     hookedWebContents.add(wc.id);
     wc.once("destroyed", () => {
       hookedWebContents.delete(wc.id);
-      for (const [id, record] of terminals) {
-        if (record.wc === wc) {
-          terminals.delete(id);
-          record.pty.kill();
-        }
+      for (const pty of terminals.takeAllFor(wc)) {
+        pty.kill();
       }
     });
   }
 }
 
-/** Look up a terminal, enforcing that `wc` is the WebContents that
- * created it — one window cannot drive another window's shell. */
-function ownedTerminal(wc: WebContents, id: unknown): TerminalRecord {
-  const record = isValidTerminalId(id) ? terminals.get(id) : undefined;
-  if (!record || record.wc !== wc) {
-    throw new Error("terminal not found");
-  }
-  return record;
-}
-
 export function writeTerminal(wc: WebContents, id: unknown, data: unknown) {
   if (typeof data !== "string") throw new Error("invalid terminal data");
-  ownedTerminal(wc, id).pty.write(data);
+  terminals.get(id, wc).write(data);
 }
 
 export function resizeTerminal(
@@ -210,10 +306,9 @@ export function resizeTerminal(
   cols: unknown,
   rows: unknown
 ) {
-  ownedTerminal(wc, id).pty.resize(
-    clampGridSize(cols, 80),
-    clampGridSize(rows, 24)
-  );
+  terminals
+    .get(id, wc)
+    .resize(clampGridSize(cols, 80), clampGridSize(rows, 24));
 }
 
 /**
@@ -223,17 +318,11 @@ export function resizeTerminal(
  * A live terminal still requires ownership, like write/resize.
  */
 export function killTerminal(wc: WebContents, id: unknown) {
-  if (!isValidTerminalId(id)) return;
-  const record = terminals.get(id);
-  if (!record) return;
-  if (record.wc !== wc) throw new Error("terminal not found");
-  terminals.delete(id);
-  record.pty.kill();
+  terminals.take(id, wc)?.kill();
 }
 
 export function disposeAllTerminals() {
-  for (const record of terminals.values()) {
-    record.pty.kill();
+  for (const pty of terminals.drainAll()) {
+    pty.kill();
   }
-  terminals.clear();
 }

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -33,6 +33,8 @@ import {
   type NavigationState,
   type OpenDialogOptions,
   type SaveDialogOptions,
+  type TerminalCreateOptions,
+  type TerminalHandlers,
 } from "./bridge/contract";
 
 const DESKTOP_PATH_ROOT = "/desktop";
@@ -131,6 +133,31 @@ ipcRenderer.on(IPC_CHANNELS.AGENT_FOCUS_SESSION, (_event, payload: unknown) => {
     new CustomEvent(IPC_CHANNELS.AGENT_FOCUS_SESSION, { detail: payload })
   );
 });
+
+/**
+ * Per-terminal handler fanout for the PTY host's push channels. The
+ * preload mints each terminal id and registers its handlers here
+ * BEFORE invoking TERMINAL_CREATE, so the shell's first output frame
+ * (emitted as soon as the PTY spawns) can never race the subscription.
+ * Same payload-only discipline as the other `ipcRenderer.on` fanouts —
+ * the Electron event object never crosses the contextBridge
+ * (GRIDA-SEC-004).
+ */
+const terminalHandlers = new Map<string, TerminalHandlers>();
+ipcRenderer.on(
+  IPC_CHANNELS.TERMINAL_DATA,
+  (_event, payload: { id: string; data: string }) => {
+    terminalHandlers.get(payload.id)?.on_data(payload.data);
+  }
+);
+ipcRenderer.on(
+  IPC_CHANNELS.TERMINAL_EXIT,
+  (_event, payload: { id: string; exit_code: number }) => {
+    const handlers = terminalHandlers.get(payload.id);
+    terminalHandlers.delete(payload.id);
+    handlers?.on_exit({ exit_code: payload.exit_code });
+  }
+);
 
 function installDesktopNavigationGuard(): void {
   const assertAllowed = (url: string | URL | null | undefined) => {
@@ -258,6 +285,9 @@ const bridge: DesktopBridge = {
       // and File -> path resolution. Command execution is agent-host-internal
       // for V1, not a public renderer bridge capability.
       shell: true,
+      // Human-interactive terminal pane (GRIDA-SEC-004) — distinct from
+      // `shell` above and from the agent's sandboxed `run_command`.
+      terminal: true,
     },
   },
 
@@ -356,6 +386,36 @@ const bridge: DesktopBridge = {
         workspace_id: workspaceId,
         rel_path: relPath,
       }) as Promise<void>,
+  },
+
+  terminal: {
+    create: async (opts: TerminalCreateOptions, handlers: TerminalHandlers) => {
+      // Caller-mints-id (cf. sessions.enqueue): registering the handlers
+      // under a preload-minted id before the invoke means no PTY output
+      // frame can be emitted before the subscription exists.
+      const id = crypto.randomUUID();
+      terminalHandlers.set(id, handlers);
+      try {
+        await ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_CREATE, {
+          id,
+          workspace_id: opts.workspace_id,
+          cols: opts.cols,
+          rows: opts.rows,
+        });
+      } catch (err) {
+        terminalHandlers.delete(id);
+        throw err;
+      }
+      return { id };
+    },
+    write: (id: string, data: string) =>
+      ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_WRITE, { id, data }),
+    resize: (id: string, cols: number, rows: number) =>
+      ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_RESIZE, { id, cols, rows }),
+    kill: async (id: string) => {
+      terminalHandlers.delete(id);
+      await ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_KILL, id);
+    },
   },
 
   host_apps: {

--- a/desktop/vite.main.config.ts
+++ b/desktop/vite.main.config.ts
@@ -9,10 +9,17 @@ import { gridaBundleGuard } from "./vite.guards";
 // `bubblewrap`) and references vendored helpers via filesystem
 // paths relative to its own install root. Bundling those paths
 // into `.vite/build/main.js` breaks resolution at runtime.
+// `node-pty` is externalised for the same reason: it loads a native
+// `.node` addon (and `spawn-helper`) via paths relative to its
+// install root.
 export default defineConfig({
   build: {
     rollupOptions: {
-      external: [...builtinModules, "@anthropic-ai/sandbox-runtime"],
+      external: [
+        ...builtinModules,
+        "@anthropic-ai/sandbox-runtime",
+        "node-pty",
+      ],
     },
   },
   // GRIDA-DESKTOP-BUILD-GUARD — fail the build if a @grida/* workspace

--- a/editor/lib/agent-chat/web-daemon-bridge.ts
+++ b/editor/lib/agent-chat/web-daemon-bridge.ts
@@ -135,7 +135,13 @@ export function createWebDaemonBridge(
     protocol: DESKTOP_BRIDGE_PROTOCOL,
     app: { version: "web-daemon-dev", platform: "web" },
     caps: {
-      native: { host_apps: false, window: false, dialog: false, shell: false },
+      native: {
+        host_apps: false,
+        window: false,
+        dialog: false,
+        shell: false,
+        terminal: false,
+      },
     },
     handshake: () => client.handshake(),
 
@@ -195,6 +201,14 @@ export function createWebDaemonBridge(
       write_file: (workspaceId, relPath, content) =>
         client.workspaces.write_file(workspaceId, relPath, content),
       trash_entry: () => unavailable("workspaces.trash_entry"),
+    },
+    terminal: {
+      // PTY host is an Electron-main capability; the web daemon bridge
+      // reports `caps.native.terminal: false` and the UI hides the pane.
+      create: () => unavailable("terminal.create"),
+      write: () => unavailable("terminal.write"),
+      resize: () => unavailable("terminal.resize"),
+      kill: () => unavailable("terminal.kill"),
     },
     host_apps: {
       resolve_preferred: async () => [],

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -711,6 +711,67 @@ export namespace workspaces {
   }
 }
 
+/* ─────────────────────── terminal namespace ─────────────────── */
+
+/**
+ * GRIDA-SEC-004 — human-interactive terminal (PTY) pane. A real,
+ * unsandboxed shell running as the user (VSCode trust model) — NOT the
+ * agent's sandboxed `run_command`. The renderer only ever names a
+ * workspace id; the desktop main process resolves the cwd and owns the
+ * PTY. This namespace is the only surface in the editor tree that
+ * touches `bridge.terminal`.
+ *
+ * The capability is additive on protocol 1 — older desktop binaries
+ * don't have it, so UI must gate on {@link isSupported}.
+ */
+export namespace terminal {
+  export function isSupported(): boolean {
+    return getDesktopBridge()?.caps.native.terminal === true;
+  }
+
+  /**
+   * Spawn a login-shell PTY rooted at the workspace root. Handlers are
+   * registered before the shell spawns, so the first output frame is
+   * never lost. Resolves with the terminal id used by the siblings.
+   */
+  export async function create(
+    opts: { workspaceId: string; cols: number; rows: number },
+    handlers: {
+      onData: (data: string) => void;
+      onExit: (info: { exitCode: number }) => void;
+    }
+  ): Promise<{ id: string }> {
+    return await bridgeOrThrow().terminal.create(
+      {
+        workspace_id: opts.workspaceId,
+        cols: opts.cols,
+        rows: opts.rows,
+      },
+      {
+        on_data: handlers.onData,
+        on_exit: (info) => handlers.onExit({ exitCode: info.exit_code }),
+      }
+    );
+  }
+
+  export async function write(id: string, data: string): Promise<void> {
+    await bridgeOrThrow().terminal.write(id, data);
+  }
+
+  export async function resize(
+    id: string,
+    cols: number,
+    rows: number
+  ): Promise<void> {
+    await bridgeOrThrow().terminal.resize(id, cols, rows);
+  }
+
+  /** Kill the shell process. Idempotent from the renderer's view. */
+  export async function kill(id: string): Promise<void> {
+    await bridgeOrThrow().terminal.kill(id);
+  }
+}
+
 /* ─────────────────────── hostApps namespace ─────────────────── */
 
 /**

--- a/editor/package.json
+++ b/editor/package.json
@@ -121,6 +121,8 @@
     "@visx/tooltip": "^3.3.0",
     "@visx/visx": "^3.11.0",
     "@visx/xychart": "^3.11.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.0",
     "ai": "6.0.197",
     "ajv": "^8.20.0",

--- a/editor/scaffolds/desktop/workbench/terminal-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/terminal-pane.tsx
@@ -1,0 +1,126 @@
+/**
+ * Terminal pane — the human-interactive shell at the bottom of the
+ * workspace workbench (xterm.js over `bridge.terminal`, VSCode-style).
+ *
+ * Lifecycle: one PTY per mount. The workbench keeps this component
+ * mounted while the panel is merely collapsed (ctrl+` toggle), so the
+ * shell — and anything running in it — survives hide/show. Unmount
+ * (window close, shell exit, workbench teardown) kills the PTY; there
+ * is no reattach in v1.
+ *
+ * GRIDA-SEC-004 — this is a view over the `terminal` bridge namespace
+ * (`@/lib/desktop/bridge`); it never touches `window.grida` directly.
+ */
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  terminal as bridgeTerminal,
+  type Workspace,
+} from "@/lib/desktop/bridge";
+import { isTerminalToggleEvent } from "./workspace-workbench-keybindings";
+import "@xterm/xterm/css/xterm.css";
+
+export type TerminalPaneProps = {
+  workspace: Workspace;
+  /**
+   * The shell process ended (`exit`, crash, or kill). The workbench
+   * unmounts the pane in response; the next toggle spawns a fresh shell.
+   */
+  onSessionEnded: () => void;
+};
+
+export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Latest callback without re-running the terminal effect (same ref
+  // pattern as the workbench's openTabsRef).
+  const onSessionEndedRef = useRef(onSessionEnded);
+  onSessionEndedRef.current = onSessionEnded;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    let disposed = false;
+    let termId: string | null = null;
+    let dispose: (() => void) | null = null;
+
+    (async () => {
+      // xterm.js is browser-only; dynamic import keeps it out of the
+      // SSR module graph (desktop routes are still server-rendered up
+      // to the bridge gate).
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import("@xterm/xterm"),
+        import("@xterm/addon-fit"),
+      ]);
+      if (disposed) return;
+
+      const term = new Terminal({ fontSize: 12, cursorBlink: true });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(el);
+      // ctrl+` must keep toggling the pane while the terminal has
+      // focus: tell xterm to skip the chord so the keydown bubbles up
+      // to the workbench's window handler.
+      term.attachCustomKeyEventHandler((e) => !isTerminalToggleEvent(e));
+      fit.fit();
+
+      const fitAndResize = () => {
+        // A collapsed panel measures 0×0; fitting then would clamp the
+        // grid to garbage. Skip — the observer re-fires on expand.
+        if (el.clientWidth === 0 || el.clientHeight === 0) return;
+        fit.fit();
+        if (termId) void bridgeTerminal.resize(termId, term.cols, term.rows);
+      };
+      const observer = new ResizeObserver(fitAndResize);
+      observer.observe(el);
+
+      dispose = () => {
+        observer.disconnect();
+        term.dispose();
+      };
+
+      try {
+        const { id } = await bridgeTerminal.create(
+          { workspaceId: workspace.id, cols: term.cols, rows: term.rows },
+          {
+            onData: (data) => term.write(data),
+            onExit: () => onSessionEndedRef.current(),
+          }
+        );
+        if (disposed) {
+          void bridgeTerminal.kill(id);
+          return;
+        }
+        termId = id;
+      } catch (err) {
+        term.write(
+          `\r\nfailed to start terminal: ${err instanceof Error ? err.message : String(err)}\r\n`
+        );
+        return;
+      }
+
+      term.onData((data) => {
+        if (termId) void bridgeTerminal.write(termId, data);
+      });
+      term.focus();
+    })();
+
+    return () => {
+      disposed = true;
+      dispose?.();
+      if (termId) void bridgeTerminal.kill(termId);
+    };
+  }, [workspace.id]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="terminal-pane"
+      // xterm owns the inner canvas; the wrapper just reserves the box.
+      // bg matches xterm's default dark background so the padding gutter
+      // doesn't flash the app background around the grid.
+      className="h-full w-full overflow-hidden bg-black p-1"
+    />
+  );
+}

--- a/editor/scaffolds/desktop/workbench/terminal-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/terminal-pane.tsx
@@ -139,6 +139,9 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
         import("@xterm/addon-fit"),
       ]);
       if (disposed) return;
+      // From here to the bridge call the failure surface is xterm
+      // itself (terminal construction and wiring) — handled by the
+      // .catch on this IIFE, since no grid exists to print into.
 
       const term = new Terminal({
         fontSize: 12,
@@ -201,6 +204,10 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
           return;
         }
         termId = id;
+        // The pane may have been resized while create() was in flight —
+        // fitAndResize skips the PTY half when termId is null — so
+        // replay the latest fitted grid to the shell.
+        void bridgeTerminal.resize(id, term.cols, term.rows);
       } catch (err) {
         term.write(
           `\r\nfailed to start terminal: ${err instanceof Error ? err.message : String(err)}\r\n`
@@ -212,7 +219,13 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
         if (termId) void bridgeTerminal.write(termId, data);
       });
       term.focus();
-    })();
+    })().catch((err) => {
+      // Import or xterm-setup failure (bridge failures are printed into
+      // the grid above). No grid exists to render the error, so log and
+      // retreat — unmounting beats leaving a dead pane open.
+      console.error("[terminal-pane] terminal startup failed:", err);
+      if (!disposed) onSessionEndedRef.current();
+    });
 
     return () => {
       disposed = true;

--- a/editor/scaffolds/desktop/workbench/terminal-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/terminal-pane.tsx
@@ -167,8 +167,14 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
 
       const fitAndResize = () => {
         // A collapsed panel measures 0×0; fitting then would clamp the
-        // grid to garbage. Skip — the observer re-fires on expand.
-        if (el.clientWidth === 0 || el.clientHeight === 0) return;
+        // grid to garbage. Skip — the observer re-fires on expand. Also
+        // drop focus: a hidden terminal must not keep swallowing
+        // keystrokes into an invisible shell (covers both the ctrl+`
+        // toggle and a drag-to-collapse).
+        if (el.clientWidth === 0 || el.clientHeight === 0) {
+          term.blur();
+          return;
+        }
         fit.fit();
         if (termId) void bridgeTerminal.resize(termId, term.cols, term.rows);
       };

--- a/editor/scaffolds/desktop/workbench/terminal-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/terminal-pane.tsx
@@ -5,8 +5,8 @@
  * Lifecycle: one PTY per mount. The workbench keeps this component
  * mounted while the panel is merely collapsed (ctrl+` toggle), so the
  * shell — and anything running in it — survives hide/show. Unmount
- * (window close, shell exit, workbench teardown) kills the PTY; there
- * is no reattach in v1.
+ * (window close, shell exit, the header's close button, workbench
+ * teardown) kills the PTY; there is no reattach in v1.
  *
  * GRIDA-SEC-004 — this is a view over the `terminal` bridge namespace
  * (`@/lib/desktop/bridge`); it never touches `window.grida` directly.
@@ -14,6 +14,9 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { XIcon } from "lucide-react";
+import { Button } from "@app/ui/components/button";
+import type { ITheme, Terminal as XTerminal } from "@xterm/xterm";
 import {
   terminal as bridgeTerminal,
   type Workspace,
@@ -21,11 +24,93 @@ import {
 import { isTerminalToggleEvent } from "./workspace-workbench-keybindings";
 import "@xterm/xterm/css/xterm.css";
 
+/**
+ * Resolve a shadcn theme variable (e.g. `--background`) to a concrete
+ * `#rrggbb[aa]` string. xterm paints its grid from parsed colors, so it
+ * can't take `var(...)` references — and the theme tokens are `oklch()`
+ * values that Chromium's computed styles do NOT serialize to rgb. A 1×1
+ * canvas is the one robust CSS-color-to-bytes converter the platform
+ * gives us.
+ */
+function themeColor(varName: string, alpha?: number): string | undefined {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  if (!raw) return undefined;
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  if (!ctx) return undefined;
+  ctx.fillStyle = "#000";
+  ctx.fillStyle = raw; // invalid strings leave the previous value
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  const hex = (n: number) => n.toString(16).padStart(2, "0");
+  const base = `#${hex(r)}${hex(g)}${hex(b)}`;
+  return alpha === undefined ? base : `${base}${hex(Math.round(alpha * 255))}`;
+}
+
+/** xterm theme derived from the active shadcn tokens. ANSI palette is
+ * left to xterm's defaults; only the chrome colors follow the app. */
+function resolveXtermTheme(): ITheme {
+  return {
+    background: themeColor("--background"),
+    foreground: themeColor("--foreground"),
+    cursor: themeColor("--foreground"),
+    cursorAccent: themeColor("--background"),
+    selectionBackground: themeColor("--primary", 0.3),
+  };
+}
+
+/**
+ * Deterministic trackpad/wheel scrolling for the normal buffer.
+ *
+ * xterm 6 scrolls through VS Code's SmoothScrollableElement, which
+ * normalizes wheel events via the legacy `wheelDeltaY / 120` and rounds
+ * every event away from zero — so each tiny pixel-delta trackpad event
+ * can scroll a whole notch, and a gesture (dozens of events) rockets
+ * the scrollback (xterm.js#4412 class). That widget's listener also
+ * runs before `attachCustomWheelEventHandler` is consulted, so the fix
+ * must intercept in the CAPTURE phase: convert pixel deltas to lines
+ * exactly (with a fractional accumulator, like any native scroller) and
+ * stop the event. Alternate-screen apps (vim/less), mouse-protocol
+ * consumers (htop), pinch-zoom (ctrl+wheel), and non-pixel wheels keep
+ * xterm's own handling.
+ */
+function attachWheelFix(el: HTMLElement, term: XTerminal): () => void {
+  let acc = 0;
+  const onWheelCapture = (e: WheelEvent) => {
+    if (e.ctrlKey) return;
+    if (e.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) return;
+    if (term.buffer.active.type === "alternate") return;
+    if (term.modes.mouseTrackingMode !== "none") return;
+    e.preventDefault();
+    e.stopPropagation();
+    const screen = el.querySelector<HTMLElement>(".xterm-screen");
+    const cell = screen && term.rows > 0 ? screen.clientHeight / term.rows : 0;
+    if (cell <= 0) return;
+    acc += e.deltaY / cell;
+    const lines = Math.trunc(acc);
+    if (lines !== 0) {
+      acc -= lines;
+      term.scrollLines(lines);
+    }
+  };
+  el.addEventListener("wheel", onWheelCapture, {
+    capture: true,
+    passive: false,
+  });
+  return () =>
+    el.removeEventListener("wheel", onWheelCapture, { capture: true });
+}
+
 export type TerminalPaneProps = {
   workspace: Workspace;
   /**
-   * The shell process ended (`exit`, crash, or kill). The workbench
-   * unmounts the pane in response; the next toggle spawns a fresh shell.
+   * The terminal session is over — the shell exited (`exit`, crash,
+   * kill) or the user clicked the header's close button. The workbench
+   * unmounts the pane in response (unmount kills the PTY); the next
+   * toggle spawns a fresh shell.
    */
   onSessionEnded: () => void;
 };
@@ -55,7 +140,11 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
       ]);
       if (disposed) return;
 
-      const term = new Terminal({ fontSize: 12, cursorBlink: true });
+      const term = new Terminal({
+        fontSize: 12,
+        cursorBlink: true,
+        theme: resolveXtermTheme(),
+      });
       const fit = new FitAddon();
       term.loadAddon(fit);
       term.open(el);
@@ -63,7 +152,18 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
       // focus: tell xterm to skip the chord so the keydown bubbles up
       // to the workbench's window handler.
       term.attachCustomKeyEventHandler((e) => !isTerminalToggleEvent(e));
+      const detachWheelFix = attachWheelFix(el, term);
       fit.fit();
+
+      // Follow live theme switches (next-themes flips the `dark` class
+      // on <html>); re-resolve the tokens and hand xterm a new theme.
+      const themeObserver = new MutationObserver(() => {
+        term.options.theme = resolveXtermTheme();
+      });
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class", "style", "data-theme"],
+      });
 
       const fitAndResize = () => {
         // A collapsed panel measures 0×0; fitting then would clamp the
@@ -72,11 +172,13 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
         fit.fit();
         if (termId) void bridgeTerminal.resize(termId, term.cols, term.rows);
       };
-      const observer = new ResizeObserver(fitAndResize);
-      observer.observe(el);
+      const resizeObserver = new ResizeObserver(fitAndResize);
+      resizeObserver.observe(el);
 
       dispose = () => {
-        observer.disconnect();
+        themeObserver.disconnect();
+        resizeObserver.disconnect();
+        detachWheelFix();
         term.dispose();
       };
 
@@ -115,12 +217,29 @@ export function TerminalPane({ workspace, onSessionEnded }: TerminalPaneProps) {
 
   return (
     <div
-      ref={containerRef}
       data-testid="terminal-pane"
-      // xterm owns the inner canvas; the wrapper just reserves the box.
-      // bg matches xterm's default dark background so the padding gutter
-      // doesn't flash the app background around the grid.
-      className="h-full w-full overflow-hidden bg-black p-1"
-    />
+      className="flex h-full w-full flex-col overflow-hidden bg-background"
+    >
+      <div className="flex shrink-0 items-center border-b px-2">
+        <span className="text-xs text-muted-foreground">Terminal</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="ml-auto"
+          aria-label="Close terminal"
+          title="Close terminal"
+          // Unmount through the workbench; the unmount cleanup above is
+          // the single PTY-kill path.
+          onClick={() => onSessionEndedRef.current()}
+        >
+          <XIcon />
+        </Button>
+      </div>
+      {/* xterm owns the inner canvas; the wrapper just reserves the box.
+          The padding gutter shows the pane background, which matches the
+          themed xterm background. */}
+      <div ref={containerRef} className="min-h-0 w-full flex-1 p-1" />
+    </div>
   );
 }

--- a/editor/scaffolds/desktop/workbench/workspace-workbench-keybindings.ts
+++ b/editor/scaffolds/desktop/workbench/workspace-workbench-keybindings.ts
@@ -46,6 +46,24 @@ export function matchWorkspaceWorkbenchKeybinding(
   return null;
 }
 
+/**
+ * Terminal pane toggle — ctrl+` on every platform (the literal Control
+ * key, not CtrlCmd; ⌘` is macOS's own window-cycling chord), matching
+ * VSCode. Exported standalone (not a `WORKSPACE_WORKBENCH_COMMANDS`
+ * entry) because it's matched in two places: the workbench's window
+ * keydown handler, and the terminal pane's xterm key handler — xterm
+ * swallows keydown by default, so the pane must recognize the chord and
+ * let it bubble back out to the workbench.
+ */
+export const TERMINAL_TOGGLE_KEYBINDING: Keybinding = kb(
+  KeyCode.Backquote,
+  M.Ctrl
+);
+
+export function isTerminalToggleEvent(event: KeyboardEvent): boolean {
+  return match(event, TERMINAL_TOGGLE_KEYBINDING);
+}
+
 const WORKSPACE_WORKBENCH_COMMAND_SET = new Set<string>(
   WORKSPACE_WORKBENCH_COMMANDS
 );

--- a/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
+++ b/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
@@ -33,7 +33,9 @@ import {
   FolderIcon,
   PanelRightCloseIcon,
   PanelRightOpenIcon,
+  SquareTerminalIcon,
 } from "lucide-react";
+import { usePanelRef } from "react-resizable-panels";
 import { Button } from "@app/ui/components/button";
 import {
   ResizableHandle,
@@ -44,7 +46,10 @@ import {
   TitleBar,
   TITLEBAR_NO_DRAG_STYLE,
 } from "@/scaffolds/desktop/chrome/title-bar";
-import type { Workspace } from "@/lib/desktop/bridge";
+import {
+  terminal as bridgeTerminal,
+  type Workspace,
+} from "@/lib/desktop/bridge";
 import {
   confirmAndTrashEntry,
   copyAbsolutePath,
@@ -52,10 +57,12 @@ import {
   matchFileActionShortcut,
   revealInFinder,
 } from "./workbench-file-actions";
+import { isTerminalToggleEvent } from "./workspace-workbench-keybindings";
 import { FileTreePane } from "./file-tree-pane";
 import { EditorPane } from "./editor-pane";
 import { WorkspaceOpenInMenu } from "./workspace-open-in-menu";
 import { AgentPane } from "./agent-pane";
+import { TerminalPane } from "./terminal-pane";
 
 /**
  * Pane sizing, matching the workstation-shell conventions:
@@ -76,6 +83,11 @@ const AGENT_PANE_MIN = "280px";
 // The editor pane fills the slack (defaultSize below), but needs its own min
 // so widening the now-uncapped chat can't crush it to zero width.
 const EDITOR_PANE_MIN = "360px";
+// Bottom terminal panel (VSCode-style). Collapsible: dragging it under
+// its min snaps it closed, and ctrl+` collapse/expand keeps the shell
+// process alive (the panel content stays mounted at zero height).
+const TERMINAL_PANE_DEFAULT = "30%";
+const TERMINAL_PANE_MIN = "120px";
 
 /**
  * Whether a keyboard event originated inside an editable surface (text
@@ -111,6 +123,36 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
   // group redistributes space cleanly to the EditorPane when the file tree pane
   // is hidden.
   const [showTree, setShowTree] = useState(true);
+
+  // Terminal pane (ctrl+` / TitleBar toggle), VSCode-style. Two facts:
+  // `terminalSpawned` — the bottom panel (and its PTY) exists; flips on
+  // first open and back off when the shell exits. `terminalOpen` —
+  // panel is expanded; derived from the panel's onResize so dragging
+  // the handle and the imperative collapse/expand stay in sync without
+  // a second source of truth. Collapse keeps the pane mounted (and the
+  // shell alive); only unmount kills the PTY.
+  // Hidden entirely against older desktop binaries whose bridge
+  // predates `terminal` (additive capability on protocol 1).
+  const supportsTerminal = bridgeTerminal.isSupported();
+  const [terminalSpawned, setTerminalSpawned] = useState(false);
+  const [terminalOpen, setTerminalOpen] = useState(false);
+  const terminalPanelRef = usePanelRef();
+
+  const toggleTerminal = useCallback(() => {
+    if (!terminalSpawned) {
+      setTerminalSpawned(true); // mounts expanded at its default size
+      return;
+    }
+    const panel = terminalPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  }, [terminalSpawned, terminalPanelRef]);
+
+  const handleTerminalSessionEnded = useCallback(() => {
+    setTerminalSpawned(false);
+    setTerminalOpen(false);
+  }, []);
 
   // Recently-closed tabs for "reopen closed tab" (Cmd/Ctrl+Shift+T),
   // most-recent last. A ref, not state — nothing renders from it, so
@@ -178,6 +220,14 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
   // entries being unavailable on an empty viewer).
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      // ctrl+` toggles the terminal pane (VSCode). The terminal pane's
+      // xterm key handler deliberately lets this chord bubble up here,
+      // so the toggle works even while the shell has focus.
+      if (supportsTerminal && isTerminalToggleEvent(e)) {
+        e.preventDefault();
+        toggleTerminal();
+        return;
+      }
       const cmd = e.metaKey || e.ctrlKey;
       if (cmd && !e.shiftKey && !e.altKey && (e.key === "b" || e.key === "B")) {
         e.preventDefault();
@@ -223,7 +273,14 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [toggleTree, activeRelPath, workspace, handleEntryTrashed]);
+  }, [
+    toggleTree,
+    activeRelPath,
+    workspace,
+    handleEntryTrashed,
+    supportsTerminal,
+    toggleTerminal,
+  ]);
 
   const openFile = useCallback((relPath: string) => {
     setOpenTabs((prev) => (prev.includes(relPath) ? prev : [...prev, relPath]));
@@ -290,6 +347,26 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1">
           <WorkspaceOpenInMenu workspace={workspace} />
+          {supportsTerminal && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              style={TITLEBAR_NO_DRAG_STYLE}
+              onClick={toggleTerminal}
+              aria-label={
+                terminalOpen ? "Hide terminal pane" : "Show terminal pane"
+              }
+              aria-pressed={terminalOpen}
+              title={
+                terminalOpen
+                  ? "Hide terminal pane (⌃`)"
+                  : "Show terminal pane (⌃`)"
+              }
+            >
+              <SquareTerminalIcon />
+            </Button>
+          )}
           <Button
             type="button"
             variant="ghost"
@@ -310,54 +387,79 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
       </TitleBar>
 
       <div className="min-h-0 flex-1">
-        {/* Horizontal is the default orientation in
-            react-resizable-panels v4 — omit the prop.
-            Order: AgentPane | EditorPane | FileTreePane. Agent-first puts the
-            agent pane in the dominant left position; the file tree pane
-            sits on the right as a secondary navigator and is
-            conditionally rendered so the EditorPane absorbs its
-            space when hidden. */}
-        <ResizablePanelGroup>
-          <ResizablePanel
-            defaultSize={AGENT_PANE_DEFAULT}
-            minSize={AGENT_PANE_MIN}
-          >
-            <AgentPane
-              workspace={workspace}
-              activeRelPath={activeRelPath}
-              onMaybeMutated={bumpTreeRefresh}
-            />
+        {/* Vertical split: the three workbench panes on top, the
+            terminal panel at the bottom (VSCode-style). The bottom pair
+            mounts on first ctrl+` and stays mounted while collapsed so
+            the shell survives toggling; shell exit unmounts it. */}
+        <ResizablePanelGroup orientation="vertical">
+          <ResizablePanel>
+            {/* Horizontal is the default orientation in
+                react-resizable-panels v4 — omit the prop.
+                Order: AgentPane | EditorPane | FileTreePane. Agent-first puts the
+                agent pane in the dominant left position; the file tree pane
+                sits on the right as a secondary navigator and is
+                conditionally rendered so the EditorPane absorbs its
+                space when hidden. */}
+            <ResizablePanelGroup>
+              <ResizablePanel
+                defaultSize={AGENT_PANE_DEFAULT}
+                minSize={AGENT_PANE_MIN}
+              >
+                <AgentPane
+                  workspace={workspace}
+                  activeRelPath={activeRelPath}
+                  onMaybeMutated={bumpTreeRefresh}
+                />
+              </ResizablePanel>
+              <ResizableHandle />
+              <ResizablePanel defaultSize="57%" minSize={EDITOR_PANE_MIN}>
+                <EditorPane
+                  workspace={workspace}
+                  openTabs={openTabs}
+                  activeRelPath={activeRelPath}
+                  onSelectTab={setActiveRelPath}
+                  onCloseTab={closeTab}
+                  onReopenClosedTab={reopenClosedTab}
+                  onSaved={bumpTreeRefresh}
+                  onFileTrashed={(rp) => handleEntryTrashed(rp, false)}
+                />
+              </ResizablePanel>
+              {showTree && (
+                <>
+                  <ResizableHandle />
+                  <ResizablePanel
+                    defaultSize={FILE_TREE_PANE_DEFAULT}
+                    minSize={FILE_TREE_PANE_MIN}
+                    maxSize={FILE_TREE_PANE_MAX}
+                    className="bg-muted/20"
+                  >
+                    <FileTreePane
+                      workspace={workspace}
+                      activeRelPath={activeRelPath}
+                      onOpenFile={(rp) => {
+                        if (rp) openFile(rp);
+                      }}
+                      refreshKey={treeRefreshKey}
+                      onEntryTrashed={handleEntryTrashed}
+                    />
+                  </ResizablePanel>
+                </>
+              )}
+            </ResizablePanelGroup>
           </ResizablePanel>
-          <ResizableHandle />
-          <ResizablePanel defaultSize="57%" minSize={EDITOR_PANE_MIN}>
-            <EditorPane
-              workspace={workspace}
-              openTabs={openTabs}
-              activeRelPath={activeRelPath}
-              onSelectTab={setActiveRelPath}
-              onCloseTab={closeTab}
-              onReopenClosedTab={reopenClosedTab}
-              onSaved={bumpTreeRefresh}
-              onFileTrashed={(rp) => handleEntryTrashed(rp, false)}
-            />
-          </ResizablePanel>
-          {showTree && (
+          {terminalSpawned && (
             <>
               <ResizableHandle />
               <ResizablePanel
-                defaultSize={FILE_TREE_PANE_DEFAULT}
-                minSize={FILE_TREE_PANE_MIN}
-                maxSize={FILE_TREE_PANE_MAX}
-                className="bg-muted/20"
+                panelRef={terminalPanelRef}
+                collapsible
+                defaultSize={TERMINAL_PANE_DEFAULT}
+                minSize={TERMINAL_PANE_MIN}
+                onResize={(size) => setTerminalOpen(size.inPixels > 0)}
               >
-                <FileTreePane
+                <TerminalPane
                   workspace={workspace}
-                  activeRelPath={activeRelPath}
-                  onOpenFile={(rp) => {
-                    if (rp) openFile(rp);
-                  }}
-                  refreshKey={treeRefreshKey}
-                  onEntryTrashed={handleEntryTrashed}
+                  onSessionEnded={handleTerminalSessionEnded}
                 />
               </ResizablePanel>
             </>

--- a/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
+++ b/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
@@ -222,10 +222,12 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
     function onKey(e: KeyboardEvent) {
       // ctrl+` toggles the terminal pane (VSCode). The terminal pane's
       // xterm key handler deliberately lets this chord bubble up here,
-      // so the toggle works even while the shell has focus.
+      // so the toggle works even while the shell has focus. Key-repeat
+      // is swallowed (preventDefault, no toggle): one press = one state
+      // change, and held-chord repeats must not leak into the shell.
       if (supportsTerminal && isTerminalToggleEvent(e)) {
         e.preventDefault();
-        toggleTerminal();
+        if (!e.repeat) toggleTerminal();
         return;
       }
       const cmd = e.metaKey || e.ctrlKey;

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -37,6 +37,12 @@ export type DesktopNativeCapabilities = {
   window: boolean;
   dialog: boolean;
   shell: boolean;
+  /**
+   * Human-interactive terminal (PTY) pane. Added after protocol 1
+   * shipped — renderers must treat a missing/falsy value as "old
+   * desktop binary, no terminal" and hide the surface.
+   */
+  terminal: boolean;
 };
 
 export type DesktopCapabilities = {
@@ -101,6 +107,21 @@ export type DesktopHostAppInfo = {
   label: string;
   installed: boolean;
   supports: Array<"workspace">;
+};
+
+export type TerminalCreateOptions = {
+  /** Workspace whose root becomes the shell's cwd. Resolved host-side
+   * from the sidecar registry — the renderer never passes a raw path. */
+  workspace_id: string;
+  cols: number;
+  rows: number;
+};
+
+export type TerminalHandlers = {
+  /** Raw PTY output frames, in order. */
+  on_data: (data: string) => void;
+  /** Fires once when the shell process exits; no more frames after. */
+  on_exit: (info: { exit_code: number }) => void;
 };
 
 export type DesktopBridge = {
@@ -171,6 +192,26 @@ export type DesktopBridge = {
      * user first.
      */
     trash_entry: (workspaceId: string, relPath: string) => Promise<void>;
+  };
+  /**
+   * GRIDA-SEC-004 — human-interactive terminal. A real, unsandboxed
+   * login PTY on the user's own machine (VSCode trust model: the human
+   * is allowed to run anything as themselves). This is deliberately
+   * NOT the agent's shell — the agent's `run_command` stays confined
+   * behind the srt sandbox and is never wired to this surface.
+   *
+   * `create` registers `handlers` before the PTY spawns, so no output
+   * frame is lost. The shell's cwd is the workspace root; the user may
+   * `cd` freely once open. Killed on window close — no reattach (v1).
+   */
+  terminal: {
+    create: (
+      opts: TerminalCreateOptions,
+      handlers: TerminalHandlers
+    ) => Promise<{ id: string }>;
+    write: (id: string, data: string) => Promise<void>;
+    resize: (id: string, cols: number, rows: number) => Promise<void>;
+    kill: (id: string) => Promise<void>;
   };
   host_apps: {
     resolve_preferred: (opts: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@react-three/drei':
         specifier: ^10.0.7
         version: 10.7.7(@react-three/fiber@9.1.2(@types/react@19.1.3)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0))(@types/react@19.1.3)(@types/three@0.170.0)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0)
@@ -462,7 +462,7 @@ importers:
         version: 16.2.6(@mdx-js/loader@3.1.1(acorn@8.16.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@number-flow/react':
         specifier: ^0.5.7
         version: 0.5.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -616,6 +616,12 @@ importers:
       '@visx/xychart':
         specifier: ^3.11.0
         version: 3.12.0(@react-spring/web@9.7.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.0(@types/react@19.1.3)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -7562,6 +7568,12 @@ packages:
 
   '@xobotyi/scrollbar-width@1.9.5':
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -18272,7 +18284,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -22089,6 +22101,10 @@ snapshots:
   '@webgpu/types@0.1.69': {}
 
   '@xobotyi/scrollbar-width@1.9.5': {}
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,11 @@ allowBuilds:
   esbuild: false
   lefthook: false
   msw: false
+  # node-pty ships prebuilt N-API binaries (prebuilds/<platform>-<arch>/)
+  # that its runtime loader falls back to, so the install script is safe
+  # to skip on darwin/win32. Linux has no prebuilds — packaging relies on
+  # electron-forge's native-module rebuild, not this install script.
+  node-pty: false
   sharp: false
   workerd: false
 overrides:


### PR DESCRIPTION

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/686f4b8a-3fa6-4351-99fe-1f750162abfb" />

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/a5174ed9-df13-4af6-8d5a-53629074ece2" />


Closes #803.

A VSCode-style **human-interactive Terminal pane** in the workspace workbench: xterm.js in the renderer + node-pty in the Electron main process, streamed over the existing path-scoped bridge. <kbd>ctrl+`</kbd> (and a TitleBar button) toggles it. This is the user's own unsandboxed login shell — deliberately **not** the agent's `srt`-confined `run_command`, and never wired into the agent's tool surface.

## What's in here (per the issue's v1 scope)

| Concern | Where |
| --- | --- |
| Bridge contract (`terminal` namespace + `caps.native.terminal`) | `packages/grida-desktop-bridge/src/index.ts` |
| Preload wiring (handler fanout, caller-mints-id) | `desktop/src/preload.ts` |
| IPC channels + guarded handlers | `desktop/src/bridge/contract.ts`, `desktop/src/main/ipc-handlers.ts` |
| PTY host (node-pty, main process) | `desktop/src/main/terminal-host.ts` (new) |
| Typed renderer client (`terminal` namespace) | `editor/lib/desktop/bridge.ts` |
| xterm.js pane | `editor/scaffolds/desktop/workbench/terminal-pane.tsx` (new) |
| Layout (collapsible bottom panel) + ctrl+` + TitleBar toggle | `workspace-workbench.tsx`, `workspace-workbench-keybindings.ts` |
| node-pty packaging | `desktop/package.json`, `forge.config.ts`, `vite.main.config.ts`, `scripts/verify-packaged-bundle.mjs` |
| GRIDA-SEC-004 | `SECURITY.md` ("Human terminal" section + files-bound list) |

Deferred per the issue: tabs/splits, scrollback persistence, reattach-on-reload, search, links.

## Design decisions (where this deviates from the issue sketch, and why)

- **`create(opts, handlers)` instead of `create` + `subscribe`.** The preload mints the terminal id (same caller-mints-id pattern as `sessions.enqueue`) and registers the data/exit handlers **before** invoking the main process, so the shell's first output frame can never race the subscription. A separate `subscribe` call would reintroduce exactly that race.
- **PTY host in main, not a utility process** — following the issue's own pointer to the sidecar's `utilityProcess.fork → child_process.spawn` migration.
- **Renderer names a workspace id, never a path.** The spawn cwd is resolved host-side from the sidecar registry (same shape as `trash_entry` / `host_apps`).
- **Collapse ≠ kill.** The bottom panel is a `collapsible` ResizablePanel; ctrl+` collapse/expand keeps the pane mounted (PTY + scrollback survive, VSCode behavior). Only window close / shell exit kills the PTY.
- **Old-binary safety.** grida.co's renderer deploys ahead of desktop binaries, so the UI gates on `caps.native.terminal === true` (additive on protocol 1) — older apps simply don't show the surface. The web-daemon bridge stubs it with `terminal: false`.
- **ctrl+` works while the terminal has focus** via xterm's `attachCustomKeyEventHandler` letting the chord bubble to the workbench handler; the chord is the literal Control key on all platforms (⌘` is macOS window cycling), matching VSCode.

## GRIDA-SEC-004 review (mandatory, done)

An interactive terminal is RCE-by-design surfaced to the renderer; the accepted trust model is VSCode's (the human runs commands as themselves, no escalation). Enforcement walked layer by layer:

1. All four invoke channels registered through the sender-frame `guarded()` wrapper (editor origin + `/desktop/*`); a contract test (`terminal-host.test.ts`) fails if one is ever registered outside it.
2. Bridge exposure stays path-scoped in the preload (untouched).
3. The PTY host binds each terminal to its creating WebContents (one window can't drive another's shell), caps PTYs per window, validates ids, and kills on window close + app quit.
4. Not in the agent's tool surface — nothing under `packages/grida-ai-agent` is touched.
5. `SECURITY.md` updated: new "Human terminal" subsection + `terminal-host.ts` / `terminal-pane.tsx` added to the files-bound list; all new files carry the tag (grep verified).

## Packaging (the issue's "don't skip" section)

- `node-pty@1.1.0` is N-API (`node-addon-api`) with **upstream prebuilds for darwin/win32** — loads under Electron with no rebuild. Added to `dependencies` (ships-on-disk set), vite `external`, and the `asar.unpack` glob.
- **Found + fixed a real upstream trap:** node-pty's npm tarball ships the darwin `spawn-helper` with mode **0644** (no exec bit, nothing in the package chmods it) → PTY spawn fails with `posix_spawnp failed`. Fixed at **build time** (`packageAfterPrune` chmod, since the installed app can be mounted read-only under macOS app translocation) and at **runtime** for the dev tree (`ensureSpawnHelperExecutable`, no-ops once the bit is present).
- **Oracle taught about dynamic imports:** `verify-packaged-bundle.mjs` only discovered `require()` externals; Rollup keeps external dynamic `import()` as-is in CJS output, so the lazily-loaded node-pty was invisible to the closure check. The regex now matches both — the bloat/missing gates work as designed.
- Linux has no upstream prebuilds: `rebuildConfig.ignoreModules` skips the pointless rebuild on darwin/win32 and compiles from source on Linux only (with a `node-abi` override so the rebuild recognizes Electron 42).
- Forge dev/start was broken by the old `node-abi` the moment any native dep existed ("Could not detect abi for 42.2.0") — same override fixes it.

## Proof of work

**Unit/static:** desktop `tsc` + 49 vitest tests green (incl. new terminal-host suite + guarded-registration anti-drift test); editor `tsc` green; `oxlint` clean; `just fmt` applied.

**Live e2e (CDP-driven real Electron + dev renderer), 15/15:**

```
PASS  bridge present — http://localhost:3000/desktop/welcome
PASS  caps.native.terminal === true
PASS  workspace registered — 869f4401b5f4d6de root=/private/tmp/grida-terminal-e2e
PASS  workbench loaded w/ terminal toggle button
PASS  terminal pane not mounted before first toggle
PASS  ctrl+` mounts terminal and shell prompt painted
PASS  shell cwd is the workspace root — "➜ grida-terminal-e2e pwd /private/tmp/grida-terminal-e2e"
PASS  command output streamed back            (echo grida-e2e-$((21*2)) → grida-e2e-42)
PASS  ctrl+` from inside terminal collapses pane (still mounted)
PASS  re-expand restores pane
PASS  PTY stayed alive while collapsed        (bg job output landed during collapse)
PASS  TitleBar button collapses / expands
PASS  shell exit unmounts the pane
PASS  next ctrl+` spawns a fresh shell
```

**Security negatives, 5/5:** `write`/`resize` on a bogus or path-shaped id → rejected (`terminal not found`); `create` with an unknown workspace id → rejected (`workspace not found`); `kill` on a missing id → resolves (documented idempotent — the unmount cleanup races the host's own exit cleanup on every normal shell exit).

**Lifecycle:** with the workbench window open, exactly one `zsh -l` with cwd = workspace root; `window.close()` → 0 shells while the app keeps running; app quit → shell gone.

**Packaging:** `pnpm package` green end-to-end — `GRIDA-DESKTOP-BUILD-GUARD` oracle reports *"ships EXACTLY the runtime closure (11 packages)"*, the packaged `app.asar.unpacked/.../spawn-helper` carries the exec bit, and the packaged `Grida.app` boots and quits cleanly.

**Runtime chmod proven:** spawn-helper deliberately stripped to 0644 before launch → first terminal create succeeds → file is 0755 after.

## Notes for reviewers

- `desktop/pnpm-workspace.yaml` gains `blockExoticSubdeps: false` (with rationale): pnpm 11 blocks git-resolved subdeps, and `@electron/rebuild → @electron/node-gyp` is commit-pinned via git by upstream — any graph re-resolution failed on it.
- `allowBuilds: node-pty: false` (root + desktop): the install script is skipped safely because the runtime loader falls back to the shipped prebuilds; Linux goes through forge's rebuild instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive, resizable terminal pane in the desktop workbench with Ctrl+` toggle, theme syncing, smooth wheel-scroll handling, persistent session lifecycle, and graceful cleanup on close/quit.

* **API**
  * Renderer bridge exposes a terminal capability with create/write/resize/kill; web daemon stubs terminal as unavailable.

* **Chores**
  * Packaging and workspace tweaks to support native terminal runtime and ensure native helper executables and externals are handled.

* **Documentation**
  * SECURITY.md documents the unsandboxed desktop terminal and guarded channel checks.

* **Tests**
  * Added terminal-host and lifecycle IPC test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->