### PR TITLE
feat(number-input): make @grida/number-input public with demo page

### DIFF
--- a/.agents/skills/seo/SKILL.md
+++ b/.agents/skills/seo/SKILL.md
@@ -83,6 +83,11 @@ Public pages belong in `editor/app/sitemap.ts`.
 - Use `priority: 1` only for the homepage.
 - Match `changeFrequency` to actual update cadence.
 - When adding a new public page, always add a sitemap entry.
+- Sitemaps are split per route group (root, `/packages`, `/library`, …). A
+  new `sitemap.ts` is invisible to crawlers until it's added as a `Sitemap:`
+  line in `editor/app/robots.txt` — non-root sitemaps are not auto-discovered.
+- Prefer deriving sitemap entries from the page's data source (see
+  `packages/sitemap.ts`) over hand-maintained URL lists, which drift.
 
 ### Google Image Search
 

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/layout.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/layout.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+const canonical = "https://grida.co/packages/@grida/number-input";
+const title = "@grida/number-input — Headless React hooks for number inputs";
+// Under Google's 160-char snippet cap.
+const description =
+  "Headless React hooks for editor-grade number inputs — step precision, commit safety, mixed values, unit suffixes, scrub gestures, snapping sliders, hex color.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://grida.co"),
+  title,
+  description,
+  keywords: [
+    "number input",
+    "react hooks",
+    "headless",
+    "scrubbing",
+    "pointer lock",
+    "slider",
+    "hex color input",
+    "design tool",
+    "Grida",
+    "@grida/number-input",
+  ],
+  alternates: { canonical },
+  openGraph: {
+    title,
+    description:
+      "The input behaviors of the Grida editor's properties panel, extracted as hooks — typed parsing, commit/change separation, mixed-value state, drag-to-scrub labels with pointer lock, mark-snapping sliders, and per-channel hex color editing.",
+    url: canonical,
+    siteName: "Grida",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    site: "@grida_co",
+    creator: "@grida_co",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  name: "@grida/number-input",
+  description,
+  url: canonical,
+  codeRepository:
+    "https://github.com/gridaco/grida/tree/main/packages/grida-number-input",
+  programmingLanguage: ["TypeScript", "JavaScript"],
+  runtimePlatform: ["Browser"],
+  license: "https://opensource.org/licenses/MIT",
+  keywords:
+    "number input, react hooks, headless, scrubbing, pointer lock, slider, hex color input, design tool",
+  author: { "@type": "Organization", name: "Grida", url: "https://grida.co" },
+  isPartOf: {
+    "@type": "SoftwareApplication",
+    name: "Grida",
+    url: "https://grida.co",
+  },
+};
+
+export default function NumberInputPackageLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD payload.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      {children}
+    </>
+  );
+}

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/page.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import React from "react";
+import {
+  useNumberInput,
+  useNumberGesture,
+  useSliderValue,
+  useHexValueInput,
+  type NumberChange,
+  type RGB,
+} from "@grida/number-input/react";
+import { Slider } from "@app/ui/components/slider";
+import { Button } from "@app/ui/components/button";
+import { CopyToClipboardInput } from "@/components/copy-to-clipboard-input";
+import { NpmLogo } from "@grida/react-icons/logos";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon } from "lucide-react";
+import Footer from "@/www/footer";
+import Header from "@/www/header";
+import Link from "next/link";
+
+const NPM_URL = "https://www.npmjs.com/package/@grida/number-input";
+const GITHUB_URL =
+  "https://github.com/gridaco/grida/tree/main/packages/grida-number-input";
+
+// Related demos — where these hooks ship in product, and the package index.
+const RELATED: { href: string; label: string }[] = [
+  { href: "/canvas", label: "Canvas playground" },
+  { href: "/packages", label: "All packages" },
+];
+
+/**
+ * Demo card — prose outside, interaction inside.
+ *
+ * Title and hint sit above the boundary; the bordered frame holds only the
+ * live control (Stage) and its state readout (Output). Same separation as
+ * the svg-editor SpecCard / tree-view ComponentDemo pattern.
+ */
+function DemoCard({
+  title,
+  hint,
+  bullets,
+  children,
+}: React.PropsWithChildren<{
+  title: string;
+  hint: React.ReactNode;
+  bullets?: React.ReactNode[];
+}>) {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1.5">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p className="text-sm text-muted-foreground max-w-2xl">{hint}</p>
+        {bullets && (
+          <ul className="text-sm text-muted-foreground max-w-2xl list-disc pl-5 space-y-1">
+            {bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="overflow-hidden rounded-lg border">{children}</div>
+    </section>
+  );
+}
+
+function Stage({ children }: React.PropsWithChildren) {
+  return (
+    <div className="flex min-h-36 flex-col items-center justify-center gap-4 bg-muted/30 px-8 py-10">
+      {children}
+    </div>
+  );
+}
+
+function Output({ children }: React.PropsWithChildren) {
+  return (
+    <div className="border-t bg-background px-4 py-2 font-mono text-xs text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+const inputClassName =
+  "w-32 px-2 py-1 text-sm border rounded-md bg-background font-mono focus:outline-none focus:ring-1 focus:ring-ring";
+
+function BasicNumberDemo() {
+  const [committed, setCommitted] = React.useState(24);
+  const input = useNumberInput({
+    value: committed,
+    step: 1,
+    mode: "fixed",
+    onValueCommit: (value: NumberChange | number) =>
+      setCommitted(value as number),
+  });
+
+  return (
+    <>
+      <Stage>
+        <input
+          ref={input.inputRef}
+          type={input.inputType}
+          className={inputClassName}
+          value={input.internalValue}
+          onChange={input.handleChange}
+          onKeyDown={input.handleKeyDown}
+          onFocus={input.handleFocus}
+          onBlur={input.handleBlur}
+        />
+      </Stage>
+      <Output>committed: {committed}</Output>
+    </>
+  );
+}
+
+function PercentageDemo() {
+  // Stored as 0–1, displayed as 0–100%.
+  const [opacity, setOpacity] = React.useState(0.5);
+  const input = useNumberInput({
+    value: opacity,
+    suffix: "%",
+    scale: 100,
+    step: 0.01,
+    min: 0,
+    max: 1,
+    mode: "fixed",
+    onValueCommit: (value: NumberChange | number) =>
+      setOpacity(value as number),
+  });
+
+  return (
+    <>
+      <Stage>
+        <input
+          ref={input.inputRef}
+          type={input.inputType}
+          className={inputClassName}
+          value={input.internalValue}
+          onChange={input.handleChange}
+          onKeyDown={input.handleKeyDown}
+          onFocus={input.handleFocus}
+          onBlur={input.handleBlur}
+        />
+      </Stage>
+      <Output>stored: {opacity.toFixed(2)}</Output>
+    </>
+  );
+}
+
+function MixedDemo() {
+  const [widths, setWidths] = React.useState<[number, number]>([80, 160]);
+  const mixed = widths[0] !== widths[1];
+  const input = useNumberInput({
+    value: mixed ? "mixed" : widths[0],
+    step: 1,
+    min: 8,
+    max: 240,
+    onValueCommit: (change: NumberChange | number) => {
+      const c = change as NumberChange;
+      if (c.type === "set") setWidths([c.value, c.value]);
+    },
+  });
+
+  return (
+    <>
+      <Stage>
+        <div className="flex items-center gap-3">
+          <input
+            ref={input.inputRef}
+            type={input.inputType}
+            className={inputClassName}
+            value={input.internalValue}
+            onChange={input.handleChange}
+            onKeyDown={input.handleKeyDown}
+            onFocus={input.handleFocus}
+            onBlur={input.handleBlur}
+          />
+          <button
+            type="button"
+            className="text-xs text-muted-foreground underline underline-offset-2"
+            onClick={() => setWidths([80, 160])}
+          >
+            reset
+          </button>
+        </div>
+        <div className="w-64 space-y-2">
+          {widths.map((w, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <div
+                className="h-4 rounded-sm bg-foreground/20"
+                style={{ width: w }}
+              />
+              <span className="text-xs text-muted-foreground font-mono">
+                {w}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Stage>
+      <Output>
+        widths: {widths[0]} · {widths[1]}
+        {mixed ? " — mixed" : ""}
+      </Output>
+    </>
+  );
+}
+
+function ScrubDemo() {
+  const [value, setValue] = React.useState(120);
+  const { bind } = useNumberGesture({
+    mode: "auto",
+    step: 1,
+    sensitivity: 1,
+    axisForValue: "x",
+    onValueChange: (change) => {
+      const c = change as NumberChange;
+      if (c.type === "delta") {
+        setValue((prev) => Math.max(0, Math.min(256, prev + c.value)));
+      }
+    },
+  });
+
+  return (
+    <>
+      <Stage>
+        <div className="flex items-center gap-2">
+          <span
+            {...bind()}
+            className="px-2 py-1 text-sm font-mono border rounded-md bg-background cursor-ew-resize select-none touch-none"
+          >
+            W
+          </span>
+          <span className="text-sm font-mono w-12">{value}</span>
+        </div>
+        <div className="w-64">
+          <div
+            className="h-4 rounded-sm bg-foreground/20"
+            style={{ width: value }}
+          />
+        </div>
+      </Stage>
+      <Output>value: {value}</Output>
+    </>
+  );
+}
+
+function SliderDemo() {
+  const marks = [0, 25, 50, 75, 100];
+  const slider = useSliderValue({
+    min: 0,
+    max: 100,
+    step: 1,
+    marks,
+    defaultValue: 40,
+  });
+
+  return (
+    <>
+      <Stage>
+        <div className="w-64 space-y-2">
+          <Slider
+            min={0}
+            max={100}
+            value={slider.value}
+            onValueChange={slider.onValueChange}
+            onValueCommit={slider.onValueCommit}
+          />
+          <div className="relative h-2">
+            {marks.map((mark) => (
+              <span
+                key={mark}
+                className="absolute size-1 rounded-full bg-foreground/30 -translate-x-1/2"
+                style={{ left: `${mark}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      </Stage>
+      <Output>
+        value: {slider.value[0]}
+        {slider.isSnapped ? " — snapped" : ""}
+      </Output>
+    </>
+  );
+}
+
+// Intentionally local — the package's rgbToHex/hexToRgb are not a committed
+// public surface, so the demo must not depend on them.
+const toHexColor = (c: RGB) =>
+  `#${[c.r, c.g, c.b].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+
+const fromHexColor = (hex: string): RGB => ({
+  r: parseInt(hex.slice(1, 3), 16),
+  g: parseInt(hex.slice(3, 5), 16),
+  b: parseInt(hex.slice(5, 7), 16),
+});
+
+function HexDemo() {
+  const [color, setColor] = React.useState<RGB>({ r: 255, g: 128, b: 64 });
+  const input = useHexValueInput({
+    value: color,
+    onValueCommit: (rgb) => setColor(rgb),
+  });
+
+  return (
+    <>
+      <Stage>
+        <div className="flex items-center gap-2">
+          {/* The swatch is a native color input — picking syncs back into the hex field. */}
+          <input
+            type="color"
+            aria-label="Pick color"
+            value={toHexColor(color)}
+            onChange={(e) => setColor(fromHexColor(e.target.value))}
+            className="size-7 cursor-pointer appearance-none rounded-md border bg-transparent p-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-[5px] [&::-webkit-color-swatch]:border-none"
+          />
+          <div className="flex items-center border rounded-md bg-background px-2 py-1">
+            <span className="text-sm font-mono text-muted-foreground">#</span>
+            <input
+              {...input}
+              className="w-20 text-sm font-mono bg-transparent focus:outline-none"
+              spellCheck={false}
+            />
+          </div>
+        </div>
+      </Stage>
+      <Output>
+        rgb({color.r}, {color.g}, {color.b})
+      </Output>
+    </>
+  );
+}
+
+export default function NumberInputPackagePage() {
+  return (
+    <main className="min-h-screen">
+      <Header className="relative" />
+
+      {/* Hero */}
+      <section className="container mx-auto px-4 pt-32 pb-12">
+        <div className="max-w-3xl mx-auto text-center space-y-6">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-zinc-200 bg-zinc-50 text-xs font-medium text-zinc-600">
+            <span className="size-1.5 rounded-full bg-amber-500" />
+            v0 · ESM + CJS · MIT
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold tracking-tight font-mono">
+            @grida/number-input
+          </h1>
+          <p className="text-lg text-muted-foreground leading-relaxed">
+            Headless React hooks for editor-grade number inputs — the input
+            behaviors of the Grida editor&apos;s properties panel, extracted as
+            a package. Typed parsing, step precision, commit safety, mixed-value
+            state, scrub gestures, snapping sliders, and hex color input.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Link href={NPM_URL} target="_blank" rel="noopener noreferrer">
+              <Button size="lg" variant="outline">
+                <NpmLogo className="size-8 mr-1" />
+                npm
+              </Button>
+            </Link>
+            <Link href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+              <Button size="lg" variant="outline">
+                <GitHubLogoIcon className="size-4 mr-2" />
+                GitHub
+              </Button>
+            </Link>
+          </div>
+          <div className="pt-2 max-w-sm mx-auto">
+            <CopyToClipboardInput value="pnpm add @grida/number-input" />
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm">
+            {RELATED.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {label}
+                <ArrowRightIcon className="size-3" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Demos */}
+      <div className="container mx-auto max-w-2xl px-4 pb-24 space-y-12">
+        <DemoCard
+          title="Number input"
+          hint={
+            <>
+              Type a value — <kbd>↑</kbd>/<kbd>↓</kbd> steps, <kbd>Shift</kbd>{" "}
+              for ×10, <kbd>Enter</kbd> or blur commits. Invalid input never
+              commits.
+            </>
+          }
+        >
+          <BasicNumberDemo />
+        </DemoCard>
+
+        <DemoCard
+          title="Suffix + display scale"
+          hint={
+            <>
+              Stored as 0–1, displayed as a percentage. Type <code>50</code> or{" "}
+              <code>50%</code> — the commit is <code>0.5</code>.
+            </>
+          }
+        >
+          <PercentageDemo />
+        </DemoCard>
+
+        <DemoCard
+          title="Mixed value (multi-selection)"
+          hint={
+            <>
+              Two objects with different widths show as <code>mixed</code> — the
+              multi-selection state in a properties panel. Commit a number to
+              set both.
+            </>
+          }
+        >
+          <MixedDemo />
+        </DemoCard>
+
+        <DemoCard
+          title="Scrub label (virtual slider)"
+          hint={
+            <>
+              Drag the <code>W</code> label horizontally to change the value —
+              pointer lock keeps the drag going past screen edges.
+            </>
+          }
+        >
+          <ScrubDemo />
+        </DemoCard>
+
+        <DemoCard
+          title="Slider with mark snapping"
+          hint="Drag near a mark (0, 25, 50, 75, 100) and the value snaps to it."
+        >
+          <SliderDemo />
+        </DemoCard>
+
+        <DemoCard
+          title="Hex color input"
+          hint={
+            <>
+              Place the caret on a channel and press <kbd>↑</kbd>/<kbd>↓</kbd>{" "}
+              to step it. Or click the swatch to pick with the native color
+              picker.
+            </>
+          }
+          bullets={[
+            <>
+              Fuzzy expansion — <code>8</code> → <code>888888</code>,{" "}
+              <code>F80</code> → <code>FF8800</code>; the first hex run is
+              extracted, <code>#</code> and stray characters are ignored.
+            </>,
+            <>
+              Alpha extraction — 4-digit (<code>RGBA</code>) and 8-digit (
+              <code>RRGGBBAA</code>) input commit the RGB plus a separate 0–1
+              opacity.
+            </>,
+            <>
+              Channel-aware stepping — a selection spanning channels steps them
+              together, and the selection is restored after each step.
+            </>,
+            <>
+              <kbd>Shift</kbd> for coarse steps; works in <code>u8</code>{" "}
+              (0–255) or <code>f32</code> (0–1) channel units.
+            </>,
+            <>
+              Free typing while focused — invalid input reverts to the last
+              valid color on commit.
+            </>,
+          ]}
+        >
+          <HexDemo />
+        </DemoCard>
+      </div>
+
+      <Footer />
+    </main>
+  );
+}

--- a/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/page.tsx
+++ b/editor/app/(tools)/(packages)/packages/[%40grida]/number-input/page.tsx
@@ -99,6 +99,7 @@ function BasicNumberDemo() {
         <input
           ref={input.inputRef}
           type={input.inputType}
+          aria-label="Value"
           className={inputClassName}
           value={input.internalValue}
           onChange={input.handleChange}
@@ -133,6 +134,7 @@ function PercentageDemo() {
         <input
           ref={input.inputRef}
           type={input.inputType}
+          aria-label="Opacity"
           className={inputClassName}
           value={input.internalValue}
           onChange={input.handleChange}
@@ -167,6 +169,7 @@ function MixedDemo() {
           <input
             ref={input.inputRef}
             type={input.inputType}
+            aria-label="Width"
             className={inputClassName}
             value={input.internalValue}
             onChange={input.handleChange}
@@ -204,8 +207,13 @@ function MixedDemo() {
   );
 }
 
+const SCRUB_MAX = 256;
+
 function ScrubDemo() {
   const [value, setValue] = React.useState(120);
+  const adjust = React.useCallback((delta: number) => {
+    setValue((prev) => Math.max(0, Math.min(SCRUB_MAX, prev + delta)));
+  }, []);
   const { bind } = useNumberGesture({
     mode: "auto",
     step: 1,
@@ -213,11 +221,20 @@ function ScrubDemo() {
     axisForValue: "x",
     onValueChange: (change) => {
       const c = change as NumberChange;
-      if (c.type === "delta") {
-        setValue((prev) => Math.max(0, Math.min(256, prev + c.value)));
-      }
+      if (c.type === "delta") adjust(c.value);
     },
   });
+
+  // Keyboard equivalent of the pointer scrub, so the control is not pointer-only.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const step = e.shiftKey ? 10 : 1;
+    if (e.key === "ArrowLeft" || e.key === "ArrowDown") adjust(-step);
+    else if (e.key === "ArrowRight" || e.key === "ArrowUp") adjust(step);
+    else if (e.key === "Home") setValue(0);
+    else if (e.key === "End") setValue(SCRUB_MAX);
+    else return;
+    e.preventDefault();
+  };
 
   return (
     <>
@@ -225,7 +242,14 @@ function ScrubDemo() {
         <div className="flex items-center gap-2">
           <span
             {...bind()}
-            className="px-2 py-1 text-sm font-mono border rounded-md bg-background cursor-ew-resize select-none touch-none"
+            role="slider"
+            tabIndex={0}
+            aria-label="Width"
+            aria-valuemin={0}
+            aria-valuemax={SCRUB_MAX}
+            aria-valuenow={value}
+            onKeyDown={handleKeyDown}
+            className="px-2 py-1 text-sm font-mono border rounded-md bg-background cursor-ew-resize select-none touch-none focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             W
           </span>
@@ -296,9 +320,14 @@ const fromHexColor = (hex: string): RGB => ({
 
 function HexDemo() {
   const [color, setColor] = React.useState<RGB>({ r: 255, g: 128, b: 64 });
+  // Set only when the committed input carried alpha (4- or 8-digit hex).
+  const [alpha, setAlpha] = React.useState<number | undefined>(undefined);
   const input = useHexValueInput({
     value: color,
-    onValueCommit: (rgb) => setColor(rgb),
+    onValueCommit: (rgb, opacity) => {
+      setColor(rgb);
+      setAlpha(opacity);
+    },
   });
 
   return (
@@ -317,6 +346,7 @@ function HexDemo() {
             <span className="text-sm font-mono text-muted-foreground">#</span>
             <input
               {...input}
+              aria-label="Hex color"
               className="w-20 text-sm font-mono bg-transparent focus:outline-none"
               spellCheck={false}
             />
@@ -325,6 +355,7 @@ function HexDemo() {
       </Stage>
       <Output>
         rgb({color.r}, {color.g}, {color.b})
+        {alpha !== undefined && ` · alpha ${alpha.toFixed(2)}`}
       </Output>
     </>
   );
@@ -462,15 +493,15 @@ export default function NumberInputPackagePage() {
             <>
               Alpha extraction — 4-digit (<code>RGBA</code>) and 8-digit (
               <code>RRGGBBAA</code>) input commit the RGB plus a separate 0–1
-              opacity.
+              opacity, shown in the readout when present.
             </>,
             <>
               Channel-aware stepping — a selection spanning channels steps them
               together, and the selection is restored after each step.
             </>,
             <>
-              <kbd>Shift</kbd> for coarse steps; works in <code>u8</code>{" "}
-              (0–255) or <code>f32</code> (0–1) channel units.
+              <kbd>Shift</kbd> for coarse steps — unit-aware: <code>u8</code>{" "}
+              (0–255, shown here) or <code>f32</code> (0–1).
             </>,
             <>
               Free typing while focused — invalid input reverts to the last

--- a/editor/app/(tools)/(packages)/packages/data.ts
+++ b/editor/app/(tools)/(packages)/packages/data.ts
@@ -94,6 +94,22 @@ export const packages = [
     ],
   },
   {
+    name: "@grida/number-input",
+    description:
+      "Headless React hooks for editor-grade number inputs — the input behaviors of the Grida editor's properties panel. Typed parsing, step precision, commit safety, mixed-value state, unit suffixes with display scaling, scrub gestures, snapping sliders, and hex color input.",
+    demoPath: "/packages/@grida/number-input",
+    npm: true,
+    features: [
+      "Commit vs change separation (set/delta outcomes)",
+      "Mixed-value state for multi-selection editing",
+      "Unit suffix + display scale (0.5 ↔ 50%)",
+      "Step-aware precision, float artifact cleanup",
+      "Drag-to-scrub labels with pointer lock",
+      "Mark-snapping slider values (Radix-compatible)",
+      "Hex color input — fuzzy parse, alpha extraction, channel stepping",
+    ],
+  },
+  {
     name: "@grida/pixel-grid",
     description:
       "A React component for rendering pixel-perfect grids in infinite canvas applications. This package provides a flexible and performant way to display grid patterns with zoom and pan capabilities.",

--- a/editor/app/(tools)/(packages)/packages/sitemap.ts
+++ b/editor/app/(tools)/(packages)/packages/sitemap.ts
@@ -1,11 +1,10 @@
 import type { MetadataRoute } from "next";
+import { Env } from "@/env";
 import { packages } from "./data";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://grida.co";
-
   return packages.map((pkg) => ({
-    url: `${baseUrl}${pkg.demoPath}`,
+    url: `${Env.gridaco}${pkg.demoPath}`,
     changeFrequency: "monthly",
     priority: 0.8,
   }));

--- a/editor/app/(tools)/(packages)/packages/sitemap.ts
+++ b/editor/app/(tools)/(packages)/packages/sitemap.ts
@@ -1,33 +1,12 @@
 import type { MetadataRoute } from "next";
+import { packages } from "./data";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://grida.co/packages";
+  const baseUrl = "https://grida.co";
 
-  return [
-    {
-      url: `${baseUrl}/@grida/refig`,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/@grida/ruler`,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/@grida/transparency-grid`,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/@grida/tree-view`,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/@grida/pixel-grid`,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-  ];
+  return packages.map((pkg) => ({
+    url: `${baseUrl}${pkg.demoPath}`,
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
 }

--- a/editor/app/robots.txt
+++ b/editor/app/robots.txt
@@ -3,3 +3,6 @@ Allow: /
 Disallow: /private/
 
 Sitemap: https://grida.co/sitemap.xml
+Sitemap: https://grida.co/packages/sitemap.xml
+Sitemap: https://grida.co/library/sitemap.xml
+Sitemap: https://grida.co/library/o/sitemap.xml

--- a/packages/grida-fonts/__tests__/typr.test.ts
+++ b/packages/grida-fonts/__tests__/typr.test.ts
@@ -313,5 +313,7 @@ describe("Typr font parsing", () => {
         const _____ = font.STAT;
       }).not.toThrow(`Font ${fontPath} should parse without errors`);
     });
-  }, 20000);
+    // 60s: four variable-font parses run ~4s locally but have hit 20-22s on
+    // slow CI runners, so a 20s budget flakes at the margin.
+  }, 60000);
 });

--- a/packages/grida-number-input/package.json
+++ b/packages/grida-number-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grida/number-input",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.1",
+  "private": false,
   "description": "Core parsing, formatting, and UI binding utilities for number inputs with multi-unit support",
   "keywords": [
     "accessibility",
@@ -18,7 +18,7 @@
     "units",
     "validation"
   ],
-  "homepage": "https://grida.co",
+  "homepage": "https://grida.co/packages/@grida/number-input",
   "license": "MIT",
   "author": "softmarshmallow",
   "repository": "https://github.com/gridaco/grida",
@@ -40,9 +40,13 @@
       "require": "./dist/react/index.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "prepack": "tsdown",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
@@ -55,13 +59,5 @@
   "peerDependencies": {
     "@use-gesture/react": "^10",
     "react": "^18.0.0 || ^19.0.0"
-  },
-  "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
-    "@use-gesture/react": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
## What

Prepares `@grida/number-input` for its first npm publish and gives it a public demo page at [`/packages/@grida/number-input`](https://grida.co/packages/@grida/number-input), following the existing package-page pattern (`@grida/tree-view`, `@grida/svg-editor`).

### Package publish prep (`packages/grida-number-input`)

- `private` dropped, `publishConfig.access: public`, version `0.0.1`, `prepack: tsdown` (fresh `dist` at publish time, same as `@grida/cmath`).
- **Peers are now required, not optional.** tsdown bundles all hooks into one file, so `dist/react/index.js` has top-level `require("react")` and `require("@use-gesture/react")` — with the previous `peerDependenciesMeta.optional` flags, a consumer without `@use-gesture/react` would crash at import time even without using `useNumberGesture`. The flags claimed an optionality the artifact doesn't have.
- `homepage` now points to the demo page (same convention as `@grida/svg-editor`).

### Demo page

Hero (status pill, npm/GitHub links, install command, related links) + six live demos, each with prose outside a bounded stage and a monospace state readout: basic number input, suffix + display scale (0.5 ↔ 50%), mixed-value multi-selection, drag-to-scrub label (`useNumberGesture`), mark-snapping slider (`useSliderValue`), and hex color input (`useHexValueInput`) with a native HTML5 color picker synced to the hex field. `layout.tsx` carries metadata + JSON-LD mirroring the `@grida/hud` page.

### Listing, sitemap, robots

- Listing card added to `packages/data.ts`.
- `packages/sitemap.ts` now derives entries from that data instead of a hand-maintained URL list.
- `robots.txt` declares the non-root sitemaps (`/packages`, `/library`, `/library/o`) — route-group sitemaps are not auto-discovered by crawlers. Both learnings recorded in the seo skill.

## Reviewer notes

- The demo annotates `onValueCommit` params (`NumberChange | number`) because `useNumberInput` types its callbacks as a raw union, which defeats contextual typing. Known package-level gap; the fix (generic `MODE` pattern, already used by `useNumberGesture`) is planned as a pre-1.0 API pass, separate from this PR.
- The page defines local RGB↔hex helpers on purpose — the package's color utilities are not a committed public surface.
- This PR does not publish; `npm publish` / the publish workflow remains a manual follow-up. The README also still needs an honesty pass (stale `useHexValueInput` API docs) before the actual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@grida/number-input` package with interactive docs and demos (parsing, multi-selection, unit scaling, gesture controls, slider snapping, hex color input).

* **Documentation**
  * Expanded SEO guidance and sitemap discovery instructions.
  * Added SEO/meta and structured data to the package docs pages.
  * Updated sitemap generation to be data-driven and robots.txt to reference additional sitemaps.

* **Chores**
  * Made `@grida/number-input` publishable (version/metadata updates).

* **Tests**
  * Increased timeout for a font-parsing test to improve CI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->