### PR TITLE
fix(agent): bound workspace hydrate scan + reads (#786)

### DIFF
--- a/packages/grida-ai-agent/src/fs/fs.test.ts
+++ b/packages/grida-ai-agent/src/fs/fs.test.ts
@@ -514,6 +514,65 @@ describe("AgentFs.hydrate", () => {
     await Promise.all([fs.hydrate(), fs.hydrate(), fs.hydrate()]);
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * Issue #786 — the read fan-out must be BOUNDED. The old
+   * `Promise.allSettled(paths.map(read))` issued one concurrent read per path;
+   * on a large backend that overflows V8's promise-combinator element cap and
+   * exhausts file descriptors. A backend that reports many paths must hydrate
+   * with a constant number of reads in flight.
+   */
+  it("reads with bounded concurrency over a large path list", async () => {
+    const N = 5_000;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    // Backend that lists N synthetic paths and tracks peak read concurrency.
+    const backend: AgentFs.Backend = {
+      async list() {
+        return Array.from({ length: N }, (_, i) => `/f${i}.txt`);
+      },
+      async read(path) {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // Yield so concurrent reads actually overlap before resolving.
+        await Promise.resolve();
+        inFlight--;
+        return `content:${path}`;
+      },
+      async write() {},
+      async delete() {},
+    };
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+
+    // Every path materialized...
+    expect(fs.list()).toHaveLength(N);
+    expect(fs.read("/f0.txt")?.content).toBe("content:/f0.txt");
+    expect(fs.read(`/f${N - 1}.txt`)?.content).toBe(`content:/f${N - 1}.txt`);
+    // ...but never more than the fixed worker width at once. (24 is the
+    // module constant; assert a small constant rather than ~N.)
+    expect(maxInFlight).toBeLessThanOrEqual(24);
+  });
+
+  it("survives a per-read rejection without aborting the hydrate", async () => {
+    const backend: AgentFs.Backend = {
+      async list() {
+        return ["/ok-a.txt", "/boom.txt", "/ok-b.txt"];
+      },
+      async read(path) {
+        if (path === "/boom.txt") throw new Error("synthetic read failure");
+        return `content:${path}`;
+      },
+      async write() {},
+      async delete() {},
+    };
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+    // The good paths still load; the failed one is simply absent.
+    expect(fs.read("/ok-a.txt")?.content).toBe("content:/ok-a.txt");
+    expect(fs.read("/ok-b.txt")?.content).toBe("content:/ok-b.txt");
+    expect(fs.read("/boom.txt")).toBeNull();
+  });
 });
 
 describe("AgentFs — auto-flush (debounced)", () => {

--- a/packages/grida-ai-agent/src/fs/index.ts
+++ b/packages/grida-ai-agent/src/fs/index.ts
@@ -50,6 +50,48 @@ const PATH_DESCRIPTION =
   "Absolute path in the agent filesystem, starting with `/`. " +
   "Examples: `/canvas.svg`, `/notes/draft.md`.";
 
+/**
+ * Max concurrent backend reads during `hydrate()` (issue #786). A small fixed
+ * width: enough to keep disk/IPC busy, low enough to never approach the OS fd
+ * limit or V8's promise-combinator element cap even when the backend lists a
+ * whole repo. The enumeration side is also bounded (workspace backend caps the
+ * path list), so this is defense in depth: any backend handing back a large
+ * list reads safely.
+ */
+const HYDRATE_READ_CONCURRENCY = 24;
+
+/**
+ * `Promise.allSettled`-shaped map with a fixed in-flight width. Results are
+ * positionally aligned to `items` (so a downstream `items[i]` ↔ `results[i]`
+ * loop is valid). Unlike `Promise.allSettled(items.map(fn))`, only `limit`
+ * calls to `fn` are ever pending at once, and the only `Promise.all` is over
+ * `limit` workers — a small constant — so a huge `items` can't overflow the
+ * combinator's element cap.
+ */
+async function mapSettledBounded<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = Array.from({
+    length: items.length,
+  });
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const i = cursor++;
+      try {
+        results[i] = { status: "fulfilled", value: await fn(items[i]) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  };
+  const width = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: width }, () => worker()));
+  return results;
+}
+
 // ---------------------------------------------------------------------------
 // AgentFs — the class.
 //
