### PR TITLE
feat(svg-editor): repeating-offset duplicate (⌘D remembers the translate delta)

### DIFF
--- a/docs/wg/feat-svg-editor/subtree-clone.md
+++ b/docs/wg/feat-svg-editor/subtree-clone.md
@@ -1,6 +1,6 @@
 ---
 title: "Subtree clone — duplicate and clone-drag"
-description: "Design note for the SVG editor's in-document subtree-clone operation: the second of the clipboard FRD's two extraction operations. Specifies the no-closure/no-shell verdict, verbatim-id collision semantics, placement and paint order, who moves during a clone-drag, the mid-drag modifier toggle, and the one-undo-step history bracket."
+description: "Design note for the SVG editor's in-document subtree-clone operation: the second of the clipboard FRD's two extraction operations. Specifies the no-closure/no-shell verdict, verbatim-id collision semantics, placement and paint order, who moves during a clone-drag, the mid-drag modifier toggle, the one-undo-step history bracket, and the repeating-offset duplicate (⌘D remembers the translate delta)."
 keywords:
   - svg
   - svg-editor
@@ -23,7 +23,9 @@ Alt-drag translate-with-clone gesture). Tracked as
 [gridaco/grida#817](https://github.com/gridaco/grida/issues/817);
 deferred from clipboard v1 by
 [the clipboard FRD](./clipboard.md)
-§Two extraction operations / §Out of scope.
+§Two extraction operations / §Out of scope. The repeating-offset
+behavior (§Repeating offset below) shipped as the follow-up
+[gridaco/grida#825](https://github.com/gridaco/grida/issues/825).
 
 ## Definition
 
@@ -83,8 +85,9 @@ untouched — the diff is exactly the clones, nothing reflows.
 
 Duplicates the selection **in place** and moves the selection to the
 clones. One history step: a single undo removes the clones and restores
-the prior selection. Repeating-offset duplication (duplicate → move →
-duplicate repeats the offset) is deliberately out of scope for v1.
+the prior selection. When the previous duplication's copies were
+translated and are duplicated again, the next copies repeat that
+offset — see §Repeating offset.
 
 ### Clone-drag (Alt + translate)
 
@@ -120,6 +123,73 @@ moves a **clone** instead of the selection:
   coexists: measurement reads the held modifier outside a gesture;
   clone-drag reads it during one.
 
+## Repeating offset
+
+The Figma-style repeating duplicate
+([gridaco/grida#825](https://github.com/gridaco/grida/issues/825);
+concept source: the main editor's `active_duplication` pattern):
+duplicate, move the copy, duplicate again — the next copy lands at the
+same relative offset from the previous one.
+
+The editor keeps a **duplication record** — the `{ origins, clones }`
+pair of the last committed duplication. It is editor-session memory,
+on the same footing as the clipboard buffer: never observable, never
+part of history. Two events arm it, both user-initiated commits:
+
+- a duplicate command (⌘D) — every duplicate re-arms the record with
+  its own origins/clones, which is what makes repeats chain (⌘D, move,
+  ⌘D, ⌘D, ⌘D marches copies at a constant stride);
+- a **cloned** translate commit (Alt-drag) — a clone-drag is a
+  duplication, so ⌘D immediately after repeats the drag offset (the
+  Figma convention, stated here rather than implied). A cancelled
+  cloned drag arms nothing; a zero-net-movement cloned commit arms a
+  record whose witnessed delta is zero, which repeats nothing.
+
+History replay never arms it: undo/redo of a duplicate re-runs the
+committed closures but does not touch the record, because the record
+is the memory of what the **user** last did, not of what the document
+last contained.
+
+### The witness, not a stored delta
+
+The record does not store the offset. At the next duplicate, the
+offset is **measured**: if the record still witnesses "duplicate, then
+rigidly translate the copies", the delta between the union bbox of
+`origins` and of `clones` is applied to the fresh clones. The repeat
+fires only when all of:
+
+- the duplicate's normalized targets are exactly the record's clones,
+  in the same (document) order — the user is duplicating the previous
+  copies and nothing else;
+- world bounds are readable for **every** member of both sets (no
+  geometry provider, a detached member, or a measureless element
+  refuses);
+- the two union bboxes agree in size within a float-noise tolerance —
+  a resized or structurally edited copy is no longer a translate of
+  its origin;
+- the measured delta is non-zero.
+
+Measuring instead of storing is what makes the feature honest about
+_any_ movement: drag, nudge, arrow keys, inspector edits, and align
+all repeat, because the witness reads where the copies actually are,
+not which command moved them.
+
+### Degradation, invalidation, history
+
+Every failed precondition **degrades to the plain duplicate-in-place
+above** — gesture-grade, never a thrown error. (The main editor
+asserts on a stale record; this contract deliberately does not — ⌘D
+must never crash because the document changed under the record.)
+
+Staleness is caught at use by the witness — there is no per-mutation
+bookkeeping watching the recorded ids. The only eager invalidation is
+`load()` / `reset()`, where every node id dies wholesale.
+
+The offset rides the translate pipeline (baseline + apply, with the
+world→local projection every one-shot translate uses) **inside the
+same single history step as the clone insertion**: one undo removes
+copy and offset together; redo restores both.
+
 ## Refusals
 
 Refusal is per-member and silent (normalized away), never a thrown
@@ -135,10 +205,7 @@ error — cloning is a gesture-grade operation:
 
 ## Out of scope
 
-Repeating-offset duplicate (the main editor's `active_duplication`
-pattern — tracked as
-[gridaco/grida#825](https://github.com/gridaco/grida/issues/825));
-clone-to-different-parent (the gesture is flat — clones are siblings of
+Clone-to-different-parent (the gesture is flat — clones are siblings of
 their origins, hierarchy changes during a cloned drag are not modeled);
 any defs deduplication on clone (Tidy's job).
 

--- a/docs/wg/feat-svg-editor/subtree-clone.md
+++ b/docs/wg/feat-svg-editor/subtree-clone.md
@@ -169,7 +169,10 @@ fires only when all of:
   float-noise tolerance. The check is per member, not per envelope — a
   resized or rearranged inner copy is no longer a translate even when
   the envelope-defining copies keep the union bbox intact;
-- the measured delta is non-zero.
+- the measured delta exceeds the same tolerance — a copy that never
+  moved, or drifted by float noise only, repeats nothing (the in-place
+  duplicate stays byte-equal instead of inheriting noise-sized
+  attribute writes).
 
 Measuring instead of storing is what makes the feature honest about
 _any_ movement: drag, nudge, arrow keys, inspector edits, and align

--- a/docs/wg/feat-svg-editor/subtree-clone.md
+++ b/docs/wg/feat-svg-editor/subtree-clone.md
@@ -164,9 +164,11 @@ fires only when all of:
 - world bounds are readable for **every** member of both sets (no
   geometry provider, a detached member, or a measureless element
   refuses);
-- the two union bboxes agree in size within a float-noise tolerance —
-  a resized or structurally edited copy is no longer a translate of
-  its origin;
+- **every copy is rigid against its own origin** (the record pairs
+  them): same size, displaced by the same delta as the union, within a
+  float-noise tolerance. The check is per member, not per envelope — a
+  resized or rearranged inner copy is no longer a translate even when
+  the envelope-defining copies keep the union bbox intact;
 - the measured delta is non-zero.
 
 Measuring instead of storing is what makes the feature honest about

--- a/packages/grida-canvas-hud/package.json
+++ b/packages/grida-canvas-hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/hud",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "description": "Canvas-based heads-up display for the Grida editor viewport",
   "keywords": [

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -667,7 +667,11 @@ editor.commands.{
   // (colliding ids resolve first-in-document-order; Tidy dedups).
   // Each clone lands as its origin's next sibling (paints above it);
   // selection moves to the clones; ONE history step. Alt-drag
-  // translate-with-clone consumes the same operation. Contract:
+  // translate-with-clone consumes the same operation. Repeating
+  // offset: duplicate → move the copy → duplicate repeats the
+  // translate delta (an Alt-drag clone commit arms the same memory);
+  // still one undo step, degrades to in-place when the preconditions
+  // don't hold. Contract:
   // https://grida.co/docs/wg/feat-svg-editor/subtree-clone
   duplicate(): NodeId[];              // clone ids (selected); [] = refusal
 

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -359,8 +359,13 @@ Implementation notes:
   `__tests__/clone-drag.browser.test.ts` (pins the dom.ts wiring —
   alt→clone mapping, redrive-on-flip, selection retarget); manual TC
   `test/svg-editor-duplicate.md`.
-- Still open (spec §Out of scope): repeating-offset duplicate (the main
-  editor's `active_duplication` pattern); clone-to-different-parent.
+- Repeating-offset duplicate shipped (gridaco/grida#825, spec
+  §Repeating offset): `commands.duplicate` measures the previous
+  duplication's translate delta via `subtree.repeat_delta` and applies
+  it to the fresh clones in the same atomic step; a cloned drag commit
+  seeds the record (`OrchestratorDeps.on_clone_commit` →
+  `_internal.seed_duplication`).
+- Still open (spec §Out of scope): clone-to-different-parent.
 
 ### 6. Snap to geometry
 

--- a/packages/grida-svg-editor/__tests__/commands-duplicate.test.ts
+++ b/packages/grida-svg-editor/__tests__/commands-duplicate.test.ts
@@ -2,12 +2,17 @@
 // over the subtree-clone operation (gridaco/grida#817). Pins: one
 // atomic history step (undo restores the document byte-equal AND the
 // prior selection), selection moves to the clones, refusal paths, and
-// the keymap row.
+// the keymap row. The repeating-offset behavior (gridaco/grida#825)
+// gets its own describe below.
 
 import { describe, expect, it } from "vitest";
 import { getKeyboardOS } from "@grida/keybinding";
 import { createSvgEditor } from "../src/index";
-import { createSvgEditorWithInternals, first_rect } from "./_helpers";
+import {
+  createSvgEditorWithInternals,
+  first_rect,
+  install_geometry,
+} from "./_helpers";
 
 const MOD_IS_META = getKeyboardOS() === "mac";
 
@@ -77,6 +82,137 @@ describe("commands.duplicate", () => {
     expect(editor.commands.duplicate()).toEqual([]);
     expect(editor.serialize()).toBe(baseline);
     expect(editor.state.can_undo).toBe(false);
+  });
+});
+
+// Repeating offset (gridaco/grida#825; spec: subtree-clone.md
+// §Repeating offset): duplicate → move the copy → duplicate again, and
+// the next copy lands at the same relative offset — applied through the
+// translate pipeline INSIDE the same atomic step. Every failed
+// precondition degrades to plain duplicate-in-place, never a throw.
+describe("commands.duplicate — repeating offset (#825)", () => {
+  const attr = (
+    editor: ReturnType<typeof createSvgEditor>,
+    id: string,
+    name: string
+  ) => editor.document.get_attr(id, name);
+
+  it("duplicate → move → duplicate repeats the translate delta", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    editor.commands.select([first_rect(editor)]);
+    const [first] = editor.commands.duplicate(); // in place at (10, 10)
+    editor.commands.translate({ dx: 30, dy: 5 });
+    const [second] = editor.commands.duplicate(); // repeats (+30, +5)
+    expect(attr(editor, first, "x")).toBe("40");
+    expect(attr(editor, second, "x")).toBe("70");
+    expect(attr(editor, second, "y")).toBe("20");
+  });
+
+  it("copy + offset are ONE history step — one undo removes both, redo restores both", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    editor.commands.select([first_rect(editor)]);
+    const [first] = editor.commands.duplicate();
+    editor.commands.translate({ dx: 30, dy: 0 });
+    const post_move = editor.serialize();
+    const [second] = editor.commands.duplicate();
+    expect(attr(editor, second, "x")).toBe("70");
+
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(post_move);
+    expect(editor.state.selection).toEqual([first]);
+
+    editor.commands.redo();
+    expect(attr(editor, second, "x")).toBe("70");
+    expect(editor.state.selection).toEqual([second]);
+  });
+
+  it("chains: every duplicate re-arms the record — copies march at a constant stride", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    editor.commands.select([first_rect(editor)]);
+    editor.commands.duplicate(); // x=10
+    editor.commands.translate({ dx: 30, dy: 0 }); // x=40
+    const [third] = editor.commands.duplicate(); // x=70
+    const [fourth] = editor.commands.duplicate(); // x=100
+    expect(attr(editor, third, "x")).toBe("70");
+    expect(attr(editor, fourth, "x")).toBe("100");
+  });
+
+  it("a copy that never moved repeats nothing — the next copy is byte-equal, in place", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    const origin = first_rect(editor);
+    editor.commands.select([origin]);
+    const [first] = editor.commands.duplicate();
+    const [second] = editor.commands.duplicate();
+    // No fabricated offset, no attribute rewrite — verbatim clone.
+    expect(editor.serialize_node(second)).toBe(editor.serialize_node(first));
+    expect(attr(editor, second, "x")).toBe("10");
+  });
+
+  it("repeat is unavailable without a geometry provider — degrades to in-place", () => {
+    const editor = createSvgEditor({ svg: SVG }); // headless, no provider
+    editor.commands.select([first_rect(editor)]);
+    const [first] = editor.commands.duplicate();
+    editor.commands.translate({ dx: 30, dy: 0 });
+    const [second] = editor.commands.duplicate();
+    expect(attr(editor, second, "x")).toBe("40"); // clone of the moved copy, in place
+    expect(editor.serialize_node(second)).toBe(editor.serialize_node(first));
+  });
+
+  it("selecting anything other than the previous clones breaks the chain", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    const origin = first_rect(editor);
+    editor.commands.select([origin]);
+    editor.commands.duplicate();
+    editor.commands.translate({ dx: 30, dy: 0 });
+    editor.commands.select([origin]); // back to the ORIGIN, not the copy
+    const [copy] = editor.commands.duplicate();
+    expect(attr(editor, copy, "x")).toBe("10"); // in place
+  });
+
+  it("resizing the copy breaks the rigid-translate witness — in-place", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    editor.commands.select([first_rect(editor)]);
+    editor.commands.duplicate();
+    editor.commands.translate({ dx: 30, dy: 0 });
+    editor.commands.set_property("width", "30"); // copy is no longer a translate of its origin
+    const [copy] = editor.commands.duplicate();
+    expect(attr(editor, copy, "x")).toBe("40"); // in place next to the resized copy
+  });
+
+  it("reset() forgets the previous duplication", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    install_geometry(editor);
+    editor.commands.select([first_rect(editor)]);
+    editor.commands.duplicate();
+    editor.commands.translate({ dx: 30, dy: 0 });
+    editor.reset();
+    editor.commands.select([first_rect(editor)]);
+    const [copy] = editor.commands.duplicate();
+    expect(attr(editor, copy, "x")).toBe("10"); // plain in-place
+  });
+
+  it("multi-member: the union offset repeats for every member", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    install_geometry(editor);
+    const ids = [...editor.tree().nodes.entries()]
+      .filter(([, n]) => n.tag === "rect" || n.tag === "circle")
+      .map(([id]) => id);
+    editor.commands.select(ids);
+    editor.commands.duplicate();
+    editor.commands.translate({ dx: 5, dy: 7 });
+    const clones = editor.commands.duplicate();
+    expect(clones).toHaveLength(2);
+    const [rect2, circle2] = clones; // document order: rect, circle
+    expect(attr(editor, rect2, "x")).toBe("20"); // 10 + 5 + 5
+    expect(attr(editor, rect2, "y")).toBe("24"); // 10 + 7 + 7
+    expect(attr(editor, circle2, "cx")).toBe("60"); // 50 + 5 + 5
+    expect(attr(editor, circle2, "cy")).toBe("64"); // 50 + 7 + 7
   });
 });
 

--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -35,6 +35,7 @@ type Internal = {
   bump_geometry: () => void;
   subscribe_translate_commit: (cb: () => void) => () => void;
   notify_translate_commit: () => void;
+  seed_duplication: (record: unknown) => void;
   set_content_edit_driver: (fn: unknown) => void;
   set_surface_hover_override_driver: (fn: unknown) => void;
   push_surface_hover: (id: unknown) => void;
@@ -62,6 +63,7 @@ describe("editor._internal contract", () => {
         "notify_translate_commit",
         "push_pick",
         "push_surface_hover",
+        "seed_duplication",
         "set_computed_resolver",
         "set_content_edit_driver",
         "set_geometry",

--- a/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
+++ b/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
@@ -248,9 +248,15 @@ describe("subtree.repeat_delta — the repeating-offset witness (#825)", () => {
 
   it("one unmeasurable member (detached, no provider, measureless tag) → null", () => {
     const record = { origins: ["a"], clones: ["a1"] };
+    // origin unmeasurable, clone measurable
     expect(
       subtree.repeat_delta(record, ["a1"], bounds({ a1: r(40, 10) }))
     ).toBe(null);
+    // origin measurable, clone unmeasurable
+    expect(subtree.repeat_delta(record, ["a1"], bounds({ a: r(10, 10) }))).toBe(
+      null
+    );
+    // neither measurable
     expect(subtree.repeat_delta(record, ["a1"], () => null)).toBe(null);
   });
 

--- a/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
+++ b/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
@@ -187,3 +187,92 @@ describe("subtree.clone_plan — refusals", () => {
     expect(plan.map((p) => p.origin)).toEqual([a]);
   });
 });
+
+// The repeating-offset witness (gridaco/grida#825; spec: subtree-clone.md
+// §Repeating offset). Pure: stub bounds tables, no editor. `null` always
+// means "no repeat — duplicate in place"; nothing in this matrix throws.
+describe("subtree.repeat_delta — the repeating-offset witness (#825)", () => {
+  const r = (x: number, y: number, w = 20, h = 20) => ({
+    x,
+    y,
+    width: w,
+    height: h,
+  });
+  const bounds =
+    (table: Record<string, ReturnType<typeof r>>) => (id: NodeId) =>
+      table[id] ?? null;
+
+  it("a rigid translate of the previous clones yields the exact delta", () => {
+    const record = { origins: ["a"], clones: ["a1"] };
+    const delta = subtree.repeat_delta(
+      record,
+      ["a1"],
+      bounds({ a: r(10, 10), a1: r(40, 15) })
+    );
+    expect(delta).toEqual({ x: 30, y: 5 });
+  });
+
+  it("multi-member: the delta is the UNION bbox offset", () => {
+    const record = { origins: ["a", "b"], clones: ["a1", "b1"] };
+    const delta = subtree.repeat_delta(
+      record,
+      ["a1", "b1"],
+      bounds({ a: r(0, 0), b: r(50, 50), a1: r(5, 7), b1: r(55, 57) })
+    );
+    expect(delta).toEqual({ x: 5, y: 7 });
+  });
+
+  it("no record → null", () => {
+    expect(subtree.repeat_delta(null, ["a"], bounds({ a: r(0, 0) }))).toBe(
+      null
+    );
+  });
+
+  it("targets must BE the previous clones, in the same order", () => {
+    const table = bounds({ a: r(10, 10), a1: r(40, 10), b1: r(70, 10) });
+    const record = { origins: ["a"], clones: ["a1"] };
+    // different node
+    expect(subtree.repeat_delta(record, ["b1"], table)).toBe(null);
+    // count mismatch
+    expect(subtree.repeat_delta(record, ["a1", "b1"], table)).toBe(null);
+    // reorder of a multi-member record
+    const multi = { origins: ["a", "b"], clones: ["a1", "b1"] };
+    expect(
+      subtree.repeat_delta(
+        multi,
+        ["b1", "a1"],
+        bounds({ a: r(0, 0), b: r(50, 0), a1: r(5, 0), b1: r(55, 0) })
+      )
+    ).toBe(null);
+  });
+
+  it("one unmeasurable member (detached, no provider, measureless tag) → null", () => {
+    const record = { origins: ["a"], clones: ["a1"] };
+    expect(
+      subtree.repeat_delta(record, ["a1"], bounds({ a1: r(40, 10) }))
+    ).toBe(null);
+    expect(subtree.repeat_delta(record, ["a1"], () => null)).toBe(null);
+  });
+
+  it("union dims drift (a resized copy) → null", () => {
+    const record = { origins: ["a"], clones: ["a1"] };
+    expect(
+      subtree.repeat_delta(
+        record,
+        ["a1"],
+        bounds({ a: r(10, 10, 20, 20), a1: r(40, 10, 30, 20) })
+      )
+    ).toBe(null);
+  });
+
+  it("zero delta (the copy never moved) → null", () => {
+    const record = { origins: ["a"], clones: ["a1"] };
+    expect(
+      subtree.repeat_delta(
+        record,
+        ["a1"],
+        bounds({ a: r(10, 10), a1: r(10, 10) })
+      )
+    ).toBe(null);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
+++ b/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
@@ -254,13 +254,45 @@ describe("subtree.repeat_delta — the repeating-offset witness (#825)", () => {
     expect(subtree.repeat_delta(record, ["a1"], () => null)).toBe(null);
   });
 
-  it("union dims drift (a resized copy) → null", () => {
+  it("a resized copy → null", () => {
     const record = { origins: ["a"], clones: ["a1"] };
     expect(
       subtree.repeat_delta(
         record,
         ["a1"],
         bounds({ a: r(10, 10, 20, 20), a1: r(40, 10, 30, 20) })
+      )
+    ).toBe(null);
+  });
+
+  it("rigidity is per member, not per envelope — an inner copy moved while the union survives → null", () => {
+    // a and c define the union corners; b is interior. Every clone of
+    // a/c shifts by (5, 5) so the union shifts rigidly — but b's clone
+    // wandered. An envelope-only check would pass; the witness must not.
+    const record = { origins: ["a", "b", "c"], clones: ["a1", "b1", "c1"] };
+    expect(
+      subtree.repeat_delta(
+        record,
+        ["a1", "b1", "c1"],
+        bounds({
+          a: r(0, 0, 10, 10),
+          b: r(20, 20, 10, 10),
+          c: r(50, 50, 10, 10),
+          a1: r(5, 5, 10, 10),
+          b1: r(30, 40, 10, 10), // not (25, 25) — non-rigid inner move
+          c1: r(55, 55, 10, 10),
+        })
+      )
+    ).toBe(null);
+  });
+
+  it("a malformed record (unpaired arrays) → null", () => {
+    const record = { origins: ["a", "b"], clones: ["a1"] };
+    expect(
+      subtree.repeat_delta(
+        record,
+        ["a1"],
+        bounds({ a: r(0, 0), b: r(50, 0), a1: r(5, 0) })
       )
     ).toBe(null);
   });

--- a/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
+++ b/packages/grida-svg-editor/__tests__/subtree-clone.test.ts
@@ -303,13 +303,22 @@ describe("subtree.repeat_delta — the repeating-offset witness (#825)", () => {
     ).toBe(null);
   });
 
-  it("zero delta (the copy never moved) → null", () => {
+  it("zero delta (the copy never moved) → null, including sub-tolerance float noise", () => {
     const record = { origins: ["a"], clones: ["a1"] };
     expect(
       subtree.repeat_delta(
         record,
         ["a1"],
         bounds({ a: r(10, 10), a1: r(10, 10) })
+      )
+    ).toBe(null);
+    // A noise-sized net delta is not a move — repeating it would write
+    // noise-sized attribute deltas onto an otherwise byte-equal clone.
+    expect(
+      subtree.repeat_delta(
+        record,
+        ["a1"],
+        bounds({ a: r(10, 10), a1: r(10.000001, 9.999999) })
       )
     ).toBe(null);
   });

--- a/packages/grida-svg-editor/__tests__/translate-pipeline/clone-drag.test.ts
+++ b/packages/grida-svg-editor/__tests__/translate-pipeline/clone-drag.test.ts
@@ -324,4 +324,25 @@ describe("clone-drag — seeds the repeating-duplicate record (#825)", () => {
     const [copy] = editor.commands.duplicate();
     expect(rect_x(editor, copy)).toBe("10");
   });
+
+  it("multi-member, gesture ids out of document order: the seeded record pairs origin↔clone correctly", () => {
+    // The record's arrays are index-paired and must come from the
+    // normalized clone PLAN — session.ids is in gesture (selection)
+    // order. Drive [b, a] reversed; the per-member rigidity witness
+    // only passes if the seed paired a↔a′ and b↔b′, not a↔b′.
+    const { editor, drive } = harness();
+    install_geometry(editor);
+    const doc = editor.document;
+    const ids = [...editor.tree().nodes.keys()].filter(
+      (id) => doc.get_attr(id, "id") === "a" || doc.get_attr(id, "id") === "b"
+    );
+    const [a, b] = ids;
+    drive([b, a], [30, 0], MODS.on);
+    drive([b, a], [30, 0], MODS.on, "commit");
+
+    const next = editor.commands.duplicate();
+    expect(next).toHaveLength(2);
+    expect(rect_x(editor, next[0])).toBe("70"); // 10 + 30 + 30
+    expect(rect_x(editor, next[1])).toBe("160"); // 100 + 30 + 30
+  });
 });

--- a/packages/grida-svg-editor/__tests__/translate-pipeline/clone-drag.test.ts
+++ b/packages/grida-svg-editor/__tests__/translate-pipeline/clone-drag.test.ts
@@ -16,7 +16,8 @@ import { createSvgEditor } from "../../src/index";
 import { TranslateOrchestrator } from "../../src/core/translate-pipeline/orchestrator";
 import type { SvgDocument } from "../../src/core/document";
 import type { NodeId } from "../../src/types";
-import { first_rect } from "../_helpers";
+import type { subtree } from "../../src/core/subtree";
+import { first_rect, install_geometry } from "../_helpers";
 
 const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect id="a" x="10" y="10" width="20" height="20"/><rect id="b" x="100" y="100" width="20" height="20"/></svg>`;
 
@@ -24,6 +25,7 @@ type Internal = {
   doc: SvgDocument;
   history: { preview: (label: string) => unknown };
   emit: () => void;
+  seed_duplication: (record: subtree.DuplicationRecord) => void;
 };
 
 const MODS = {
@@ -53,6 +55,9 @@ function harness(opts?: { snap?: boolean }) {
       selection_calls.push([...ids]);
       editor.commands.select([...ids]);
     },
+    // Mirrors the dom.ts wiring: a cloned commit arms the editor's
+    // repeating-duplicate record (#825).
+    on_clone_commit: (record) => internal.seed_duplication(record),
   });
   const snap = opts?.snap ?? false;
   const drive = (
@@ -287,5 +292,36 @@ describe("clone-drag — commit", () => {
     expect(rect_x(editor, ids[1])).toBe("100");
     expect(rect_x(editor, clones[0])).toBe("15");
     expect(rect_x(editor, clones[1])).toBe("105");
+  });
+});
+
+// Alt-drag seeds the repeating-duplicate record (gridaco/grida#825;
+// spec: subtree-clone.md §Repeating offset): a CLONED commit is a
+// duplication, so ⌘D right after repeats the drag offset — the Figma
+// convention. Cancel never seeds.
+describe("clone-drag — seeds the repeating-duplicate record (#825)", () => {
+  it("⌘D after an alt-drag commit repeats the drag offset", () => {
+    const { editor, drive } = harness();
+    install_geometry(editor);
+    const a = first_rect(editor);
+    drive([a], [30, 0], MODS.on);
+    drive([a], [30, 0], MODS.on, "commit");
+    const committed = editor.state.selection;
+    expect(committed).toHaveLength(1);
+    expect(rect_x(editor, committed[0])).toBe("40");
+
+    const [next] = editor.commands.duplicate();
+    expect(rect_x(editor, next)).toBe("70");
+  });
+
+  it("a cancelled cloned drag seeds nothing — the next ⌘D clones in place", () => {
+    const { editor, orch, drive } = harness();
+    install_geometry(editor);
+    const a = first_rect(editor);
+    drive([a], [30, 0], MODS.on);
+    orch.cancel();
+    editor.commands.select([a]);
+    const [copy] = editor.commands.duplicate();
+    expect(rect_x(editor, copy)).toBe("10");
   });
 });

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -25,6 +25,7 @@ import { group as group_policy } from "./group";
 import {
   translate_pipeline,
   type TranslateBaseline,
+  type TranslatePlan,
   type TranslateStage,
 } from "./translate-pipeline";
 import { rotate_pipeline } from "./rotate-pipeline";
@@ -399,6 +400,17 @@ export type Commands = {
    * (so a clone's internal self-reference resolves to the ORIGINAL);
    * dedup is the explicit Tidy command's job.
    *
+   * **Repeating offset** (gridaco/grida#825, spec §Repeating offset):
+   * duplicate, move the copy, duplicate again — the next copy lands at
+   * the same relative offset from the previous one (Figma's repeating
+   * duplicate; an Alt-drag clone commit arms the same memory, so ⌘D
+   * after a clone-drag repeats the drag offset). Still ONE history
+   * step: a single `undo()` removes copy + offset together. Requires an
+   * attached geometry provider; when the repeat's preconditions don't
+   * hold (selection isn't the previous clones, a copy was resized,
+   * nothing moved, no geometry) the command degrades to the plain
+   * in-place duplicate above — never an error.
+   *
    * Refusal (no mutation, no history): an empty selection, or one that
    * normalizes to nothing cloneable (document root, nested `<svg>`,
    * stale / non-element ids) → `[]`. Returns the clone ids in document
@@ -582,6 +594,16 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
    * `reset()` / undo, like the OS clipboard it mirrors.
    */
   let clipboard_buffer: string | null = null;
+  /**
+   * The last committed duplication — read by the NEXT `duplicate()` to
+   * repeat the user's translate delta (gridaco/grida#825; spec
+   * §Repeating offset). Session state like `clipboard_buffer`: not in
+   * `EditorState`, not history-managed (undo/redo replay never re-arms
+   * it — only a user-initiated ⌘D or cloned-drag commit does). Staleness
+   * is caught at use by `subtree.repeat_delta`; the only eager clears are
+   * `load()` / `reset()`, where every NodeId dies wholesale.
+   */
+  let active_duplication: subtree.DuplicationRecord | null = null;
   const listeners = new Set<(state: EditorState) => void>();
   let attached_surface: Surface | null = null;
   /**
@@ -2104,20 +2126,52 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   }
 
   /**
-   * Duplicate-in-place over `subtree.clone_plan` — see the `Commands`
-   * doc. Same atomic shape as `insert_fragment_impl`: closures own the
+   * Duplicate over `subtree.clone_plan` — see the `Commands` doc. Same
+   * atomic shape as `insert_fragment_impl`: closures own the
    * insert/remove pair so redo re-inserts the same NodeIds.
+   *
+   * Repeating offset (gridaco/grida#825, spec §Repeating offset): when
+   * the targets are exactly the previous duplication's clones and
+   * geometry witnesses a rigid translate between that record's origins
+   * and clones, the fresh clones land displaced by the same delta. The
+   * offset rides the translate pipeline INSIDE the same atomic step —
+   * one undo removes copy + offset together. Clone baselines are
+   * key-swapped from the origins (a clone is a verbatim copy at rest —
+   * the orchestrator's `enter_clone` trick), so nothing reads the
+   * detached clones. Any failed precondition degrades to plain
+   * duplicate-in-place; never an error.
    */
   function duplicate(): NodeId[] {
     const plan = subtree.clone_plan(doc, selection);
     if (plan.length === 0) return [];
     const clones = plan.map((p) => p.clone);
+    const origins = plan.map((p) => p.origin);
     const previous_selection = selection;
+    // Measured BEFORE any mutation: both bbox reads (previous origins,
+    // previous clones) must see the document as the user left it.
+    const delta = subtree.repeat_delta(active_duplication, origins, (id) =>
+      geometry_provider ? geometry_provider.bounds_of(id) : null
+    );
+    let offset_plan: TranslatePlan | null = null;
+    if (delta) {
+      const baselines = new Map<NodeId, TranslateBaseline>();
+      for (const p of plan) {
+        baselines.set(
+          p.clone,
+          translate_pipeline.intent.capture_baseline(doc, p.origin)
+        );
+      }
+      offset_plan = { ids: clones, baselines, delta };
+    }
     const apply = () => {
       subtree.insert_plan(doc, plan);
+      if (offset_plan) {
+        translate_pipeline.apply(doc, offset_plan, project_world_delta);
+      }
       set_selection(clones);
     };
     const revert = () => {
+      if (offset_plan) translate_pipeline.revert(doc, offset_plan);
       subtree.remove_plan(doc, plan);
       set_selection(previous_selection);
     };
@@ -2125,6 +2179,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     history.atomic("duplicate", (tx) => {
       tx.push({ providerId: PROVIDER_ID, apply, revert });
     });
+    // Arm the record AFTER the commit, OUTSIDE the closures — history
+    // replay must not re-arm a stale record.
+    active_duplication = { origins, clones };
     return clones;
   }
 
@@ -2356,6 +2413,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     mode = "select";
     tool = TOOL_CURSOR;
     history.clear();
+    active_duplication = null;
     baseline_revision = doc.revision;
     load_version++;
     emit();
@@ -2436,6 +2494,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     scope = null;
     mode = "select";
     tool = TOOL_CURSOR;
+    active_duplication = null;
     baseline_revision = doc.revision;
     emit();
   }
@@ -2695,6 +2754,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
         };
       },
       notify_translate_commit,
+      seed_duplication(record: subtree.DuplicationRecord) {
+        active_duplication = record;
+      },
       set_content_edit_driver(fn: ((target: NodeId) => boolean) | null) {
         content_edit_driver = fn;
       },

--- a/packages/grida-svg-editor/src/core/subtree.ts
+++ b/packages/grida-svg-editor/src/core/subtree.ts
@@ -28,7 +28,9 @@
  * the explicit Tidy command's job.
  */
 
-import type { NodeId } from "../types";
+import cmath from "@grida/cmath";
+import type { NodeId, Rect, Vec2 } from "../types";
+import { array_shallow_equal } from "../util/equal";
 import type { SvgDocument } from "./document";
 
 export namespace subtree {
@@ -158,5 +160,93 @@ export namespace subtree {
    */
   export function remove_plan(doc: SvgDocument, plan: SubtreeClonePlan): void {
     for (const p of plan) doc.remove(p.clone);
+  }
+
+  /**
+   * The last committed duplication — the memory the repeating-offset
+   * behavior reads (gridaco/grida#825; spec:
+   * [docs/wg/feat-svg-editor/subtree-clone.md](../../../../docs/wg/feat-svg-editor/subtree-clone.md)
+   * §Repeating offset). Armed by `commands.duplicate` and by a cloned
+   * translate commit (Alt-drag); consumed and re-armed by the next
+   * `duplicate()`. Editor-session state — never observable, never in
+   * history. Staleness is caught at use by {@link repeat_delta}, not by
+   * per-mutation bookkeeping.
+   */
+  export type DuplicationRecord = {
+    origins: ReadonlyArray<NodeId>;
+    clones: ReadonlyArray<NodeId>;
+  };
+
+  /** Union-bbox dimension tolerance for the rigid-translate witness in
+   *  {@link repeat_delta}. Generous against float noise from re-encoded
+   *  path data / `getBBox`, far below anything a user would call a
+   *  resize. */
+  const REPEAT_DIMS_EPSILON = 0.01;
+
+  /**
+   * The repeating-offset delta (gridaco/grida#825): given the previous
+   * duplication's record and the CURRENT duplicate's normalized origins,
+   * return the world-space offset the fresh clones should repeat, or
+   * `null` for "no repeat — duplicate in place".
+   *
+   * The repeat fires only when the record still witnesses
+   * "duplicate, then rigidly translate the copies":
+   *   - `targets` is exactly `record.clones`, in the same (document)
+   *     order — the user is duplicating the previous duplication's
+   *     copies and nothing else;
+   *   - `bounds_of` answers for EVERY member of both sets (a detached
+   *     member, a measureless tag, or a missing geometry provider all
+   *     refuse);
+   *   - the two union bboxes agree in size within
+   *     {@link REPEAT_DIMS_EPSILON} — a resized or structurally edited
+   *     copy is no longer a translate of its origin;
+   *   - the union top-left delta is non-zero (a copy that never moved
+   *     repeats nothing).
+   *
+   * Pure and gesture-grade: reads only through `bounds_of`, never
+   * throws — every failed precondition degrades to `null` (the main
+   * editor's `active_duplication` assert-on-mismatch is deliberately
+   * NOT copied; ⌘D must never crash on a stale record).
+   */
+  export function repeat_delta(
+    record: DuplicationRecord | null,
+    targets: ReadonlyArray<NodeId>,
+    bounds_of: (id: NodeId) => Rect | null
+  ): Vec2 | null {
+    if (record === null) return null;
+    if (record.origins.length === 0 || record.clones.length === 0) return null;
+    if (!array_shallow_equal(record.clones, targets)) return null;
+    const origin_bounds = collect_bounds(record.origins, bounds_of);
+    if (origin_bounds === null) return null;
+    const clone_bounds = collect_bounds(record.clones, bounds_of);
+    if (clone_bounds === null) return null;
+    const a = cmath.rect.union(origin_bounds);
+    const b = cmath.rect.union(clone_bounds);
+    if (
+      Math.abs(a.width - b.width) > REPEAT_DIMS_EPSILON ||
+      Math.abs(a.height - b.height) > REPEAT_DIMS_EPSILON
+    ) {
+      return null;
+    }
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    if (dx === 0 && dy === 0) return null;
+    return { x: dx, y: dy };
+  }
+
+  /** All-or-nothing bounds gather for {@link repeat_delta} — one
+   *  unmeasurable member and the record can't witness a rigid
+   *  translate. */
+  function collect_bounds(
+    ids: ReadonlyArray<NodeId>,
+    bounds_of: (id: NodeId) => Rect | null
+  ): Rect[] | null {
+    const out: Rect[] = [];
+    for (const id of ids) {
+      const r = bounds_of(id);
+      if (r === null) return null;
+      out.push(r);
+    }
+    return out;
   }
 }

--- a/packages/grida-svg-editor/src/core/subtree.ts
+++ b/packages/grida-svg-editor/src/core/subtree.ts
@@ -209,8 +209,10 @@ export namespace subtree {
    *     check is per member, not per envelope — a rearranged or
    *     resized inner copy is no longer a translate even when the
    *     envelope-defining copies keep the union bbox intact;
-   *   - the union top-left delta is non-zero (a copy that never moved
-   *     repeats nothing).
+   *   - the union top-left delta exceeds the same tolerance (a copy
+   *     that never moved — or drifted by float noise only — repeats
+   *     nothing; the in-place duplicate stays byte-equal instead of
+   *     inheriting noise-sized attribute writes).
    *
    * Pure and gesture-grade: reads only through `bounds_of`, never
    * throws — every failed precondition degrades to `null` (the main
@@ -246,7 +248,15 @@ export namespace subtree {
         return null;
       }
     }
-    if (dx === 0 && dy === 0) return null;
+    // Same tolerance as the rigidity check: a sub-epsilon net delta is
+    // float noise, not a move — degrade to the byte-equal in-place
+    // duplicate rather than fabricate noise-sized attribute writes.
+    if (
+      Math.abs(dx) <= REPEAT_RIGID_EPSILON &&
+      Math.abs(dy) <= REPEAT_RIGID_EPSILON
+    ) {
+      return null;
+    }
     return { x: dx, y: dy };
   }
 

--- a/packages/grida-svg-editor/src/core/subtree.ts
+++ b/packages/grida-svg-editor/src/core/subtree.ts
@@ -171,17 +171,23 @@ export namespace subtree {
    * `duplicate()`. Editor-session state — never observable, never in
    * history. Staleness is caught at use by {@link repeat_delta}, not by
    * per-mutation bookkeeping.
+   *
+   * The arrays are INDEX-PAIRED: `clones[i]` is the clone of
+   * `origins[i]` (both producers derive them from the same
+   * {@link SubtreeClonePlan}). {@link repeat_delta}'s per-member
+   * rigidity check depends on that pairing.
    */
   export type DuplicationRecord = {
     origins: ReadonlyArray<NodeId>;
     clones: ReadonlyArray<NodeId>;
   };
 
-  /** Union-bbox dimension tolerance for the rigid-translate witness in
-   *  {@link repeat_delta}. Generous against float noise from re-encoded
-   *  path data / `getBBox`, far below anything a user would call a
-   *  resize. */
-  const REPEAT_DIMS_EPSILON = 0.01;
+  /** Per-member rigidity tolerance for the rigid-translate witness in
+   *  {@link repeat_delta} — position drift from the shared delta, and
+   *  size drift from the origin. Generous against float noise from
+   *  re-encoded path data / `getBBox`, far below anything a user would
+   *  call a move or a resize. */
+  const REPEAT_RIGID_EPSILON = 0.01;
 
   /**
    * The repeating-offset delta (gridaco/grida#825): given the previous
@@ -197,9 +203,12 @@ export namespace subtree {
    *   - `bounds_of` answers for EVERY member of both sets (a detached
    *     member, a measureless tag, or a missing geometry provider all
    *     refuse);
-   *   - the two union bboxes agree in size within
-   *     {@link REPEAT_DIMS_EPSILON} — a resized or structurally edited
-   *     copy is no longer a translate of its origin;
+   *   - EVERY clone is rigid against its own origin (the record's
+   *     arrays are index-paired): same size, displaced by the same
+   *     delta as the union, within {@link REPEAT_RIGID_EPSILON}. The
+   *     check is per member, not per envelope — a rearranged or
+   *     resized inner copy is no longer a translate even when the
+   *     envelope-defining copies keep the union bbox intact;
    *   - the union top-left delta is non-zero (a copy that never moved
    *     repeats nothing).
    *
@@ -214,7 +223,8 @@ export namespace subtree {
     bounds_of: (id: NodeId) => Rect | null
   ): Vec2 | null {
     if (record === null) return null;
-    if (record.origins.length === 0 || record.clones.length === 0) return null;
+    if (record.origins.length === 0) return null;
+    if (record.origins.length !== record.clones.length) return null;
     if (!array_shallow_equal(record.clones, targets)) return null;
     const origin_bounds = collect_bounds(record.origins, bounds_of);
     if (origin_bounds === null) return null;
@@ -222,14 +232,20 @@ export namespace subtree {
     if (clone_bounds === null) return null;
     const a = cmath.rect.union(origin_bounds);
     const b = cmath.rect.union(clone_bounds);
-    if (
-      Math.abs(a.width - b.width) > REPEAT_DIMS_EPSILON ||
-      Math.abs(a.height - b.height) > REPEAT_DIMS_EPSILON
-    ) {
-      return null;
-    }
     const dx = b.x - a.x;
     const dy = b.y - a.y;
+    for (let i = 0; i < origin_bounds.length; i++) {
+      const o = origin_bounds[i];
+      const c = clone_bounds[i];
+      if (
+        Math.abs(c.x - o.x - dx) > REPEAT_RIGID_EPSILON ||
+        Math.abs(c.y - o.y - dy) > REPEAT_RIGID_EPSILON ||
+        Math.abs(c.width - o.width) > REPEAT_RIGID_EPSILON ||
+        Math.abs(c.height - o.height) > REPEAT_RIGID_EPSILON
+      ) {
+        return null;
+      }
+    }
     if (dx === 0 && dy === 0) return null;
     return { x: dx, y: dy };
   }

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -17,6 +17,7 @@ import type { NodeId, PickEvent, Unsubscribe } from "../types";
 import type { DomComputedResolver } from "./editor";
 import type { GeometryProvider } from "./geometry";
 import type { SvgDocument } from "./document";
+import type { subtree } from "./subtree";
 
 export interface SurfaceBridge {
   /** Low-level IR. Mutating directly bypasses history; surfaces read
@@ -81,6 +82,13 @@ export interface SurfaceBridge {
   /** surface → editor: publish a translate commit. Called by the
    *  translate orchestrator after a drag settles. */
   notify_translate_commit(): void;
+
+  /** surface → editor: arm the repeating-duplicate record after a CLONED
+   *  translate commit (gridaco/grida#825), so a follow-up `duplicate()`
+   *  (⌘D) repeats the drag offset — the Figma alt-drag-then-⌘D
+   *  convention. Commit-time only, never preview or cancel; spec:
+   *  docs/wg/feat-svg-editor/subtree-clone.md §Repeating offset. */
+  seed_duplication(record: subtree.DuplicationRecord): void;
 
   /** editor → surface: register the driver that mounts inline content
    *  editing (text-edit, vector-edit) on a target node. The editor calls

--- a/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
@@ -99,6 +99,12 @@ export type OrchestratorDeps = {
    *  wire it still gets correct document mutations; only the selection
    *  chrome lags. */
   set_selection?: (ids: ReadonlyArray<NodeId>) => void;
+  /** Arm the editor's repeating-duplicate record on a CLONED commit
+   *  (gridaco/grida#825): ⌘D after an Alt-drag clone repeats the drag
+   *  offset. Fired exactly once per cloned commit, after the history
+   *  step exists — never on preview frames or cancel. Optional — a host
+   *  without the duplicate command omits it. */
+  on_clone_commit?: (record: subtree.DuplicationRecord) => void;
 };
 
 const PROVIDER_ID = "svg-editor";
@@ -158,8 +164,19 @@ export class TranslateOrchestrator {
     }
 
     if (opts.phase === "commit") {
+      const cloned = session.clone;
       session.preview.commit();
       this.dispose_session();
+      if (cloned !== null) {
+        // Seed the repeating-duplicate memory (#825) — a cloned drag is
+        // a duplication; ⌘D right after repeats its offset. Zero-net-
+        // movement commits seed too: the delta they witness is (0,0),
+        // which the consumer treats as duplicate-in-place.
+        this.deps.on_clone_commit?.({
+          origins: session.ids,
+          clones: cloned.ids,
+        });
+      }
     }
     return result;
   }

--- a/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
+++ b/packages/grida-svg-editor/src/core/translate-pipeline/orchestrator.ts
@@ -171,9 +171,12 @@ export class TranslateOrchestrator {
         // Seed the repeating-duplicate memory (#825) — a cloned drag is
         // a duplication; ⌘D right after repeats its offset. Zero-net-
         // movement commits seed too: the delta they witness is (0,0),
-        // which the consumer treats as duplicate-in-place.
+        // which the consumer treats as duplicate-in-place. Origins come
+        // from the PLAN, not `session.ids`: the record's arrays are
+        // index-paired, and the plan is normalized (document order,
+        // refusals dropped) while the at-open ids are neither.
         this.deps.on_clone_commit?.({
-          origins: session.ids,
+          origins: cloned.plan.map((p) => p.origin),
           clones: cloned.ids,
         });
       }

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -647,6 +647,10 @@ class DomSurface implements Surface {
       // the selection (and with it the HUD chrome, via subscribe) must
       // follow the movers.
       set_selection: (ids) => this.editor.commands.select(ids),
+      // A cloned commit arms the repeating-duplicate record so a
+      // follow-up ⌘D repeats the drag offset (gridaco/grida#825).
+      on_clone_commit: (record) =>
+        this.editor_internal().seed_duplication(record),
     });
 
     // Resize funnel — same shape as translate, distinct lifecycle.

--- a/test/svg-editor-duplicate.md
+++ b/test/svg-editor-duplicate.md
@@ -1,9 +1,19 @@
 ---
 id: TC-SVGEDITOR-DUPLICATE-001
-title: Alt-drag clones and moves the clone; ⌘D duplicates in place; both are one undo step
+title: Alt-drag clones and moves the clone; ⌘D duplicates and repeats the previous offset; both are one undo step
 module: svg-editor
 area: duplicate
-tags: [duplicate, clone, alt-drag, modifier, history, undo, selection]
+tags:
+  [
+    duplicate,
+    clone,
+    alt-drag,
+    modifier,
+    history,
+    undo,
+    selection,
+    repeating-offset,
+  ]
 status: untested
 severity: high
 date: 2026-06-11
@@ -22,6 +32,9 @@ Duplicate and Alt-drag both consume the **subtree-clone** operation
 (spec: `docs/wg/feat-svg-editor/subtree-clone.md`): the clone is a
 verbatim copy — no defs are duplicated, authored ids are repeated as-is
 — inserted directly after its origin, so it paints right on top of it.
+⌘D also carries the **repeating offset** (spec §Repeating offset):
+duplicate → move the copy → ⌘D again lands the next copy at the same
+relative offset, and an Alt-drag clone commit arms the same memory.
 
 Alt-drag follows the Figma convention: **the clone moves, the origin
 stays**. The toggle is live — the clone appears the moment Alt is
@@ -66,11 +79,27 @@ here.
 8. **Measurement coexistence**: with nothing dragging, hover with Alt
    held. Expected: the measurement overlay still works; no clone is
    created outside a drag.
+9. **Repeating offset (⌘D remembers the move)**: select a shape, press
+   ⌘D, drag the copy somewhere, press ⌘D again. Expected: the third
+   copy lands at the same relative offset from the second as the
+   second sits from the first. Keep pressing ⌘D: copies march at a
+   constant stride. ONE ⌘Z per copy removes that copy AND its offset
+   together. Moving the copy with arrow keys / nudge instead of a drag
+   repeats the same way (the offset is measured, not tied to a
+   gesture).
+10. **Alt-drag seeds the repeat**: Alt-drag a shape to clone-and-move
+    it, release, then press ⌘D. Expected: the next copy repeats the
+    drag offset (Figma convention).
+11. **Repeat degrades, never breaks**: after ⌘D + move, resize the
+    copy, then ⌘D. Expected: plain duplicate-in-place (the chain is
+    broken by the resize), no error. Same when re-selecting a
+    different node between duplicates.
 
 ## Notes
 
-Shipped with gridaco/grida#817. A cloned drag committed with zero NET
-movement (drag out and back, release with Alt held) is a
+Shipped with gridaco/grida#817; the repeating offset (steps 9–11) with
+gridaco/grida#825 (spec §Repeating offset). A cloned drag committed
+with zero NET movement (drag out and back, release with Alt held) is a
 duplicate-in-place (same outcome as ⌘D); a press-release that never
 crosses the drag threshold is a tap — no gesture, no clone. The
 committed history label remains "move" (label is fixed at gesture


### PR DESCRIPTION
Closes #825 (follow-up to #817, deferred there by design).

Duplicate (⌘D), move the copy, ⌘D again → the next copy lands at the **same relative offset** from the previous one — Figma's repeating duplicate. An Alt-drag clone commit arms the same memory, so clone-drag → ⌘D repeats the drag offset.

## Layer triage (README doctrine / sdk-design)

Walking the deciding table: not a P1-customization question, not host-owned (P2), not per-element semantics (P3), no separate-layer claim (P5) → **core, internally modular**; a named built-in. **Zero new public API**: `duplicate(): NodeId[]` keeps its signature, and the duplication record is editor-session state like `clipboard_buffer` — not in `EditorState`, not observable (P6: no consumer exists to shape such a view).

## What changed

- **`core/subtree.ts`** — `subtree.DuplicationRecord` + pure `subtree.repeat_delta`. The offset is **measured**, not stored: if the record still witnesses "duplicate, then rigidly translate the copies", the union-bbox delta between the record's origins and clones is the repeat. Measuring is what makes drag, nudge, arrow keys, inspector edits, and align all repeat. The witness refuses — `null` → plain duplicate-in-place — on selection divergence, any unmeasurable member (incl. no geometry provider), union-dims drift (a resized copy), or zero delta. Never a throw: the main editor's `assert` on a stale record is deliberately **not** copied.
- **`core/editor.ts`** — `duplicate()` applies the offset via the translate pipeline (baselines key-swapped from the origins — the orchestrator's `enter_clone` trick — plus the standard world→local projection) **inside the same `history.atomic` step**: one undo removes copy + offset together. The record is armed after commit, outside the closures, so history replay never re-arms it. `load()` / `reset()` clear it eagerly (ids die wholesale); everything else is validate-at-use — no per-mutation bookkeeping.
- **`core/translate-pipeline/orchestrator.ts` → `core/surface-bridge.ts` → `dom.ts`** — optional `OrchestratorDeps.on_clone_commit`, fired exactly once per **cloned** commit (never preview/cancel), bridged via `_internal.seed_duplication`. A zero-net-movement cloned commit seeds a record whose witnessed delta is zero — repeats nothing, consistent with the spec's duplicate-in-place equivalence.

## Spec & tests (definition of done from #825)

- `docs/wg/feat-svg-editor/subtree-clone.md` gains **§Repeating offset** (record semantics, arm/witness/degrade/invalidate rules, Alt-drag seeding stated rather than implied); the §Out of scope entry is retired.
- Headless tests: command-level spec in `commands-duplicate.test.ts` (repeat, one-undo-step + redo, chaining stride, no-geometry / selection-change / resize / reset degradations, multi-member union offset, zero-move byte-equality), pure `repeat_delta` refusal matrix in `subtree-clone.test.ts`, seed/cancel in `translate-pipeline/clone-drag.test.ts`. The `internal-surface.test.ts` key pin caught the bridge addition and was updated — the anti-drift guard doing its job.
- Manual TC `test/svg-editor-duplicate.md` extended (steps 9–11); README command note + TODO updated.

## Verification

- `pnpm vitest run` — 1268 tests, 82 files, all green
- `pnpm test:browser` — 25 tests (incl. `clone-drag.browser.test.ts` exercising the real dom.ts wiring), all green
- `tsc --noEmit`, `oxlint`, `oxfmt` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ⌘D now repeats the last clone movement (per-session translate offset) and applies the offset in the same undo step; Alt‑drag/clone commit and arrow/nudge can arm the next ⌘D; reset/load/undo/redo clear the record. Multi-selection repeats use a union offset; failing preconditions degrade to in‑place duplicates.

* **Documentation**
  * Docs and README updated to describe repeating‑offset semantics, triggers, degradation and undo behavior.

* **Tests**
  * New/expanded tests cover seeding, repeat‑offset measurement, undo behavior, multi‑member cases, and degradation scenarios.

* **Chore**
  * HUD package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->