### PR TITLE
feat(svg-editor): point-level path editing — keyboard nudge, shift axis-lock, geometry snap

### DIFF
--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -42,6 +42,7 @@ type Internal = {
   push_pick: (e: unknown) => void;
   set_computed_resolver: (fn: unknown) => void;
   set_geometry: (p: unknown) => void;
+  register_command: (id: string, handler: unknown) => () => void;
 };
 
 function internalOf(editor: ReturnType<typeof createSvgEditor>): Internal {
@@ -63,6 +64,7 @@ describe("editor._internal contract", () => {
         "notify_translate_commit",
         "push_pick",
         "push_surface_hover",
+        "register_command",
         "seed_duplication",
         "set_computed_resolver",
         "set_content_edit_driver",

--- a/packages/grida-svg-editor/__tests__/vector-edit-nudge-axislock.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-nudge-axislock.browser.test.ts
@@ -1,0 +1,179 @@
+// End-to-end proof for two point-level path-edit affordances, driven
+// through the real surface in headless Chromium (so getScreenCTM is the
+// actual layout engine, not jsdom's identity):
+//
+//   - gridaco/grida#849 — arrow keys nudge the path SUB-SELECTION (the
+//     selected vertices), not the whole element.
+//   - gridaco/grida#848 — Shift axis-locks a vertex drag to one axis,
+//     matching whole-object translate.
+//
+// The surface is mounted at the document origin under an identity camera,
+// so client px == world == SVG user units (see `attachSurface`). A path of
+// straight `L` segments keeps the committed `d` a clean list of vertex
+// coordinates we can read back by extracting the numbers in order.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  attachSurface,
+  nodeIdByName,
+  pointer,
+  type AttachedSurface,
+} from "./_browser-helpers";
+
+// v0 (100,100) · v1 (300,100) · v2 (300,300). Well separated so a tap at a
+// vertex is unambiguous and a 1px nudge is plainly visible.
+const PATH = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+  <path id="p" d="M 100 100 L 300 100 L 300 300" fill="none" stroke="#222"/>
+</svg>`;
+
+let s: AttachedSurface | null = null;
+afterEach(() => {
+  s?.dispose();
+  s = null;
+});
+
+/** Vertex coordinates of the committed `d`, in order. All segments here are
+ *  straight `L`s with zero tangents, so the path data is just the vertex
+ *  list — extract every number and pair them up. */
+function vertices(a: AttachedSurface): Array<[number, number]> {
+  const d = a.editor.document.get_attr(nodeIdByName(a.editor, "p"), "d") ?? "";
+  const nums = (d.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i + 1 < nums.length; i += 2) out.push([nums[i], nums[i + 1]]);
+  return out;
+}
+
+/** Dispatch an arrow keydown straight into the keymap (bypasses the
+ *  surface's attention gate, which is irrelevant to the routing under
+ *  test). The surface has registered its `transform.nudge` override on the
+ *  registry, so this still exercises `handle_nudge_command`. */
+function arrow(a: AttachedSurface, code: string, shiftKey = false): boolean {
+  return a.editor.keymap.dispatch({
+    code,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey,
+    altKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+function enterPathEdit(a: AttachedSurface): void {
+  const id = nodeIdByName(a.editor, "p");
+  a.editor.commands.select(id);
+  a.editor.enter_content_edit(id);
+  expect(a.editor.state.mode).toBe("edit-content");
+}
+
+/** Tap (down+up, no drag) at a client point — selects whatever control is
+ *  under the cursor. */
+function tap(a: AttachedSurface, x: number, y: number): void {
+  const win = a.container.ownerDocument.defaultView!;
+  pointer(a.container, "pointerdown", x, y, 1);
+  pointer(win, "pointerup", x, y, 0);
+}
+
+describe("#849 — arrow nudge moves the path sub-selection, not the element", () => {
+  it("ArrowRight moves only the selected vertex by 1px", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+
+    // Select v1 by tapping it.
+    tap(s, 300, 100);
+
+    expect(arrow(s, "ArrowRight")).toBe(true);
+
+    const v = vertices(s);
+    expect(v[0]).toEqual([100, 100]); // v0 unchanged
+    expect(v[1]).toEqual([301, 100]); // v1 nudged +1 x
+    expect(v[2]).toEqual([300, 300]); // v2 unchanged
+  });
+
+  it("Shift+ArrowDown moves the selected vertex by 10px in y", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+    tap(s, 300, 100); // v1
+
+    expect(arrow(s, "ArrowDown", true)).toBe(true);
+
+    const v = vertices(s);
+    expect(v[0]).toEqual([100, 100]);
+    expect(v[1]).toEqual([300, 110]);
+    expect(v[2]).toEqual([300, 300]);
+  });
+
+  it("with no sub-selection, arrows are a consumed no-op (element does not move)", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+    // No vertex tapped — empty sub-selection.
+    const before = vertices(s);
+    expect(arrow(s, "ArrowRight")).toBe(true); // owned by path-edit
+    expect(vertices(s)).toEqual(before); // nothing moved
+  });
+});
+
+describe("#848 — Shift axis-locks a vertex drag", () => {
+  it("a diagonal drag with Shift collapses to the dominant axis", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+    const win = s.container.ownerDocument.defaultView!;
+    const shift = { shiftKey: true };
+
+    // Drag v1 from (300,100) toward (340,112): |dx|=40 > |dy|=12, so the
+    // lock keeps x and zeroes y.
+    pointer(s.container, "pointerdown", 300, 100, 1, shift);
+    pointer(win, "pointermove", 320, 106, 1, shift);
+    pointer(win, "pointermove", 340, 112, 1, shift);
+    pointer(win, "pointerup", 340, 112, 0, shift);
+
+    const v = vertices(s);
+    expect(v[0]).toEqual([100, 100]); // v0 unchanged
+    expect(v[1][0]).toBeCloseTo(340, 3); // x followed the drag
+    expect(v[1][1]).toBeCloseTo(100, 3); // y locked at the start
+    expect(v[2]).toEqual([300, 300]); // v2 unchanged
+  });
+
+  it("without Shift the same drag moves both axes (lock is opt-in)", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+    const win = s.container.ownerDocument.defaultView!;
+
+    pointer(s.container, "pointerdown", 300, 100, 1);
+    pointer(win, "pointermove", 320, 106, 1);
+    pointer(win, "pointermove", 340, 112, 1);
+    pointer(win, "pointerup", 340, 112, 0);
+
+    const v = vertices(s);
+    expect(v[1][0]).toBeCloseTo(340, 3);
+    expect(v[1][1]).toBeCloseTo(112, 3); // y followed too — no lock
+  });
+
+  it("a <line> endpoint drag with Shift collapses to the dominant axis", () => {
+    // Horizontal line; drag the p2 endpoint (300,100) down-right with
+    // Shift held. |dx|=40 > |dy|=12 ⇒ the lock keeps x and zeroes y, so
+    // the line stays orthogonal.
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <line id="ln" x1="100" y1="100" x2="300" y2="100" stroke="#222"/>
+      </svg>`
+    );
+    const id = nodeIdByName(s.editor, "ln");
+    s.editor.commands.select(id);
+    s.editor.enter_content_edit(id);
+    expect(s.editor.state.mode).toBe("edit-content");
+
+    const win = s.container.ownerDocument.defaultView!;
+    const shift = { shiftKey: true };
+    pointer(s.container, "pointerdown", 300, 100, 1, shift);
+    pointer(win, "pointermove", 320, 106, 1, shift);
+    pointer(win, "pointermove", 340, 112, 1, shift);
+    pointer(win, "pointerup", 340, 112, 0, shift);
+
+    const num = (n: string) =>
+      Number(s!.editor.document.get_attr(id, n) ?? "NaN");
+    expect(num("x1")).toBeCloseTo(100, 3); // p1 untouched
+    expect(num("y1")).toBeCloseTo(100, 3);
+    expect(num("x2")).toBeCloseTo(340, 3); // p2 x followed the drag
+    expect(num("y2")).toBeCloseTo(100, 3); // p2 y locked at the start
+  });
+});

--- a/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
@@ -69,12 +69,12 @@ function tap(a: AttachedSurface, x: number, y: number): void {
   pointer(win, "pointerup", x, y, 0);
 }
 