@@ -194,10 +236,18 @@ export class AgentFs {
       console.warn("[agent-fs] backend.list failed:", err);
       return;
     }
-    // Fan out reads; the apply-to-state step that follows must be
-    // sequential (binding.load + Map mutations aren't reentrant).
-    const reads = await Promise.allSettled(
-      paths.map((p) => this.backend.read(p))
+    // Fan out reads with BOUNDED concurrency (issue #786). The old
+    // `Promise.allSettled(paths.map(read))` issued one read per path at once:
+    // on a large backend (a real workspace tree) that exhausts file
+    // descriptors, and a long-enough list overflows V8's promise-combinator
+    // element cap ("Too many elements passed to Promise.all"). A fixed-width
+    // worker pool keeps in-flight reads constant regardless of list size. The
+    // apply-to-state step that follows must stay sequential (binding.load +
+    // Map mutations aren't reentrant).
+    const reads = await mapSettledBounded(
+      paths,
+      HYDRATE_READ_CONCURRENCY,
+      (p) => this.backend.read(p)
     );
     for (let i = 0; i < paths.length; i++) {
       if (this.disposed) return;

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
@@ -143,6 +143,35 @@ describe("WorkspaceAgentFsBackend — bounded/filtered hydrate scan", () => {
     expect(listed.some((p) => p.includes("/node_modules/"))).toBe(false);
     expect(listed.some((p) => p.includes("/dist/"))).toBe(false);
   });
+
+  /**
+   * #786 follow-up (Codex review): a binary-heavy subtree that sorts BEFORE the
+   * source must not consume the file cap. `read()` returns null for binary
+   * content, so those paths never hydrate — counting them toward SCAN_MAX_FILES
+   * would let an `assets/` of images starve the real source that sorts after
+   * it. The walk must drop known-binary files at enumeration time.
+   */
+  it("does not let a binary asset subtree crowd out source files", async () => {
+    // `assets` sorts before `src`; seed it with images that read() can't serve.
+    for (let i = 0; i < 60; i++) {
+      await writeFile(`assets/img${i}.png`);
+      await writeFile(`assets/icon${i}.webp`);
+    }
+    await writeFile("assets/logo.svg"); // svg is text — must survive
+    await writeFile("src/index.ts");
+    await writeFile("src/app.tsx");
+
+    const listed = await backend.list();
+
+    expect(listed).toContain("/src/index.ts");
+    expect(listed).toContain("/src/app.tsx");
+    expect(listed).toContain("/assets/logo.svg");
+    // No binary asset leaks in — neither the .png nor the .webp.
+    expect(listed.some((p) => p.endsWith(".png"))).toBe(false);
+    expect(listed.some((p) => p.endsWith(".webp"))).toBe(false);
+    // 120 binaries dropped; only the 3 text files remain.
+    expect(listed).toHaveLength(3);
+  });
 });
 
 /**

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
@@ -68,6 +68,84 @@ describe("WorkspaceAgentFsBackend — path mapping", () => {
 });
 
 /**
+ * Issue #786 — the hydrate enumeration must be BOUNDED + FILTERED. An
+ * unfiltered walk over a real project (`node_modules`, `.git`, build output)
+ * returns the whole tree, which the downstream read fan-out then tries to
+ * slurp at once → OOM / "Too many elements passed to Promise.all". These pin
+ * that `list()` skips the heavy/generated subtrees while still surfacing the
+ * real source files.
+ */
+describe("WorkspaceAgentFsBackend — bounded/filtered hydrate scan", () => {
+  let baseDir: string;
+  let workspaceRoot: string;
+  let backend: WorkspaceAgentFsBackend;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "grida-wsfs-scan-"));
+    const wsDir = path.join(baseDir, "ws");
+    await fs.mkdir(wsDir);
+    workspaceRoot = await fs.realpath(wsDir);
+    const registry = new WorkspaceRegistry(path.join(baseDir, "ud"));
+    const ws = await registry.open(workspaceRoot);
+    backend = new WorkspaceAgentFsBackend(ws);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(rel: string, content = "x"): Promise<void> {
+    const abs = path.join(workspaceRoot, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  it("walks real source but skips node_modules / .git / build output", async () => {
+    // Real source — must appear.
+    await writeFile("src/index.ts");
+    await writeFile("src/lib/util.ts");
+    await writeFile("README.md");
+    // Heavy/generated subtrees — must NOT appear. Seed each with enough
+    // entries that a regression (no filtering) is unmistakable.
+    for (let i = 0; i < 50; i++) {
+      await writeFile(`node_modules/pkg${i}/index.js`);
+      await writeFile(`node_modules/pkg${i}/nested/deep/file${i}.js`);
+    }
+    await writeFile(".git/objects/ab/cdef");
+    await writeFile(".git/HEAD", "ref: refs/heads/main");
+    await writeFile("dist/bundle.js");
+    await writeFile("target/debug/artifact.bin");
+    await writeFile(".next/cache/x");
+
+    const listed = await backend.list();
+
+    expect(listed).toContain("/src/index.ts");
+    expect(listed).toContain("/src/lib/util.ts");
+    expect(listed).toContain("/README.md");
+    // None of the ignored subtrees leak in.
+    expect(listed.some((p) => p.startsWith("/node_modules/"))).toBe(false);
+    expect(listed.some((p) => p.startsWith("/.git/"))).toBe(false);
+    expect(listed.some((p) => p.startsWith("/dist/"))).toBe(false);
+    expect(listed.some((p) => p.startsWith("/target/"))).toBe(false);
+    expect(listed.some((p) => p.startsWith("/.next/"))).toBe(false);
+    // The whole tree had 100+ node_modules files; the bounded list is tiny.
+    expect(listed).toHaveLength(3);
+  });
+
+  it("skips an ignored dir even when nested under real source", async () => {
+    await writeFile("packages/app/src/main.ts");
+    await writeFile("packages/app/node_modules/dep/index.js");
+    await writeFile("packages/app/dist/out.js");
+
+    const listed = await backend.list();
+
+    expect(listed).toContain("/packages/app/src/main.ts");
+    expect(listed.some((p) => p.includes("/node_modules/"))).toBe(false);
+    expect(listed.some((p) => p.includes("/dist/"))).toBe(false);
+  });
+});
+
+/**
  * GRIDA-SEC-004 — the supervised approval gate (RFC `permission modes`, Phase
  * 2) is wired here: the command capability's `needs_approval` predicate is the
  * single source the run_command tool's `needsApproval` reads. `accept-edits`

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
@@ -14,6 +14,11 @@ import type { SkillId } from "../agent";
 import { AGENT_DEFAULT_MODE, type AgentMode } from "../protocol/mode";
 import { createAgentCommandBackend } from "./command-backend";
 import { workspaceFs } from "../workspaces/fs";
+import {
+  isIgnoredScanDir,
+  SCAN_MAX_DEPTH,
+  SCAN_MAX_FILES,
+} from "../workspaces/scan";
 import type { Workspace, WorkspaceRegistry } from "../workspaces";
 
 export type WorkspaceAgentBindingRequest = {
@@ -99,9 +104,25 @@ export async function createWorkspaceAgentBindings(
 export class WorkspaceAgentFsBackend implements AgentFs.Backend {
   constructor(private readonly workspace: Workspace) {}
 
+  /**
+   * Enumerate the workspace tree for hydration (issue #786). The scan is
+   * BOUNDED: it skips well-known heavy/generated directories (`node_modules`,
+   * `.git`, build output — see `workspaces/scan`) and stops at a file-count /
+   * depth cap. An unbounded walk over a real repo returns hundreds of
+   * thousands to millions of paths, which the downstream read fan-out then
+   * tries to slurp at once — the OOM / "Too many elements passed to
+   * Promise.all" failure this guards against.
+   */
   async list(): Promise<string[]> {
     const out: string[] = [];
-    await this.walk("", out);
+    const truncated = await this.walk("", 0, out);
+    if (truncated) {
+      console.warn(
+        `[agent-fs] workspace hydrate scan hit a cap at ${this.workspace.root} ` +
+          `(${SCAN_MAX_FILES}-file / depth-${SCAN_MAX_DEPTH}); the agent's initial ` +
+          `file list is truncated. It can still read any path on demand via the shell.`
+      );
+    }
     return out;
   }
 
