### PR TITLE
fix(svg-editor): text resized via HUD is not undone by cmd+z

### DIFF
--- a/packages/grida-svg-editor/__tests__/_helpers.ts
+++ b/packages/grida-svg-editor/__tests__/_helpers.ts
@@ -28,6 +28,25 @@ export function rect(x: number, y: number, w = 10, h = 10): Rect {
   return { x, y, width: w, height: h };
 }
 
+/** Id of the first `<tag>` in document order. Accepts either the
+ *  editor (most common) or the bare document. */
+export function first_tag(
+  source: ReturnType<typeof createSvgEditor> | SvgDocument,
+  tag: string
+): string {
+  // Editor surface has `.tree()`; SvgDocument has `.all_elements()` + `.tag_of()`.
+  if ("tree" in source) {
+    for (const [id, n] of source.tree().nodes) {
+      if (n.tag === tag) return id;
+    }
+  } else {
+    for (const id of source.all_elements()) {
+      if (source.tag_of(id) === tag) return id;
+    }
+  }
+  throw new Error(`no <${tag}> in document`);
+}
+
 /** Id of the first `<rect>` in document order. Two overloads so tests
  *  can pass either the editor (most common) or the bare document. */
 export function first_rect(editor: ReturnType<typeof createSvgEditor>): string;
