### PR TITLE
chore(editor): universal /ai/playground hub + relocate music playground

### DIFF
--- a/editor/app/(www)/(ai)/ai/music/_components/hero-prompt-input.tsx
+++ b/editor/app/(www)/(ai)/ai/music/_components/hero-prompt-input.tsx
@@ -12,7 +12,7 @@ import {
   type PromptInputMessage,
 } from "@app/ui/ai-elements/prompt-input";
 
-const PLAYGROUND_HREF = "/ai/music/playground";
+const PLAYGROUND_HREF = "/ai/playground/music";
 
 export function HeroPromptInput() {
   const router = useRouter();

--- a/editor/app/(www)/(ai)/ai/music/_components/track-showcase.tsx
+++ b/editor/app/(www)/(ai)/ai/music/_components/track-showcase.tsx
@@ -317,7 +317,7 @@ export function TrackShowcase({ tracks }: { tracks: ShowcaseTrack[] }) {
         <PromptReveal prompt={activeTrack.prompt} />
         <Link
           href={{
-            pathname: "/ai/music/playground",
+            pathname: "/ai/playground/music",
             query: { prompt: activeTrack.prompt },
           }}
           className="text-sm font-medium underline-offset-4 hover:underline mt-3"

--- a/editor/app/(www)/(ai)/ai/music/page.tsx
+++ b/editor/app/(www)/(ai)/ai/music/page.tsx
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
   },
 };
 
