### PR TITLE
feat(desktop): watch workspace files for external changes + save-conflict guard (#805)

### DIFF
--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -121,9 +121,12 @@ const config: ForgeConfig = {
     // (vendor/seccomp/*/apply-seccomp) that cannot run from inside an asar —
     // unpack it so they land on a real filesystem. node-pty likewise: its
     // native `pty.node` addon and `spawn-helper` executable cannot load/run
-    // from inside an asar.
+    // from inside an asar. @parcel/watcher (issue #805) is the same: its
+    // per-platform prebuild package (`@parcel/watcher-<platform>-<arch>`)
+    // carries the `.node` addon, which must load from the real filesystem.
     asar: {
-      unpack: "**/node_modules/{@anthropic-ai/sandbox-runtime,node-pty}/**",
+      unpack:
+        "**/node_modules/{@anthropic-ai/sandbox-runtime,node-pty,@parcel/watcher,@parcel/watcher-*}/**",
     },
     appBundleId: appBundleId,
     icon: icon,

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -144,16 +144,26 @@ const config: ForgeConfig = {
     extendInfo: "./Info.plist",
     appCategoryType: "public.app-category.developer-tools",
   },
-  // node-pty is the only native dependency. Upstream ships N-API prebuilt
-  // binaries for darwin/win32 (its loader falls back to prebuilds/<platform>-
-  // <arch>), so rebuilding there is pure waste — and would force every dev
-  // machine to carry a C++ toolchain. Linux has no upstream prebuilds, so it
-  // is the one platform where @electron/rebuild must compile from source
-  // (requires the distro toolchain; GitHub's ubuntu runners ship it).
-  // node-abi is overridden in pnpm-workspace.yaml so the rebuild recognizes
-  // current Electron versions.
+  // Native dependencies and their @electron/rebuild policy:
+  //
+  // - node-pty ships N-API prebuilt binaries for darwin/win32 (its loader
+  //   falls back to prebuilds/<platform>-<arch>), so rebuilding there is pure
+  //   waste — and would force every dev machine to carry a C++ toolchain.
+  //   Linux has no upstream prebuild, so it is the one platform where it must
+  //   compile from source (GitHub's ubuntu runners ship the toolchain).
+  //   node-abi is overridden in pnpm-workspace.yaml so the rebuild recognizes
+  //   current Electron versions.
+  // - @parcel/watcher (issue #805) ships N-API prebuilds for EVERY platform as
+  //   separate `@parcel/watcher-<os>-<arch>` packages, so it must never be
+  //   compiled from source. Rebuilding it is not just waste — it fails on the
+  //   windows runner (no configured VS C++ build tools), and the N-API prebuild
+  //   loads under Electron without an ABI-specific rebuild. Always ignore it;
+  //   the shipped per-platform prebuild package provides the addon.
   rebuildConfig: {
-    ignoreModules: process.platform === "linux" ? [] : ["node-pty"],
+    ignoreModules: [
+      "@parcel/watcher",
+      ...(process.platform === "linux" ? [] : ["node-pty"]),
+    ],
   },
   hooks: {
     // node-pty's npm tarball ships the darwin prebuilt `spawn-helper`

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.52",
     "@hono/node-server": "^1.13.7",
+    "@parcel/watcher": "^2.5.6",
     "hono": "^4.6.14",
     "node-pty": "^1.1.0",
     "undici": "^7.24.4"

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.23)
+      '@parcel/watcher':
+        specifier: ^2.5.6
+        version: 2.5.6
       hono:
         specifier: ^4.6.14
         version: 4.12.23
@@ -547,6 +550,94 @@ packages:
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@pondwader/socks5-server@1.0.10':
     resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
@@ -3679,6 +3770,66 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.130.0': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.0.4
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
 
   '@pondwader/socks5-server@1.0.10': {}
 

--- a/desktop/pnpm-workspace.yaml
+++ b/desktop/pnpm-workspace.yaml
@@ -26,6 +26,11 @@ allowBuilds:
   # unnecessary on darwin/win32; Linux packaging goes through forge's
   # native-module rebuild instead.
   node-pty: false
+  # Skipped: @parcel/watcher (issue #805 workspace watcher) ships per-platform
+  # N-API prebuilds as optionalDependencies (@parcel/watcher-<platform>-<arch>)
+  # that its loader resolves at require time; the `install` build-from-source
+  # script is only the no-prebuild fallback. Same story as node-pty.
+  "@parcel/watcher": false
 overrides:
   # @electron/rebuild pins an old node-abi that throws "Could not detect abi"
   # for current Electron releases. Only the Linux packaging path actually

--- a/desktop/scripts/verify-packaged-bundle.mjs
+++ b/desktop/scripts/verify-packaged-bundle.mjs
@@ -137,10 +137,18 @@ const missing = [];
 const closure = new Set(); // package names that legitimately ship
 const visited = new Set();
 
-function verify(name, fromDir, requiredBy) {
+function verify(name, fromDir, requiredBy, optional = false) {
   const dir = findPackageDir(name, fromDir);
   if (!dir) {
-    missing.push({ spec: name, requiredBy });
+    // A missing REQUIRED dependency crashes on launch — the whole point of
+    // this oracle. A missing OPTIONAL dependency does not: native prebuilds
+    // shipped as per-platform optionalDependencies (e.g.
+    // `@parcel/watcher-<os>-<arch>`) install only for the current platform,
+    // so every other platform's package is legitimately absent, and the
+    // owning package tolerates that absence at runtime (it requires only the
+    // one matching the host). Flagging them would make the build un-shippable
+    // on every OS. Only required deps that are missing are failures.
+    if (!optional) missing.push({ spec: name, requiredBy });
     return;
   }
   if (visited.has(dir)) return;
@@ -149,11 +157,15 @@ function verify(name, fromDir, requiredBy) {
   const pj = JSON.parse(
     fs.readFileSync(path.join(dir, "package.json"), "utf8")
   );
-  // Follow dependencies + optionalDependencies — both can be installed and ship
-  // alongside the package, so both are legitimate members of the closure.
-  const deps = { ...pj.dependencies, ...pj.optionalDependencies };
-  for (const dep of Object.keys(deps)) {
-    verify(dep, dir, name);
+  // Required deps must all resolve. Optional deps that ARE present still join
+  // the closure (so they aren't later flagged as bloat) and are recursed into
+  // to verify their own closure — but an absent one is not a failure (see the
+  // `optional` guard above).
+  for (const dep of Object.keys(pj.dependencies ?? {})) {
+    verify(dep, dir, name, false);
+  }
+  for (const dep of Object.keys(pj.optionalDependencies ?? {})) {
+    verify(dep, dir, name, true);
   }
 }
 

--- a/desktop/src/bridge/contract.ts
+++ b/desktop/src/bridge/contract.ts
@@ -20,6 +20,8 @@ export type {
   TerminalCreateOptions,
   TerminalHandlers,
   Workspace,
+  WorkspaceChangeEvent,
+  WorkspaceChangeHandler,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -38,6 +40,8 @@ export const IPC_CHANNELS = {
   AGENT_FOCUS_SESSION: "grida:agent:focus-session",
   WORKSPACE_COMMAND: "grida:workspace:command",
   WORKSPACE_TRASH_ENTRY: "grida:workspace:trash-entry",
+  WORKSPACE_SUBSCRIBE_CHANGES: "grida:workspace:subscribe-changes",
+  WORKSPACE_UNSUBSCRIBE_CHANGES: "grida:workspace:unsubscribe-changes",
   DIALOG_CONFIRM: "grida:dialog:confirm",
   DIALOG_OPEN: "grida:dialog:open",
   DIALOG_SAVE_AS: "grida:dialog:save-as",
@@ -52,6 +56,7 @@ export const IPC_CHANNELS = {
   // main → renderer push channels (no invoke response)
   TERMINAL_DATA: "grida:terminal:data",
   TERMINAL_EXIT: "grida:terminal:exit",
+  WORKSPACE_CHANGE: "grida:workspace:change",
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from "./main/agent-sidecar-supervisor";
 import { registerIpcHandlers } from "./main/ipc-handlers";
 import { disposeAllTerminals } from "./main/terminal-host";
+import { disposeAllWorkspaceWatches } from "./main/workspace-watcher-host";
 import { agentSidecarClient } from "./main/agent-sidecar-client";
 import { startAgentNotifications } from "./main/agent-notifications";
 import { routeDeepLink } from "./main/protocol-router";
@@ -355,7 +356,9 @@ app.on("activate", () => {
 
 app.on("before-quit", () => {
   // Belt-and-suspenders — supervisor also listens for this event, and
-  // terminal PTYs are also killed per-window on webContents teardown.
+  // terminal PTYs / workspace watches are also torn down per-window on
+  // webContents teardown.
   stopAgentSidecar();
   disposeAllTerminals();
+  void disposeAllWorkspaceWatches();
 });

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -33,6 +33,10 @@ import {
   resizeTerminal,
   writeTerminal,
 } from "./terminal-host";
+import {
+  subscribeWorkspaceChanges,
+  unsubscribeWorkspaceChanges,
+} from "./workspace-watcher-host";
 import { trashWorkspaceEntry } from "./workspace-files";
 
 // `new URL(EDITOR_BASE_URL).origin` is needed per IPC invoke; parse the
@@ -287,6 +291,27 @@ export function registerIpcHandlers() {
 
   guarded(IPC_CHANNELS.TERMINAL_KILL, (event, id: string) => {
     killTerminal(event.sender, id);
+  });
+
+  // issue #805 — workspace file-change watcher. The watch root is the
+  // workspace root resolved host-side from the sidecar registry; the
+  // renderer only names a workspace id (never a raw path), exactly like
+  // TERMINAL_CREATE and WORKSPACE_TRASH_ENTRY. The watcher host binds each
+  // subscription to its creating WebContents (push + kill-on-close).
+  guarded(
+    IPC_CHANNELS.WORKSPACE_SUBSCRIBE_CHANGES,
+    async (event, opts: { id: string; workspace_id: string }) => {
+      const workspace = await findWorkspaceOrThrow(opts.workspace_id);
+      await subscribeWorkspaceChanges(event.sender, {
+        id: opts.id,
+        root: workspace.root,
+        workspaceId: opts.workspace_id,
+      });
+    }
+  );
+
+  guarded(IPC_CHANNELS.WORKSPACE_UNSUBSCRIBE_CHANGES, (_event, id: string) => {
+    unsubscribeWorkspaceChanges(id);
   });
 }
 

--- a/desktop/src/main/workspace-watcher-host.test.ts
+++ b/desktop/src/main/workspace-watcher-host.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  coalesceChanges,
+  isValidSubscriptionId,
+  toRelativeChange,
+  WorkspaceWatchRegistry,
+} from "./workspace-watcher-host";
+
+describe("isValidSubscriptionId", () => {
+  it("accepts UUID-shaped tokens and rejects everything else", () => {
+    expect(isValidSubscriptionId("0b8d7c2e-91c4-4b6e-a9f4-2f6a4a9d1c0e")).toBe(
+      true
+    );
+    expect(isValidSubscriptionId("")).toBe(false);
+    expect(isValidSubscriptionId("a".repeat(65))).toBe(false);
+    expect(isValidSubscriptionId("../etc/passwd")).toBe(false);
+    expect(isValidSubscriptionId(42)).toBe(false);
+  });
+});
+
+describe("toRelativeChange", () => {
+  const root = "/work/space";
+
+  it("maps native event types to coarse kinds with a workspace-relative path", () => {
+    expect(
+      toRelativeChange(root, { type: "create", path: "/work/space/a.svg" })
+    ).toEqual({ kind: "added", rel_path: "a.svg" });
+    expect(
+      toRelativeChange(root, { type: "update", path: "/work/space/dir/b.svg" })
+    ).toEqual({ kind: "changed", rel_path: "dir/b.svg" });
+    expect(
+      toRelativeChange(root, { type: "delete", path: "/work/space/dir/c.svg" })
+    ).toEqual({ kind: "deleted", rel_path: "dir/c.svg" });
+  });
+
+  it("drops the root itself and any path that escapes the root", () => {
+    expect(
+      toRelativeChange(root, { type: "update", path: "/work/space" })
+    ).toBe(null);
+    expect(
+      toRelativeChange(root, { type: "update", path: "/work/other/secret" })
+    ).toBe(null);
+    expect(
+      toRelativeChange(root, { type: "update", path: "/work/spacex/x" })
+    ).toBe(null);
+  });
+});
+
+describe("coalesceChanges", () => {
+  it("keeps one event per path with the most recent kind winning", () => {
+    expect(
+      coalesceChanges([
+        { kind: "changed", rel_path: "a" },
+        { kind: "changed", rel_path: "a" },
+      ])
+    ).toEqual([{ kind: "changed", rel_path: "a" }]);
+
+    // create then delete within one window → the file is gone
+    expect(
+      coalesceChanges([
+        { kind: "added", rel_path: "tmp" },
+        { kind: "deleted", rel_path: "tmp" },
+      ])
+    ).toEqual([{ kind: "deleted", rel_path: "tmp" }]);
+
+    // distinct paths preserved
+    expect(
+      coalesceChanges([
+        { kind: "added", rel_path: "a" },
+        { kind: "changed", rel_path: "b" },
+      ])
+    ).toEqual([
+      { kind: "added", rel_path: "a" },
+      { kind: "changed", rel_path: "b" },
+    ]);
+  });
+});
+
+/**
+ * The ref-counting protocol: one OS watch per root shared across every
+ * subscriber, so the host knows to start the watch on the first
+ * subscriber and dispose it on the last — across windows.
+ */
+describe("WorkspaceWatchRegistry", () => {
+  const owner = { id: 1 };
+  const other = { id: 2 };
+  const root = "/work/space";
+
+  it("first subscriber for a root signals firstForRoot; a second does not", () => {
+    const reg = new WorkspaceWatchRegistry<object>(8);
+    expect(reg.add("a", owner, root, "w1").firstForRoot).toBe(true);
+    expect(reg.add("b", other, root, "w1").firstForRoot).toBe(false);
+  });
+
+  it("rejects a duplicate id and enforces the per-owner cap", () => {
+    const reg = new WorkspaceWatchRegistry<object>(2);
+    reg.add("a", owner, root, "w1");
+    expect(() => reg.add("a", owner, "/other", "w2")).toThrow(/already exists/);
+    reg.add("b", owner, "/other", "w2");
+    expect(() => reg.add("c", owner, "/third", "w3")).toThrow(/too many/);
+    // a different window is unaffected
+    reg.add("c", other, "/third", "w3");
+  });
+
+  it("only the last subscriber leaving a root signals lastForRoot", () => {
+    const reg = new WorkspaceWatchRegistry<object>(8);
+    reg.add("a", owner, root, "w1");
+    reg.add("b", other, root, "w1");
+    expect(reg.remove("a")).toEqual({ root, lastForRoot: false });
+    expect(reg.remove("b")).toEqual({ root, lastForRoot: true });
+    // unknown id is idempotent (renderer unmount races host cleanup)
+    expect(reg.remove("a")).toBeNull();
+    expect(reg.remove("nope")).toBeNull();
+  });
+
+  it("subscribersOfRoot returns every live subscriber's id + owner", () => {
+    const reg = new WorkspaceWatchRegistry<object>(8);
+    reg.add("a", owner, root, "w1");
+    reg.add("b", other, root, "w1");
+    expect(reg.subscribersOfRoot(root)).toEqual([
+      { id: "a", owner },
+      { id: "b", owner: other },
+    ]);
+    expect(reg.subscribersOfRoot("/unwatched")).toEqual([]);
+  });
+
+  it("removeAllFor disposes only roots that lost their last subscriber", () => {
+    const reg = new WorkspaceWatchRegistry<object>(8);
+    reg.add("a", owner, root, "w1"); // shared root
+    reg.add("b", other, root, "w1"); // shared root, other window
+    reg.add("c", owner, "/solo", "w2"); // owner-only root
+    // owner's window closes: /solo loses its last subscriber, the shared
+    // root still has `other`, so it is NOT disposed.
+    expect(reg.removeAllFor(owner).sort()).toEqual(["/solo"]);
+    expect(reg.hasSubscribersForRoot(root)).toBe(true);
+    expect(reg.hasSubscribersForRoot("/solo")).toBe(false);
+    expect(reg.remove("b")).toEqual({ root, lastForRoot: true });
+  });
+});
+
+// GRIDA-SEC-004 anti-drift: every workspace-watch IPC channel must be
+// registered through `guarded(` — the sender-frame gate that keeps the
+// surface reachable only from editor-origin `/desktop/*` frames. A bare
+// `ipcMain.handle(IPC_CHANNELS.WORKSPACE_...` ships it without the gate.
+describe("workspace-watch IPC registration", () => {
+  it("registers every workspace-watch invoke channel via guarded()", () => {
+    const source = fs.readFileSync(
+      new URL("./ipc-handlers.ts", import.meta.url),
+      "utf8"
+    );
+    for (const channel of [
+      "WORKSPACE_SUBSCRIBE_CHANGES",
+      "WORKSPACE_UNSUBSCRIBE_CHANGES",
+    ]) {
+      expect(source).toMatch(
+        new RegExp(`guarded\\(\\s*IPC_CHANNELS.${channel}`)
+      );
+      expect(source).not.toMatch(
+        new RegExp(`ipcMain.handle\\(\\s*IPC_CHANNELS.${channel}`)
+      );
+    }
+  });
+});

--- a/desktop/src/main/workspace-watcher-host.ts
+++ b/desktop/src/main/workspace-watcher-host.ts
@@ -231,6 +231,26 @@ type WatchState = {
 };
 const watches = new Map<string, WatchState>();
 
+/**
+ * In-flight `startWatch` promise per root (issue #805). Serializes startup so
+ * concurrent subscribers to the same root share ONE OS watch attempt: the
+ * first subscriber starts it, later subscribers (and any sub/unsub churn that
+ * lands while the OS `subscribe()` is in flight) await the same promise rather
+ * than racing a second watch. Cleared when the start settles, and by
+ * `disposeWatch` so a fresh subscriber after a teardown starts a NEW watch
+ * instead of awaiting the disposed one.
+ */
+const startingByRoot = new Map<string, Promise<void>>();
+function ensureWatchStarted(root: string): Promise<void> {
+  const existing = startingByRoot.get(root);
+  if (existing) return existing;
+  const p = startWatch(root).finally(() => {
+    if (startingByRoot.get(root) === p) startingByRoot.delete(root);
+  });
+  startingByRoot.set(root, p);
+  return p;
+}
+
 /** WebContents ids that already have a kill-on-destroy hook. */
 const hookedWebContents = new Set<number>();
 
@@ -274,15 +294,20 @@ export async function subscribeWorkspaceChanges(
     });
   }
 
-  if (firstForRoot) {
-    try {
-      await startWatch(root);
-    } catch (err) {
-      // The OS watch couldn't start — roll the subscription back so the
-      // renderer's promise rejects and it can fall back to pull-refresh.
-      registry.remove(id);
-      throw err;
+  // The first subscriber starts the OS watch; concurrent later subscribers
+  // await that same in-flight start (so they never return success before the
+  // watch exists). If the start fails, EVERY awaiting subscriber rolls back
+  // and the renderer falls back to pull-refresh.
+  try {
+    if (firstForRoot) {
+      await ensureWatchStarted(root);
+    } else {
+      const pending = startingByRoot.get(root);
+      if (pending) await pending;
     }
+  } catch (err) {
+    registry.remove(id);
+    throw err;
   }
 }
 
@@ -293,7 +318,12 @@ export function unsubscribeWorkspaceChanges(id: unknown): void {
 }
 
 async function startWatch(root: string): Promise<void> {
-  watches.set(root, { sub: "starting", buffer: new Map(), timer: null });
+  // Hold our own state object so a teardown + fresh start that lands while our
+  // subscribe() is in flight is detected by IDENTITY, not just presence: a
+  // newer cycle replaces `watches[root]` with a different object, and we must
+  // not stamp our now-stale handle onto it (that would leak/duplicate a watch).
+  const state: WatchState = { sub: "starting", buffer: new Map(), timer: null };
+  watches.set(root, state);
   const watcher = await loadWatcher();
   let subscription: AsyncSubscription;
   try {
@@ -303,18 +333,19 @@ async function startWatch(root: string): Promise<void> {
       { ignore: [...WATCH_IGNORE] } satisfies ParcelOptions
     );
   } catch (err) {
-    watches.delete(root);
+    if (watches.get(root) === state) watches.delete(root);
     throw err;
   }
-  // A teardown (last unsubscribe / window close) may have landed while the
-  // subscribe() was in flight: `disposeWatch` deleted the entry. Honor it
-  // by closing the handle we just opened instead of resurrecting it.
-  if (!watches.has(root) || !registry.hasSubscribersForRoot(root)) {
+  // A teardown (last unsubscribe / window close) — or a newer start cycle —
+  // may have landed while subscribe() was in flight. If our state is no longer
+  // the current one (or the root lost its subscribers), close the handle we
+  // just opened instead of resurrecting or duplicating the watch.
+  if (watches.get(root) !== state || !registry.hasSubscribersForRoot(root)) {
     void subscription.unsubscribe().catch(() => {});
-    watches.delete(root);
+    if (watches.get(root) === state) watches.delete(root);
     return;
   }
-  watches.get(root)!.sub = subscription;
+  state.sub = subscription;
 }
 
 function onRawEvents(
@@ -357,6 +388,10 @@ function flush(root: string): void {
 }
 
 async function disposeWatch(root: string): Promise<void> {
+  // Invalidate any in-flight start first: a subscriber arriving after this
+  // teardown must start a fresh watch, not await the disposed one. The pending
+  // startWatch (if any) sees its state evicted and closes its own handle.
+  startingByRoot.delete(root);
   const state = watches.get(root);
   if (!state) return;
   watches.delete(root);

--- a/desktop/src/main/workspace-watcher-host.ts
+++ b/desktop/src/main/workspace-watcher-host.ts
@@ -1,0 +1,375 @@
+/**
+ * Workspace file-change watcher host (issue #805).
+ *
+ * Owns the OS-level recursive watch behind `bridge.workspaces.
+ * subscribe_changes`. When a workspace file changes on disk outside the
+ * editor — a `git checkout`, another editor, or *the agent's own write* —
+ * the host pushes a coalesced batch of `WorkspaceChangeEvent`s to every
+ * renderer subscribed to that workspace, which then reloads the open
+ * editor (when clean) and surgically refreshes the file tree.
+ *
+ * Placement mirrors `terminal-host.ts`: a native module (`@parcel/watcher`,
+ * the recursive per-OS backend VSCode uses) loaded in the privileged
+ * desktop main process, reached only through `guarded()` IPC channels
+ * (sender frame must be editor-origin `/desktop/*`). The watch root is a
+ * workspace root resolved host-side from the sidecar registry — the
+ * renderer only ever names a workspace id, never a raw path.
+ *
+ * One OS watch per workspace ROOT, ref-counted across every subscriber
+ * (multiple panes / windows on the same folder share a single watcher).
+ * Subscription ids are minted by the preload (caller-mints-id, like
+ * `terminal.create`) so the renderer's change handler is registered
+ * before the first event can fire.
+ *
+ * See /SECURITY.md `GRIDA-SEC-004`.
+ */
+
+import path from "node:path";
+import type { WebContents } from "electron";
+import type { WorkspaceChangeEvent } from "../bridge/contract";
+import { IPC_CHANNELS } from "../bridge/contract";
+
+// `@parcel/watcher` is an `export =` namespace module — reference its
+// types via the indexed-import form (robust regardless of esModuleInterop)
+// rather than named imports.
+type AsyncSubscription = import("@parcel/watcher").AsyncSubscription;
+type ParcelEvent = import("@parcel/watcher").Event;
+type ParcelOptions = import("@parcel/watcher").Options;
+
+/** Renderer-minted handle: UUID-sized opaque token, nothing fancier. */
+const SUBSCRIPTION_ID_RE = /^[0-9a-zA-Z-]{1,64}$/;
+
+/**
+ * A runaway renderer loop must not pin unbounded watches. The UI opens
+ * one subscription per workspace per window; 8 leaves ample headroom.
+ */
+const MAX_SUBSCRIPTIONS_PER_WEBCONTENTS = 8;
+
+/**
+ * Coalesce window. Raw FS events arrive in bursts (a save is often
+ * unlink+create+chmod; a `git checkout` touches hundreds of files); we
+ * buffer by path and flush once per window so the renderer sees one tidy
+ * batch instead of a storm. VSCode uses ~75ms at the watcher source.
+ */
+export const COALESCE_MS = 75;
+
+/**
+ * Pushed down to the native backend so giant, irrelevant subtrees never
+ * generate events. Matches the workspace tree's own hidden/noise set;
+ * `.git` churns constantly and `node_modules` is enormous.
+ */
+export const WATCH_IGNORE: readonly string[] = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/.next/**",
+  "**/.turbo/**",
+  "**/target/**",
+  "**/dist/**",
+];
+
+export function isValidSubscriptionId(id: unknown): id is string {
+  return typeof id === "string" && SUBSCRIPTION_ID_RE.test(id);
+}
+
+/**
+ * Map a raw `@parcel/watcher` event to the bridge shape: native event
+ * type → coarse `kind`, absolute path → workspace-relative POSIX path.
+ * Returns `null` for a path that resolves outside `root` (defensive — the
+ * backend reports inside the watched dir, but a symlinked emission must
+ * not leak an out-of-tree path to the renderer).
+ *
+ * Pure (no fs, no Electron) so the conversion is unit-testable.
+ */
+export function toRelativeChange(
+  root: string,
+  event: Pick<ParcelEvent, "type" | "path">
+): WorkspaceChangeEvent | null {
+  const rel = path.relative(root, event.path);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  const rel_path = rel.split(path.sep).join("/");
+  const kind =
+    event.type === "create"
+      ? "added"
+      : event.type === "delete"
+        ? "deleted"
+        : "changed";
+  return { kind, rel_path };
+}
+
+/**
+ * Coalesce a buffer of changes: at most one event per `rel_path`, the
+ * most recent kind winning (a rapid update→update collapses to one
+ * `changed`; a create-then-delete collapses to `deleted` — the file is
+ * gone, which is the truth the renderer should act on). Pure.
+ */
+export function coalesceChanges(
+  events: readonly WorkspaceChangeEvent[]
+): WorkspaceChangeEvent[] {
+  const byPath = new Map<string, WorkspaceChangeEvent["kind"]>();
+  for (const e of events) byPath.set(e.rel_path, e.kind);
+  return [...byPath].map(([rel_path, kind]) => ({ kind, rel_path }));
+}
+
+/**
+ * Ref-counts subscriptions per owner (WebContents) AND per workspace root
+ * so a single OS watch backs every subscriber of the same folder. Generic
+ * over the owner type so the bookkeeping is unit-testable without Electron
+ * or `@parcel/watcher` (workspace-watcher-host.test.ts). The host layer
+ * owns the actual watch handles, keyed by root; this class only answers
+ * "is this the first / last subscriber for the root" so the host knows
+ * when to start / dispose the watch.
+ */
+export class WorkspaceWatchRegistry<TOwner extends object> {
+  private readonly subs = new Map<
+    string,
+    { owner: TOwner; root: string; workspaceId: string }
+  >();
+  /** root → set of subscription ids watching it (refcount + fan-out). */
+  private readonly roots = new Map<string, Set<string>>();
+
+  constructor(private readonly maxPerOwner: number) {}
+
+  /**
+   * Register a subscription. Throws on an invalid or already-used id, or
+   * when the owner is at cap. Returns whether this is the FIRST subscriber
+   * for `root` (the caller then starts the OS watch).
+   */
+  add(
+    id: unknown,
+    owner: TOwner,
+    root: string,
+    workspaceId: string
+  ): { firstForRoot: boolean } {
+    if (!isValidSubscriptionId(id)) {
+      throw new Error("invalid subscription id");
+    }
+    if (this.subs.has(id)) {
+      throw new Error(`subscription already exists: ${id}`);
+    }
+    let owned = 0;
+    for (const record of this.subs.values()) {
+      if (record.owner === owner) owned += 1;
+    }
+    if (owned >= this.maxPerOwner) {
+      throw new Error("too many workspace watchers for this window");
+    }
+    this.subs.set(id, { owner, root, workspaceId });
+    let set = this.roots.get(root);
+    const firstForRoot = set === undefined;
+    if (!set) {
+      set = new Set();
+      this.roots.set(root, set);
+    }
+    set.add(id);
+    return { firstForRoot };
+  }
+
+  /**
+   * Drop a subscription. Returns the root it watched and whether it was
+   * the LAST subscriber (the caller then disposes the OS watch), or `null`
+   * for an unknown id (idempotent — renderer unmount races host cleanup).
+   */
+  remove(id: unknown): { root: string; lastForRoot: boolean } | null {
+    if (!isValidSubscriptionId(id)) return null;
+    const record = this.subs.get(id);
+    if (!record) return null;
+    this.subs.delete(id);
+    const set = this.roots.get(record.root);
+    set?.delete(id);
+    const lastForRoot = !set || set.size === 0;
+    if (lastForRoot) this.roots.delete(record.root);
+    return { root: record.root, lastForRoot };
+  }
+
+  /** Subscribers currently watching `root` (live fan-out target). */
+  subscribersOfRoot(root: string): Array<{ id: string; owner: TOwner }> {
+    const set = this.roots.get(root);
+    if (!set) return [];
+    const out: Array<{ id: string; owner: TOwner }> = [];
+    for (const id of set) {
+      const record = this.subs.get(id);
+      if (record) out.push({ id, owner: record.owner });
+    }
+    return out;
+  }
+
+  hasSubscribersForRoot(root: string): boolean {
+    return (this.roots.get(root)?.size ?? 0) > 0;
+  }
+
+  /**
+   * Drop every subscription owned by `owner` (its window closed). Returns
+   * the roots that lost their last subscriber, for the host to dispose.
+   */
+  removeAllFor(owner: TOwner): string[] {
+    const disposedRoots: string[] = [];
+    // Safe to iterate the live map: `remove` only deletes the current
+    // entry, and deleting the current key mid Map-iteration is well-defined.
+    for (const [id, record] of this.subs) {
+      if (record.owner !== owner) continue;
+      const result = this.remove(id);
+      if (result?.lastForRoot) disposedRoots.push(result.root);
+    }
+    return disposedRoots;
+  }
+}
+
+// ─────────────────────────── Electron host ───────────────────────────
+
+const registry = new WorkspaceWatchRegistry<WebContents>(
+  MAX_SUBSCRIPTIONS_PER_WEBCONTENTS
+);
+
+/** Per-root watch state. `sub` is `"starting"` between the async
+ * subscribe() call and its resolution so a teardown mid-start is handled
+ * by the startWatch post-await check rather than racing a half-open
+ * handle. `buffer` coalesces by rel_path; `timer` is the pending flush. */
+type WatchState = {
+  sub: AsyncSubscription | "starting";
+  buffer: Map<string, WorkspaceChangeEvent["kind"]>;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+const watches = new Map<string, WatchState>();
+
+/** WebContents ids that already have a kill-on-destroy hook. */
+const hookedWebContents = new Set<number>();
+
+// @parcel/watcher is a native module, loaded lazily so importing this
+// module (e.g. from tests exercising the pure helpers + registry) never
+// touches the addon. The vite main bundle leaves it external; see
+// vite.main.config.ts + the packaging recipe in forge.config.ts.
+let watcherModule: typeof import("@parcel/watcher") | null = null;
+async function loadWatcher(): Promise<typeof import("@parcel/watcher")> {
+  if (!watcherModule) {
+    watcherModule = await import("@parcel/watcher");
+  }
+  return watcherModule;
+}
+
+/**
+ * Register a renderer's subscription and ensure the workspace root is
+ * being watched. `wc` owns the subscription (kill-on-close + the only
+ * window that receives its events). `root` is the host-resolved absolute
+ * workspace root — the caller (ipc-handlers) resolves it from the sidecar
+ * registry; this function never sees a renderer-supplied path.
+ */
+export async function subscribeWorkspaceChanges(
+  wc: WebContents,
+  opts: { id: string; root: string; workspaceId: string }
+): Promise<void> {
+  const { id, root } = opts;
+  // Synchronous reservation BEFORE the await below — closes the window
+  // where two concurrent subscribes for a fresh root both think they're
+  // first (and start two watches).
+  const { firstForRoot } = registry.add(id, wc, root, opts.workspaceId);
+
+  // Kill subscriptions on window close — no reattach in v1.
+  if (!hookedWebContents.has(wc.id)) {
+    hookedWebContents.add(wc.id);
+    wc.once("destroyed", () => {
+      hookedWebContents.delete(wc.id);
+      for (const disposedRoot of registry.removeAllFor(wc)) {
+        void disposeWatch(disposedRoot);
+      }
+    });
+  }
+
+  if (firstForRoot) {
+    try {
+      await startWatch(root);
+    } catch (err) {
+      // The OS watch couldn't start — roll the subscription back so the
+      // renderer's promise rejects and it can fall back to pull-refresh.
+      registry.remove(id);
+      throw err;
+    }
+  }
+}
+
+/** Tear down one subscription; disposes the OS watch if it was the last. */
+export function unsubscribeWorkspaceChanges(id: unknown): void {
+  const result = registry.remove(id);
+  if (result?.lastForRoot) void disposeWatch(result.root);
+}
+
+async function startWatch(root: string): Promise<void> {
+  watches.set(root, { sub: "starting", buffer: new Map(), timer: null });
+  const watcher = await loadWatcher();
+  let subscription: AsyncSubscription;
+  try {
+    subscription = await watcher.subscribe(
+      root,
+      (err, events) => onRawEvents(root, err, events),
+      { ignore: [...WATCH_IGNORE] } satisfies ParcelOptions
+    );
+  } catch (err) {
+    watches.delete(root);
+    throw err;
+  }
+  // A teardown (last unsubscribe / window close) may have landed while the
+  // subscribe() was in flight: `disposeWatch` deleted the entry. Honor it
+  // by closing the handle we just opened instead of resurrecting it.
+  if (!watches.has(root) || !registry.hasSubscribersForRoot(root)) {
+    void subscription.unsubscribe().catch(() => {});
+    watches.delete(root);
+    return;
+  }
+  watches.get(root)!.sub = subscription;
+}
+
+function onRawEvents(
+  root: string,
+  err: Error | null,
+  events: ParcelEvent[]
+): void {
+  const state = watches.get(root);
+  if (!state) return;
+  if (err) {
+    console.error(`[grida] workspace watch error (${root}):`, err);
+    return;
+  }
+  for (const event of events) {
+    const change = toRelativeChange(root, event);
+    if (change) state.buffer.set(change.rel_path, change.kind);
+  }
+  if (state.buffer.size > 0 && state.timer === null) {
+    state.timer = setTimeout(() => flush(root), COALESCE_MS);
+  }
+}
+
+function flush(root: string): void {
+  const state = watches.get(root);
+  if (!state) return;
+  state.timer = null;
+  if (state.buffer.size === 0) return;
+  const events: WorkspaceChangeEvent[] = [...state.buffer].map(
+    ([rel_path, kind]) => ({ kind, rel_path })
+  );
+  state.buffer.clear();
+  for (const { id, owner } of registry.subscribersOfRoot(root)) {
+    if (!owner.isDestroyed()) {
+      owner.send(IPC_CHANNELS.WORKSPACE_CHANGE, {
+        subscription_id: id,
+        events,
+      });
+    }
+  }
+}
+
+async function disposeWatch(root: string): Promise<void> {
+  const state = watches.get(root);
+  if (!state) return;
+  watches.delete(root);
+  if (state.timer !== null) clearTimeout(state.timer);
+  if (state.sub !== "starting") {
+    await state.sub.unsubscribe().catch(() => {});
+  }
+  // If still "starting", the in-flight startWatch sees the deleted entry
+  // after its await and unsubscribes the handle itself.
+}
+
+/** App-quit belt-and-suspenders for paths that skip webContents teardown. */
+export async function disposeAllWorkspaceWatches(): Promise<void> {
+  const roots = [...watches.keys()];
+  await Promise.all(roots.map((root) => disposeWatch(root)));
+}

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -35,6 +35,8 @@ import {
   type SaveDialogOptions,
   type TerminalCreateOptions,
   type TerminalHandlers,
+  type WorkspaceChangeEvent,
+  type WorkspaceChangeHandler,
 } from "./bridge/contract";
 
 const DESKTOP_PATH_ROOT = "/desktop";
@@ -156,6 +158,25 @@ ipcRenderer.on(
     const handlers = terminalHandlers.get(payload.id);
     terminalHandlers.delete(payload.id);
     handlers?.on_exit({ exit_code: payload.exit_code });
+  }
+);
+
+/**
+ * Workspace file-change fanout (issue #805). Same payload-only discipline
+ * as the terminal fanout: one module-level `ipcRenderer.on` routes each
+ * pushed batch to the renderer-supplied handler by subscription id; the
+ * Electron event object never crosses the contextBridge (GRIDA-SEC-004).
+ * The handler is registered under a preload-minted id BEFORE the
+ * SUBSCRIBE_CHANGES invoke, so no early event can race the subscription.
+ */
+const workspaceChangeHandlers = new Map<string, WorkspaceChangeHandler>();
+ipcRenderer.on(
+  IPC_CHANNELS.WORKSPACE_CHANGE,
+  (
+    _event,
+    payload: { subscription_id: string; events: WorkspaceChangeEvent[] }
+  ) => {
+    workspaceChangeHandlers.get(payload.subscription_id)?.(payload.events);
   }
 );
 
@@ -288,6 +309,8 @@ const bridge: DesktopBridge = {
       // Human-interactive terminal pane (GRIDA-SEC-004) — distinct from
       // `shell` above and from the agent's sandboxed `run_command`.
       terminal: true,
+      // Workspace file-change watcher (issue #805).
+      workspace_watch: true,
     },
   },
 
@@ -376,8 +399,13 @@ const bridge: DesktopBridge = {
       agentClient.workspaces.read_file(workspaceId, relPath),
     read_file_bytes: (workspaceId, relPath) =>
       agentClient.workspaces.read_file_bytes(workspaceId, relPath),
-    write_file: (workspaceId, relPath, content) =>
-      agentClient.workspaces.write_file(workspaceId, relPath, content),
+    write_file: (workspaceId, relPath, content, expectedMtime) =>
+      agentClient.workspaces.write_file(
+        workspaceId,
+        relPath,
+        content,
+        expectedMtime
+      ),
     // Unlike its siblings, trash is a native host capability rather than
     // an agent-sidecar operation: it routes to the main process (which
     // re-validates workspace containment) and calls `shell.trashItem`.
@@ -386,6 +414,30 @@ const bridge: DesktopBridge = {
         workspace_id: workspaceId,
         rel_path: relPath,
       }) as Promise<void>,
+    subscribe_changes: async (workspaceId, onChange) => {
+      // Caller-mints-id (cf. terminal.create): register the handler under
+      // a preload-minted id before the invoke so no pushed event can land
+      // before the subscription exists.
+      const id = crypto.randomUUID();
+      workspaceChangeHandlers.set(id, onChange);
+      try {
+        await ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_SUBSCRIBE_CHANGES, {
+          id,
+          workspace_id: workspaceId,
+        });
+      } catch (err) {
+        workspaceChangeHandlers.delete(id);
+        throw err;
+      }
+      return { subscription_id: id };
+    },
+    unsubscribe_changes: async (subscriptionId) => {
+      workspaceChangeHandlers.delete(subscriptionId);
+      await ipcRenderer.invoke(
+        IPC_CHANNELS.WORKSPACE_UNSUBSCRIBE_CHANGES,
+        subscriptionId
+      );
+    },
   },
 
   terminal: {

--- a/desktop/vite.main.config.ts
+++ b/desktop/vite.main.config.ts
@@ -11,7 +11,10 @@ import { gridaBundleGuard } from "./vite.guards";
 // into `.vite/build/main.js` breaks resolution at runtime.
 // `node-pty` is externalised for the same reason: it loads a native
 // `.node` addon (and `spawn-helper`) via paths relative to its
-// install root.
+// install root. `@parcel/watcher` (issue #805 workspace watcher) is the
+// third native module: it resolves a per-platform `.node` prebuild
+// (`@parcel/watcher-<platform>-<arch>`) at require time, which can't be
+// bundled into `main.js`.
 export default defineConfig({
   build: {
     rollupOptions: {
@@ -19,6 +22,7 @@ export default defineConfig({
         ...builtinModules,
         "@anthropic-ai/sandbox-runtime",
         "node-pty",
+        "@parcel/watcher",
       ],
     },
   },

--- a/editor/lib/agent-chat/web-daemon-bridge.ts
+++ b/editor/lib/agent-chat/web-daemon-bridge.ts
@@ -141,6 +141,9 @@ export function createWebDaemonBridge(
         dialog: false,
         shell: false,
         terminal: false,
+        // OS file watcher is an Electron-main capability; the web daemon
+        // bridge has no main process, so the UI falls back to pull-refresh.
+        workspace_watch: false,
       },
     },
     handshake: () => client.handshake(),
@@ -198,9 +201,18 @@ export function createWebDaemonBridge(
         client.workspaces.read_file(workspaceId, relPath),
       read_file_bytes: (workspaceId, relPath) =>
         client.workspaces.read_file_bytes(workspaceId, relPath),
-      write_file: (workspaceId, relPath, content) =>
-        client.workspaces.write_file(workspaceId, relPath, content),
+      write_file: (workspaceId, relPath, content, expectedMtime) =>
+        client.workspaces.write_file(
+          workspaceId,
+          relPath,
+          content,
+          expectedMtime
+        ),
       trash_entry: () => unavailable("workspaces.trash_entry"),
+      // OS file watcher is an Electron-main capability; the daemon bridge
+      // reports `caps.native.workspace_watch: false` and the UI pull-refreshes.
+      subscribe_changes: () => unavailable("workspaces.subscribe_changes"),
+      unsubscribe_changes: () => unavailable("workspaces.unsubscribe_changes"),
     },
     terminal: {
       // PTY host is an Electron-main capability; the web daemon bridge

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -839,6 +839,15 @@ export namespace workspaces {
     workspaceId: string,
     onChange: (events: WorkspaceChangeEvent[]) => void
   ): Promise<{ subscriptionId: string }> {
+    // Gate explicitly: on an old protocol-1 binary the bridge lacks this
+    // method, so an ungated call would throw an opaque `TypeError`. Fail with
+    // a clear, deterministic error instead. Callers should prefer
+    // {@link isWatchSupported} before subscribing.
+    if (!isWatchSupported()) {
+      throw new Error(
+        "workspaces.subscribe_changes: workspace watch is not supported by this desktop binary"
+      );
+    }
     const { subscription_id } =
       await bridgeOrThrow().workspaces.subscribe_changes(workspaceId, onChange);
     return { subscriptionId: subscription_id };
@@ -847,6 +856,9 @@ export namespace workspaces {
   export async function unsubscribeChanges(
     subscriptionId: string
   ): Promise<void> {
+    // No-op when unsupported: there can be no live subscription to tear down,
+    // and teardown paths must not throw (they run in effect cleanups).
+    if (!isWatchSupported()) return;
     await bridgeOrThrow().workspaces.unsubscribe_changes(subscriptionId);
   }
   /**

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -50,6 +50,7 @@ import type {
   DesktopHostAppInfo,
   NavigationState,
   Workspace,
+  WorkspaceChangeEvent,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -107,6 +108,7 @@ export type {
   RecentEntry,
   SaveDialogOptions,
   Workspace,
+  WorkspaceChangeEvent,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -775,20 +777,77 @@ export namespace workspaces {
   }
   /**
    * Atomic write via tmpfile + rename inside the workspace. Creates
-   * parent directories. The renderer should compare the returned
-   * `mtime` against its last-read `mtime` if it cares about external
-   * edits.
+   * parent directories.
+   *
+   * `expectedMtime` is the optimistic-concurrency token (issue #805):
+   * pass the mtime last observed for this file (from `readFile` or a
+   * prior `writeFile`) and the host rejects — instead of silently
+   * clobbering — when the file on disk has advanced past it. The
+   * rejection is detectable with {@link isWriteConflict}; resolve it by
+   * reloading from disk or re-calling with `expectedMtime` omitted
+   * (force overwrite). Omit it entirely for last-writer-wins.
    */
   export async function writeFile(
     workspaceId: string,
     relPath: string,
-    content: string
+    content: string,
+    expectedMtime?: number
   ): Promise<WorkspaceWriteFileResult> {
     return await bridgeOrThrow().workspaces.write_file(
       workspaceId,
       relPath,
-      content
+      content,
+      expectedMtime
     );
+  }
+  /**
+   * True when a {@link writeFile} rejection is the optimistic-concurrency
+   * conflict (HTTP 409 `modified-since`) rather than a generic failure.
+   *
+   * Detection is deliberately tolerant: on the web path the rejection is
+   * a real `AgentTransport.HttpError` carrying `status`/`code`, but on the
+   * desktop path it has crossed the Electron `contextBridge`, which can
+   * strip custom Error properties. The one field that always survives is
+   * `message` — and the host sets the 409 body's `error` to the literal
+   * code `"modified-since"`, so the carried message contains it verbatim.
+   * We key off whichever signal is present.
+   */
+  export function isWriteConflict(err: unknown): boolean {
+    if (!err || typeof err !== "object") return false;
+    const e = err as { status?: number; code?: string; message?: unknown };
+    if (e.code === "modified-since") return true;
+    return (
+      typeof e.message === "string" && e.message.includes("modified-since")
+    );
+  }
+  /**
+   * True when this desktop binary can watch the workspace for external
+   * file changes (issue #805). Additive on protocol 1 — older binaries
+   * lack the channel, so the workbench falls back to pull/manual refresh.
+   * Gate any `subscribeChanges` call on this.
+   */
+  export function isWatchSupported(): boolean {
+    return getDesktopBridge()?.caps.native.workspace_watch === true;
+  }
+  /**
+   * Subscribe to external file-system changes under the workspace root.
+   * `onChange` receives coalesced batches; the returned `subscriptionId`
+   * tears the watch down via {@link unsubscribeChanges}. The handler is
+   * registered before the OS watch starts, so no early event is dropped.
+   */
+  export async function subscribeChanges(
+    workspaceId: string,
+    onChange: (events: WorkspaceChangeEvent[]) => void
+  ): Promise<{ subscriptionId: string }> {
+    const { subscription_id } =
+      await bridgeOrThrow().workspaces.subscribe_changes(workspaceId, onChange);
+    return { subscriptionId: subscription_id };
+  }
+  /** Stop a subscription started by {@link subscribeChanges}. */
+  export async function unsubscribeChanges(
+    subscriptionId: string
+  ): Promise<void> {
+    await bridgeOrThrow().workspaces.unsubscribe_changes(subscriptionId);
   }
   /**
    * Move a workspace entry (file or folder) to the OS trash

--- a/editor/scaffolds/desktop/workbench/editor-pane-svg-editor.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane-svg-editor.tsx
@@ -210,6 +210,13 @@ function Surface({
     setSaveError(null);
     try {
       const r = await workspacesNs.readFile(workspaceId, relPath);
+      // Echo suppression (issue #805): our own save produces a watcher
+      // `changed` event for this same file, which lands here once the buffer
+      // is clean again. `lastMtimeRef` is the mtime we last wrote/loaded; if
+      // disk hasn't advanced past it there's nothing new to take, and calling
+      // editor.load() would needlessly reset selection / history / mode on
+      // every Cmd+S. Reload only when disk genuinely moved ahead of us.
+      if (r.mtime === lastMtimeRef.current) return;
       editor.load(r.content);
       lastMtimeRef.current = r.mtime;
       setSavedVersion(editor.state.content_version);

--- a/editor/scaffolds/desktop/workbench/editor-pane-svg-editor.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane-svg-editor.tsx
@@ -16,7 +16,7 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertCircleIcon } from "lucide-react";
 import {
   SvgEditorCanvas,
@@ -25,11 +25,22 @@ import {
   useSvgEditor,
 } from "@grida/svg-editor/react";
 import { cn } from "@app/ui/lib/utils";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@app/ui/components/alert-dialog";
 import { workspaces as workspacesNs } from "@/lib/desktop/bridge";
+import { useWorkspaceChanges } from "./workspace-changes";
 
 type LoadState =
   | { kind: "loading" }
-  | { kind: "ready"; content: string }
+  | { kind: "ready"; content: string; mtime: number }
   | { kind: "error"; message: string };
 
 export function EditorPaneSvgEditor({
@@ -54,7 +65,7 @@ export function EditorPaneSvgEditor({
       .readFile(workspaceId, relPath)
       .then((r) => {
         if (cancelled) return;
-        setState({ kind: "ready", content: r.content });
+        setState({ kind: "ready", content: r.content, mtime: r.mtime });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -93,6 +104,7 @@ export function EditorPaneSvgEditor({
         workspaceId={workspaceId}
         relPath={relPath}
         active={active}
+        initialMtime={state.mtime}
         onDirtyChange={onDirtyChange}
         onSaved={onSaved}
       />
@@ -106,12 +118,14 @@ function Surface({
   workspaceId,
   relPath,
   active,
+  initialMtime,
   onDirtyChange,
   onSaved,
 }: {
   workspaceId: string;
   relPath: string;
   active: boolean;
+  initialMtime: number;
   onDirtyChange: (dirty: boolean) => void;
   onSaved?: () => void;
 }) {
@@ -122,27 +136,107 @@ function Surface({
   );
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // The conflict-detection token (issue #805): the mtime we last observed
+  // on disk for this file — seeded at load, advanced on every successful
+  // write / reload. A ref (not state) so `onSave` stays referentially
+  // stable and the Cmd+S listener doesn't re-bind on each save.
+  const lastMtimeRef = useRef<number>(initialMtime);
+  // Set when a save is rejected because disk advanced past our token. Holds
+  // the content the user tried to write so "Overwrite anyway" can re-issue
+  // it without re-serializing a since-changed editor.
+  const [conflict, setConflict] = useState<{
+    content: string;
+    snapshot: number;
+  } | null>(null);
   const dirty = contentVersion !== savedVersion;
 
   useEffect(() => {
     onDirtyChange(dirty);
   }, [dirty, onDirtyChange]);
 
-  const onSave = useCallback(async () => {
-    setSaveError(null);
-    setSaving(true);
+  // The single write→commit path behind both a normal save and a forced
+  // overwrite. On success it advances the mtime token and re-baselines
+  // `savedVersion` to the pre-write `snapshot`. The two callers differ only
+  // here: a guarded save passes `expectedMtime` (a stale token rejects) and
+  // an `onConflict` to raise the resolver; a force-overwrite passes neither
+  // (no precondition → last-writer-wins). Every other failure is an error.
+  const commitWrite = useCallback(
+    async (
+      content: string,
+      snapshot: number,
+      opts: { expectedMtime?: number; onConflict?: () => void }
+    ) => {
+      setSaveError(null);
+      setSaving(true);
+      try {
+        const res = await workspacesNs.writeFile(
+          workspaceId,
+          relPath,
+          content,
+          opts.expectedMtime
+        );
+        lastMtimeRef.current = res.mtime;
+        setSavedVersion(snapshot);
+        onSaved?.();
+      } catch (err) {
+        if (opts.onConflict && workspacesNs.isWriteConflict(err)) {
+          opts.onConflict();
+        } else {
+          setSaveError(err instanceof Error ? err.message : "Save failed.");
+        }
+      } finally {
+        setSaving(false);
+      }
+    },
+    [workspaceId, relPath, onSaved]
+  );
+
+  const onSave = useCallback(() => {
     const snapshot = editor.state.content_version;
     const content = editor.serialize();
+    return commitWrite(content, snapshot, {
+      expectedMtime: lastMtimeRef.current,
+      onConflict: () => setConflict({ content, snapshot }),
+    });
+  }, [editor, commitWrite]);
+
+  // Replace the editor's document with the current bytes on disk, then
+  // re-baseline `savedVersion` to the post-load content_version so the
+  // freshly-reloaded file reads as clean (editor.load() bumps the
+  // version — without re-baselining it would show as dirty). Used by the
+  // conflict resolver's "Reload from disk".
+  const reloadFromDisk = useCallback(async () => {
+    setConflict(null);
+    setSaveError(null);
     try {
-      await workspacesNs.writeFile(workspaceId, relPath, content);
-      setSavedVersion(snapshot);
-      onSaved?.();
+      const r = await workspacesNs.readFile(workspaceId, relPath);
+      editor.load(r.content);
+      lastMtimeRef.current = r.mtime;
+      setSavedVersion(editor.state.content_version);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Save failed.");
-    } finally {
-      setSaving(false);
+      setSaveError(err instanceof Error ? err.message : "Reload failed.");
     }
-  }, [workspaceId, relPath, editor, onSaved]);
+  }, [workspaceId, relPath, editor]);
+
+  // Force the user's content over the disk version: empty options → no
+  // precondition (last-writer-wins) and no conflict handler.
+  const overwriteAnyway = useCallback(() => {
+    if (!conflict) return;
+    setConflict(null);
+    return commitWrite(conflict.content, conflict.snapshot, {});
+  }, [conflict, commitWrite]);
+
+  // React to external changes to THIS file (issue #805). When the buffer
+  // is clean we take the new bytes seamlessly; when it's dirty we keep the
+  // user's edits and let the save-time guard surface the conflict (the
+  // stale mtime makes the next Cmd+S reject) — VSCode's non-dirty-reload /
+  // dirty-defer split. A delete is left alone (a reload would just ENOENT;
+  // the save guard treats the missing file as a conflict too).
+  useWorkspaceChanges((events) => {
+    const mine = events.find((e) => e.rel_path === relPath);
+    if (!mine || mine.kind === "deleted") return;
+    if (!dirty && !saving && conflict === null) void reloadFromDisk();
+  });
 
   useEffect(() => {
     if (!active) return;
@@ -167,7 +261,68 @@ function Surface({
           onDismiss={() => setSaveError(null)}
         />
       )}
+      <SaveConflictDialog
+        relPath={relPath}
+        open={conflict !== null}
+        onKeepEditing={() => setConflict(null)}
+        onReload={reloadFromDisk}
+        onOverwrite={overwriteAnyway}
+      />
     </div>
+  );
+}
+
+/**
+ * Save-time conflict resolver (issue #805). Shown when a Cmd+S is
+ * rejected because the file changed on disk since we loaded it. The
+ * structured SVG editor can't show a meaningful 3-way *text* diff, so we
+ * offer the three editor-agnostic choices VSCode falls back to rather
+ * than a diff surface: keep editing, discard-and-reload, or overwrite.
+ */
+function SaveConflictDialog({
+  relPath,
+  open,
+  onKeepEditing,
+  onReload,
+  onOverwrite,
+}: {
+  relPath: string;
+  open: boolean;
+  onKeepEditing: () => void;
+  onReload: () => void;
+  onOverwrite: () => void;
+}) {
+  const name = relPath.split("/").pop() || relPath;
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onKeepEditing();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>File changed on disk</AlertDialogTitle>
+          <AlertDialogDescription>
+            &ldquo;{name}&rdquo; was modified outside the editor since you
+            opened it. Saving now would overwrite that change. Reload to take
+            the version on disk (discarding your edits), or overwrite it with
+            yours.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onKeepEditing}>
+            Keep editing
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onReload}>
+            Reload from disk
+          </AlertDialogAction>
+          <AlertDialogAction variant="destructive" onClick={onOverwrite}>
+            Overwrite anyway
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/editor/scaffolds/desktop/workbench/file-tree-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/file-tree-pane.tsx
@@ -40,6 +40,7 @@ import {
 import { FileContextMenu } from "./workbench-file-context-menu";
 import { confirmAndTrashEntry } from "./workbench-file-actions";
 import { WorkspaceFileTree } from "./file-tree-source";
+import { useWorkspaceChanges } from "./workspace-changes";
 
 const INDENT_STEP = 12;
 const INDENT_BASE = 4;
@@ -162,6 +163,20 @@ function FileTreePaneInner({
     },
     [reload]
   );
+
+  // External file changes (issue #805): surgically reload the parent dir
+  // of each changed path. Events arrive already coalesced by the host;
+  // we dedupe by parent so one `git checkout` touching many files reloads
+  // each affected (and currently-expanded) folder once. `reload` no-ops
+  // for dirs that were never listed, so a change deep in a collapsed
+  // subtree costs nothing.
+  useWorkspaceChanges((events) => {
+    const parents = new Set<string>();
+    for (const e of events) {
+      parents.add(WorkspaceFileTree.parentRelPath(e.rel_path));
+    }
+    for (const parent of parents) reload(parent);
+  });
 
   const afterTrashed = useCallback(
     (relPath: string, isDirectory: boolean) => {

--- a/editor/scaffolds/desktop/workbench/workspace-changes.tsx
+++ b/editor/scaffolds/desktop/workbench/workspace-changes.tsx
@@ -62,9 +62,14 @@ export function WorkspaceChangesProvider({
       .subscribeChanges(workspaceId, (events) => {
         // Snapshot (Array.from, not live iteration) so a listener
         // attaching/detaching mid-dispatch can't mutate the set we're
-        // iterating.
+        // iterating. Isolate each callback so one throwing consumer (e.g. the
+        // editor) can't suppress the batch for the others (e.g. the file tree).
         for (const listener of Array.from(listenersRef.current)) {
-          listener(events);
+          try {
+            listener(events);
+          } catch (err) {
+            console.error("[workspace-changes] listener callback failed", err);
+          }
         }
       })
       .then((handle) => {

--- a/editor/scaffolds/desktop/workbench/workspace-changes.tsx
+++ b/editor/scaffolds/desktop/workbench/workspace-changes.tsx
@@ -1,0 +1,106 @@
+/**
+ * Workspace external-change fan-out (issue #805).
+ *
+ * One `workspaces.subscribe_changes` subscription per open workspace,
+ * shared by every consumer in the workbench — the file tree (surgical
+ * refresh of the affected parent) and each open editor pane (reload when
+ * clean / defer to the save-time conflict guard when dirty).
+ *
+ * A workbench-scoped context rather than prop-drilling through
+ * `EditorPane` + the tab stack: the consumers are scattered (the tree and
+ * each mounted pane) and all want the same stream. The subscription lives
+ * in the provider; consumers attach via {@link useWorkspaceChanges}, which
+ * holds the handler in a ref so it can be an inline closure without
+ * re-subscribing.
+ *
+ * No-op on desktop binaries without the watcher capability (and entirely
+ * on the web bridge): the provider simply never starts a subscription, so
+ * consumers fall back to the existing pull/manual refresh.
+ */
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+import {
+  workspaces as workspacesNs,
+  type WorkspaceChangeEvent,
+} from "@/lib/desktop/bridge";
+
+type ChangeListener = (events: WorkspaceChangeEvent[]) => void;
+type Subscribe = (listener: ChangeListener) => () => void;
+
+const WorkspaceChangesContext = createContext<Subscribe | null>(null);
+
+export function WorkspaceChangesProvider({
+  workspaceId,
+  children,
+}: {
+  workspaceId: string;
+  children: ReactNode;
+}) {
+  const listenersRef = useRef<Set<ChangeListener>>(new Set());
+
+  const subscribe = useCallback<Subscribe>((listener) => {
+    const listeners = listenersRef.current;
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!workspacesNs.isWatchSupported()) return;
+    let cancelled = false;
+    let subscriptionId: string | null = null;
+    workspacesNs
+      .subscribeChanges(workspaceId, (events) => {
+        // Snapshot (Array.from, not live iteration) so a listener
+        // attaching/detaching mid-dispatch can't mutate the set we're
+        // iterating.
+        for (const listener of Array.from(listenersRef.current)) {
+          listener(events);
+        }
+      })
+      .then((handle) => {
+        subscriptionId = handle.subscriptionId;
+        // The effect cleaned up before the async subscribe resolved.
+        if (cancelled) void workspacesNs.unsubscribeChanges(subscriptionId);
+      })
+      .catch(() => {
+        // Watch couldn't start (old binary / host error) — consumers stay
+        // on pull-refresh; nothing else to do.
+      });
+    return () => {
+      cancelled = true;
+      if (subscriptionId) void workspacesNs.unsubscribeChanges(subscriptionId);
+    };
+  }, [workspaceId]);
+
+  return (
+    <WorkspaceChangesContext.Provider value={subscribe}>
+      {children}
+    </WorkspaceChangesContext.Provider>
+  );
+}
+
+/**
+ * Attach a handler for coalesced external file-change batches under the
+ * workspace. No-op when the provider is absent or the binary lacks the
+ * watcher. `onChanges` is held in a ref, so an inline closure is fine and
+ * never causes a re-subscribe.
+ */
+export function useWorkspaceChanges(onChanges: ChangeListener): void {
+  const subscribe = useContext(WorkspaceChangesContext);
+  const ref = useRef(onChanges);
+  ref.current = onChanges;
+  useEffect(() => {
+    if (!subscribe) return;
+    return subscribe((events) => ref.current(events));
+  }, [subscribe]);
+}

--- a/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
+++ b/editor/scaffolds/desktop/workbench/workspace-workbench.tsx
@@ -63,6 +63,7 @@ import { EditorPane } from "./editor-pane";
 import { WorkspaceOpenInMenu } from "./workspace-open-in-menu";
 import { AgentPane } from "./agent-pane";
 import { TerminalPane } from "./terminal-pane";
+import { WorkspaceChangesProvider } from "./workspace-changes";
 
 /**
  * Pane sizing, matching the workstation-shell conventions:
@@ -330,144 +331,148 @@ export function WorkspaceWorkbench({ workspace }: { workspace: Workspace }) {
   }, [openFile]);
 
   return (
-    <div className="flex h-screen w-screen flex-col bg-background">
-      {/* The TitleBar exposes back/forward (Chromium history) and
+    <WorkspaceChangesProvider workspaceId={workspace.id}>
+      <div className="flex h-screen w-screen flex-col bg-background">
+        {/* The TitleBar exposes back/forward (Chromium history) and
           carries the workspace workbench's own chrome. Workspace-level
           actions sit flush right so they don't compete with the
           back/forward pair that NavButtons pins to the left. */}
-      <TitleBar>
-        <div className="flex min-w-0 flex-1 items-center overflow-hidden">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <FolderIcon className="size-3.5 shrink-0 text-sky-500" />
-            <span className="truncate font-medium text-foreground">
-              {workspace.name}
-            </span>
-            <span className="truncate font-mono text-muted-foreground">
-              {workspace.root}
-            </span>
+        <TitleBar>
+          <div className="flex min-w-0 flex-1 items-center overflow-hidden">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <FolderIcon className="size-3.5 shrink-0 text-sky-500" />
+              <span className="truncate font-medium text-foreground">
+                {workspace.name}
+              </span>
+              <span className="truncate font-mono text-muted-foreground">
+                {workspace.root}
+              </span>
+            </div>
           </div>
-        </div>
-        <div className="ml-auto flex shrink-0 items-center gap-1">
-          <WorkspaceOpenInMenu workspace={workspace} />
-          {supportsTerminal && (
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            <WorkspaceOpenInMenu workspace={workspace} />
+            {supportsTerminal && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                style={TITLEBAR_NO_DRAG_STYLE}
+                onClick={toggleTerminal}
+                aria-label={
+                  terminalOpen ? "Hide terminal pane" : "Show terminal pane"
+                }
+                aria-pressed={terminalOpen}
+                title={
+                  terminalOpen
+                    ? "Hide terminal pane (⌃`)"
+                    : "Show terminal pane (⌃`)"
+                }
+              >
+                <SquareTerminalIcon />
+              </Button>
+            )}
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
               style={TITLEBAR_NO_DRAG_STYLE}
-              onClick={toggleTerminal}
+              onClick={toggleTree}
               aria-label={
-                terminalOpen ? "Hide terminal pane" : "Show terminal pane"
+                showTree ? "Hide file tree pane" : "Show file tree pane"
               }
-              aria-pressed={terminalOpen}
+              aria-pressed={showTree}
               title={
-                terminalOpen
-                  ? "Hide terminal pane (⌃`)"
-                  : "Show terminal pane (⌃`)"
+                showTree
+                  ? "Hide file tree pane (⌘B)"
+                  : "Show file tree pane (⌘B)"
               }
             >
-              <SquareTerminalIcon />
+              {showTree ? <PanelRightCloseIcon /> : <PanelRightOpenIcon />}
             </Button>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            style={TITLEBAR_NO_DRAG_STYLE}
-            onClick={toggleTree}
-            aria-label={
-              showTree ? "Hide file tree pane" : "Show file tree pane"
-            }
-            aria-pressed={showTree}
-            title={
-              showTree ? "Hide file tree pane (⌘B)" : "Show file tree pane (⌘B)"
-            }
-          >
-            {showTree ? <PanelRightCloseIcon /> : <PanelRightOpenIcon />}
-          </Button>
-        </div>
-      </TitleBar>
+          </div>
+        </TitleBar>
 
-      <div className="min-h-0 flex-1">
-        {/* Vertical split: the three workbench panes on top, the
+        <div className="min-h-0 flex-1">
+          {/* Vertical split: the three workbench panes on top, the
             terminal panel at the bottom (VSCode-style). The bottom pair
             mounts on first ctrl+` and stays mounted while collapsed so
             the shell survives toggling; shell exit unmounts it. */}
-        <ResizablePanelGroup orientation="vertical">
-          <ResizablePanel>
-            {/* Horizontal is the default orientation in
+          <ResizablePanelGroup orientation="vertical">
+            <ResizablePanel>
+              {/* Horizontal is the default orientation in
                 react-resizable-panels v4 — omit the prop.
                 Order: AgentPane | EditorPane | FileTreePane. Agent-first puts the
                 agent pane in the dominant left position; the file tree pane
                 sits on the right as a secondary navigator and is
                 conditionally rendered so the EditorPane absorbs its
                 space when hidden. */}
-            <ResizablePanelGroup>
-              <ResizablePanel
-                defaultSize={AGENT_PANE_DEFAULT}
-                minSize={AGENT_PANE_MIN}
-              >
-                <AgentPane
-                  workspace={workspace}
-                  activeRelPath={activeRelPath}
-                  onMaybeMutated={bumpTreeRefresh}
-                />
-              </ResizablePanel>
-              <ResizableHandle />
-              <ResizablePanel defaultSize="57%" minSize={EDITOR_PANE_MIN}>
-                <EditorPane
-                  workspace={workspace}
-                  openTabs={openTabs}
-                  activeRelPath={activeRelPath}
-                  onSelectTab={setActiveRelPath}
-                  onCloseTab={closeTab}
-                  onReopenClosedTab={reopenClosedTab}
-                  onSaved={bumpTreeRefresh}
-                  onFileTrashed={(rp) => handleEntryTrashed(rp, false)}
-                />
-              </ResizablePanel>
-              {showTree && (
-                <>
-                  <ResizableHandle />
-                  <ResizablePanel
-                    defaultSize={FILE_TREE_PANE_DEFAULT}
-                    minSize={FILE_TREE_PANE_MIN}
-                    maxSize={FILE_TREE_PANE_MAX}
-                    className="bg-muted/20"
-                  >
-                    <FileTreePane
-                      workspace={workspace}
-                      activeRelPath={activeRelPath}
-                      onOpenFile={(rp) => {
-                        if (rp) openFile(rp);
-                      }}
-                      refreshKey={treeRefreshKey}
-                      onEntryTrashed={handleEntryTrashed}
-                    />
-                  </ResizablePanel>
-                </>
-              )}
-            </ResizablePanelGroup>
-          </ResizablePanel>
-          {terminalSpawned && (
-            <>
-              <ResizableHandle />
-              <ResizablePanel
-                panelRef={terminalPanelRef}
-                collapsible
-                defaultSize={TERMINAL_PANE_DEFAULT}
-                minSize={TERMINAL_PANE_MIN}
-                onResize={(size) => setTerminalOpen(size.inPixels > 0)}
-              >
-                <TerminalPane
-                  workspace={workspace}
-                  onSessionEnded={handleTerminalSessionEnded}
-                />
-              </ResizablePanel>
-            </>
-          )}
-        </ResizablePanelGroup>
+              <ResizablePanelGroup>
+                <ResizablePanel
+                  defaultSize={AGENT_PANE_DEFAULT}
+                  minSize={AGENT_PANE_MIN}
+                >
+                  <AgentPane
+                    workspace={workspace}
+                    activeRelPath={activeRelPath}
+                    onMaybeMutated={bumpTreeRefresh}
+                  />
+                </ResizablePanel>
+                <ResizableHandle />
+                <ResizablePanel defaultSize="57%" minSize={EDITOR_PANE_MIN}>
+                  <EditorPane
+                    workspace={workspace}
+                    openTabs={openTabs}
+                    activeRelPath={activeRelPath}
+                    onSelectTab={setActiveRelPath}
+                    onCloseTab={closeTab}
+                    onReopenClosedTab={reopenClosedTab}
+                    onSaved={bumpTreeRefresh}
+                    onFileTrashed={(rp) => handleEntryTrashed(rp, false)}
+                  />
+                </ResizablePanel>
+                {showTree && (
+                  <>
+                    <ResizableHandle />
+                    <ResizablePanel
+                      defaultSize={FILE_TREE_PANE_DEFAULT}
+                      minSize={FILE_TREE_PANE_MIN}
+                      maxSize={FILE_TREE_PANE_MAX}
+                      className="bg-muted/20"
+                    >
+                      <FileTreePane
+                        workspace={workspace}
+                        activeRelPath={activeRelPath}
+                        onOpenFile={(rp) => {
+                          if (rp) openFile(rp);
+                        }}
+                        refreshKey={treeRefreshKey}
+                        onEntryTrashed={handleEntryTrashed}
+                      />
+                    </ResizablePanel>
+                  </>
+                )}
+              </ResizablePanelGroup>
+            </ResizablePanel>
+            {terminalSpawned && (
+              <>
+                <ResizableHandle />
+                <ResizablePanel
+                  panelRef={terminalPanelRef}
+                  collapsible
+                  defaultSize={TERMINAL_PANE_DEFAULT}
+                  minSize={TERMINAL_PANE_MIN}
+                  onResize={(size) => setTerminalOpen(size.inPixels > 0)}
+                >
+                  <TerminalPane
+                    workspace={workspace}
+                    onSessionEnded={handleTerminalSessionEnded}
+                  />
+                </ResizablePanel>
+              </>
+            )}
+          </ResizablePanelGroup>
+        </div>
       </div>
-    </div>
+    </WorkspaceChangesProvider>
   );
 }

--- a/packages/grida-ai-agent/src/http/routes/workspaces.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.ts
@@ -141,12 +141,17 @@ export function registerWorkspacesRoutes(
     }
   });
 
-  // POST /workspaces/writefile { workspaceId, relPath, content } → {mtime}
+  // POST /workspaces/writefile
+  //   { workspaceId, relPath, content, expected_mtime? } → {mtime}
+  // expected_mtime is the optimistic-concurrency token (issue #805):
+  // when present and the file on disk has advanced past it, the write is
+  // rejected with 409 `modified-since` carrying the current mtime.
   app.post("/workspaces/writefile", async (c) => {
     const r = await body(c, {
       workspace_id: v.string,
       rel_path: v.string,
       content: v.stringAllowEmpty,
+      expected_mtime: v.optional(v.number),
     });
     if (!r.ok) return r.res;
     const workspace = await requireWorkspace(c, registry, r.data.workspace_id);
@@ -155,7 +160,8 @@ export function registerWorkspacesRoutes(
       const result = await workspaceFs.writeFile(
         workspace,
         r.data.rel_path,
-        r.data.content
+        r.data.content,
+        { expected_mtime: r.data.expected_mtime }
       );
       return c.json(result);
     } catch (err) {
@@ -171,13 +177,19 @@ export function registerWorkspacesRoutes(
  */
 function mapFsError(err: unknown, c: Context) {
   if (err instanceof workspaceFs.Exception) {
-    const status = err.detail.code === "path-escapes-workspace" ? 403 : 400;
+    const status =
+      err.detail.code === "path-escapes-workspace"
+        ? 403
+        : err.detail.code === "modified-since"
+          ? 409
+          : 400;
     return c.json(
       {
         error: err.detail.code,
         code: err.detail.code,
         rel_path: err.detail.rel_path,
         size: err.detail.size,
+        mtime: err.detail.mtime,
       },
       status
     );

--- a/packages/grida-ai-agent/src/http/validate.ts
+++ b/packages/grida-ai-agent/src/http/validate.ts
@@ -34,6 +34,11 @@ export namespace v {
       ? { ok: true, value: raw }
       : { ok: false, error: "must be a boolean" };
 
+  export const number: Validator<number> = (raw) =>
+    typeof raw === "number" && Number.isFinite(raw)
+      ? { ok: true, value: raw }
+      : { ok: false, error: "must be a finite number" };
+
   export const array: Validator<unknown[]> = (raw) =>
     Array.isArray(raw)
       ? { ok: true, value: raw }

--- a/packages/grida-ai-agent/src/storage/atomic-write.ts
+++ b/packages/grida-ai-agent/src/storage/atomic-write.ts
@@ -27,6 +27,17 @@ export type AtomicWriteOptions = {
    * created paths under `userData`.
    */
   ensure_dir?: boolean;
+  /**
+   * Last-chance precondition (issue #805 optimistic concurrency): invoked
+   * AFTER the tmp file is staged and immediately BEFORE the atomic rename.
+   * Throw to abort the publish — the staged tmp file is cleaned up and the
+   * error propagates. Running it here (rather than as a caller-side preflight)
+   * shrinks the check→replace window to the single `rename` syscall instead of
+   * spanning the potentially-slow tmp write. It is NOT fully atomic — rename(2)
+   * takes no precondition — but that residual sub-syscall window is the
+   * accepted cost of mtime-based optimistic concurrency.
+   */
+  before_commit?: () => void | Promise<void>;
 };
 
 export async function atomicWrite(
@@ -51,6 +62,9 @@ export async function atomicWrite(
   try {
     await fs.writeFile(tmpPath, content, { mode: opts.mode ?? 0o600 });
     tmpCreated = true;
+    // Enforce the optimistic-concurrency precondition as late as possible —
+    // a throw here aborts the publish and the catch below removes the tmp.
+    if (opts.before_commit) await opts.before_commit();
     await fs.rename(tmpPath, filePath);
     tmpCreated = false;
   } catch (err) {

--- a/packages/grida-ai-agent/src/transport.ts
+++ b/packages/grida-ai-agent/src/transport.ts
@@ -380,12 +380,17 @@ export namespace AgentTransport {
       write_file: async (
         workspaceId: string,
         relPath: string,
-        content: string
+        content: string,
+        // Optimistic-concurrency token (issue #805): the mtime the caller
+        // last observed. Omitted → last-writer-wins; present → the host
+        // rejects with 409 `modified-since` if disk has advanced.
+        expectedMtime?: number
       ): Promise<WorkspaceWriteFileResult> =>
         await this.postJson<WorkspaceWriteFileResult>("/workspaces/writefile", {
           workspace_id: workspaceId,
           rel_path: relPath,
           content,
+          expected_mtime: expectedMtime,
         }),
     } as const;
 

--- a/packages/grida-ai-agent/src/workspaces.fs.test.ts
+++ b/packages/grida-ai-agent/src/workspaces.fs.test.ts
@@ -82,4 +82,71 @@ describe("workspaceFs", () => {
       fs.access(path.join(outside, "new.txt"))
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  describe("writeFile optimistic-concurrency guard (issue #805)", () => {
+    it("writes without a precondition (last-writer-wins)", async () => {
+      const res = await workspaceFs.writeFile(
+        fixture.workspace,
+        "a.svg",
+        "<svg/>"
+      );
+      expect(typeof res.mtime).toBe("number");
+    });
+
+    it("accepts a write when expected_mtime matches disk", async () => {
+      const first = await workspaceFs.writeFile(
+        fixture.workspace,
+        "a.svg",
+        "<svg/>"
+      );
+      await workspaceFs.writeFile(fixture.workspace, "a.svg", "<svg id='2'/>", {
+        expected_mtime: first.mtime,
+      });
+      const { content } = await workspaceFs.readFile(
+        fixture.workspace,
+        "a.svg"
+      );
+      expect(content).toBe("<svg id='2'/>");
+    });
+
+    it("rejects a stale write with modified-since carrying the disk mtime", async () => {
+      const first = await workspaceFs.writeFile(
+        fixture.workspace,
+        "a.svg",
+        "<svg/>"
+      );
+      await expect(
+        workspaceFs.writeFile(fixture.workspace, "a.svg", "clobber", {
+          // a token older than disk → disk has "advanced" past it
+          expected_mtime: first.mtime - 1000,
+        })
+      ).rejects.toMatchObject({
+        detail: { code: "modified-since", mtime: first.mtime },
+      });
+      // the write was refused — disk content is untouched
+      const { content } = await workspaceFs.readFile(
+        fixture.workspace,
+        "a.svg"
+      );
+      expect(content).toBe("<svg/>");
+    });
+
+    it("treats a deleted-on-disk file as a conflict when expected_mtime is set", async () => {
+      const first = await workspaceFs.writeFile(
+        fixture.workspace,
+        "a.svg",
+        "<svg/>"
+      );
+      await fs.rm(path.join(fixture.workspace_root, "a.svg"));
+      await expect(
+        workspaceFs.writeFile(fixture.workspace, "a.svg", "resurrect", {
+          expected_mtime: first.mtime,
+        })
+      ).rejects.toMatchObject({ detail: { code: "modified-since" } });
+      // not silently recreated under the old name
+      await expect(
+        fs.access(path.join(fixture.workspace_root, "a.svg"))
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
 });

--- a/packages/grida-ai-agent/src/workspaces/fs.ts
+++ b/packages/grida-ai-agent/src/workspaces/fs.ts
@@ -53,13 +53,21 @@ export namespace workspaceFs {
     | "not-a-directory"
     | "not-a-file"
     | "file-too-large"
-    | "file-not-utf8";
+    | "file-not-utf8"
+    | "modified-since";
 
   export type ErrorDetail = {
     code: ErrorCode;
     workspace_id?: string;
     rel_path?: string;
     size?: number;
+    /**
+     * Current on-disk mtime, set on `modified-since` so the client can
+     * reconcile (reload / overwrite-with-this-as-the-new-baseline)
+     * without a second round trip. Omitted when the expected file is
+     * gone on disk (deleted out from under the caller).
+     */
+    mtime?: number;
   };
 
   /**
@@ -265,6 +273,21 @@ export namespace workspaceFs {
    * directory). Creates parent directories if needed. Returns the new
    * mtime so the client can update its conflict-detection state.
    *
+   * Optimistic-concurrency guard (issue #805): when the caller passes
+   * `expected_mtime` (the mtime it captured the last time it read or
+   * wrote the file), the write is rejected with `modified-since` if the
+   * file on disk has advanced past that token — an external writer (or
+   * the agent) changed it in the meantime, and a blind write would
+   * silently clobber that change with no conflict detection. The caller
+   * resolves the conflict (reload from disk / overwrite anyway) and
+   * retries. Omitting `expected_mtime` keeps the old last-writer-wins
+   * behavior, so the agent's own writes and first-time creates are
+   * unaffected.
+   *
+   * A file that was deleted out from under the caller (ENOENT while an
+   * `expected_mtime` was supplied) is also a conflict — we don't
+   * silently resurrect it under the old name.
+   *
    * Note: we don't enforce MAX_FILE_BYTES on the write side — the
    * client can always re-read a file it just wrote, but a Monaco
    * buffer of 50MB is the user's problem to surface, not the agent host's
@@ -273,7 +296,8 @@ export namespace workspaceFs {
   export async function writeFile(
     workspace: Workspace,
     relPath: string,
-    content: string
+    content: string,
+    options: { expected_mtime?: number } = {}
   ): Promise<{ mtime: number }> {
     // mustExist:false — we may be creating a new file. But the parent
     // dir must be inside the workspace, which `resolveInside` verifies
@@ -283,6 +307,26 @@ export namespace workspaceFs {
     // policy boundary).
     const abs = await resolveInside(workspace, relPath, { must_exist: false });
     await resolveWritableParent(workspace, abs, relPath);
+    if (options.expected_mtime !== undefined) {
+      // Plain Stats (not the bigint overload) — mtimeMs is a number that
+      // round-trips through the JSON precondition token verbatim.
+      let current: import("node:fs").Stats | undefined;
+      try {
+        current = await fs.stat(abs);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+        // ENOENT → the file the caller expected is gone; fall through to
+        // the !current conflict below rather than re-creating it blindly.
+      }
+      if (!current || current.mtimeMs !== options.expected_mtime) {
+        throw new Exception({
+          code: "modified-since",
+          workspace_id: workspace.id,
+          rel_path: relPath,
+          mtime: current?.mtimeMs,
+        });
+      }
+    }
     // User-owned content — default 0o644 instead of `auth.json`'s 0o600.
     await atomicWrite(abs, content, { ensure_dir: false, mode: 0o644 });
     const stat = await fs.stat(abs);

--- a/packages/grida-ai-agent/src/workspaces/fs.ts
+++ b/packages/grida-ai-agent/src/workspaces/fs.ts
@@ -307,28 +307,42 @@ export namespace workspaceFs {
     // policy boundary).
     const abs = await resolveInside(workspace, relPath, { must_exist: false });
     await resolveWritableParent(workspace, abs, relPath);
-    if (options.expected_mtime !== undefined) {
-      // Plain Stats (not the bigint overload) — mtimeMs is a number that
-      // round-trips through the JSON precondition token verbatim.
-      let current: import("node:fs").Stats | undefined;
-      try {
-        current = await fs.stat(abs);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-        // ENOENT → the file the caller expected is gone; fall through to
-        // the !current conflict below rather than re-creating it blindly.
-      }
-      if (!current || current.mtimeMs !== options.expected_mtime) {
-        throw new Exception({
-          code: "modified-since",
-          workspace_id: workspace.id,
-          rel_path: relPath,
-          mtime: current?.mtimeMs,
-        });
-      }
-    }
+    // Optimistic-concurrency precondition (issue #805), enforced as
+    // atomicWrite's `before_commit` hook so it runs immediately before the
+    // rename that publishes the bytes — the check→replace gap is then a single
+    // rename syscall, not the whole tmp-write. A mismatch (or an ENOENT: the
+    // file was deleted out from under us) aborts the write before the rename;
+    // atomicWrite removes the tmp it had staged. Omitting `expected_mtime`
+    // keeps last-writer-wins, so agent writes / first creates are unaffected.
+    const before_commit =
+      options.expected_mtime === undefined
+        ? undefined
+        : async () => {
+            // Plain Stats (not the bigint overload) — mtimeMs is a number that
+            // round-trips through the JSON precondition token verbatim.
+            let current: import("node:fs").Stats | undefined;
+            try {
+              current = await fs.stat(abs);
+            } catch (err) {
+              if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+              // ENOENT → the expected file is gone; fall through to the
+              // `!current` conflict rather than re-creating it blindly.
+            }
+            if (!current || current.mtimeMs !== options.expected_mtime) {
+              throw new Exception({
+                code: "modified-since",
+                workspace_id: workspace.id,
+                rel_path: relPath,
+                mtime: current?.mtimeMs,
+              });
+            }
+          };
     // User-owned content — default 0o644 instead of `auth.json`'s 0o600.
-    await atomicWrite(abs, content, { ensure_dir: false, mode: 0o644 });
+    await atomicWrite(abs, content, {
+      ensure_dir: false,
+      mode: 0o644,
+      before_commit,
+    });
     const stat = await fs.stat(abs);
     return { mtime: stat.mtimeMs };
   }

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -45,6 +45,12 @@ export type DesktopNativeCapabilities = {
    * desktop binary, no terminal" and hide the surface.
    */
   terminal: boolean;
+  /**
+   * Workspace file-change watcher (issue #805) — `workspaces.subscribe_changes`.
+   * Added after protocol 1 shipped; treat a missing/falsy value as "old
+   * desktop binary" and fall back to manual/pull refresh.
+   */
+  workspace_watch: boolean;
 };
 
 export type DesktopCapabilities = {
@@ -110,6 +116,22 @@ export type DesktopHostAppInfo = {
   installed: boolean;
   supports: Array<"workspace">;
 };
+
+/**
+ * A single coalesced external change under a watched workspace root
+ * (issue #805). `kind` is intentionally coarse — the renderer reacts by
+ * re-reading the affected path / re-listing its parent, so it doesn't
+ * need byte-level deltas. A rename surfaces as `deleted` (old path) +
+ * `added` (new path) in v1.
+ */
+export type WorkspaceChangeEvent = {
+  kind: "added" | "changed" | "deleted";
+  /** Workspace-relative POSIX path of the changed entry. */
+  rel_path: string;
+};
+
+/** Receives coalesced batches of {@link WorkspaceChangeEvent}. */
+export type WorkspaceChangeHandler = (events: WorkspaceChangeEvent[]) => void;
 
 export type TerminalCreateOptions = {
   /** Workspace whose root becomes the shell's cwd. Resolved host-side
@@ -179,10 +201,19 @@ export type DesktopBridge = {
       workspaceId: string,
       relPath: string
     ) => Promise<WorkspaceReadFileBytesResult>;
+    /**
+     * Write `content` to `relPath`. `expectedMtime` is the optimistic-
+     * concurrency token (issue #805): the mtime the renderer last
+     * observed for this file. When supplied and the file on disk has
+     * advanced past it, the host rejects with a 409 `modified-since`
+     * error instead of silently clobbering the external change. Omit it
+     * for force-overwrite / first-time-create / last-writer-wins.
+     */
     write_file: (
       workspaceId: string,
       relPath: string,
-      content: string
+      content: string,
+      expectedMtime?: number
     ) => Promise<WorkspaceWriteFileResult>;
     /**
      * Move a workspace entry (file or folder) to the OS trash
@@ -194,6 +225,26 @@ export type DesktopBridge = {
      * user first.
      */
     trash_entry: (workspaceId: string, relPath: string) => Promise<void>;
+    /**
+     * Subscribe to external file-system changes under the workspace root
+     * (issue #805). The host watches the real directory tree and pushes
+     * coalesced batches of {@link WorkspaceChangeEvent} — covering edits
+     * made outside the editor, including the agent's own writes. Like
+     * `trash_entry` this is a native host capability (the OS watcher lives
+     * in the desktop main process), not an agent-sidecar operation.
+     *
+     * `subscribe_changes` registers `on_change` before the OS watch
+     * starts (caller-mints-id, mirroring `terminal.create`) so an early
+     * event can't race the subscription. Resolves with the id used to
+     * {@link unsubscribe_changes}. Additive on protocol 1 — gate the UI on
+     * `caps.native.workspace_watch`; older binaries lack the channel.
+     */
+    subscribe_changes: (
+      workspaceId: string,
+      on_change: WorkspaceChangeHandler
+    ) => Promise<{ subscription_id: string }>;
+    /** Stop a subscription started by {@link subscribe_changes}. */
+    unsubscribe_changes: (subscriptionId: string) => Promise<void>;
   };
   /**
    * GRIDA-SEC-004 — human-interactive terminal. A real, unsandboxed


### PR DESCRIPTION
Closes #805.

Grida Desktop treats the agent as a **first-class concurrent writer**, but the workbench had no awareness of changes made to workspace files *outside* the open editor — the agent's own writes, a `git checkout`, another editor. Saving over an externally-modified file silently clobbered it. This implements the VSCode model end-to-end.

## What changed

### 1. Save-conflict guard — the data-loss fix (transport-agnostic: protects web **and** desktop)
- `workspaces.writeFile` takes an optional `expected_mtime` precondition. A stale token is rejected with **409 `modified-since`** (carrying the current on-disk mtime) instead of silently overwriting. Omitting it preserves last-writer-wins, so agent writes and first-time creates are unaffected.
- Plumbed as a first-class optional param through every layer: `fs` → http route → transport → bridge contract → preload → editor client.
- `isWriteConflict()` detects the rejection tolerantly across the Electron `contextBridge` (which strips custom `Error` properties — so it keys off the surviving `message` string, with `status`/`code` as belt-and-suspenders).
- The open SVG editor surfaces a **Keep editing / Reload from disk / Overwrite anyway** resolver.

### 2. OS watcher (desktop-only, behind additive cap `native.workspace_watch`)
- New main-process host on **`@parcel/watcher`** (the recursive per-OS backend VSCode uses), mirroring `terminal-host.ts`: one OS watch per workspace root, **ref-counted across windows/panes**, ~75 ms coalesced batches, ignore globs (`.git`, `node_modules`, build dirs) pushed to the native backend, torn down on window close / app quit.
- Reached only through `guarded()` IPC; the watch root is resolved **host-side** from the sidecar registry (the renderer only ever names a workspace id, never a raw path). Subscription ids are preload-minted *before* the watch starts so no early event can race. See **GRIDA-SEC-004**.
- Native-module packaging mirrors `node-pty`: `dependencies` + vite external + `asar.unpack` glob + `pnpm allowBuilds:false` (rely on per-platform prebuilds).

### 3. Renderer wiring
- `WorkspaceChangesProvider` holds **one** subscription per workspace; consumers attach via `useWorkspaceChanges`. The open editor reloads-when-clean / defers-to-the-save-guard-when-dirty; the file tree reloads only the affected parent dirs.
- The web daemon bridge stubs the watch methods (`caps.workspace_watch: false`), so non-Electron hosts fall back cleanly to pull-refresh.

## Reviewer notes
- **Security boundary (GRIDA-SEC-004):** every new IPC channel is `guarded()`; workspace-id → root resolution is host-side; the contextBridge fanout passes structured-clone payloads only (never the Electron event object). An anti-drift test asserts the `guarded()` registration.
- **Packaging not yet exercised in CI:** the `@parcel/watcher` deps/external/`asar.unpack`/prebuild recipe is correct-by-construction (the bundle oracle auto-discovers the dynamic `import()` and follows the prebuild `optionalDependencies`), but a real `electron-forge package` run on each platform is still worth confirming.

## Tests
- `workspaces.fs` conflict-guard: last-writer-wins, matching/stale mtime, deleted-on-disk = conflict.
- Desktop `workspace-watcher-host`: pure helpers, ref-count registry, and the GRIDA-SEC-004 `guarded()` anti-drift check.
- Verified locally: agent suite **513 passed**, desktop **65 passed**, desktop + editor typecheck clean, oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time external workspace file watching on desktop, with coalesced change updates (including targeted file tree refresh).
  * Idle editors auto-reload to pick up external updates.
  * Saving now supports optimistic concurrency to prevent overwriting newer on-disk changes; conflicts show a dialog with options to keep editing, reload from disk, or overwrite.

* **Chores**
  * Improved macOS packaging/rebuild handling so the native file-watcher add-on works reliably, including updated bundle verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->