@@ -35,17 +54,7 @@ export function first_rect(doc: SvgDocument): string;
 export function first_rect(
   source: ReturnType<typeof createSvgEditor> | SvgDocument
 ): string {
-  // Editor surface has `.tree()`; SvgDocument has `.all_elements()` + `.tag_of()`.
-  if ("tree" in source) {
-    for (const [id, n] of source.tree().nodes) {
-      if (n.tag === "rect") return id;
-    }
-  } else {
-    for (const id of source.all_elements()) {
-      if (source.tag_of(id) === "rect") return id;
-    }
-  }
-  throw new Error("no <rect> in document");
+  return first_tag(source, "rect");
 }
 
 /**

--- a/packages/grida-svg-editor/__tests__/intents.test.ts
+++ b/packages/grida-svg-editor/__tests__/intents.test.ts
@@ -142,6 +142,7 @@ describe("compute_resize_factors", () => {
   const baseline = {
     bbox: { x: 0, y: 0, width: 100, height: 50 },
     attrs: { kind: "rect" as const, x: 0, y: 0, w: 100, h: 50 },
+    raw: [],
   };
 
   it("se drag scales positive from nw anchor", () => {

--- a/packages/grida-svg-editor/__tests__/resize-capability.test.ts
+++ b/packages/grida-svg-editor/__tests__/resize-capability.test.ts
@@ -13,6 +13,7 @@ function rect_baseline(x = 0, y = 0, w = 100, h = 50): ResizeBaseline {
   return {
     bbox: { x, y, width: w, height: h },
     attrs: { kind: "rect", x, y, w, h },
+    raw: [],
   };
 }
 
@@ -20,6 +21,7 @@ function circle_baseline(cx = 50, cy = 50, r = 25): ResizeBaseline {
   return {
     bbox: { x: cx - r, y: cy - r, width: r * 2, height: r * 2 },
     attrs: { kind: "circle", cx, cy, r },
+    raw: [],
   };
 }
 
@@ -27,6 +29,7 @@ function text_baseline(): ResizeBaseline {
   return {
     bbox: { x: 0, y: 0, width: 100, height: 20 },
     attrs: { kind: "text", x: 0, y: 0, fontSize: 16 },
+    raw: [],
   };
 }
 

--- a/packages/grida-svg-editor/__tests__/resize-pipeline.test.ts
+++ b/packages/grida-svg-editor/__tests__/resize-pipeline.test.ts
@@ -21,6 +21,7 @@ function rect_baseline(x = 0, y = 0, w = 100, h = 50): ResizeBaseline {
   return {
     bbox: { x, y, width: w, height: h },
     attrs: { kind: "rect", x, y, w, h },
+    raw: [],
   };
 }
 
@@ -28,6 +29,7 @@ function circle_baseline(cx = 50, cy = 50, r = 25): ResizeBaseline {
   return {
     bbox: { x: cx - r, y: cy - r, width: r * 2, height: r * 2 },
     attrs: { kind: "circle", cx, cy, r },
+    raw: [],
   };
 }
 
@@ -35,6 +37,7 @@ function text_baseline_at(x: number, y: number): ResizeBaseline {
   return {
     bbox: { x, y, width: 100, height: 20 },
     attrs: { kind: "text", x, y, fontSize: 16 },
+    raw: [],
   };
 }
 

--- a/packages/grida-svg-editor/__tests__/resize-revert-restore.test.ts
+++ b/packages/grida-svg-editor/__tests__/resize-revert-restore.test.ts
@@ -1,0 +1,198 @@
+// Resize revert = byte-exact snapshot restore (`intent.restore`), NOT
+// an identity-scale re-application. Regression suite for the class of
+// bugs where revert routed through `intent.apply(..., 1, 1, ...)` and
+// silently no-op'd whenever a per-tag handler refused the gesture
+// shape:
+//
+//   - text resized via the HUD could not be undone (resize_text
+//     refuses non-corner input, and sx = sy = 1 is non-corner);
+//   - Escape-cancel mid-gesture left the text resized (Preview.discard
+//     drives the same revert);
+//   - undo after a committed resize of a rotated element kept the
+//     commit-phase pivot renormalization (revert never wrote
+//     `transform`);
+//   - undo fabricated attrs that were absent before the gesture
+//     (e.g. `font-size="16"` on a <text> that inherited its size).
+//
+// The HUD cases drive `ResizeOrchestrator` wired exactly like the DOM
+// adapter (dom.ts); the RPC case goes through `commands.resize_by`.
+
+import { describe, expect, it } from "vitest";
+import { ResizeOrchestrator } from "../src/core/resize-pipeline";
+import type { ResizeOptions } from "../src/core/resize-pipeline";
+import { createSvgEditorWithInternals, first_tag } from "./_helpers";
+import type { Rect } from "../src/types";
+
+const OPTS: ResizeOptions = {
+  pixel_grid_quantum: null,
+  snap_enabled: false,
+  snap_threshold_px: 10,
+};
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><rect x="10" y="10" width="100" height="50"/><text x="50" y="100" font-size="16">hello</text></svg>`;
+
+/** Mirror of the DOM adapter's orchestrator wiring (dom.ts), with a
+ *  fixed world bbox per node — the orchestrator captures it once at
+ *  gesture open, so a static map is faithful to a real gesture. */
+function make_orchestrator(
+  editor: ReturnType<typeof createSvgEditorWithInternals>,
+  bboxes: Record<string, Rect>
+): ResizeOrchestrator {
+  return new ResizeOrchestrator({
+    get_doc: () => editor._internal.doc,
+    emit: () => editor._internal.emit(),
+    open_preview: (label) => editor._internal.history.preview(label),
+    open_snap: () => null,
+    options: () => OPTS,
+    bbox_world: (id) => bboxes[id] ?? { x: 0, y: 0, width: 0, height: 0 },
+  });
+}
+
+/** Preview frame + commit, like a real handle drag. */
+function drag_se(
+  orch: ResizeOrchestrator,
+  id: string,
+  target_width: number,
+  target_height: number,
+  phase: "commit" | "preview-only" = "commit"
+): void {
+  const input = {
+    ids: [id],
+    direction: "se" as const,
+    target_width,
+    target_height,
+  };
+  const modifiers = { aspect_lock: "off", force_disable_snap: false } as const;
+  orch.drive(input, modifiers, { phase: "preview", snap: false });
+  if (phase === "commit") {
+    orch.drive(input, modifiers, { phase: "commit", snap: false });
+  }
+}
+
+describe("HUD resize → undo restores", () => {
+  it("rect: undo restores width/height", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    const rect_id = first_tag(editor, "rect");
+    const orch = make_orchestrator(editor, {
+      [rect_id]: { x: 10, y: 10, width: 100, height: 50 },
+    });
+
+    drag_se(orch, rect_id, 200, 100);
+    expect(editor.document.get_attr(rect_id, "width")).toBe("200");
+    expect(editor.state.can_undo).toBe(true);
+
+    editor.commands.undo();
+    expect(editor.document.get_attr(rect_id, "width")).toBe("100");
+    expect(editor.document.get_attr(rect_id, "height")).toBe("50");
+  });
+
+  it("text: undo restores x/y/font-size (corner drag scales uniformly)", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    const text_id = first_tag(editor, "text");
+    const orch = make_orchestrator(editor, {
+      [text_id]: { x: 50, y: 84, width: 40, height: 20 },
+    });
+
+    drag_se(orch, text_id, 80, 40); // s = min(2, 2) = 2
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("32");
+    expect(editor.state.can_undo).toBe(true);
+
+    editor.commands.undo();
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("16");
+    expect(editor.document.get_attr(text_id, "x")).toBe("50");
+    expect(editor.document.get_attr(text_id, "y")).toBe("100");
+  });
+
+  it("text: redo re-applies after undo", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    const text_id = first_tag(editor, "text");
+    const orch = make_orchestrator(editor, {
+      [text_id]: { x: 50, y: 84, width: 40, height: 20 },
+    });
+
+    drag_se(orch, text_id, 80, 40);
+    editor.commands.undo();
+    editor.commands.redo();
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("32");
+    editor.commands.undo();
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("16");
+  });
+
+  it("text without font-size attr: undo REMOVES the attr instead of fabricating the 16px fallback", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><text x="50" y="100">hello</text></svg>`;
+    const editor = createSvgEditorWithInternals({ svg });
+    const text_id = first_tag(editor, "text");
+    const orch = make_orchestrator(editor, {
+      [text_id]: { x: 50, y: 84, width: 40, height: 20 },
+    });
+
+    drag_se(orch, text_id, 80, 40);
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("32");
+
+    editor.commands.undo();
+    expect(editor.document.get_attr(text_id, "font-size")).toBeNull();
+  });
+
+  it("rotated rect (explicit pivot): undo restores the transform byte-exact after commit-phase pivot renormalization", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><rect x="10" y="10" width="100" height="50" transform="rotate(30 60 35)"/></svg>`;
+    const editor = createSvgEditorWithInternals({ svg });
+    const rect_id = first_tag(editor, "rect");
+    const orch = make_orchestrator(editor, {
+      [rect_id]: { x: 10, y: 10, width: 100, height: 50 },
+    });
+
+    drag_se(orch, rect_id, 200, 100);
+    // commit moved the pivot to the new local center
+    expect(editor.document.get_attr(rect_id, "transform")).not.toBe(
+      "rotate(30 60 35)"
+    );
+
+    editor.commands.undo();
+    expect(editor.document.get_attr(rect_id, "transform")).toBe(
+      "rotate(30 60 35)"
+    );
+    expect(editor.document.get_attr(rect_id, "x")).toBe("10");
+    expect(editor.document.get_attr(rect_id, "y")).toBe("10");
+    expect(editor.document.get_attr(rect_id, "width")).toBe("100");
+    expect(editor.document.get_attr(rect_id, "height")).toBe("50");
+  });
+});
+
+describe("HUD resize → Escape-cancel restores", () => {
+  it("text: cancel mid-gesture rolls the preview back", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    const text_id = first_tag(editor, "text");
+    const orch = make_orchestrator(editor, {
+      [text_id]: { x: 50, y: 84, width: 40, height: 20 },
+    });
+
+    drag_se(orch, text_id, 80, 40, "preview-only");
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("32");
+
+    // Escape → DomSurface calls resize_orchestrator.cancel() →
+    // preview.discard() → delta.revert()
+    orch.cancel();
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("16");
+    expect(editor.state.can_undo).toBe(false);
+  });
+});
+
+describe("commands.resize_by (RPC path) → undo restores", () => {
+  it("text: undo after a both-axes resize_by restores font-size", () => {
+    const editor = createSvgEditorWithInternals({ svg: SVG });
+    const text_id = first_tag(editor, "text");
+    // resize_by needs a geometry provider; supply the text bbox directly.
+    editor._internal.set_geometry({
+      bounds_of: (id) =>
+        id === text_id ? { x: 50, y: 84, width: 40, height: 20 } : null,
+    });
+
+    editor.commands.select([text_id], { mode: "set" });
+    expect(editor.commands.resize_by({ dw: 40, dh: 20 })).toBe(true); // s = 2
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("32");
+
+    editor.commands.undo();
+    expect(editor.document.get_attr(text_id, "font-size")).toBe("16");
+    expect(editor.document.get_attr(text_id, "x")).toBe("50");
+  });
+});