@@ -161,19 +182,54 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
     return p.slice(1);
   }
 
-  private async walk(relPath: string, out: string[]): Promise<void> {
-    const entries = await workspaceFs.readDir(this.workspace, relPath);
-    await Promise.all(
-      entries.map(async (entry) => {
-        if (entry.kind === "directory") {
-          await this.walk(entry.rel_path, out);
-          return;
-        }
-        if (entry.kind === "file" || entry.kind === "symlink") {
-          out.push("/" + entry.rel_path.replace(/\\/g, "/"));
-        }
-      })
-    );
+  /**
+   * Depth-first, in-order walk that appends file paths to `out` and returns
+   * whether the scan was TRUNCATED (hit the file or depth cap somewhere). The
+   * two caps differ in reach: the file cap is global — once `out` is full every
+   * frame unwinds via the loop-top guard — while the depth cap is per-branch:
+   * a too-deep subtree is skipped but its shallower siblings are still walked.
+   * Both surface as a `true` return so the caller can warn once.
+   *
+   * Sequential (not the prior per-level `Promise.all`) so the cap is honored
+   * deterministically and the walk never holds more than one open `readDir`
+   * per level — on a huge tree the parallel version's fan-out was itself a
+   * source of fd / memory pressure. `readDir` is cheap; with the heavy dirs
+   * skipped, a normal repo's hundreds of directories cost a few ms.
+   *
+   * A directory we can't read (a permission error, or a race where it vanished
+   * between listing and descent) is skipped, not fatal: one unreadable corner
+   * of the tree must not abort the whole hydrate.
+   */
+  private async walk(
+    relPath: string,
+    depth: number,
+    out: string[]
+  ): Promise<boolean> {
+    if (depth > SCAN_MAX_DEPTH) return true;
+    let entries: workspaceFs.Entry[];
+    try {
+      entries = await workspaceFs.readDir(this.workspace, relPath);
+    } catch (err) {
+      console.warn(
+        `[agent-fs] workspace hydrate scan skipped ${relPath || "/"}:`,
+        err
+      );
+      return false;
+    }
+    let truncated = false;
+    for (const entry of entries) {
+      if (out.length >= SCAN_MAX_FILES) return true;
+      if (entry.kind === "directory") {
+        // Skip heavy/generated subtrees (node_modules, .git, build output, …).
+        if (isIgnoredScanDir(entry.name)) continue;
+        if (await this.walk(entry.rel_path, depth + 1, out)) truncated = true;
+        continue;
+      }
+      if (entry.kind === "file" || entry.kind === "symlink") {
+        out.push("/" + entry.rel_path.replace(/\\/g, "/"));
+      }
+    }
+    return truncated;
   }
 }
 

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
@@ -16,6 +16,7 @@ import { createAgentCommandBackend } from "./command-backend";
 import { workspaceFs } from "../workspaces/fs";
 import {
   isIgnoredScanDir,
+  isIgnoredScanFile,
   SCAN_MAX_DEPTH,
   SCAN_MAX_FILES,
 } from "../workspaces/scan";