-const PLAYGROUND_HREF = "/ai/music/playground";
+const PLAYGROUND_HREF = "/ai/playground/music";
 
 const FAQS: { q: string; a: string }[] = [
   {

--- a/editor/app/(www)/(ai)/ai/playground/music/_page.tsx
+++ b/editor/app/(www)/(ai)/ai/playground/music/_page.tsx
@@ -53,7 +53,7 @@ export default function AudioGenTool({
     <AuthProvider>
       <PromptInputProvider initialInput={initialPrompt}>
         <div className="container mx-auto px-4 pt-24 md:pt-28 xl:pt-36 pb-24 min-h-screen">
-          <div className="max-w-3xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <header className="mb-10 text-left">
               <h1 className="text-3xl font-semibold tracking-tight mb-3">
                 AI Music Generator
@@ -111,7 +111,7 @@ function Workspace() {
           prompt,
           image_inputs: image_inputs.length > 0 ? image_inputs : undefined,
         });
-        const data = credits.consume(env, { next: "/ai/music/playground" });
+        const data = credits.consume(env, { next: "/ai/playground/music" });
         if (!data) {
           if (env.success === false) setError(env.message);
           return;
@@ -133,89 +133,92 @@ function Workspace() {
   const handleSubmitWithAuth = withAuth(handleSubmit);
 
   return (
-    <div className="grid gap-6">
-      <PromptInput
-        accept="image/*"
-        multiple
-        maxFiles={10}
-        maxFileSize={8 * 1024 * 1024}
-        onSubmit={(message) => handleSubmitWithAuth(message)}
-      >
-        <PromptInputBody>
-          <PromptInputAttachments>
-            {(attachment) => <PromptInputAttachment data={attachment} />}
-          </PromptInputAttachments>
-          <PromptInputTextarea placeholder="Describe the music you want — genre, mood, instruments, tempo…" />
-        </PromptInputBody>
-        <PromptInputFooter>
-          <PromptInputTools>
-            <PromptInputActionMenu>
-              <PromptInputActionMenuTrigger />
-              <PromptInputActionMenuContent>
-                <PromptInputActionAddAttachments label="Attach reference image" />
-              </PromptInputActionMenuContent>
-            </PromptInputActionMenu>
-            <Select
-              value={modelId}
-              onValueChange={(v) => setModelId(v as ai.audio.AudioModelId)}
-            >
-              <SelectTrigger className="w-min border-none h-8">
-                <SelectValue>{card.label}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {ai.audio.audio_model_ids.map((id) => {
-                  const m = ai.audio.models[id];
-                  return (
-                    <SelectItem key={id} value={id}>
-                      <div className="flex items-center justify-between gap-2 w-full">
-                        <span>{m.label}</span>
-                        <Badge variant="outline" className="ml-2">
-                          ~{m.duration_label}
-                        </Badge>
-                      </div>
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-          </PromptInputTools>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground font-mono">
-              {credits.formatted ?? "—"} left
-            </span>
-            <PromptInputSubmit
-              disabled={loading}
-              status={loading ? "submitted" : undefined}
-            />
-          </div>
-        </PromptInputFooter>
-      </PromptInput>
+    <div className="grid gap-8 lg:grid-cols-2 lg:items-start">
+      {/* in */}
+      <div className="grid gap-6 content-start lg:sticky lg:top-28">
+        <PromptInput
+          accept="image/*"
+          multiple
+          maxFiles={10}
+          maxFileSize={8 * 1024 * 1024}
+          onSubmit={(message) => handleSubmitWithAuth(message)}
+        >
+          <PromptInputBody>
+            <PromptInputAttachments>
+              {(attachment) => <PromptInputAttachment data={attachment} />}
+            </PromptInputAttachments>
+            <PromptInputTextarea placeholder="Describe the music you want — genre, mood, instruments, tempo…" />
+          </PromptInputBody>
+          <PromptInputFooter>
+            <PromptInputTools>
+              <PromptInputActionMenu>
+                <PromptInputActionMenuTrigger />
+                <PromptInputActionMenuContent>
+                  <PromptInputActionAddAttachments label="Attach reference image" />
+                </PromptInputActionMenuContent>
+              </PromptInputActionMenu>
+              <Select
+                value={modelId}
+                onValueChange={(v) => setModelId(v as ai.audio.AudioModelId)}
+              >
+                <SelectTrigger className="w-min border-none h-8">
+                  <SelectValue>{card.label}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {ai.audio.audio_model_ids.map((id) => {
+                    const m = ai.audio.models[id];
+                    return (
+                      <SelectItem key={id} value={id}>
+                        <div className="flex items-center justify-between gap-2 w-full">
+                          <span>{m.label}</span>
+                          <Badge variant="outline" className="ml-2">
+                            ~{m.duration_label}
+                          </Badge>
+                        </div>
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </PromptInputTools>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground font-mono">
+                {credits.formatted ?? "—"} left
+              </span>
+              <PromptInputSubmit
+                disabled={loading}
+                status={loading ? "submitted" : undefined}
+              />
+            </div>
+          </PromptInputFooter>
+        </PromptInput>
 
-      <div className="flex flex-wrap gap-2">
-        {PROMPT_PRESETS.map((p) => (
-          <PromptChip
-            key={p}
-            label={p}
-            disabled={loading}
-            onClick={() => handleSubmitWithAuth({ text: p, files: [] })}
-          />
-        ))}
+        <div className="flex flex-wrap gap-2">
+          {PROMPT_PRESETS.map((p) => (
+            <PromptChip
+              key={p}
+              label={p}
+              disabled={loading}
+              onClick={() => handleSubmitWithAuth({ text: p, files: [] })}
+            />
+          ))}
+        </div>
+
+        {error && (
+          <div className="text-sm text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-4 py-2">
+            {error}
+          </div>
+        )}
       </div>
 
-      {error && (
-        <div className="text-sm text-destructive border border-destructive/30 bg-destructive/5 rounded-md px-4 py-2">
-          {error}
-        </div>
-      )}
-
-      {loading && results.length === 0 && (
-        <div className="flex items-center gap-3 rounded-lg border bg-muted/40 px-4 py-6 text-sm text-muted-foreground">
-          <Loader2Icon className="size-4 animate-spin" />
-          Generating with {card.label} — this can take 10–30 seconds…
-        </div>
-      )}
-
+      {/* out */}
       <div className="space-y-4">
+        {loading && results.length === 0 && (
+          <div className="flex items-center gap-3 rounded-lg border bg-muted/40 px-4 py-6 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Generating with {card.label} — this can take 10–30 seconds…
+          </div>
+        )}
         {results.map((r) => (
           <ResultCard key={r.id} item={r} />
         ))}

--- a/editor/app/(www)/(ai)/ai/playground/music/page.tsx
+++ b/editor/app/(www)/(ai)/ai/playground/music/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     description:
       "Generate music with Google Lyria 3 and Lyria 3 Pro from a prompt or reference image.",
     type: "website",
-    url: "https://grida.co/ai/music/playground",
+    url: "https://grida.co/ai/playground/music",
   },
   twitter: {
     card: "summary_large_image",

--- a/editor/app/(www)/(ai)/ai/playground/page.tsx
+++ b/editor/app/(www)/(ai)/ai/playground/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@app/ui/components/card";
+import { FormInput, Image as ImageIcon, Music2 } from "lucide-react";
+import Header from "@/www/header";
+import Footer from "@/www/footer";
+
+export const metadata: Metadata = {
+  title: "AI Playground — Grida",
+  description:
+    "A universal playground for Grida's AI tools — generate music, images, and forms from a prompt.",
+  keywords: [
+    "ai playground",
+    "ai music",
+    "ai image generation",
+    "ai forms",
+    "grida ai",
+  ],
+  openGraph: {
+    title: "AI Playground — Grida",
+    description:
+      "A universal playground for Grida's AI tools — generate music, images, and forms from a prompt.",
+    type: "website",
+    url: "https://grida.co/ai/playground",
+  },
+};
+
+type Item = {
+  title: string;
+  description: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+const items: Item[] = [
+  {
+    title: "Music",
+    description: "Generate music with Google Lyria 3 and Lyria 3 Pro.",
+    href: "/ai/playground/music",
+    icon: Music2,
+  },
+  {
+    title: "Image",
+    description: "Generate and edit images from a prompt.",
+    href: "/playground/image",
+    icon: ImageIcon,
+  },
+  {
+    title: "Forms",
+    description: "Generate form schemas with AI.",
+    href: "/forms/ai",
+    icon: FormInput,
+  },
+];
+
+export default function AiPlaygroundPage() {
+  return (
+    <main>
+      <Header />
+      <div className="container mx-auto px-4 pt-24 md:pt-28 xl:pt-36 pb-24 md:pb-32 min-h-screen">
+        <div className="max-w-5xl mx-auto">
+          <header className="mb-20 text-left">
+            <h1 className="text-3xl font-semibold tracking-tight mb-4">
+              AI Playground
+            </h1>
+            <p className="text-muted-foreground text-sm font-light">
+              Generate music, images, and forms from a prompt.
+            </p>
+          </header>
+
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item) => (
+              <Link href={item.href} key={item.href} className="group block">
+                <Card className="h-full border transition-all duration-200 hover:border-foreground/20 hover:shadow-sm">
+                  <CardHeader className="pb-4">
+                    <div className="flex items-start gap-3 mb-2">
+                      <div className="mt-0.5 p-1.5 rounded-md bg-muted/50 group-hover:bg-muted transition-colors">
+                        <item.icon className="size-4" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <CardTitle className="text-base font-medium leading-tight mb-1.5 group-hover:underline">
+                          {item.title}
+                        </CardTitle>
+                        <CardDescription className="text-sm leading-relaxed">
+                          {item.description}
+                        </CardDescription>
+                      </div>
+                    </div>
+                  </CardHeader>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  );
+}

--- a/editor/app/sitemap.ts
+++ b/editor/app/sitemap.ts
@@ -183,7 +183,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
-      url: "https://grida.co/ai/music/playground",
+      url: "https://grida.co/ai/playground",
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: "https://grida.co/ai/playground/music",
       changeFrequency: "monthly",
       priority: 0.5,
     },

--- a/editor/www/data/sitemap.ts
+++ b/editor/www/data/sitemap.ts
@@ -9,6 +9,7 @@ export namespace sitemap {
     downlaods: "/downloads",
     packages: "/packages",
     ai_models: "/ai/models",
+    ai_playground: "/ai/playground",
     sdk: "/sdk",
     tools: "/tools",
     library: "/library",


### PR DESCRIPTION
## What

Introduces a universal **`/ai/playground`** hub and relocates the music playground beneath it. Previously there was no single entry point for AI playgrounds — each modality shipped its own page in a different place.

### Changes

- **New hub** — `/ai/playground` ([page.tsx](https://github.com/gridaco/grida/blob/chore/universal-ai-playground/editor/app/(www)/(ai)/ai/playground/page.tsx)) under the existing `(www)/(ai)` route group, so it inherits the shared `<AiCredits.Provider>`. Lists Music / Image / Forms as a simple bordered card grid, styled to match the `/tools` catalog page.
- **Music playground relocated** — `/ai/music/playground` → `/ai/playground/music` (hard move via `git mv`, no redirect). Fixed the OpenGraph `url` and the credit-gate `next` path inside the moved files.
- **Referrers repointed** — `PLAYGROUND_HREF` in the music landing + hero prompt input, and the `pathname` in `track-showcase`.
- **Sitemap** — `app/sitemap.ts` repointed to the new music URL and added the hub URL; `ai_playground` added to `www/data/sitemap.ts`.
- **Layout** — reworked the music playground into a two-column layout: **left = input** (prompt + presets, sticky on `lg`), **right = output** (results / empty state). Single column below `lg`.

### Decisions (scoped with the requester)

- **Music only** is physically moved. Image (`/playground/image`) and Forms (`/forms/ai`) stay where they are — the hub just links to them.
- **Hard move, no redirects** — old `/ai/music/playground` no longer serves the playground.
- The general `/playground` hub is left untouched.

## Why

Consolidate AI playgrounds under one discoverable, canonical home (`/ai/playground`) instead of scattering them by modality.

## Verification

- `grep` for `/ai/music/playground` in source → 0 matches; oxlint/oxfmt clean (pre-commit).
- Dev server (`:3000`): `/ai/playground` and `/ai/playground/music` render 200 with no page-level console errors; music landing's CTAs (7) all point to the new path; old `/ai/music/playground` behaves as a nonexistent route.
- Two-column layout verified at 1440px; stacks correctly below `lg`.

> Note: `pnpm typecheck` (needs packages + wasm bundle built) was not run — relied on the Next dev server compiling every changed route without error. The `grida-canvas-wasm` console errors seen locally are an unbuilt-wasm dev artifact, unrelated to these static pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new AI Playground hub providing quick access to Music, Image, and Form generation tools.
  * Redesigned music playground with an improved two-column layout—sticky controls on the left, results on the right.

* **Improvements**
  * Restructured playground navigation paths for clearer URL hierarchy.
  * Updated SEO metadata and sitemap entries for enhanced discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->