-function arrow(a: AttachedSurface, code: string): boolean {
+function arrow(a: AttachedSurface, code: string, shiftKey = false): boolean {
   return a.editor.keymap.dispatch({
     code,
     metaKey: false,
     ctrlKey: false,
-    shiftKey: false,
+    shiftKey,
     altKey: false,
     preventDefault: () => {},
   } as unknown as KeyboardEvent);
@@ -230,5 +230,29 @@ describe("#844 — axis-lock + snap compose like the translate pipeline", () => 
     const v = vertices(s);
     expect(v[0][0]).toBeCloseTo(103.5, 1); // 7 screen px ÷ 2 = 3.5 local; NOT snapped to 100
     expect(v[0][1]).toBeCloseTo(100, 3);
+  });
+
+  it("a Shift+Arrow nudge moves the exact screen step on a skewed path (no axis-lock collapse)", () => {
+    // skewX(30): screen_x = local_x + tan(30)·local_y, screen_y = local_y.
+    // v0 local (100,100) → screen (157.7,100). Shift+ArrowDown nudges 10px DOWN
+    // ON SCREEN; projecting that screen step to local yields a delta with BOTH
+    // components (−tan30·10, 10). Locking the projected-local delta (the old
+    // order) would collapse the x part and move the point wrong; locking the
+    // RAW single-axis screen delta first is a no-op, so the nudge is exact.
+    // (gridaco/grida#844 review.)
+    const TAN30 = Math.tan(Math.PI / 6); // ≈ 0.5773
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <path id="p" transform="skewX(30)" d="M 100 100 L 200 300" fill="none" stroke="#222"/>
+      </svg>`
+    );
+    enterPathEdit(s);
+    tap(s, 100 + TAN30 * 100, 100); // select v0 at its screen position
+
+    expect(arrow(s, "ArrowDown", true)).toBe(true); // Shift ⇒ 10px step
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(100 - TAN30 * 10, 1); // x compensates ≈ 94.23
+    expect(v[0][1]).toBeCloseTo(110, 3); // y + 10 (exact screen-down step)
   });
 });

--- a/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
@@ -181,3 +181,54 @@ describe("#844 — point snap for <line> endpoints", () => {
     expect(num("y2")).toBeCloseTo(100, 3); // p2 y snapped onto p1's row
   });
 });
+
+describe("#844 — axis-lock + snap compose like the translate pipeline", () => {
+  it("a Shift-locked mostly-vertical drag is not flipped horizontal by an x-snap", () => {
+    // v0 (300,100), v1 (310,200). Drag v0 by (dx=4, dy=8) with Shift — the
+    // user's intent is vertical (|dy| > |dx|). Locking AFTER snap would let an
+    // x correction toward v1's column grow dx past dy and flip the lock to
+    // horizontal; locking the RAW delta BEFORE snap (translate-pipeline order
+    // `axis_lock → snap`) keeps dominance the user's intent. (gridaco/grida#844
+    // review.)
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <path id="p" d="M 300 100 L 310 200" fill="none" stroke="#222"/>
+      </svg>`
+    );
+    enterPathEdit(s);
+    const win = s.container.ownerDocument.defaultView!;
+    const shift = { shiftKey: true };
+    pointer(s.container, "pointerdown", 300, 100, 1, shift);
+    pointer(win, "pointermove", 302, 104, 1, shift);
+    pointer(win, "pointermove", 304, 108, 1, shift);
+    pointer(win, "pointerup", 304, 108, 0, shift);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(300, 3); // x stayed locked — not flipped
+    expect(v[0][1]).toBeCloseTo(108, 3); // moved along the dominant (y) axis
+  });
+
+  it("snap threshold stays screen pixels under a non-uniform element transform", () => {
+    // transform="scale(2 1)" → 1 local x-unit = 2 screen px, 1 local y = 1px.
+    // v0 local (100,100) → screen (200,100); v1 local (100,300) → screen
+    // (200,300). Drag v0 7px right on screen — that's only 3.5 local x, which a
+    // single area-scale threshold (÷√2 ≈ 4.24 local) would treat as in-range
+    // and snap back onto v1's column. A screen-pixel threshold sees 7px > 6px
+    // and leaves it free. (gridaco/grida#844 review.)
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <path id="p" transform="scale(2 1)" d="M 100 100 L 100 300" fill="none" stroke="#222"/>
+      </svg>`
+    );
+    enterPathEdit(s);
+    const win = s.container.ownerDocument.defaultView!;
+    pointer(s.container, "pointerdown", 200, 100, 1);
+    pointer(win, "pointermove", 203.5, 100, 1);
+    pointer(win, "pointermove", 207, 100, 1);
+    pointer(win, "pointerup", 207, 100, 0);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(103.5, 1); // 7 screen px ÷ 2 = 3.5 local; NOT snapped to 100
+    expect(v[0][1]).toBeCloseTo(100, 3);
+  });
+});

--- a/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-edit-point-snap.browser.test.ts
@@ -1,0 +1,183 @@
+// End-to-end proof for point-level geometry snapping (gridaco/grida#844):
+// dragging a path vertex — or a `<line>` endpoint — snaps to the same
+// element's other points (x/y align + land-on-point), honoring the global
+// snap toggle + threshold. Keyboard nudge is exempt (moves the exact step).
+//
+// Driven through the real surface in headless Chromium so `getScreenCTM` is
+// the actual layout engine. The surface is mounted at the document origin
+// under an identity camera, so client px == world == SVG user units (see
+// `attachSurface`) and the default 6px snap threshold is 6 units here. A
+// path of straight `L` segments keeps the committed `d` a clean vertex list
+// we can read back by extracting the numbers in order.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  attachSurface,
+  nodeIdByName,
+  pointer,
+  type AttachedSurface,
+} from "./_browser-helpers";
+
+// v0 (100,100) · v1 (300,100) · v2 (300,300). v1 and v2 share x=300, so a
+// vertex dragged near that column has two snap anchors to align against.
+const PATH = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+  <path id="p" d="M 100 100 L 300 100 L 300 300" fill="none" stroke="#222"/>
+</svg>`;
+
+let s: AttachedSurface | null = null;
+afterEach(() => {
+  s?.dispose();
+  s = null;
+});
+
+/** Vertex coordinates of the committed `d`, in order — straight `L`s with
+ *  zero tangents, so the path data is just the vertex list. */
+function vertices(a: AttachedSurface): Array<[number, number]> {
+  const d = a.editor.document.get_attr(nodeIdByName(a.editor, "p"), "d") ?? "";
+  const nums = (d.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i + 1 < nums.length; i += 2) out.push([nums[i], nums[i + 1]]);
+  return out;
+}
+
+function enterPathEdit(a: AttachedSurface): void {
+  const id = nodeIdByName(a.editor, "p");
+  a.editor.commands.select(id);
+  a.editor.enter_content_edit(id);
+  expect(a.editor.state.mode).toBe("edit-content");
+}
+
+/** Drag a control from one client point to another: down, a promote move,
+ *  the destination move, then up. Mirrors the real gesture sequence the HUD
+ *  needs to lift "pending" → an active vertex/endpoint translate. */
+function drag(
+  a: AttachedSurface,
+  from: [number, number],
+  to: [number, number]
+): void {
+  const win = a.container.ownerDocument.defaultView!;
+  pointer(a.container, "pointerdown", from[0], from[1], 1);
+  pointer(win, "pointermove", (from[0] + to[0]) / 2, (from[1] + to[1]) / 2, 1);
+  pointer(win, "pointermove", to[0], to[1], 1);
+  pointer(win, "pointerup", to[0], to[1], 0);
+}
+
+/** Tap (down+up, no drag) — selects whatever control is under the cursor. */
+function tap(a: AttachedSurface, x: number, y: number): void {
+  const win = a.container.ownerDocument.defaultView!;
+  pointer(a.container, "pointerdown", x, y, 1);
+  pointer(win, "pointerup", x, y, 0);
+}
+
+function arrow(a: AttachedSurface, code: string): boolean {
+  return a.editor.keymap.dispatch({
+    code,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+describe("#844 — point snap for path vertices", () => {
+  it("aligns a dragged vertex to a neighbor's x when within threshold", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+
+    // Drag v0 to (296,200): x=296 is 4px from the x=300 column (v1/v2),
+    // within the 6px threshold ⇒ x snaps to 300. y=200 has no anchor near.
+    drag(s, [100, 100], [296, 200]);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(300, 3); // x snapped onto the column
+    expect(v[0][1]).toBeCloseTo(200, 3); // y free — followed the cursor
+    expect(v[1]).toEqual([300, 100]); // neighbors untouched
+    expect(v[2]).toEqual([300, 300]);
+  });
+
+  it("lands a dragged vertex exactly on a neighbor point when close on both axes", () => {
+    s = attachSurface(PATH);
+    enterPathEdit(s);
+
+    // Drag v0 toward v1 (300,100): final (297,103) is within 6px on x AND y.
+    drag(s, [100, 100], [297, 103]);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(300, 3); // landed on v1.x
+    expect(v[0][1]).toBeCloseTo(100, 3); // landed on v1.y
+  });
+
+  it("does not snap when the global snap toggle is off", () => {
+    s = attachSurface(PATH);
+    s.editor.set_style({ snap_enabled: false });
+    enterPathEdit(s);
+
+    // Same drag as the x-align case — with snap off the vertex goes exactly
+    // where the cursor goes (free point dragging, per the issue).
+    drag(s, [100, 100], [296, 200]);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(296, 3);
+    expect(v[0][1]).toBeCloseTo(200, 3);
+  });
+
+  it("selecting a vertex within threshold of a neighbor does not move it", () => {
+    // v0 rests at (296,200) — 4px from the x=300 column, inside the 6px
+    // threshold. Snap is position-based, so without a movement guard a bare
+    // tap (select) would jump it onto the column. Clicking must not relocate.
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <path id="p" d="M 296 200 L 300 100 L 300 300" fill="none" stroke="#222"/>
+      </svg>`
+    );
+    enterPathEdit(s);
+    tap(s, 296, 200); // select v0
+    expect(vertices(s)[0]).toEqual([296, 200]); // unmoved by selection
+  });
+
+  it("a keyboard nudge moves the exact step and never snaps onto a neighbor", () => {
+    // v0 starts at (296,200) — one ArrowRight takes it to 297, which is
+    // within 6px of the x=300 column. A drag would snap to 300; a nudge must
+    // not (it moves by exactly 1px).
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <path id="p" d="M 296 200 L 300 100 L 300 300" fill="none" stroke="#222"/>
+      </svg>`
+    );
+    enterPathEdit(s);
+    tap(s, 296, 200); // select v0
+
+    expect(arrow(s, "ArrowRight")).toBe(true);
+
+    const v = vertices(s);
+    expect(v[0][0]).toBeCloseTo(297, 3); // exact +1, NOT snapped to 300
+    expect(v[0][1]).toBeCloseTo(200, 3);
+  });
+});
+
+describe("#844 — point snap for <line> endpoints", () => {
+  it("snaps a dragged endpoint onto the opposite endpoint's axis (stays orthogonal)", () => {
+    // p1 (100,100) · p2 (300,150). Drag p2 to (350,103): y=103 is 3px from
+    // p1's y=100 ⇒ y snaps to 100, leaving a horizontal line. x is far from
+    // p1's x=100, so it follows the cursor.
+    s = attachSurface(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" width="600" height="400">
+        <line id="ln" x1="100" y1="100" x2="300" y2="150" stroke="#222"/>
+      </svg>`
+    );
+    const id = nodeIdByName(s.editor, "ln");
+    s.editor.commands.select(id);
+    s.editor.enter_content_edit(id);
+    expect(s.editor.state.mode).toBe("edit-content");
+
+    drag(s, [300, 150], [350, 103]);
+
+    const num = (n: string) =>
+      Number(s!.editor.document.get_attr(id, n) ?? "NaN");
+    expect(num("x1")).toBeCloseTo(100, 3); // p1 untouched
+    expect(num("y1")).toBeCloseTo(100, 3);
+    expect(num("x2")).toBeCloseTo(350, 3); // p2 x followed the cursor
+    expect(num("y2")).toBeCloseTo(100, 3); // p2 y snapped onto p1's row
+  });
+});

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -2883,6 +2883,9 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       set_geometry(p: GeometryProvider | null) {
         geometry_provider = p;
       },
+      register_command(id, handler) {
+        return registry.register(id, handler);
+      },
       bump_geometry() {
         // A surface-observed reflow the IR can't see (web font settled
         // after the font-* write). Advance ONLY the geometry channel:

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -14,6 +14,7 @@
 
 import type { Preview } from "@grida/history";
 import type { NodeId, PickEvent, Unsubscribe } from "../types";
+import type { CommandHandler, CommandId } from "../commands/registry";
 import type { DomComputedResolver } from "./editor";
 import type { GeometryProvider } from "./geometry";
 import type { SvgDocument } from "./document";
@@ -125,4 +126,14 @@ export interface SurfaceBridge {
    *  Required for any command that needs world bounds — `resize_to`,
    *  `rotate`, `align`. With no provider, those commands return false. */
   set_geometry(p: GeometryProvider | null): void;
+
+  /** surface → editor: register (or replace) a command handler on the
+   *  editor's command registry. The DOM surface installs surface-aware
+   *  variants of built-in commands here — e.g. a `transform.nudge` that
+   *  routes to vector sub-selection nudge during content-edit
+   *  (gridaco/grida#849). The registry does NOT stack handlers, so a plain
+   *  unregister leaves the slot empty; the surface re-registers the
+   *  headless default on detach (see `default_nudge_handler`). Returns the
+   *  registry's unregister fn. */
+  register_command(id: CommandId, handler: CommandHandler): () => void;
 }

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -2912,10 +2912,12 @@ class DomSurface implements Surface {
    * Shift axis-lock for point-level drags (gridaco/grida#848) — the
    * vertex / endpoint counterpart of whole-object translate's
    * `axis_lock: "by_dominance"` (see `current_translate_modifiers`).
-   * Collapses the lesser axis of a local-frame delta when Shift is held,
-   * via the same cmath rule the translate pipeline's `axis_lock` stage
-   * uses; identity when Shift is up. Pull-at-consume from the HUD modifier
-   * store so a mid-drag Shift press/release reflects on the next frame.
+   * Collapses the lesser axis of a delta when Shift is held, via the same
+   * cmath rule the translate pipeline's `axis_lock` stage uses; identity when
+   * Shift is up. Space-agnostic: the point path applies it to the raw screen
+   * delta (before snap), so dominance reflects the user's drag intent. Pull-
+   * at-consume from the HUD modifier store so a mid-drag Shift press/release
+   * reflects on the next frame.
    */
   private axis_lock_point_delta(dx: number, dy: number): [number, number] {
     if (!this.hud.modifiers().shift) return [dx, dy];
@@ -2929,19 +2931,21 @@ class DomSurface implements Surface {
    * delta so it aligns with (or lands on) a sibling point: a path's other
    * vertices, or a `<line>`'s opposite endpoint.
    *
-   * Runs entirely in the element's **local frame**: agents (the moving
-   * point[s]) and neighbors (the static sibling points) come straight from
-   * the path's vector network / line attributes — no projection, no separate
-   * neighbor source. The corrected delta is returned in that same local frame
-   * so the caller applies it exactly where it already applies the local drag
-   * delta. Only the snap GUIDE is projected to screen (via the element CTM)
-   * for HUD rendering.
+   * Runs in **screen space** (container CSS-px, the HUD's identity frame). The
+   * caller projects the moving point[s] (agents) and the static sibling points
+   * (neighbors) through the element CTM first, and feeds the drag delta in the
+   * same space. Screen space is the right frame because the threshold and the
+   * rendered guide are both screen-pixel concepts: the configured
+   * `snap_threshold_px` stays user-visible pixels on BOTH axes for any element
+   * CTM — even a non-uniform / rotated one, which a single area-scale would
+   * distort (gridaco/grida#844 review) — and the guide needs no reprojection.
+   * The caller converts the returned screen delta back to local for the write.
    *
-   * Honors the global snap toggle (`style.snap_enabled`) and threshold
-   * (`style.snap_threshold_px`, converted to local units by the CTM scale) —
+   * Honors the global snap toggle (`style.snap_enabled`) and threshold —
    * snap off ⇒ free point dragging, per the issue. Bypassed when
-   * `suppress_point_snap` is set (keyboard nudge). Identity when there are no
-   * neighbors / agents.
+   * `suppress_point_snap` is set (keyboard nudge) or the point hasn't moved
+   * (a pure tap / select must never relocate a control). Identity when there
+   * are no neighbors / agents.
    *
    * The shared `SnapSession` drops 0-area rects (its empty-`<g>` "jerk to
    * origin" defense), so each point is modeled as a sub-pixel square centered
@@ -2949,20 +2953,19 @@ class DomSurface implements Surface {
    * matched same-edge offset carries the same ±eps on both sides), so eps
    * magnitude is immaterial as long as it stays far below the threshold.
    */
-  private snap_local_point_delta(
+  private snap_point_delta_screen(
     raw_dx: number,
     raw_dy: number,
-    agents_local: ReadonlyArray<readonly [number, number]>,
-    neighbors_local: ReadonlyArray<readonly [number, number]>,
-    ctm: DOMMatrix
+    agents_screen: ReadonlyArray<readonly [number, number]>,
+    neighbors_screen: ReadonlyArray<readonly [number, number]>
   ): [number, number] {
     this.point_snap_guide = undefined;
     const style = this.editor.style;
     if (
       this.suppress_point_snap ||
       !style.snap_enabled ||
-      agents_local.length === 0 ||
-      neighbors_local.length === 0 ||
+      agents_screen.length === 0 ||
+      neighbors_screen.length === 0 ||
       // Snap engages only once the point has actually moved. A pure tap
       // (select) commits a zero-delta translate; without this guard a vertex
       // already resting within threshold of a neighbor would jump onto it on
@@ -2972,17 +2975,14 @@ class DomSurface implements Surface {
       return [raw_dx, raw_dy];
     }
 
-    // Local threshold = screen threshold ÷ local-to-screen scale, so the
-    // engaged distance is constant on screen regardless of camera zoom or
-    // element scale (parity with the translate pipeline's `px / zoom`).
-    const det = ctm.a * ctm.d - ctm.c * ctm.b;
-    const scale = Math.sqrt(Math.abs(det)) || 1;
-    const threshold_local = style.snap_threshold_px / scale;
-    // Inflate each point to a sub-pixel square so the shared SnapSession
-    // keeps it (it drops 0-area rects). Symmetric, and far below the
-    // threshold, so the worst-case residue it can leave in the corrected
-    // delta (an opposite-edge match) is ≤ eps — invisible (~6e-6 units).
-    const eps = threshold_local * 1e-6 || 1e-9;
+    // Threshold is the user's screen-pixel setting applied directly — no
+    // scale conversion, so it's the same engaged distance on x and y under
+    // any element transform.
+    const threshold = style.snap_threshold_px;
+    // Inflate each point to a sub-pixel square so the shared SnapSession keeps
+    // it (it drops 0-area rects). Symmetric and far below the threshold, so
+    // the worst-case residue (an opposite-edge match) is ≤ eps — sub-pixel.
+    const eps = threshold * 1e-6 || 1e-9;
     const to_rect = (p: readonly [number, number]): Rect => ({
       x: p[0] - eps / 2,
       y: p[1] - eps / 2,
@@ -2991,28 +2991,23 @@ class DomSurface implements Surface {
     });
 
     const session = new SnapSession({
-      agents: agents_local.map(to_rect),
-      neighbors: neighbors_local.map(to_rect),
+      agents: agents_screen.map(to_rect),
+      neighbors: neighbors_screen.map(to_rect),
     });
     const { delta, guide } = session.snap(
       { x: raw_dx, y: raw_dy },
-      { enabled: true, threshold_px: threshold_local }
+      { enabled: true, threshold_px: threshold }
     );
     session.dispose();
-
-    if (guide) {
-      this.point_snap_guide = this.project_local_guide_to_screen(
-        guide,
-        ctm,
-        this.container_offset()
-      );
-    }
+    // The guide is already in screen space (the HUD's identity frame) — render
+    // it directly, no reprojection.
+    this.point_snap_guide = guide;
     return [delta.x, delta.y];
   }
 
   /** Split a path's baseline vertices into the snap agents (the moving
-   *  sub-selection) and neighbors (everything else) for
-   *  {@link snap_local_point_delta}. Both in path-local space. */
+   *  sub-selection) and neighbors (everything else) for the point-snap pass.
+   *  Both in path-local space; the caller projects them to screen. */
   private vertex_snap_points(
     model: PathModel,
     moving: ReadonlyArray<number>
@@ -3030,47 +3025,6 @@ class DomSurface implements Surface {
     return { agents, neighbors };
   }
 
-  /** Project a point-snap guide from an element's local frame to screen
-   *  CSS-px (the HUD canvas's identity coordinate system), via the element
-   *  CTM + container offset — the same projection `vector_of` uses for
-   *  vertex chrome. The local-frame analog of `project_guide_to_screen`
-   *  (which projects world-space orchestrator guides via the camera). */
-  private project_local_guide_to_screen(
-    g: import("@grida/cmath/_snap").guide.SnapGuide,
-    ctm: DOMMatrix,
-    container_offset: readonly [number, number]
-  ): import("@grida/cmath/_snap").guide.SnapGuide {
-    return {
-      lines: g.lines.map((l) => {
-        const [x1, y1] = project_point_through_ctm(
-          l.x1,
-          l.y1,
-          ctm,
-          container_offset
-        );
-        const [x2, y2] = project_point_through_ctm(
-          l.x2,
-          l.y2,
-          ctm,
-          container_offset
-        );
-        return { ...l, x1, y1, x2, y2 };
-      }),
-      points: g.points.map(([x, y]) =>
-        project_point_through_ctm(x, y, ctm, container_offset)
-      ),
-      rules: g.rules.map(([axis, value]) => {
-        const [px, py] = project_point_through_ctm(
-          axis === "x" ? value : 0,
-          axis === "x" ? 0 : value,
-          ctm,
-          container_offset
-        );
-        return [axis, axis === "x" ? px : py];
-      }),
-    };
-  }
-
   /** Translation from screen/page CSS-px to the HUD's container-identity
    *  space: subtract the container's page offset, add its scroll. Used at
    *  every `getScreenCTM` projection boundary (chrome, marquee, point snap)
@@ -3084,14 +3038,55 @@ class DomSurface implements Surface {
   }
 
   /**
+   * Local-frame drag delta for a point sub-selection (vertices or a `<line>`
+   * endpoint), composed exactly like whole-object translate: **axis-lock then
+   * snap** (translate-pipeline stage order `axis_lock → snap`). The raw delta
+   * and the agent / neighbor points are all in screen space (container
+   * CSS-px):
+   *
+   *   1. Shift axis-lock collapses the lesser axis of the RAW screen delta —
+   *      dominance is the user's intent, decided before snap can perturb it
+   *      (gridaco/grida#844 review: locking the snapped delta could flip the
+   *      axis). The lock is screen-aligned, matching the drag and the guides.
+   *   2. Point snap aligns the locked delta to the sibling points.
+   *   3. The result projects back into the element's local frame via the
+   *      inverse CTM for `translateVertices` / the endpoint write.
+   *
+   * `agents_local` / `neighbors_local` are projected to screen here so the
+   * snap threshold stays user-visible pixels under any element CTM.
+   */
+  private point_drag_local_delta(
+    ctm: DOMMatrix,
+    raw_screen_dx: number,
+    raw_screen_dy: number,
+    agents_local: ReadonlyArray<readonly [number, number]>,
+    neighbors_local: ReadonlyArray<readonly [number, number]>
+  ): [number, number] {
+    // 1. axis-lock the RAW screen delta (before snap — matches the pipeline).
+    let [sx, sy] = this.axis_lock_point_delta(raw_screen_dx, raw_screen_dy);
+    // 2. snap in screen space.
+    const offset = this.container_offset();
+    const to_screen = (p: readonly [number, number]): [number, number] =>
+      project_point_through_ctm(p[0], p[1], ctm, offset);
+    [sx, sy] = this.snap_point_delta_screen(
+      sx,
+      sy,
+      agents_local.map(to_screen),
+      neighbors_local.map(to_screen)
+    );
+    // 3. screen → local for the mutation.
+    const det = ctm.a * ctm.d - ctm.c * ctm.b;
+    return det !== 0 ? project_delta_inverse_ctm(sx, sy, ctm) : [sx, sy];
+  }
+
+  /**
    * Local-frame drag delta for a vertex sub-selection, from the HUD's
-   * container-space `dx/dy`. Inverse-projects through the element CTM (so a
-   * path under a scaled `<g>` / nested viewport tracks the cursor 1:1) then
-   * point-snaps to the path's other vertices (#844) — before axis-lock, so
-   * the lock keeps final say on a constrained axis. Identity when the element
-   * has no usable CTM. A tangent-only drag (empty `indices`) yields no snap
-   * agents, so snap is a no-op. Shared by the two vertex-translate handlers;
-   * the caller applies axis-lock and feeds the result to `translateVertices`.
+   * container-space `dx/dy`. Resolves the element CTM and the snap neighbor
+   * set (the path's other vertices), then defers to `point_drag_local_delta`
+   * for the axis-lock → snap → project composition. Falls back to a plain
+   * axis-lock of the raw delta when the element has no usable CTM. A
+   * tangent-only drag (empty `indices`) has no vertex agents, so snap is a
+   * no-op. Shared by the two vertex-translate handlers.
    */
   private vertex_drag_local_delta(
     node_id: NodeId,
@@ -3105,26 +3100,12 @@ class DomSurface implements Surface {
       el instanceof SVGGraphicsElement && typeof el.getScreenCTM === "function"
         ? el.getScreenCTM()
         : null;
-    if (!ctm) return [dx, dy];
-
-    let local_dx = dx;
-    let local_dy = dy;
-    const det = ctm.a * ctm.d - ctm.c * ctm.b;
-    if (det !== 0) {
-      [local_dx, local_dy] = project_delta_inverse_ctm(dx, dy, ctm);
-    }
-
+    if (!ctm) return this.axis_lock_point_delta(dx, dy);
     const { agents, neighbors } = this.vertex_snap_points(
       baseline_model,
       indices
     );
-    return this.snap_local_point_delta(
-      local_dx,
-      local_dy,
-      agents,
-      neighbors,
-      ctm
-    );
+    return this.point_drag_local_delta(ctm, dx, dy, agents, neighbors);
   }
 
   /** Snapshot of HUD modifier state mapped to the orchestrator's `GestureModifiers`.
@@ -3303,35 +3284,47 @@ class DomSurface implements Surface {
 
     const base_x = endpoint === "p1" ? initial.x1 : initial.x2;
     const base_y = endpoint === "p1" ? initial.y1 : initial.y2;
-    let dx = target_x - base_x;
-    let dy = target_y - base_y;
 
-    // #844: snap the dragged endpoint to the line's OPPOSITE endpoint
-    // (orthogonal-align / land-on-point), in the line's own frame. The
-    // other endpoint is the only same-element point a line exposes.
+    // #848 axis-lock + #844 snap, composed in pipeline order (lock → snap).
+    // The opposite endpoint is the only same-element point a line exposes, so
+    // it is the lone snap neighbor (orthogonal-align / land-on-point). Done in
+    // screen space — see `point_drag_local_delta` — relative to the gesture-
+    // start endpoint, so the result is a clean delta off the original.
     const el = this.element_index.get(id);
     const ctm =
       el instanceof SVGGraphicsElement && typeof el.getScreenCTM === "function"
         ? el.getScreenCTM()
         : null;
+    let final_x: number;
+    let final_y: number;
     if (ctm) {
+      const offset = this.container_offset();
+      const base_screen = project_point_through_ctm(
+        base_x,
+        base_y,
+        ctm,
+        offset
+      );
       const other: readonly [number, number] =
         endpoint === "p1" ? [initial.x2, initial.y2] : [initial.x1, initial.y1];
-      [dx, dy] = this.snap_local_point_delta(
-        dx,
-        dy,
+      const [ldx, ldy] = this.point_drag_local_delta(
+        ctm,
+        intent.pos[0] - base_screen[0],
+        intent.pos[1] - base_screen[1],
         [[base_x, base_y]],
-        [other],
-        ctm
+        [other]
       );
+      final_x = base_x + ldx;
+      final_y = base_y + ldy;
+    } else {
+      // No usable CTM — fall back to the locally-resolved cursor target + lock.
+      const [ldx, ldy] = this.axis_lock_point_delta(
+        target_x - base_x,
+        target_y - base_y
+      );
+      final_x = base_x + ldx;
+      final_y = base_y + ldy;
     }
-
-    // #848: Shift axis-locks the (snapped) endpoint delta relative to its
-    // gesture-start position (parity with whole-object translate) — the lock
-    // keeps final say on a constrained axis, keeping the move orthogonal.
-    const [locked_dx, locked_dy] = this.axis_lock_point_delta(dx, dy);
-    const final_x = base_x + locked_dx;
-    const final_y = base_y + locked_dy;
 
     const apply = () => {
       if (endpoint === "p1") {
@@ -4395,24 +4388,17 @@ class DomSurface implements Surface {
 
     const baseline_d = this.active_preview.initial_d;
     const indices = this.active_preview.indices;
-    // HUD reports `dx, dy` in container CSS-px (its own doc-space).
-    // The PathModel expects deltas in the path's local SVG coord space.
-    // Project the delta back through the inverse of the CTM's linear part
-    // (no translation: a delta is camera-invariant under translation).
-    // Mirrors what `container_point_in_own_frame` does for absolute points.
-    // Project the HUD's container-space delta into the path's local frame
-    // and point-snap it (#844). See `vertex_drag_local_delta`.
-    let [local_dx, local_dy] = this.vertex_drag_local_delta(
+    // The HUD reports `dx, dy` in container CSS-px; resolve the local-frame
+    // delta to feed `translateVertices` — axis-lock (#848) and point-snap
+    // (#844) compose inside, in the translate pipeline's `axis_lock → snap`
+    // order. See `vertex_drag_local_delta`.
+    const [local_dx, local_dy] = this.vertex_drag_local_delta(
       node_id,
       this.active_preview.baseline_model,
       indices,
       intent.dx,
       intent.dy
     );
-
-    // #848: Shift axis-locks the vertex drag (by-dominance, in the path's
-    // local frame) — parity with whole-object translate.
-    [local_dx, local_dy] = this.axis_lock_point_delta(local_dx, local_dy);
 
     // Derive the in-flight model from the baseline each frame. dx,dy is the
     // total delta from gesture start; replaying from baseline each frame
@@ -4573,25 +4559,18 @@ class DomSurface implements Surface {
     }
 
     const baseline_d = this.active_preview.initial_d;
-    // HUD reports dx/dy in container CSS-px (its own doc-space). The
-    // PathModel expects deltas in the path's local SVG coord space — same
-    // projection as `handle_translate_vertices`.
-    // Project the HUD's container-space delta into the path's local frame
-    // and point-snap it (#844; bypassed for keyboard nudge via
-    // `suppress_point_snap`). See `vertex_drag_local_delta`.
-    let [local_dx, local_dy] = this.vertex_drag_local_delta(
+    // The HUD reports `dx, dy` in container CSS-px; resolve the local-frame
+    // delta to feed `translateVertices`. Axis-lock (#848) and point-snap
+    // (#844) compose inside, in the translate pipeline's `axis_lock → snap`
+    // order; snap is bypassed for keyboard nudge (`suppress_point_snap`).
+    // See `vertex_drag_local_delta`.
+    const [local_dx, local_dy] = this.vertex_drag_local_delta(
       node_id,
       this.active_preview.baseline_model,
       indices,
       intent.dx,
       intent.dy
     );
-
-    // #848: Shift axis-locks the drag (by-dominance, in the path's local
-    // frame) — parity with whole-object translate. A keyboard nudge
-    // (`nudge_vector_selection`) feeds a single-axis delta, so the lock is
-    // a no-op there even when Shift is the 10px modifier.
-    [local_dx, local_dy] = this.axis_lock_point_delta(local_dx, local_dy);
 
     // Derive in-flight model from cached baseline each frame — replaying
     // from baseline (instead of accumulating) keeps chrome and document

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -32,6 +32,7 @@ import {
 import { cursors as hud_cursors } from "@grida/hud/cursors";
 import { measure, type Measurement } from "@grida/cmath/_measurement";
 import cmath from "@grida/cmath";
+import { default_nudge_handler } from "./commands/defaults";
 import { Camera } from "./core/camera";
 import type {
   DomComputedResolver,
@@ -1024,6 +1025,22 @@ class DomSurface implements Surface {
     this.editor_hover_internal = internal;
     internal.set_content_edit_driver((id) => this.enter_content_edit(id));
     this.teardown.push(() => internal.set_content_edit_driver(null));
+
+    // Arrow-key nudge: in vector content-edit, route to the path sub-
+    // selection (vertices / segments / tangents) instead of leaking to a
+    // whole-element move — the keyboard counterpart of dragging those
+    // points (gridaco/grida#849). Outside content-edit it falls back to
+    // the headless whole-element nudge. The registry doesn't stack
+    // handlers, so detach restores `default_nudge_handler`.
+    internal.register_command("transform.nudge", (args) =>
+      this.handle_nudge_command(args)
+    );
+    this.teardown.push(() =>
+      internal.register_command(
+        "transform.nudge",
+        default_nudge_handler(this.editor)
+      )
+    );
 
     // Delegates to `getComputedStyle()` so `dom_computed_*` honors `<style>`
     // matching, `var()`, and inheritance — the cases the headless cascade
@@ -2861,6 +2878,21 @@ class DomSurface implements Surface {
     if (intent.phase === "commit") this.request_redraw();
   }
 
+  /**
+   * Shift axis-lock for point-level drags (gridaco/grida#848) — the
+   * vertex / endpoint counterpart of whole-object translate's
+   * `axis_lock: "by_dominance"` (see `current_translate_modifiers`).
+   * Collapses the lesser axis of a local-frame delta when Shift is held,
+   * via the same cmath rule the translate pipeline's `axis_lock` stage
+   * uses; identity when Shift is up. Pull-at-consume from the HUD modifier
+   * store so a mid-drag Shift press/release reflects on the next frame.
+   */
+  private axis_lock_point_delta(dx: number, dy: number): [number, number] {
+    if (!this.hud.modifiers().shift) return [dx, dy];
+    const locked = cmath.ext.movement.axisLockedByDominance([dx, dy]);
+    return cmath.ext.movement.normalize(locked);
+  }
+
   /** Snapshot of HUD modifier state mapped to the orchestrator's `GestureModifiers`.
    *  Pull-at-consume: HUD is the canonical store (see `sync_modifiers`),
    *  read live so mid-drag Shift press/release reflects on the next pass. */
@@ -3035,13 +3067,26 @@ class DomSurface implements Surface {
     const target_x = pos_own.x;
     const target_y = pos_own.y;
 
+    // #848: Shift axis-locks the endpoint drag relative to its gesture-
+    // start position (parity with whole-object translate). The endpoint
+    // tracks the cursor; locking the delta from the original endpoint
+    // keeps the move purely horizontal or vertical.
+    const base_x = endpoint === "p1" ? initial.x1 : initial.x2;
+    const base_y = endpoint === "p1" ? initial.y1 : initial.y2;
+    const [locked_dx, locked_dy] = this.axis_lock_point_delta(
+      target_x - base_x,
+      target_y - base_y
+    );
+    const final_x = base_x + locked_dx;
+    const final_y = base_y + locked_dy;
+
     const apply = () => {
       if (endpoint === "p1") {
-        doc.set_attr(id, "x1", String(target_x));
-        doc.set_attr(id, "y1", String(target_y));
+        doc.set_attr(id, "x1", String(final_x));
+        doc.set_attr(id, "y1", String(final_y));
       } else {
-        doc.set_attr(id, "x2", String(target_x));
-        doc.set_attr(id, "y2", String(target_y));
+        doc.set_attr(id, "x2", String(final_x));
+        doc.set_attr(id, "y2", String(final_y));
       }
       emit();
     };
@@ -4132,6 +4177,10 @@ class DomSurface implements Surface {
       }
     }
 
+    // #848: Shift axis-locks the vertex drag (by-dominance, in the path's
+    // local frame) — parity with whole-object translate.
+    [local_dx, local_dy] = this.axis_lock_point_delta(local_dx, local_dy);
+
     // Derive the in-flight model from the baseline each frame. dx,dy is the
     // total delta from gesture start; replaying from baseline each frame
     // (instead of accumulating from the previous frame) keeps the chrome
@@ -4312,6 +4361,12 @@ class DomSurface implements Surface {
       }
     }
 
+    // #848: Shift axis-locks the drag (by-dominance, in the path's local
+    // frame) — parity with whole-object translate. A keyboard nudge
+    // (`nudge_vector_selection`) feeds a single-axis delta, so the lock is
+    // a no-op there even when Shift is the 10px modifier.
+    [local_dx, local_dy] = this.axis_lock_point_delta(local_dx, local_dy);
+
     // Derive in-flight model from cached baseline each frame — replaying
     // from baseline (instead of accumulating) keeps chrome and document
     // byte-identical with no per-frame drift.
@@ -4367,6 +4422,60 @@ class DomSurface implements Surface {
         )
       );
     }
+  }
+
+  /**
+   * Surface-aware `transform.nudge` handler — registered over the headless
+   * default on attach (gridaco/grida#849). In vector content-edit, arrow
+   * keys nudge the path sub-selection (the keyboard counterpart of
+   * dragging vertices / segments / tangents) rather than leaking to a
+   * whole-element move (the bug). This mirrors text-edit, where the inline
+   * editor owns the arrow keys. Outside content-edit it delegates to the
+   * headless `default_nudge_handler` (whole-element nudge) — the same
+   * handler the registry restores on detach, so the override and the
+   * default can never drift.
+   *
+   * While a vector session is open the arrows are OWNED by it: an empty
+   * sub-selection is a consumed no-op, never a whole-element nudge — same
+   * "content-edit captures arrows" contract as text-edit.
+   */
+  private handle_nudge_command(args?: unknown): boolean {
+    const { dx, dy } = args as { dx: number; dy: number };
+    if (this.editor.state.mode === "edit-content" && this.vector_edit) {
+      this.nudge_vector_selection(dx, dy);
+      return true;
+    }
+    return default_nudge_handler(this.editor)(args) === true;
+  }
+
+  /**
+   * Discrete keyboard nudge of the vector sub-selection. Reuses the drag
+   * path ({@link handle_translate_vector_selection}) by synthesizing a
+   * single commit-phase intent, so a nudge is byte-identical to a one-step
+   * drag of the same points: same union resolution (selected vertices ∪
+   * selected-segment endpoints ∪ tangents), same parent-vertex tangent
+   * exclusion, same history bracket + sub-selection capture.
+   *
+   * `dx`/`dy` arrive in world units (1px, or 10px with Shift — already
+   * resolved by the keymap binding). `handle_translate_vector_selection`
+   * expects container CSS-px (it projects back through the inverse
+   * screen-CTM), so scale by the camera zoom on the way in; the projection
+   * recovers the world delta in the path's local frame. A no-sub-selection
+   * session resolves to a no-op inside the handler.
+   */
+  private nudge_vector_selection(dx: number, dy: number): void {
+    const ses = this.vector_edit;
+    if (!ses) return;
+    const zoom = this.camera.zoom || 1;
+    this.handle_translate_vector_selection({
+      kind: "translate_vector_selection",
+      node_id: ses.node_id,
+      additional_vertex_indices: [],
+      dx: dx * zoom,
+      dy: dy * zoom,
+      phase: "commit",
+    });
+    this.request_redraw();
   }
 
   /** Mirror handler for `select_tangent` (analogous to `select_vertex`). */

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -537,6 +537,25 @@ class DomSurface implements Surface {
    *  one session at a time. */
   private vector_edit: VectorEditSession | null = null;
 
+  /** Screen-space snap guide for the in-flight point-level drag (#844) — a
+   *  dragged path vertex / `<line>` endpoint snapped to a sibling point.
+   *  Already projected to container CSS-px (the HUD's identity space) at
+   *  snap time, so `compute_snap_extra` renders it directly. `undefined`
+   *  when no point snap is engaged; cleared on the commit frame and on
+   *  `cancel_in_flight`. Point drags run only in vector/endpoint edit, which
+   *  is mutually exclusive with the orchestrator gestures, so this never
+   *  competes with the translate / resize / insert guides. */
+  private point_snap_guide:
+    | import("@grida/cmath/_snap").guide.SnapGuide
+    | undefined = undefined;
+
+  /** When set, point-level snap (#844) is bypassed for the current call.
+   *  A keyboard nudge replays the drag path (`nudge_vector_selection` →
+   *  `handle_translate_vector_selection`) but must move by the exact step,
+   *  never snap onto a neighbor — same as Figma's arrow nudge. Scoped
+   *  around the synthesized commit and reset in a `finally`. */
+  private suppress_point_snap = false;
+
   /** Snapshot of the vector-edit sub-selection at the START of an in-flight
    *  region-selection gesture (marquee OR lasso). Captured on the first
    *  preview, used as the merge baseline for every subsequent preview
@@ -1778,6 +1797,15 @@ class DomSurface implements Surface {
   }
 
   private compute_snap_extra(): HUDDraw | undefined {
+    // Point-level snap (#844) — a vertex / `<line>` endpoint drag. Runs only
+    // in vector/endpoint edit, mutually exclusive with every orchestrator
+    // gesture below, so it takes precedence. Already in screen space.
+    if (this.point_snap_guide) {
+      return snapGuideToHUDDraw(
+        this.point_snap_guide,
+        this.editor.style.measurement_color
+      );
+    }
     // Insertion-drag wins when active — it's mutually exclusive with the
     // other gesture types (no translate / resize / nudge-dwell can run
     // while pending_insert is open).
@@ -1911,6 +1939,8 @@ class DomSurface implements Surface {
     if (this.active_preview) {
       this.active_preview.session.discard();
       this.active_preview = null;
+      // Drop any in-flight point-snap guide (#844) along with the preview.
+      this.point_snap_guide = undefined;
       canceled = true;
     }
     if (this.pending_insert) {
@@ -2893,6 +2923,210 @@ class DomSurface implements Surface {
     return cmath.ext.movement.normalize(locked);
   }
 
+  /**
+   * Point-level snap (gridaco/grida#844) — the vertex / endpoint counterpart
+   * of whole-object translate's edge/center snap. Snaps a dragged point's
+   * delta so it aligns with (or lands on) a sibling point: a path's other
+   * vertices, or a `<line>`'s opposite endpoint.
+   *
+   * Runs entirely in the element's **local frame**: agents (the moving
+   * point[s]) and neighbors (the static sibling points) come straight from
+   * the path's vector network / line attributes — no projection, no separate
+   * neighbor source. The corrected delta is returned in that same local frame
+   * so the caller applies it exactly where it already applies the local drag
+   * delta. Only the snap GUIDE is projected to screen (via the element CTM)
+   * for HUD rendering.
+   *
+   * Honors the global snap toggle (`style.snap_enabled`) and threshold
+   * (`style.snap_threshold_px`, converted to local units by the CTM scale) —
+   * snap off ⇒ free point dragging, per the issue. Bypassed when
+   * `suppress_point_snap` is set (keyboard nudge). Identity when there are no
+   * neighbors / agents.
+   *
+   * The shared `SnapSession` drops 0-area rects (its empty-`<g>` "jerk to
+   * origin" defense), so each point is modeled as a sub-pixel square centered
+   * on it. Symmetric inflation cancels in the corrected delta (the engine's
+   * matched same-edge offset carries the same ±eps on both sides), so eps
+   * magnitude is immaterial as long as it stays far below the threshold.
+   */
+  private snap_local_point_delta(
+    raw_dx: number,
+    raw_dy: number,
+    agents_local: ReadonlyArray<readonly [number, number]>,
+    neighbors_local: ReadonlyArray<readonly [number, number]>,
+    ctm: DOMMatrix
+  ): [number, number] {
+    this.point_snap_guide = undefined;
+    const style = this.editor.style;
+    if (
+      this.suppress_point_snap ||
+      !style.snap_enabled ||
+      agents_local.length === 0 ||
+      neighbors_local.length === 0 ||
+      // Snap engages only once the point has actually moved. A pure tap
+      // (select) commits a zero-delta translate; without this guard a vertex
+      // already resting within threshold of a neighbor would jump onto it on
+      // mere selection — clicking a control must never relocate it.
+      (raw_dx === 0 && raw_dy === 0)
+    ) {
+      return [raw_dx, raw_dy];
+    }
+
+    // Local threshold = screen threshold ÷ local-to-screen scale, so the
+    // engaged distance is constant on screen regardless of camera zoom or
+    // element scale (parity with the translate pipeline's `px / zoom`).
+    const det = ctm.a * ctm.d - ctm.c * ctm.b;
+    const scale = Math.sqrt(Math.abs(det)) || 1;
+    const threshold_local = style.snap_threshold_px / scale;
+    // Inflate each point to a sub-pixel square so the shared SnapSession
+    // keeps it (it drops 0-area rects). Symmetric, and far below the
+    // threshold, so the worst-case residue it can leave in the corrected
+    // delta (an opposite-edge match) is ≤ eps — invisible (~6e-6 units).
+    const eps = threshold_local * 1e-6 || 1e-9;
+    const to_rect = (p: readonly [number, number]): Rect => ({
+      x: p[0] - eps / 2,
+      y: p[1] - eps / 2,
+      width: eps,
+      height: eps,
+    });
+
+    const session = new SnapSession({
+      agents: agents_local.map(to_rect),
+      neighbors: neighbors_local.map(to_rect),
+    });
+    const { delta, guide } = session.snap(
+      { x: raw_dx, y: raw_dy },
+      { enabled: true, threshold_px: threshold_local }
+    );
+    session.dispose();
+
+    if (guide) {
+      this.point_snap_guide = this.project_local_guide_to_screen(
+        guide,
+        ctm,
+        this.container_offset()
+      );
+    }
+    return [delta.x, delta.y];
+  }
+
+  /** Split a path's baseline vertices into the snap agents (the moving
+   *  sub-selection) and neighbors (everything else) for
+   *  {@link snap_local_point_delta}. Both in path-local space. */
+  private vertex_snap_points(
+    model: PathModel,
+    moving: ReadonlyArray<number>
+  ): {
+    agents: Array<readonly [number, number]>;
+    neighbors: Array<readonly [number, number]>;
+  } {
+    const verts = model.snapshot().vertices;
+    const moving_set = new Set(moving);
+    const agents: Array<readonly [number, number]> = [];
+    const neighbors: Array<readonly [number, number]> = [];
+    for (let i = 0; i < verts.length; i++) {
+      (moving_set.has(i) ? agents : neighbors).push(verts[i]);
+    }
+    return { agents, neighbors };
+  }
+
+  /** Project a point-snap guide from an element's local frame to screen
+   *  CSS-px (the HUD canvas's identity coordinate system), via the element
+   *  CTM + container offset — the same projection `vector_of` uses for
+   *  vertex chrome. The local-frame analog of `project_guide_to_screen`
+   *  (which projects world-space orchestrator guides via the camera). */
+  private project_local_guide_to_screen(
+    g: import("@grida/cmath/_snap").guide.SnapGuide,
+    ctm: DOMMatrix,
+    container_offset: readonly [number, number]
+  ): import("@grida/cmath/_snap").guide.SnapGuide {
+    return {
+      lines: g.lines.map((l) => {
+        const [x1, y1] = project_point_through_ctm(
+          l.x1,
+          l.y1,
+          ctm,
+          container_offset
+        );
+        const [x2, y2] = project_point_through_ctm(
+          l.x2,
+          l.y2,
+          ctm,
+          container_offset
+        );
+        return { ...l, x1, y1, x2, y2 };
+      }),
+      points: g.points.map(([x, y]) =>
+        project_point_through_ctm(x, y, ctm, container_offset)
+      ),
+      rules: g.rules.map(([axis, value]) => {
+        const [px, py] = project_point_through_ctm(
+          axis === "x" ? value : 0,
+          axis === "x" ? 0 : value,
+          ctm,
+          container_offset
+        );
+        return [axis, axis === "x" ? px : py];
+      }),
+    };
+  }
+
+  /** Translation from screen/page CSS-px to the HUD's container-identity
+   *  space: subtract the container's page offset, add its scroll. Used at
+   *  every `getScreenCTM` projection boundary (chrome, marquee, point snap)
+   *  so they share one definition of "where the container's origin is". */
+  private container_offset(): [number, number] {
+    const cr = this.container.getBoundingClientRect();
+    return [
+      -cr.left + this.container.scrollLeft,
+      -cr.top + this.container.scrollTop,
+    ];
+  }
+
+  /**
+   * Local-frame drag delta for a vertex sub-selection, from the HUD's
+   * container-space `dx/dy`. Inverse-projects through the element CTM (so a
+   * path under a scaled `<g>` / nested viewport tracks the cursor 1:1) then
+   * point-snaps to the path's other vertices (#844) — before axis-lock, so
+   * the lock keeps final say on a constrained axis. Identity when the element
+   * has no usable CTM. A tangent-only drag (empty `indices`) yields no snap
+   * agents, so snap is a no-op. Shared by the two vertex-translate handlers;
+   * the caller applies axis-lock and feeds the result to `translateVertices`.
+   */
+  private vertex_drag_local_delta(
+    node_id: NodeId,
+    baseline_model: PathModel,
+    indices: ReadonlyArray<number>,
+    dx: number,
+    dy: number
+  ): [number, number] {
+    const el = this.element_index.get(node_id);
+    const ctm =
+      el instanceof SVGGraphicsElement && typeof el.getScreenCTM === "function"
+        ? el.getScreenCTM()
+        : null;
+    if (!ctm) return [dx, dy];
+
+    let local_dx = dx;
+    let local_dy = dy;
+    const det = ctm.a * ctm.d - ctm.c * ctm.b;
+    if (det !== 0) {
+      [local_dx, local_dy] = project_delta_inverse_ctm(dx, dy, ctm);
+    }
+
+    const { agents, neighbors } = this.vertex_snap_points(
+      baseline_model,
+      indices
+    );
+    return this.snap_local_point_delta(
+      local_dx,
+      local_dy,
+      agents,
+      neighbors,
+      ctm
+    );
+  }
+
   /** Snapshot of HUD modifier state mapped to the orchestrator's `GestureModifiers`.
    *  Pull-at-consume: HUD is the canonical store (see `sync_modifiers`),
    *  read live so mid-drag Shift press/release reflects on the next pass. */
@@ -3067,16 +3301,35 @@ class DomSurface implements Surface {
     const target_x = pos_own.x;
     const target_y = pos_own.y;
 
-    // #848: Shift axis-locks the endpoint drag relative to its gesture-
-    // start position (parity with whole-object translate). The endpoint
-    // tracks the cursor; locking the delta from the original endpoint
-    // keeps the move purely horizontal or vertical.
     const base_x = endpoint === "p1" ? initial.x1 : initial.x2;
     const base_y = endpoint === "p1" ? initial.y1 : initial.y2;
-    const [locked_dx, locked_dy] = this.axis_lock_point_delta(
-      target_x - base_x,
-      target_y - base_y
-    );
+    let dx = target_x - base_x;
+    let dy = target_y - base_y;
+
+    // #844: snap the dragged endpoint to the line's OPPOSITE endpoint
+    // (orthogonal-align / land-on-point), in the line's own frame. The
+    // other endpoint is the only same-element point a line exposes.
+    const el = this.element_index.get(id);
+    const ctm =
+      el instanceof SVGGraphicsElement && typeof el.getScreenCTM === "function"
+        ? el.getScreenCTM()
+        : null;
+    if (ctm) {
+      const other: readonly [number, number] =
+        endpoint === "p1" ? [initial.x2, initial.y2] : [initial.x1, initial.y1];
+      [dx, dy] = this.snap_local_point_delta(
+        dx,
+        dy,
+        [[base_x, base_y]],
+        [other],
+        ctm
+      );
+    }
+
+    // #848: Shift axis-locks the (snapped) endpoint delta relative to its
+    // gesture-start position (parity with whole-object translate) — the lock
+    // keeps final say on a constrained axis, keeping the move orthogonal.
+    const [locked_dx, locked_dy] = this.axis_lock_point_delta(dx, dy);
     const final_x = base_x + locked_dx;
     const final_y = base_y + locked_dy;
 
@@ -3104,6 +3357,8 @@ class DomSurface implements Surface {
       revert,
     });
     if (intent.phase === "commit") {
+      // Drag is over — drop the snap guide so it doesn't linger past pointerup.
+      this.point_snap_guide = undefined;
       this.active_preview.session.commit();
       this.active_preview = null;
     }
@@ -3245,11 +3500,7 @@ class DomSurface implements Surface {
     if (typeof el.getScreenCTM !== "function") return;
     const ctm = el.getScreenCTM();
     if (!ctm) return;
-    const cr = this.container.getBoundingClientRect();
-    const offset: [number, number] = [
-      -cr.left + this.container.scrollLeft,
-      -cr.top + this.container.scrollTop,
-    ];
+    const offset = this.container_offset();
 
     // Derive the model from the live `d` — same doctrine as `vector_of`.
     const model = this.session_model();
@@ -3347,11 +3598,7 @@ class DomSurface implements Surface {
     if (typeof el.getScreenCTM !== "function") return;
     const ctm = el.getScreenCTM();
     if (!ctm) return;
-    const cr = this.container.getBoundingClientRect();
-    const offset: [number, number] = [
-      -cr.left + this.container.scrollLeft,
-      -cr.top + this.container.scrollTop,
-    ];
+    const offset = this.container_offset();
 
     const model = this.session_model();
     if (!model) return;
@@ -3794,11 +4041,7 @@ class DomSurface implements Surface {
     if (typeof el.getScreenCTM !== "function") return null;
     const ctm = el.getScreenCTM();
     if (!ctm) return null;
-    const cr = this.container.getBoundingClientRect();
-    const offset: [number, number] = [
-      -cr.left + this.container.scrollLeft,
-      -cr.top + this.container.scrollTop,
-    ];
+    const offset = this.container_offset();
 
     const vertices: [number, number][] = Array.from(
       { length: snap.vertices.length },
@@ -4157,25 +4400,15 @@ class DomSurface implements Surface {
     // Project the delta back through the inverse of the CTM's linear part
     // (no translation: a delta is camera-invariant under translation).
     // Mirrors what `container_point_in_own_frame` does for absolute points.
-    let local_dx = intent.dx;
-    let local_dy = intent.dy;
-    const el = this.element_index.get(node_id);
-    if (
-      el instanceof SVGGraphicsElement &&
-      typeof el.getScreenCTM === "function"
-    ) {
-      const ctm = el.getScreenCTM();
-      if (ctm) {
-        const det = ctm.a * ctm.d - ctm.c * ctm.b;
-        if (det !== 0) {
-          [local_dx, local_dy] = project_delta_inverse_ctm(
-            intent.dx,
-            intent.dy,
-            ctm
-          );
-        }
-      }
-    }
+    // Project the HUD's container-space delta into the path's local frame
+    // and point-snap it (#844). See `vertex_drag_local_delta`.
+    let [local_dx, local_dy] = this.vertex_drag_local_delta(
+      node_id,
+      this.active_preview.baseline_model,
+      indices,
+      intent.dx,
+      intent.dy
+    );
 
     // #848: Shift axis-locks the vertex drag (by-dominance, in the path's
     // local frame) — parity with whole-object translate.
@@ -4196,6 +4429,8 @@ class DomSurface implements Surface {
     this.active_preview.preview_model = preview_model;
 
     if (intent.phase === "commit") {
+      // Drag is over — drop the snap guide so it doesn't linger past pointerup.
+      this.point_snap_guide = undefined;
       // Build the committed delta with sub-selection capture so undo /
       // redo restores selection alongside `d`. See the vector-edit
       // selection-history note in `handle_set_tangent_intent` — the
@@ -4341,25 +4576,16 @@ class DomSurface implements Surface {
     // HUD reports dx/dy in container CSS-px (its own doc-space). The
     // PathModel expects deltas in the path's local SVG coord space — same
     // projection as `handle_translate_vertices`.
-    let local_dx = intent.dx;
-    let local_dy = intent.dy;
-    const el = this.element_index.get(node_id);
-    if (
-      el instanceof SVGGraphicsElement &&
-      typeof el.getScreenCTM === "function"
-    ) {
-      const ctm = el.getScreenCTM();
-      if (ctm) {
-        const det = ctm.a * ctm.d - ctm.c * ctm.b;
-        if (det !== 0) {
-          [local_dx, local_dy] = project_delta_inverse_ctm(
-            intent.dx,
-            intent.dy,
-            ctm
-          );
-        }
-      }
-    }
+    // Project the HUD's container-space delta into the path's local frame
+    // and point-snap it (#844; bypassed for keyboard nudge via
+    // `suppress_point_snap`). See `vertex_drag_local_delta`.
+    let [local_dx, local_dy] = this.vertex_drag_local_delta(
+      node_id,
+      this.active_preview.baseline_model,
+      indices,
+      intent.dx,
+      intent.dy
+    );
 
     // #848: Shift axis-locks the drag (by-dominance, in the path's local
     // frame) — parity with whole-object translate. A keyboard nudge
@@ -4396,6 +4622,8 @@ class DomSurface implements Surface {
     this.active_preview.preview_model = preview_model;
 
     if (intent.phase === "commit") {
+      // Drag is over — drop the snap guide so it doesn't linger past pointerup.
+      this.point_snap_guide = undefined;
       const before_selection = this.active_preview.before_selection;
       const after_selection = this.vector_edit.snapshot_selection();
       this.active_preview.session.set(
@@ -4467,14 +4695,21 @@ class DomSurface implements Surface {
     const ses = this.vector_edit;
     if (!ses) return;
     const zoom = this.camera.zoom || 1;
-    this.handle_translate_vector_selection({
-      kind: "translate_vector_selection",
-      node_id: ses.node_id,
-      additional_vertex_indices: [],
-      dx: dx * zoom,
-      dy: dy * zoom,
-      phase: "commit",
-    });
+    // A keyboard nudge moves by the exact step — never snap onto a neighbor
+    // (#844; Figma parity). Replays the drag path with point snap bypassed.
+    this.suppress_point_snap = true;
+    try {
+      this.handle_translate_vector_selection({
+        kind: "translate_vector_selection",
+        node_id: ses.node_id,
+        additional_vertex_indices: [],
+        dx: dx * zoom,
+        dy: dy * zoom,
+        phase: "commit",
+      });
+    } finally {
+      this.suppress_point_snap = false;
+    }
     this.request_redraw();
   }
 

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -3985,6 +3985,10 @@ class DomSurface implements Surface {
     }
     this.vector_edit = null;
     this.vector_edit_region_baseline = null;
+    // Drop any in-flight point-snap guide (#844) — `compute_snap_extra`
+    // prioritizes it, so it must not survive a content-edit exit that
+    // bypasses the per-gesture commit / cancel clears.
+    this.point_snap_guide = undefined;
     this.hud.setVectorSelection(null);
     if (
       this.current_tool.type === "lasso" ||


### PR DESCRIPTION
Point-level editing affordances for `@grida/svg-editor` path content-edit and `<line>` endpoint controls. Three sibling issues, each the point-granularity counterpart of an existing whole-object affordance.

## What changed

**#849 — arrow-key nudge moves the path sub-selection** (`feat(svg-editor): keyboard vertex nudge + shift axis-lock in path edit`)
In vector content-edit, arrows now nudge the selected vertices/segments/tangents (keyboard counterpart of dragging them) instead of leaking to a whole-element move. While a vector session is open the arrows are owned by it — an empty sub-selection is a consumed no-op, matching the text-edit "content-edit captures arrows" contract. Implemented via a `register_command` seam on the editor `_internal` bag (the surface overrides `transform.nudge` on attach, restores the headless default on detach).

**#848 — Shift axis-locks point-level drags**
Vertex drags and `<line>` endpoint drags now axis-lock under Shift (by-dominance, in the element's local frame) — parity with whole-object translate's `axis_lock`.

**#844 — snap geometry at the point level**
Dragging a path vertex or a `<line>` endpoint snaps to the same element's other points — x/y align + land-on-point — with a snap guide, honoring the global snap toggle + threshold.

## Why

The editor already assists when you move/resize whole objects (edges/centers snap, alignment guides, axis-lock, nudge). At the point level that assistance disappeared — precise vector work was guesswork. These close that gap, matching the main Grida canvas vector editor and Figma.

## Design notes for reviewers

- **Snap runs in the element's local frame**, reusing the shared `SnapSession` engine *unchanged*. v1 scope is same-element points, which are naturally local, so the neighbors come straight from the path's vector network / line attrs with zero projection, and the corrected delta applies exactly where the handlers already apply the local drag delta. Only the guide is projected local→screen (via the element CTM) and rendered through the existing `compute_snap_extra` path.
- **Point = sub-pixel rect.** `SnapSession` drops zero-area rects (the empty-`<g>` "jerk to origin" defense, shared with object snap — left untouched), so each point is modeled as a symmetric sub-pixel square; the inflation cancels in the corrected delta (residue ~6e-6 units).
- **Two behavioral guards:** snap is suppressed for keyboard nudge (arrows move the exact step — Figma parity) and for zero-movement gestures (a tap that *selects* a vertex must never relocate it — caught in testing when a vertex resting within threshold jumped onto its neighbor on click).
- The three point-drag handlers share a `vertex_drag_local_delta` helper; the container-offset projection was consolidated into one `container_offset()` accessor (previously inlined 4×).

## Tests

- New browser suites (real Chromium / real `getScreenCTM`): `vector-edit-nudge-axislock` (6) and `vector-edit-point-snap` (6) — covering nudge routing, axis-lock on vertices and line endpoints, x-align / land-on-point snap, snap-off, tap-no-move, and nudge-never-snaps.
- Full gate green: **1365 node + 47 browser tests, typecheck, oxlint 0/0, oxfmt**.

Bumps `@grida/svg-editor` → `1.0.0-alpha.20`.

Closes #849, closes #848, closes #844.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added point-level snapping for vector vertices and line endpoints so drags align with nearby anchors.
  * Improved keyboard nudge behavior for vector edits, including Shift axis-lock and consistent step movement.
* **Bug Fixes**
  * Made snapping compose correctly with axis-lock and respect screen-pixel snap thresholds under non-uniform SVG transforms; keyboard nudges bypass snapping to prevent unintended jumps.
* **Tests**
  * Added browser end-to-end coverage for vertex/endpoint snapping and nudge/axis-lock combinations.
* **Chores**
  * Updated package version to `1.0.0-alpha.20`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->