--- a/packages/grida-svg-editor/__tests__/resize-snapshot-coverage.test.ts
+++ b/packages/grida-svg-editor/__tests__/resize-snapshot-coverage.test.ts
@@ -1,0 +1,154 @@
+// The raw-snapshot coverage contract: every attribute a resize gesture
+// can write — via the per-tag Policy Class handler (`dispatch_resize`),
+// commit-phase pivot renormalization, or the group-translate arm of
+// editor.ts `commit_resize` — must be listed in `baseline.raw`, or
+// `intent.restore` (undo / Escape-cancel) silently misses it on revert.
+//
+// `RESIZE_WRITE_ATTRS` is the handlers' write surface as data; this
+// suite cross-checks it against the LIVE write paths by diffing real
+// documents before/after, so a handler that starts writing a new
+// attribute fails here instead of shipping broken undo.
+
+import { describe, expect, it } from "vitest";
+import { SvgDocument } from "../src/core/document";
+import { resize_pipeline } from "../src/core/resize-pipeline";
+import { translate_pipeline } from "../src/core/translate-pipeline";
+import { RESIZE_WRITE_ATTRS } from "../src/core/policy-class/handlers/resize";
+import { first_tag } from "./_helpers";
+
+/** One representative element per resizable tag, every writable attr
+ *  present with a non-default value. */
+const FIXTURES: Record<string, string> = {
+  rect: `<rect x="10" y="20" width="100" height="50"/>`,
+  image: `<image x="1" y="2" width="30" height="40"/>`,
+  use: `<use x="3" y="4" width="20" height="10"/>`,
+  circle: `<circle cx="50" cy="60" r="25"/>`,
+  ellipse: `<ellipse cx="40" cy="30" rx="20" ry="10"/>`,
+  line: `<line x1="0" y1="0" x2="50" y2="40"/>`,
+  polyline: `<polyline points="0,0 10,5 20,0"/>`,
+  polygon: `<polygon points="0,0 10,0 5,8"/>`,
+  path: `<path d="M 0 0 L 10 10 C 20 20 30 10 40 0 Z"/>`,
+  text: `<text x="5" y="15" font-size="12">hi</text>`,
+};
+
+const BBOX = { x: 0, y: 0, width: 100, height: 50 };
+
+function make_doc(
+  tag: string,
+  transform?: string
+): {
+  doc: SvgDocument;
+  id: string;
+} {
+  const el = transform
+    ? FIXTURES[tag].replace("/>", ` transform="${transform}"/>`)
+    : FIXTURES[tag];
+  const doc = new SvgDocument(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">${el}</svg>`
+  );
+  return { doc, id: first_tag(doc, tag) };
+}
+
+function attr_map(doc: SvgDocument, id: string): Map<string, string> {
+  return new Map(doc.attributes_of(id).map((a) => [a.name, a.value]));
+}
+
+/** Names added, removed, or value-changed between two snapshots. */
+function changed_attrs(
+  before: Map<string, string>,
+  after: Map<string, string>
+): string[] {
+  const names = new Set([...before.keys(), ...after.keys()]);
+  return [...names].filter((n) => before.get(n) !== after.get(n));
+}
+
+function raw_names(
+  baseline: ReturnType<typeof resize_pipeline.intent.capture_baseline>
+): Set<string> {
+  return new Set(baseline.raw.map((a) => a.name));
+}
+
+describe("RESIZE_WRITE_ATTRS table completeness", () => {
+  it("covers exactly the is_resizable tag set", () => {
+    for (const tag of Object.keys(RESIZE_WRITE_ATTRS)) {
+      expect(resize_pipeline.intent.is_resizable(tag)).toBe(true);
+    }
+    for (const tag of Object.keys(FIXTURES)) {
+      expect(RESIZE_WRITE_ATTRS[tag]).toBeDefined();
+    }
+  });
+});
+
+describe("resize-commit writes ⊆ baseline.raw", () => {
+  for (const tag of Object.keys(FIXTURES)) {
+    it(`${tag}`, () => {
+      const { doc, id } = make_doc(tag);
+      const baseline = resize_pipeline.intent.capture_baseline(doc, id, BBOX);
+      const before = attr_map(doc, id);
+      resize_pipeline.intent.apply(
+        doc,
+        id,
+        baseline,
+        2,
+        3,
+        { x: 0, y: 0 },
+        "commit"
+      );
+      const written = changed_attrs(before, attr_map(doc, id));
+      expect(written.length).toBeGreaterThan(0);
+      const covered = raw_names(baseline);
+      for (const name of written) expect(covered).toContain(name);
+    });
+  }
+
+  it("rotated rect (explicit pivot): pivot renormalization's transform write is covered", () => {
+    const { doc, id } = make_doc("rect", "rotate(30 60 45)");
+    const baseline = resize_pipeline.intent.capture_baseline(doc, id, BBOX);
+    const before = attr_map(doc, id);
+    resize_pipeline.intent.apply(
+      doc,
+      id,
+      baseline,
+      2,
+      3,
+      { x: 0, y: 0 },
+      "commit"
+    );
+    const written = changed_attrs(before, attr_map(doc, id));
+    expect(written).toContain("transform");
+    const covered = raw_names(baseline);
+    for (const name of written) expect(covered).toContain(name);
+  });
+});
+
+// editor.ts `commit_resize` reverts the WHOLE step (scale + group
+// translate) through resize's snapshot alone — so translate's write
+// surface must also be covered, for plain and transform-positioned
+// elements alike.
+describe("translate writes ⊆ baseline.raw (commit_resize group-translate arm)", () => {
+  for (const tag of Object.keys(FIXTURES)) {
+    it(`${tag}`, () => {
+      const { doc, id } = make_doc(tag);
+      const baseline = resize_pipeline.intent.capture_baseline(doc, id, BBOX);
+      const before = attr_map(doc, id);
+      const tb = translate_pipeline.intent.capture_baseline(doc, id);
+      translate_pipeline.intent.apply(doc, id, tb, 7, 11);
+      const written = changed_attrs(before, attr_map(doc, id));
+      expect(written.length).toBeGreaterThan(0);
+      const covered = raw_names(baseline);
+      for (const name of written) expect(covered).toContain(name);
+    });
+  }
+
+  it("transformed rect: viaTransform's transform write is covered", () => {
+    const { doc, id } = make_doc("rect", "translate(3 4)");
+    const baseline = resize_pipeline.intent.capture_baseline(doc, id, BBOX);
+    const before = attr_map(doc, id);
+    const tb = translate_pipeline.intent.capture_baseline(doc, id);
+    translate_pipeline.intent.apply(doc, id, tb, 7, 11);
+    const written = changed_attrs(before, attr_map(doc, id));
+    expect(written).toContain("transform");
+    const covered = raw_names(baseline);
+    for (const name of written) expect(covered).toContain(name);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/resize-snapshot-coverage.test.ts
+++ b/packages/grida-svg-editor/__tests__/resize-snapshot-coverage.test.ts
@@ -70,8 +70,11 @@ function raw_names(
 
 describe("RESIZE_WRITE_ATTRS table completeness", () => {
   it("covers exactly the is_resizable tag set", () => {
+    // Bidirectional: a table entry without a fixture would silently
+    // skip that tag's per-tag coverage cases below, and vice versa.
     for (const tag of Object.keys(RESIZE_WRITE_ATTRS)) {
       expect(resize_pipeline.intent.is_resizable(tag)).toBe(true);
+      expect(FIXTURES[tag]).toBeDefined();
     }
     for (const tag of Object.keys(FIXTURES)) {
       expect(RESIZE_WRITE_ATTRS[tag]).toBeDefined();

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.17",
+  "version": "1.0.0-alpha.18",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -1098,7 +1098,6 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   type ResizeMember = {
     id: NodeId;
     rz: ResizeBaseline;
-    transform_pre: string | null;
     bbox: { x: number; y: number; width: number; height: number };
   };
 
@@ -1142,7 +1141,6 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       members.push({
         id,
         rz: resize_pipeline.intent.capture_baseline(doc, id, bbox),
-        transform_pre: doc.get_attr(id, "transform"),
         bbox,
       });
     }
@@ -1207,12 +1205,13 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       emit();
     };
     const revert = () => {
-      for (const { m, origin } of ops) {
-        // apply_resize at sx=sy=1 writes attrs back to baseline regardless of
-        // origin; transform is restored directly (apply_translate.viaTransform
-        // may have rewritten it during apply; apply_resize never touches it).
-        resize_pipeline.intent.apply(doc, m.id, m.rz, 1, 1, origin);
-        doc.set_attr(m.id, "transform", m.transform_pre);
+      for (const { m } of ops) {
+        // Byte-exact snapshot restore — covers every attr the apply step
+        // can write (per-tag geometry, plus `transform` rewritten by
+        // apply_translate.viaTransform / pivot renormalization). NOT
+        // apply at sx=sy=1: handlers may refuse gesture shapes (text
+        // refuses non-corner input) and would silently skip the restore.
+        resize_pipeline.intent.restore(doc, m.id, m.rz);
       }
       emit();
     };

--- a/packages/grida-svg-editor/src/core/policy-class/handlers/resize.ts
+++ b/packages/grida-svg-editor/src/core/policy-class/handlers/resize.ts
@@ -54,6 +54,30 @@ function scale_path_d(
   }
 }
 
+/**
+ * `dispatch_resize`'s write surface as data: the attribute names each
+ * handler may write, by tag. Capture-side snapshots (the resize
+ * pipeline's `baseline.raw`) are built from this list so revert can
+ * restore exactly what a handler may touch — when a handler starts
+ * writing a new attribute, extend this table or undo will silently
+ * miss it. Cross-checked against the live handlers by
+ * `__tests__/resize-snapshot-coverage.test.ts`.
+ */
+export const RESIZE_WRITE_ATTRS: Readonly<
+  Record<string, ReadonlyArray<string>>
+> = {
+  rect: ["x", "y", "width", "height"],
+  image: ["x", "y", "width", "height"],
+  use: ["x", "y", "width", "height"],
+  circle: ["cx", "cy", "r"],
+  ellipse: ["cx", "cy", "rx", "ry"],
+  line: ["x1", "y1", "x2", "y2"],
+  polyline: ["points"],
+  polygon: ["points"],
+  path: ["d"],
+  text: ["x", "y", "font-size"],
+};
+
 // ─── Per-class handlers ─────────────────────────────────────────────────────
 
 /**

--- a/packages/grida-svg-editor/src/core/resize-pipeline/resize-pipeline.ts
+++ b/packages/grida-svg-editor/src/core/resize-pipeline/resize-pipeline.ts
@@ -28,7 +28,10 @@ import type { NodeId, Rect } from "../../types";
 import type { SvgDocument } from "../document";
 import { hit_shape_svg } from "../hit-shape-svg";
 import { transform, type TransformOp } from "../transform";
-import { dispatch_resize } from "../policy-class/handlers/resize";
+import {
+  dispatch_resize,
+  RESIZE_WRITE_ATTRS,
+} from "../policy-class/handlers/resize";
 import { resize_capability } from "../resize-capability";
 import type { SnapSession } from "../snap";
 
@@ -49,9 +52,21 @@ export type ResizeAttrs =
   | { kind: "text"; x: number; y: number; fontSize: number }
   | { kind: "unsupported" };
 
+/** Exact pre-gesture attribute strings — one entry per attribute a
+ *  resize may write on the captured tag (per-tag geometry set plus
+ *  `transform`, which commit-phase pivot renormalization rewrites).
+ *  `null` = the attribute was absent. `intent.restore` writes these
+ *  back verbatim so revert is byte-exact and independent of handler
+ *  gesture semantics. */
+export type ResizeRawAttrs = ReadonlyArray<{
+  readonly name: string;
+  readonly value: string | null;
+}>;
+
 export type ResizeBaseline = {
   bbox: Rect;
   attrs: ResizeAttrs;
+  raw: ResizeRawAttrs;
 };
 
 /** Input to the pipeline. `dx` / `dy` are in **world space** (root-SVG
@@ -131,6 +146,16 @@ export namespace resize_pipeline {
       fallback = 0
     ): number {
       return svg_parse.parse_number(doc.get_attr(id, name), fallback);
+    }
+
+    /** Attribute names a resize gesture may write for `tag`: the
+     *  handler write surface (`RESIZE_WRITE_ATTRS`, owned next to the
+     *  handlers) plus `transform` — the pipeline's own write
+     *  (commit-phase `renormalize_rotate_pivot`). Drives the
+     *  `baseline.raw` snapshot that `restore` writes back. */
+    function writable_attrs(tag: string): ReadonlyArray<string> {
+      const handler_writes = RESIZE_WRITE_ATTRS[tag];
+      return handler_writes ? [...handler_writes, "transform"] : [];
     }
 
     export function is_resizable(tag: string): boolean {
@@ -238,7 +263,30 @@ export namespace resize_pipeline {
         default:
           attrs = { kind: "unsupported" };
       }
-      return { bbox, attrs };
+      const raw = writable_attrs(tag).map((name) => ({
+        name,
+        value: doc.get_attr(id, name),
+      }));
+      return { bbox, attrs, raw };
+    }
+
+    /**
+     * Restore an element to its exact pre-gesture state by writing the
+     * `baseline.raw` snapshot back verbatim (`null` removes the attr).
+     *
+     * Deliberately NOT `apply(..., 1, 1, ...)`: handlers may refuse
+     * gesture shapes (text refuses non-corner input), so an identity
+     * re-application routes the restore through those refusal arms and
+     * silently no-ops — nor can any identity-scale write recover the
+     * commit-phase `transform` rewrite. Mirrors
+     * `translate_pipeline.intent.revert`'s exact-attr restore.
+     */
+    export function restore(
+      doc: SvgDocument,
+      id: NodeId,
+      baseline: ResizeBaseline
+    ): void {
+      for (const a of baseline.raw) doc.set_attr(id, a.name, a.value);
     }
 
     export function compute_factors(
@@ -826,18 +874,9 @@ export namespace resize_pipeline {
   }
 
   export function revert(doc: SvgDocument, plan: ResizePlan): void {
-    const f = intent.compute_factors(
-      plan.baseline,
-      plan.direction,
-      0,
-      0,
-      false
-    );
     const members = plan.members ?? [{ id: plan.id, baseline: plan.baseline }];
     for (const m of members) {
-      // "preview" — revert restores baseline geometry; the transform
-      // was never touched during preview, so no recomposition is owed.
-      intent.apply(doc, m.id, m.baseline, 1, 1, f.origin, "preview");
+      intent.restore(doc, m.id, m.baseline);
     }
   }
 
@@ -872,6 +911,10 @@ export namespace resize_pipeline {
         w: union.width,
         h: union.height,
       },
+      // Math carrier only — never bound to a real node, so there is
+      // nothing to snapshot or restore. `apply`/`revert` always run
+      // against each member's own captured baseline.
+      raw: [],
     };
   }
 }

--- a/test/svg-editor-resize-undo.md
+++ b/test/svg-editor-resize-undo.md
@@ -1,0 +1,78 @@
+---
+id: TC-SVGEDITOR-RESIZE-001
+title: HUD resize of text is undone by Cmd+Z and rolled back by Escape
+module: svg-editor
+area: resize
+tags: [resize, hud, text, history, undo]
+status: untested
+severity: high
+date: 2026-06-12
+updated: 2026-06-12
+automatable: true
+covered_by:
+  - packages/grida-svg-editor/__tests__/resize-revert-restore.test.ts
+  - packages/grida-svg-editor/__tests__/resize-snapshot-coverage.test.ts
+---
+
+## Behavior
+
+A committed HUD resize is one undoable history step for **every**
+resizable tag, including `<text>`. Undo must restore the exact
+pre-gesture attribute state — byte-exact strings, and **absence**: if
+the element had no `font-size` attribute before the gesture, undo
+removes the one the gesture wrote rather than leaving a fabricated
+`font-size="16"` behind.
+
+The invariant under test is the revert contract, not the gesture: the
+resize history delta reverts by restoring a raw attribute snapshot
+captured at gesture open (`resize_pipeline.intent.restore`), never by
+re-applying the gesture at identity scale. Per-tag handlers are
+allowed to _refuse_ gesture shapes (text refuses edge drags; a corner
+drag scales `x`/`y`/`font-size` uniformly), and a refusal arm must not
+be able to swallow a revert. The historical bug: revert ran the text
+handler with `sx = sy = 1`, which the handler classified as a refused
+non-corner gesture — so Cmd+Z popped the history entry while the
+document silently kept the resized values. The same revert backs
+Escape-cancel and the `resize_to`/`resize_by` RPC path, and also
+restores `transform` (commit-phase rotate-pivot renormalization), so
+all of those are exercised here.
+
+## Steps
+
+Open the SVG editor demo at `http://localhost:3000/svg/` (or
+`/svg/examples/default`). Insert or pick a `<text>` element.
+
+1. **Corner resize → undo.** Select the text, drag the SE corner
+   handle outward until the text visibly grows, release.
+   - Expected: text stays at the new size; one history entry exists.
+   - Press `Cmd/Ctrl+Z`. Expected: the text returns to its exact
+     pre-drag position and size (inspect `x`, `y`, `font-size` in the
+     inspector / serialized SVG).
+   - Press `Cmd/Ctrl+Shift+Z` (redo). Expected: the resized state
+     returns.
+
+2. **Escape-cancel.** Select the text, start dragging the SE corner
+   handle, and press `Escape` while the pointer is still down.
+   - Expected: the text snaps back to its pre-drag size immediately;
+     no history entry is left (Cmd+Z does not change the text).
+
+3. **Absence restored.** Use a text element with no `font-size`
+   attribute (size inherited from CSS). Corner-resize it, then undo.
+   - Expected: the serialized element has **no** `font-size`
+     attribute after undo — its rendered size returns to the
+     inherited value.
+
+4. **Rotated element.** Give a `<rect>` an explicit-pivot rotation
+   (`transform="rotate(30 60 35)"`), corner-resize it, undo.
+   - Expected: the `transform` string is restored byte-exact and the
+     rect renders exactly as before the drag.
+
+## Notes
+
+Etiology and fix: revert previously routed through
+`intent.apply(..., 1, 1, ...)` in two places —
+`resize_pipeline.revert` (HUD gesture) and the `commit_resize` revert
+in `core/editor.ts` (`resize_to` / `resize_by`) — both now restore the
+raw snapshot. The unit suite in `covered_by` drives the orchestrator
+with the same wiring as the DOM adapter; this TC verifies the real
+pointer → HUD → keymap chain on top.


### PR DESCRIPTION
## Problem

Resizing a `<text>` via the HUD corner handles committed a history entry that **cmd+z could not undo** — the entry popped off the stack but the document silently kept the resized values.

## Etiology

Resize revert was encoded as *re-applying the gesture at identity scale* (`intent.apply(..., 1, 1, ...)`) through the Policy Class handlers. Handlers are allowed to **refuse** gesture shapes — and `resize_text`'s non-corner refusal arm (`sx !== 1 && sy !== 1`) classifies the identity input as a refused edge drag, so the revert no-ops. The implicit contract "every handler is identity-restoring at scale 1" was unstated and already violated by the one handler with a refusal arm.

Same root defect, three more presentations (all confirmed by failing tests before the fix):

- **Escape-cancel** mid-gesture left the text resized (`Preview.discard` → same revert)
- **`resize_to` / `resize_by`** (inspector / keyboard) had a second copy of the bad revert in `core/editor.ts`
- **Rotated elements** (latent): commit-phase pivot renormalization rewrites `transform`, which no identity-scale write can recover — undo restored the geometry but kept the recomposed pivot

## Fix

`ResizeBaseline` now carries a **raw attribute snapshot** — exact pre-gesture strings (`null` = absent) for every attribute resize can write on that tag, plus `transform` — captured at the single chokepoint `capture_baseline`. A new `intent.restore` writes it back verbatim; both revert sites use it. The sibling translate pipeline already established this doctrine for `<tspan>` ("revert restores the exact original attribute strings, including removal when absent"); resize now follows it.

Properties the old path could never have:

- **Refusal-immune** — handlers stay free to refuse gesture shapes; revert no longer routes through them
- **Byte-exact** — `transform="rotate(30 60 35)"` round-trips verbatim (P1-friendly)
- **Absence-preserving** — undo *removes* a `font-size` the gesture fabricated on a text that inherited its size, instead of stamping the 16px fallback

## Keeping it from drifting

The per-tag write surface lives as data (`RESIZE_WRITE_ATTRS`) colocated with the handlers that own the writes, and `resize-snapshot-coverage.test.ts` cross-checks it against the **live** write paths: it diffs real documents before/after `dispatch_resize` (commit phase, incl. pivot renormalization) and `translate_pipeline.intent.apply` (the `commit_resize` group-translate arm), asserting every written attribute is covered by the snapshot. A handler that starts writing a new attribute fails CI instead of shipping broken undo.

## Tests

- `resize-revert-restore.test.ts` — 7 regression tests driving `ResizeOrchestrator` with the DOM adapter's exact wiring: text undo/redo, Escape-cancel, absent-attr removal, rotated-pivot byte-exact restore, the RPC path, rect contrast
- `resize-snapshot-coverage.test.ts` — 23 cross-check tests (see above)
- `test/svg-editor-resize-undo.md` — manual TC (`TC-SVGEDITOR-RESIZE-001`) for the real pointer → HUD → keymap chain
- Full package gate: 1301 node tests + 25 browser tests pass, typecheck and oxlint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Undo/restore now performs byte-exact attribute restoration, including correct removal of originally-missing attributes and preserving exact transforms.
  * Cancel/Escape during resize reliably rolls back preview without leaving history.

* **New Features**
  * Resize now records exact pre-change attribute strings for precise restores.
  * Added an explicit list of attributes the resize logic may write to ensure coverage.

* **Tests**
  * New regression and snapshot-coverage suites for resize undo/redo, cancel, and rotated-element cases.

* **Documentation**
  * Added end-to-end test specification for resize undo behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->