@@ -226,6 +227,11 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
         continue;
       }
       if (entry.kind === "file" || entry.kind === "symlink") {
+        // Skip known-binary files: `read()` returns null for them, so they
+        // never hydrate — counting them toward SCAN_MAX_FILES would let a
+        // binary-heavy subtree (an `assets/` of images) starve the real
+        // source files that sort after it. See `workspaces/scan`.
+        if (isIgnoredScanFile(entry.name)) continue;
         out.push("/" + entry.rel_path.replace(/\\/g, "/"));
       }
     }

--- a/packages/grida-ai-agent/src/workspaces/scan.test.ts
+++ b/packages/grida-ai-agent/src/workspaces/scan.test.ts
@@ -4,7 +4,12 @@
  * caps are the backstop for a tree that is genuinely huge regardless.
  */
 import { describe, expect, it } from "vitest";
-import { isIgnoredScanDir, SCAN_MAX_DEPTH, SCAN_MAX_FILES } from "./scan";
+import {
+  isIgnoredScanDir,
+  isIgnoredScanFile,
+  SCAN_MAX_DEPTH,
+  SCAN_MAX_FILES,
+} from "./scan";
 
 describe("isIgnoredScanDir", () => {
   it("skips the heavy/generated dirs that cause the blow-up", () => {
@@ -37,6 +42,49 @@ describe("isIgnoredScanDir", () => {
     expect(isIgnoredScanDir("node_modules_backup")).toBe(false);
     expect(isIgnoredScanDir("my-dist")).toBe(false);
     expect(isIgnoredScanDir("targeting")).toBe(false);
+  });
+});
+
+describe("isIgnoredScanFile", () => {
+  it("skips known-binary content that can't hydrate as text", () => {
+    for (const name of [
+      "logo.png",
+      "photo.JPG", // case-insensitive on the extension
+      "icon.webp",
+      "font.woff2",
+      "clip.mp4",
+      "bundle.wasm",
+      "lib.so",
+      "report.pdf",
+      "weights.safetensors",
+      "data.parquet",
+      "archive.tar.gz", // final extension only
+    ]) {
+      expect(isIgnoredScanFile(name)).toBe(true);
+    }
+  });
+
+  it("keeps source/text files — including svg (XML the agent edits)", () => {
+    for (const name of [
+      "index.ts",
+      "App.tsx",
+      "README.md",
+      "data.json",
+      "styles.css",
+      "chart.svg",
+      "notes.txt",
+      "script.py",
+      "Cargo.toml",
+    ]) {
+      expect(isIgnoredScanFile(name)).toBe(false);
+    }
+  });
+
+  it("keeps extension-less files and dotfiles", () => {
+    expect(isIgnoredScanFile("Makefile")).toBe(false);
+    expect(isIgnoredScanFile("LICENSE")).toBe(false);
+    expect(isIgnoredScanFile(".gitignore")).toBe(false);
+    expect(isIgnoredScanFile(".env")).toBe(false);
   });
 });
 

--- a/packages/grida-ai-agent/src/workspaces/scan.test.ts
+++ b/packages/grida-ai-agent/src/workspaces/scan.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Workspace hydrate-scan policy (issue #786). The ignore set is what stops the
+ * agent from slurping `node_modules` / `.git` / build output on every run; the
+ * caps are the backstop for a tree that is genuinely huge regardless.
+ */
+import { describe, expect, it } from "vitest";
+import { isIgnoredScanDir, SCAN_MAX_DEPTH, SCAN_MAX_FILES } from "./scan";
+
+describe("isIgnoredScanDir", () => {
+  it("skips the heavy/generated dirs that cause the blow-up", () => {
+    for (const name of [
+      ".git",
+      "node_modules",
+      "dist",
+      "build",
+      ".next",
+      ".turbo",
+      "target",
+      ".venv",
+      "__pycache__",
+      ".cache",
+      "coverage",
+    ]) {
+      expect(isIgnoredScanDir(name)).toBe(true);
+    }
+  });
+
+  it("does not skip ordinary source dirs", () => {
+    for (const name of ["src", "lib", "app", "components", "tests", "docs"]) {
+      expect(isIgnoredScanDir(name)).toBe(false);
+    }
+  });
+
+  it("matches by exact basename only (no prefix/substring match)", () => {
+    // A real source dir that merely contains an ignored name as a substring
+    // must NOT be skipped.
+    expect(isIgnoredScanDir("node_modules_backup")).toBe(false);
+    expect(isIgnoredScanDir("my-dist")).toBe(false);
+    expect(isIgnoredScanDir("targeting")).toBe(false);
+  });
+});
+
+describe("scan caps", () => {
+  it("exposes sane positive bounds", () => {
+    expect(SCAN_MAX_FILES).toBeGreaterThan(0);
+    expect(SCAN_MAX_DEPTH).toBeGreaterThan(0);
+  });
+});

--- a/packages/grida-ai-agent/src/workspaces/scan.ts
+++ b/packages/grida-ai-agent/src/workspaces/scan.ts
@@ -1,0 +1,103 @@
+/**
+ * Workspace hydrate-scan policy (issue #786).
+ *
+ * When a workspace-bound agent starts, it hydrates a virtual filesystem over
+ * the opened workspace — it enumerates the tree so the model's `list_files` /
+ * `read_file` tools have something to see. Left unbounded, that walk reads
+ * every path in the repo: `node_modules`, `.git`, build output, caches — a
+ * real project is hundreds of thousands to millions of entries, which
+ * overflows the read fan-out (`AgentFs` runHydrate) and OOMs the host. The
+ * run then dies before the model ever speaks; the client only sees a dropped
+ * stream ("network error").
+ *
+ * This module is the scan half of the bound: which directories the hydrate
+ * walk must NOT descend into, and the hard caps that stop a pathological tree
+ * (no ignored dirs, just genuinely huge) regardless. It is a sibling to
+ * `fs/scope.ts` (the no-clobber WRITE policy): both are hand-maintained lists
+ * that fail safe — a gap here costs a slower-than-ideal scan, never a
+ * correctness breach (the agent can still reach any path on demand via the
+ * shell, or `read_file` once it's listed).
+ *
+ * NOTE this is deliberately a curated heuristic, not a `.gitignore` engine.
+ * The ignored set targets the well-known dependency / VCS / build / cache
+ * directories of this repo's ecosystems (JS/TS, Rust, Python). Honoring a
+ * project's own `.gitignore` is a reasonable future refinement; it is not
+ * required to stop the blow-up, and parsing gitignore semantics correctly is
+ * its own surface.
+ *
+ * Distinct from `fs/scope.ts`: that set is no-CLOBBER (`.git` is protected
+ * from writes; `node_modules` is NOT, because the agent may legitimately
+ * write there via the package manager). This set is no-SCAN: both `.git` and
+ * `node_modules` are skipped because hydrating them is pure waste. The two
+ * lists overlap but answer different questions, so they stay separate.
+ */
+
+/**
+ * Directory basenames the hydrate walk skips entirely (the whole subtree).
+ * Matched by basename anywhere in the tree — a `node_modules` at any depth is
+ * skipped, mirroring `scope.ts`'s segment match.
+ */
+const IGNORED_SCAN_DIRS: ReadonlySet<string> = new Set([
+  // VCS
+  ".git",
+  ".hg",
+  ".svn",
+  // JS/TS dependencies + package-manager state
+  "node_modules",
+  ".pnpm",
+  ".yarn",
+  "bower_components",
+  // build / framework output
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".nuxt",
+  ".svelte-kit",
+  ".turbo",
+  ".output",
+  // caches / coverage / test output
+  ".cache",
+  ".parcel-cache",
+  "coverage",
+  ".nyc_output",
+  // Rust / native build output
+  "target",
+  // Python virtualenvs + caches
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".tox",
+  // IaC / editor caches that bloat without being source
+  ".terraform",
+  ".gradle",
+]);
+
+/**
+ * Hard cap on the number of files the hydrate walk enumerates. A real source
+ * tree (ignored dirs removed) is comfortably under this; the cap exists so a
+ * pathological tree — one genuinely full of source files, or a directory
+ * named in none of the ignore entries that nonetheless holds a million
+ * files — still terminates with a bounded, usable file list instead of
+ * exhausting memory. On overflow the caller warns and proceeds with the
+ * truncated list (the agent reaches the rest via the shell).
+ */
+export const SCAN_MAX_FILES = 10_000;
+
+/**
+ * Backstop on recursion depth. Normal trees are well under this; the cap
+ * guards against an accidentally-deep or adversarial layout. Symlinked
+ * directories are reported as `symlink` (never recursed), so this is not the
+ * cycle guard — it's a depth sanity bound.
+ */
+export const SCAN_MAX_DEPTH = 32;
+
+/**
+ * Whether the hydrate walk should skip a directory with this basename
+ * (and its whole subtree). `name` is the entry basename, not a path.
+ */
+export function isIgnoredScanDir(name: string): boolean {
+  return IGNORED_SCAN_DIRS.has(name);
+}

--- a/packages/grida-ai-agent/src/workspaces/scan.ts
+++ b/packages/grida-ai-agent/src/workspaces/scan.ts
@@ -11,12 +11,23 @@
  * stream ("network error").
  *
  * This module is the scan half of the bound: which directories the hydrate
- * walk must NOT descend into, and the hard caps that stop a pathological tree
- * (no ignored dirs, just genuinely huge) regardless. It is a sibling to
- * `fs/scope.ts` (the no-clobber WRITE policy): both are hand-maintained lists
- * that fail safe — a gap here costs a slower-than-ideal scan, never a
- * correctness breach (the agent can still reach any path on demand via the
- * shell, or `read_file` once it's listed).
+ * walk must NOT descend into, which files it must NOT enumerate, and the hard
+ * caps that stop a pathological tree (no ignored dirs, just genuinely huge)
+ * regardless. It is a sibling to `fs/scope.ts` (the no-clobber WRITE policy):
+ * both are hand-maintained lists that fail safe — a gap here costs a
+ * slower-than-ideal scan, never a correctness breach (the agent can still
+ * reach any path on demand via the shell, or `read_file` once it's listed).
+ *
+ * The file-extension skip exists because hydrate can only serve TEXT: the
+ * workspace backend's `read()` returns `null` for binary / non-utf8 / oversized
+ * content, so a binary file never enters the hydrated map and is invisible to
+ * `list_files` / `read_file` regardless. Enumerating it is therefore pure
+ * waste TWICE over — a wasted `read()` that returns null, AND a slot consumed
+ * against the file cap. The second is the dangerous one: a binary-heavy subtree
+ * that sorts early (an `assets/` full of images) could otherwise fill the cap
+ * and starve the real source files that sort after it, leaving the model with
+ * an effectively empty filesystem. Skipping known-binary extensions at
+ * enumeration time keeps the cap budget for files that can actually hydrate.
  *
  * NOTE this is deliberately a curated heuristic, not a `.gitignore` engine.
  * The ignored set targets the well-known dependency / VCS / build / cache
@@ -100,4 +111,113 @@ export const SCAN_MAX_DEPTH = 32;
  */
 export function isIgnoredScanDir(name: string): boolean {
   return IGNORED_SCAN_DIRS.has(name);
+}
+
+/**
+ * File extensions the hydrate walk skips — content the workspace backend's
+ * `read()` can never serve as text, so enumerating it only wastes a `read()`
+ * and a file-cap slot (see the module header). Curated to the common binary
+ * families; an extension-less binary or an exotic format slips through and is
+ * simply read-then-dropped (the null-read safety net still holds), so a gap
+ * here is a missed optimization, never a correctness breach. Matched on the
+ * lowercased final extension. NOTE `.svg` is deliberately ABSENT — it is XML
+ * text and a first-class canvas source the agent edits.
+ */
+const IGNORED_SCAN_FILE_EXTENSIONS: ReadonlySet<string> = new Set([
+  // raster / vector-binary images
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "bmp",
+  "ico",
+  "webp",
+  "tiff",
+  "tif",
+  "avif",
+  "heic",
+  "heif",
+  "psd",
+  "ai",
+  // fonts
+  "woff",
+  "woff2",
+  "ttf",
+  "otf",
+  "eot",
+  // video
+  "mp4",
+  "webm",
+  "mov",
+  "avi",
+  "mkv",
+  "m4v",
+  "wmv",
+  "flv",
+  // audio
+  "mp3",
+  "wav",
+  "flac",
+  "ogg",
+  "m4a",
+  "aac",
+  // archives / compressed
+  "zip",
+  "tar",
+  "gz",
+  "tgz",
+  "bz2",
+  "7z",
+  "rar",
+  "xz",
+  "zst",
+  // compiled / native / bytecode
+  "exe",
+  "dll",
+  "so",
+  "dylib",
+  "o",
+  "a",
+  "class",
+  "jar",
+  "wasm",
+  "node",
+  "bin",
+  "dat",
+  // binary documents
+  "pdf",
+  "doc",
+  "docx",
+  "xls",
+  "xlsx",
+  "ppt",
+  "pptx",
+  // databases / data blobs / model weights
+  "sqlite",
+  "db",
+  "parquet",
+  "onnx",
+  "npy",
+  "npz",
+  "safetensors",
+  "h5",
+  "pt",
+  "pth",
+  "ckpt",
+  // disk images
+  "dmg",
+  "iso",
+  "img",
+]);
+
+/**
+ * Whether the hydrate walk should skip a file with this basename because it is
+ * known-binary (its content can't hydrate as text). `name` is the entry
+ * basename, not a path. A dotfile with no extension (`.gitignore`) or any
+ * extension-less file is kept.
+ */
+export function isIgnoredScanFile(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return false;
+  return IGNORED_SCAN_FILE_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
 }


### PR DESCRIPTION
## Summary

Fixes #786 — a workspace-bound agent crashed on large repos and surfaced as a generic **"network error"** in the UI.

On every run, `fs.hydrate()` enumerated the **entire** workspace tree (no ignore list, no caps) and then read **every** file at once via `Promise.allSettled(paths.map(read))`. On a real project this walked `node_modules` / `.git` / build output — hundreds of thousands to millions of paths — overflowing V8's promise-combinator element cap (`Too many elements passed to Promise.all`) and/or exhausting file descriptors (EMFILE), killing the run before the model ever spoke.

## What changed

Two **localized, behavior-compatible** bounds. The full lazy read-on-access refactor (the issue's preferred long-term shape) is **deliberately scoped out** — it would make `AgentFs.read` async and ripple into the synchronous client path; tracked as follow-up.

**1. Enumeration bound — workspace backend** (`workspaces/scan.ts`, `WorkspaceAgentFsBackend.walk`)
- New `workspaces/scan` policy module: an ignore set for well-known heavy/generated dirs (`node_modules`, `.git`, `dist`, `.next`, `target`, `__pycache__`, caches, …) + hard caps `SCAN_MAX_FILES=10_000`, `SCAN_MAX_DEPTH=32`.
- `walk` is now a bounded, **sequential DFS** that skips ignored subtrees, tolerates per-directory read failures (skips, never aborts the whole hydrate), and **warns on truncation** — never silently caps.
- Distinct from `fs/scope.ts` (no-clobber **write** policy): both `.git` and `node_modules` are no-**scan**, but only `.git` is no-**clobber** (the agent may legitimately write under `node_modules` via a package manager). The two lists answer different questions and stay separate.

**2. Read fan-out bound — generic, all backends** (`fs/index.ts` `runHydrate`)
- Reads now go through a fixed-width worker pool (`mapSettledBounded`, concurrency `24`) instead of one concurrent read per path. Any backend reporting a large list hydrates safely — defense in depth alongside the enumeration cap.

## Behavior notes for reviewers

- **Truncation is not silent.** Hitting either cap logs a `console.warn` naming the workspace root; the agent can still reach unlisted paths on demand via the shell. The two caps differ in reach: the **file cap is global** (every frame unwinds), the **depth cap is per-branch** (a too-deep subtree is skipped but shallower siblings are still walked).
- `node_modules`/`.git` filtering is a curated heuristic, **not** a `.gitignore` engine — sufficient to stop the blow-up; honoring project `.gitignore` is a possible future refinement.

## Verification

- **Unit:** ignore-set + caps (`scan.test.ts`), bounded/filtered walk incl. nested-under-source (`workspace-agent-bindings.test.ts`), and bounded-concurrency reads with peak-in-flight ≤ 24 + per-read-rejection survival (`fs.test.ts`). All green (68 tests in the touched suites).
- **End-to-end against the real grida monorepo** (the reported repro): `list()` hits the 10k cap and warns; hydrate completes with **0 `node_modules` / 0 `.git`** paths and **no EMFILE**.
- **Through the live daemon HTTP path** (the browser web-bridge's exact server code): `POST /agent/run` for the grida workspace → hydrate → stream completes (`run response opened`), **0 EMFILE / 0 stream-failed**, vs. the old `run failed reason=error err=Too many elements`.

## Out of scope (follow-up)

- Lazy index + read-on-access (avoids the eager whole-tree read each turn; needs the async `AgentFs.read` change + a `grep_files` semantics decision).
- Per-run hydrate is not memoized across turns — left as-is; the bounds make it safe, not free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Workspace hydration now uses bounded concurrency to avoid excessive parallel backend reads.
  * Workspace “hydrate” enumeration is bounded and uses safety caps for max files/depth.
  * Build-heavy and generated content is filtered out, and binary assets are excluded from listings.
* **Reliability**
  * Hydration remains resilient if individual backend reads fail; successful entries still load.
  * Unreadable directories no longer break hydration; traversal continues for other paths.
  * When scan limits are reached, hydration emits a warning that results were truncated.
* **Tests**
  * Added coverage for bounded concurrency, fault tolerance, scan filtering, and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->