### PR TITLE
feat(svg-editor): draw text-edit caret + selection on the HUD

### DIFF
--- a/packages/grida-canvas-hud/__tests__/classes/text-edit/surface.test.ts
+++ b/packages/grida-canvas-hud/__tests__/classes/text-edit/surface.test.ts
@@ -1,0 +1,144 @@
+// Tests for the text-edit named-class builder.
+//
+// Pins:
+//   - Caret thickness is zoom-invariant (constant screen px) while its
+//     length tracks the projected glyph height.
+//   - Caret anchor + angle follow the local→world transform (rotated text).
+//   - Selection rects project to closed, translucent doc-space polygons.
+//   - Caret is suppressed when not visible / absent (blink + read-only).
+//   - Semantic group propagates to every emitted primitive.
+
+import { describe, it, expect } from "vitest";
+import cmath from "@grida/cmath";
+import {
+  buildTextEditChrome,
+  DEFAULT_CARET_SCREEN_WIDTH,
+  type TextEditCaret,
+} from "../../../classes/text-edit";
+
+const IDENTITY = cmath.transform.identity;
+const CARET: TextEditCaret = { top: [10, 0], bottom: [10, 20] };
+
+describe("buildTextEditChrome — caret", () => {
+  it("width is constant across zoom; length tracks the projected height", () => {
+    const chrome = { transform: IDENTITY, caret: CARET, caretVisible: true };
+    const r1 = buildTextEditChrome({ chrome, camera: IDENTITY });
+    const r4 = buildTextEditChrome({
+      chrome,
+      camera: cmath.transform.scale(IDENTITY, 4, [0, 0]),
+    });
+
+    expect(r1.screenRects).toHaveLength(1);
+    expect(r4.screenRects).toHaveLength(1);
+    // Width never multiplies by zoom — it is a literal screen-px constant.
+    expect(r1.screenRects[0].width).toBe(DEFAULT_CARET_SCREEN_WIDTH);
+    expect(r4.screenRects[0].width).toBe(DEFAULT_CARET_SCREEN_WIDTH);
+    // Height (projected length) does scale with zoom.
+    expect(r1.screenRects[0].height).toBeCloseTo(20, 5);
+    expect(r4.screenRects[0].height).toBeCloseTo(80, 5);
+  });
+
+  it("anchor + angle track a rotation transform (rotated text)", () => {
+    const rot = cmath.transform.rotate(IDENTITY, 90, [0, 0]); // local → world
+    const r = buildTextEditChrome({
+      chrome: { transform: rot, caret: CARET, caretVisible: true },
+      camera: IDENTITY,
+    });
+
+    // Anchor is the projected caret midpoint.
+    const mid: cmath.Vector2 = [10, 10];
+    const expected = cmath.vector2.transform(mid, rot);
+    expect(r.screenRects[0].x).toBeCloseTo(expected[0], 5);
+    expect(r.screenRects[0].y).toBeCloseTo(expected[1], 5);
+    // Caret rotates 90° with the text (angle stored in radians).
+    expect(Math.abs(r.screenRects[0].angle ?? 0)).toBeCloseTo(Math.PI / 2, 5);
+    // Rotation preserves length.
+    expect(r.screenRects[0].height).toBeCloseTo(20, 5);
+  });
+
+  it("angle follows the projected segment under shear (not the matrix x-axis)", () => {
+    // skewX: x' = x + 0.5y. The matrix x-axis angle is 0, but a vertical caret
+    // segment tilts — the angle must track the segment, not the matrix.
+    const shear: cmath.Transform = [
+      [1, 0.5, 0],
+      [0, 1, 0],
+    ];
+    const r = buildTextEditChrome({
+      chrome: { transform: shear, caret: CARET, caretVisible: true },
+      camera: IDENTITY,
+    });
+    const t = cmath.vector2.transform(CARET.top, shear);
+    const b = cmath.vector2.transform(CARET.bottom, shear);
+    const expected = Math.atan2(b[1] - t[1], b[0] - t[0]) - Math.PI / 2;
+    expect(r.screenRects[0].angle).toBeCloseTo(expected, 5);
+    // Not zero — the matrix x-axis angle (atan2(b, a) = 0) would be wrong here.
+    expect(Math.abs(r.screenRects[0].angle ?? 0)).toBeGreaterThan(0.05);
+  });
+
+  it("is suppressed when not visible or absent", () => {
+    const hidden = buildTextEditChrome({
+      chrome: { transform: IDENTITY, caret: CARET, caretVisible: false },
+      camera: IDENTITY,
+    });
+    expect(hidden.screenRects).toHaveLength(0);
+
+    const absent = buildTextEditChrome({
+      chrome: {
+        transform: IDENTITY,
+        selectionRects: [{ x: 0, y: 0, width: 10, height: 10 }],
+      },
+      camera: IDENTITY,
+    });
+    expect(absent.screenRects).toHaveLength(0);
+  });
+});
+
+describe("buildTextEditChrome — selection", () => {
+  it("projects each rect to a closed translucent polygon", () => {
+    // local → world: scale 2 + translate (5, 7), as a full affine.
+    const transform: cmath.Transform = [
+      [2, 0, 5],
+      [0, 2, 7],
+    ];
+    const r = buildTextEditChrome({
+      chrome: {
+        transform,
+        selectionRects: [{ x: 0, y: 0, width: 100, height: 20 }],
+      },
+      camera: IDENTITY,
+    });
+
+    expect(r.polylines).toHaveLength(1);
+    const pl = r.polylines[0];
+    expect(pl.points).toHaveLength(5); // 4 corners + closing point
+    expect(pl.points[0]).toEqual(pl.points[4]); // closed
+    expect(pl.stroke).toBe(false);
+    expect(pl.fill).toBe(true);
+    expect(pl.fillPaint).toEqual({
+      kind: "solid",
+      color: "#2563eb",
+      opacity: 0.25,
+    });
+    // Top-left corner is the projected (0,0).
+    const tl = cmath.vector2.transform([0, 0], transform);
+    expect(pl.points[0][0]).toBeCloseTo(tl[0], 5);
+    expect(pl.points[0][1]).toBeCloseTo(tl[1], 5);
+  });
+});
+
+describe("buildTextEditChrome — group", () => {
+  it("propagates the semantic group to caret + selection", () => {
+    const r = buildTextEditChrome({
+      chrome: {
+        transform: IDENTITY,
+        caret: CARET,
+        caretVisible: true,
+        selectionRects: [{ x: 0, y: 0, width: 10, height: 10 }],
+        group: "text-edit",
+      },
+      camera: IDENTITY,
+    });
+    expect(r.screenRects[0].group).toBe("text-edit");
+    expect(r.polylines[0].group).toBe("text-edit");
+  });
+});

--- a/packages/grida-canvas-hud/classes/text-edit/index.ts
+++ b/packages/grida-canvas-hud/classes/text-edit/index.ts
@@ -1,0 +1,22 @@
+// Text-edit — named-class entry point.
+//
+// Re-exports the class's public surface. Decoration-only, so the split is
+// thinner than padding/transform-box (no intent.ts / priority.ts):
+//
+// - surface.ts   the chrome builder + anti-goals + caret-width constant
+// - input.ts     TextEditChromeInput + sub-types
+//
+// @unstable — svg-editor is the only consumer; the main canvas editor paints
+// its caret in WASM/Skia and does not consume this.
+
+export type {
+  TextEditCaret,
+  TextEditChromeInput,
+  TextEditChromeStyle,
+  TextEditSelectionRect,
+} from "./input";
+export {
+  buildTextEditChrome,
+  DEFAULT_CARET_SCREEN_WIDTH,
+  type TextEditChromeDraw,
+} from "./surface";

--- a/packages/grida-canvas-hud/classes/text-edit/input.ts
+++ b/packages/grida-canvas-hud/classes/text-edit/input.ts
@@ -1,0 +1,82 @@
+// Text-edit — public input types.
+//
+// The host-pushed contract for inline-text-edit chrome: a caret + selection
+// highlights, expressed in a LOCAL coordinate space with a `transform` that
+// maps local → world/doc. Decoration-only — no gestures, intents, or hit
+// regions (unlike padding/transform-box). Everything here is `@unstable`
+// until a second independent integration ratifies the shape.
+
+import type cmath from "@grida/cmath";
+import type { HUDSemanticGroup } from "../../primitives/types";
+
+/**
+ * Caret as two LOCAL endpoints (top, bottom) — NOT a position + height. Two
+ * endpoints let the `transform` tilt/scale the caret as a true affine of a
+ * line segment, which a `{x, top, height}` triple cannot. This is the honest
+ * shape for rotated text and the future per-run textPath case; the common
+ * axis-aligned caret maps trivially (`top=[x, m.top]`, `bottom=[x, m.top+h]`).
+ *
+ * @unstable
+ */
+export interface TextEditCaret {
+  /** Caret top endpoint, local space. */
+  top: cmath.Vector2;
+  /** Caret bottom endpoint, local space. */
+  bottom: cmath.Vector2;
+}
+
+/** One selection-highlight rect in LOCAL space. @unstable */
+export interface TextEditSelectionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Optional visual overrides; the builder supplies defaults when absent. @unstable */
+export interface TextEditChromeStyle {
+  /** Caret fill color. Default `#2563eb`. */
+  caretColor?: string;
+  /** Caret on-screen thickness in CSS px (zoom-independent). Default 1.5. */
+  caretScreenWidth?: number;
+  /** Selection fill color. Default `#2563eb`. */
+  selectionColor?: string;
+  /** Selection fill opacity, 0–1. Default 0.25. */
+  selectionOpacity?: number;
+}
+
+/**
+ * Host-pushed text-edit chrome (caret + selection highlights). All geometry
+ * is LOCAL; `transform` maps local → world/doc. The HUD composes `transform`
+ * with its own camera (world → screen) at draw time, so the chrome places
+ * correctly under arbitrary affines (rotated text, nested `<g>` transforms).
+ *
+ * This is the focused generalization that anticipates `<textPath>` WITHOUT
+ * per-glyph path-following: a textPath host emits per-run caret/rects in each
+ * run's local frame and the same composition applies. A single affine cannot
+ * express a curved baseline — that remains out of scope.
+ *
+ * Schema-level feature flag — pass `null` to `setTextEditChrome` to disable.
+ * The caret blinks via the host re-pushing with a flipped `caretVisible`.
+ *
+ * @unstable
+ */
+export interface TextEditChromeInput {
+  /** local → world/doc affine. cmath.Transform is a full 2×3 (carries shear). */
+  transform: cmath.Transform;
+  /** Caret geometry; omit when there is no caret (e.g. read-only highlight). */
+  caret?: TextEditCaret;
+  /** Caret blink/visibility. The caret draws only when `caret` is set AND this is true. */
+  caretVisible?: boolean;
+  /** Selection-highlight rects, local space. Empty/omitted = no selection. */
+  selectionRects?: readonly TextEditSelectionRect[];
+  /** Visual overrides; builder defaults when absent. */
+  style?: TextEditChromeStyle;
+  /**
+   * Optional semantic group for the visibility policy. Stamped on every
+   * emitted primitive so a host can suppress the whole chrome atomically.
+   * Default: always rendered while set (the active edit locus has no gesture
+   * during which you'd want it hidden).
+   */
+  group?: HUDSemanticGroup;
+}

--- a/packages/grida-canvas-hud/classes/text-edit/surface.ts
+++ b/packages/grida-canvas-hud/classes/text-edit/surface.ts
@@ -1,0 +1,127 @@
+// Text-edit — named-class chrome.
+//
+// What this draws — a blinking caret (a fixed on-screen-thickness bar) and
+// zero-or-more selection highlight rects (translucent fills), for inline text
+// content-edit. Both are composited ON the HUD canvas, above the content and
+// the selection box, so the caret is never occluded and the thickness stays
+// constant at any zoom. This mirrors the Skia text-edit overlay
+// (`crates/grida/src/overlay/widgets/text_edit_decoration.rs`).
+//
+// Anti-goals (what this class is NOT):
+//
+// - **Not a text-edit engine.** The host runs the editor and computes glyph
+//   geometry (caret endpoints, selection rects) in a local frame; this only
+//   projects and paints. No layout, no IME, no input.
+// - **Not interactive.** Decoration-only — no gestures, intents, hit regions,
+//   or hover. Hence no `intent.ts` / `priority.ts` (thinner than padding).
+// - **Not path-following.** A single affine `transform` places the chrome;
+//   a curved-baseline `<textPath>` caret is out of scope (a host emits
+//   per-run chrome, each with its own local frame).
+
+import cmath from "@grida/cmath";
+import type { HUDPolyline, HUDScreenRect } from "../../primitives/types";
+import type { TextEditChromeInput } from "./input";
+
+/** On-screen caret thickness in CSS px — zoom-independent by construction. */
+export const DEFAULT_CARET_SCREEN_WIDTH = 1.5;
+const DEFAULT_CARET_COLOR = "#2563eb";
+const DEFAULT_SELECTION_COLOR = "#2563eb";
+const DEFAULT_SELECTION_OPACITY = 0.25;
+
+/**
+ * The primitives the text-edit chrome contributes to a frame. Decoration-only,
+ * so this is raw draw primitives (not `OverlayElement`s with hit regions):
+ *
+ * - `polylines` — selection fills, doc-space polygons (the HUD applies the
+ *   camera). Merge into the decoration `polylines` band.
+ * - `screenRects` — the caret, a screen-sized rect anchored at a doc point.
+ *   Merge into the `screenRects` band (above the selection box → never occluded).
+ */
+export interface TextEditChromeDraw {
+  polylines: HUDPolyline[];
+  screenRects: HUDScreenRect[];
+}
+
+/**
+ * Build the per-frame text-edit chrome.
+ *
+ * Composition mirrors `chrome.ts:pushTransformedChrome`:
+ * `local_to_screen = multiply(camera, chrome.transform)`. The selection rects
+ * project to doc space via `chrome.transform` (the HUD applies the camera when
+ * painting); the caret anchor projects the same way, while its on-screen
+ * length + angle come from `local_to_screen` so the bar tracks the projected
+ * glyph height and rotates with the text.
+ *
+ * @param camera the HUD's world→screen transform (`state.getTransform()`).
+ */
+export function buildTextEditChrome(input: {
+  chrome: TextEditChromeInput;
+  camera: cmath.Transform;
+}): TextEditChromeDraw {
+  const { chrome, camera } = input;
+  const style = chrome.style ?? {};
+  const caretColor = style.caretColor ?? DEFAULT_CARET_COLOR;
+  const caretScreenWidth = style.caretScreenWidth ?? DEFAULT_CARET_SCREEN_WIDTH;
+  const selectionColor = style.selectionColor ?? DEFAULT_SELECTION_COLOR;
+  const selectionOpacity = style.selectionOpacity ?? DEFAULT_SELECTION_OPACITY;
+  const { group } = chrome;
+
+  const polylines: HUDPolyline[] = [];
+  const screenRects: HUDScreenRect[] = [];
+
+  const local_to_screen = cmath.transform.multiply(camera, chrome.transform);
+
+  // ── Selection fills (translucent, doc-space polygons) ────────────────────
+  for (const r of chrome.selectionRects ?? []) {
+    const corners = cmath.rect
+      .toCorners({ x: r.x, y: r.y, width: r.width, height: r.height })
+      .map((p) => cmath.vector2.transform(p, chrome.transform));
+    polylines.push({
+      points: [...corners, corners[0]],
+      stroke: false,
+      fill: true,
+      fillPaint: {
+        kind: "solid",
+        color: selectionColor,
+        opacity: selectionOpacity,
+      },
+      group,
+    });
+  }
+
+  // ── Caret (constant on-screen thickness, doc-anchored, rotates with text) ─
+  if (chrome.caret && chrome.caretVisible) {
+    const { top, bottom } = chrome.caret;
+    const mid_local: cmath.Vector2 = [
+      (top[0] + bottom[0]) / 2,
+      (top[1] + bottom[1]) / 2,
+    ];
+    const anchor_doc = cmath.vector2.transform(mid_local, chrome.transform);
+    const top_screen = cmath.vector2.transform(top, local_to_screen);
+    const bottom_screen = cmath.vector2.transform(bottom, local_to_screen);
+    const dx = bottom_screen[0] - top_screen[0];
+    const dy = bottom_screen[1] - top_screen[1];
+    const screen_len = Math.hypot(dx, dy);
+    // Angle from the projected caret segment itself — NOT the matrix's rotation
+    // component (`cmath.transform.angle`). The two agree under rotation/scale
+    // but diverge under shear/skew, where the matrix x-axis no longer matches
+    // the caret's on-screen slant. Deriving it from the segment keeps the bar
+    // aligned with `screen_len` (same endpoints). `-90°` because the screen
+    // rect's long axis (height) is its local +y.
+    const angle_rad = Math.atan2(dy, dx) - Math.PI / 2;
+    screenRects.push({
+      x: anchor_doc[0],
+      y: anchor_doc[1],
+      width: caretScreenWidth,
+      height: screen_len,
+      anchor: "center",
+      angle: angle_rad,
+      fill: true,
+      stroke: false,
+      fillColor: caretColor,
+      group,
+    });
+  }
+
+  return { polylines, screenRects };
+}

--- a/packages/grida-canvas-hud/index.ts
+++ b/packages/grida-canvas-hud/index.ts
@@ -149,6 +149,19 @@ export {
   type TransformBoxCorners,
 } from "./primitives/transform-box";
 
+// Text-edit (named class) — @unstable. Decoration-only caret + selection
+// chrome for inline text content-edit. svg-editor is the only consumer; the
+// main canvas editor paints its caret in WASM/Skia and does not consume this.
+export {
+  buildTextEditChrome,
+  DEFAULT_CARET_SCREEN_WIDTH,
+  type TextEditChromeDraw,
+  type TextEditChromeInput,
+  type TextEditCaret,
+  type TextEditSelectionRect,
+  type TextEditChromeStyle,
+} from "./classes/text-edit";
+
 // Selection-controls — pure-geometry model + priority ladder (UX rule).
 export {
   HUDHitPriority,

--- a/packages/grida-canvas-hud/surface/surface.ts
+++ b/packages/grida-canvas-hud/surface/surface.ts
@@ -49,6 +49,10 @@ import {
   buildTransformBox,
   type TransformBoxInput,
 } from "../classes/transform-box";
+import {
+  buildTextEditChrome,
+  type TextEditChromeInput,
+} from "../classes/text-edit";
 import type { OverlayElement } from "../event/overlay";
 import type { VectorSubSelection } from "../event/state";
 
@@ -216,6 +220,12 @@ export class Surface {
    * `setPaddingOverlay`.
    */
   private paddingOverlay: PaddingOverlayInput | null = null;
+  /**
+   * Text-edit chrome input (caret + selection). `null` = no chrome drawn.
+   * Hosts push on inline content-edit (and on every caret move / blink tick /
+   * selection change / camera change); clear on exit. See `setTextEditChrome`.
+   */
+  private textEditChrome: TextEditChromeInput | null = null;
   // Explicit host color override; when set, beats `style.chromeColor` in
   // every paint until cleared via `setColor(null)`.
   private colorOverride: string | undefined;
@@ -393,6 +403,29 @@ export class Surface {
    */
   setPaddingOverlay(input: PaddingOverlayInput | null): void {
     this.paddingOverlay = input;
+  }
+
+  /**
+   * Configure or clear the built-in text-edit chrome — caret + selection
+   * highlights for inline text content-edit. `null` = no chrome drawn
+   * (schema-level feature flag).
+   *
+   * One atomic setter (not separate setCaret / setSelection): caret and
+   * selection are one visual state of one editing session, and a blink tick
+   * only flips `caretVisible` while the selection is unchanged — re-pushing
+   * the whole struct keeps the two from tearing across frames and matches the
+   * Skia `TextEditingDecorations` model. Re-push on every caret move /
+   * selection change / blink tick / camera change. The host owns redraw
+   * timing (this only stores state; `draw()` paints it next frame).
+   *
+   * The caret is drawn ABOVE the selection box (it's a screen-sized rect in
+   * the screenRects band) at a constant on-screen thickness, so it is never
+   * occluded and never scales with zoom. See `@grida/hud/classes/text-edit`.
+   *
+   * @unstable
+   */
+  setTextEditChrome(input: TextEditChromeInput | null): void {
+    this.textEditChrome = input;
   }
 
   /**
@@ -653,10 +686,26 @@ export class Surface {
     } else {
       this.hudCanvas.setParametricHandles(null);
     }
+    // Text-edit chrome (caret + selection). Decoration-only — built here and
+    // merged directly (no `fanOverlays`, no hit regions). Selection fills join
+    // the `polylines` band; the caret joins the `screenRects` band so it paints
+    // ABOVE the selection box and stays a constant on-screen thickness.
+    const text_edit = this.textEditChrome
+      ? buildTextEditChrome({
+          chrome: this.textEditChrome,
+          camera: this.state.getTransform(),
+        })
+      : null;
+
     // Merge overlay-fanned lines + polylines into the decoration so they're
     // drawn in the same pass as everything else. Polylines carry the
-    // path-edit segment outlines; lines carry tangent handle lines.
-    const has_extras = lines.length > 0 || polylines.length > 0;
+    // path-edit segment outlines + text-edit selection fills; lines carry
+    // tangent handle lines. When nothing is active these stay the original
+    // (empty) references — no per-frame allocation on the idle path.
+    const all_polylines = text_edit
+      ? [...polylines, ...text_edit.polylines]
+      : polylines;
+    const has_extras = lines.length > 0 || all_polylines.length > 0;
     const decoration_with_extras: HUDDraw = has_extras
       ? {
           ...decoration,
@@ -665,14 +714,17 @@ export class Surface {
               ? [...(decoration.lines ?? []), ...lines]
               : decoration.lines,
           polylines:
-            polylines.length > 0
-              ? [...(decoration.polylines ?? []), ...polylines]
+            all_polylines.length > 0
+              ? [...(decoration.polylines ?? []), ...all_polylines]
               : decoration.polylines,
         }
       : decoration;
+    const all_screenRects = text_edit
+      ? [...screenRects, ...text_edit.screenRects]
+      : screenRects;
     this.hudCanvas.draw(
       filterHUDDrawByGroup(
-        mergeDraws(decoration_with_extras, extra, screenRects),
+        mergeDraws(decoration_with_extras, extra, all_screenRects),
         { hidden }
       )
     );

--- a/packages/grida-svg-editor/__tests__/text-edit-caret-hud.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/text-edit-caret-hud.browser.test.ts
@@ -1,0 +1,124 @@
+// Text-edit caret + selection are drawn by the HUD (canvas-owned chrome), not
+// by an SVG/DOM overlay. The svg-editor's job is to PROJECT the caret/selection
+// geometry (local → container px) and push it to `hud.setTextEditChrome`.
+//
+// This drives the REAL editor end-to-end and spies on the HUD setter to prove
+// the seam: (1) entering content-edit pushes a visible caret projected onto the
+// text; (2) a camera zoom re-projects it (larger-scale transform); (3) exiting
+// clears it. Real Chromium is required — the projection rides `getScreenCTM`,
+// which only a real SVG layout engine produces.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Surface as HUDSurface, type TextEditChromeInput } from "@grida/hud";
+import {
+  attachSurface,
+  nodeIdByName,
+  type AttachedSurface,
+} from "./_browser-helpers";
+
+const FIXTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200"><text id="t" x="40" y="80" font-size="20" font-family="sans-serif">Text</text></svg>`;
+
+/** Apply a cmath.Transform [[a,c,e],[b,d,f]] to a local point. */
+function project(
+  t: TextEditChromeInput["transform"],
+  p: readonly [number, number]
+) {
+  return [
+    t[0][0] * p[0] + t[0][1] * p[1] + t[0][2],
+    t[1][0] * p[0] + t[1][1] * p[1] + t[1][2],
+  ] as const;
+}
+
+const lastInput = (
+  spy: ReturnType<typeof vi.spyOn>
+): TextEditChromeInput | null =>
+  (spy.mock.calls.at(-1)?.[0] ?? null) as TextEditChromeInput | null;
+
+describe("text-edit chrome → HUD", () => {
+  let s: AttachedSurface;
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    spy?.mockRestore();
+    s?.dispose();
+    document.body.innerHTML = "";
+  });
+
+  it("pushes a projected caret on enter, re-projects on zoom, clears on exit", () => {
+    spy = vi.spyOn(HUDSurface.prototype, "setTextEditChrome");
+    s = attachSurface(FIXTURE);
+    const id = nodeIdByName(s.editor, "t");
+    s.editor.enter_content_edit(id);
+
+    // Entering selects-all (caret hidden). Click the text to collapse to a caret.
+    const textEl = s.elementByName("t");
+    const tr = textEl.getBoundingClientRect();
+    const px = tr.left + tr.width * 0.5;
+    const py = tr.top + tr.height * 0.5;
+    textEl.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerId: 1,
+        clientX: px,
+        clientY: py,
+        button: 0,
+        buttons: 1,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      })
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 1,
+        clientX: px,
+        clientY: py,
+        button: 0,
+        buttons: 0,
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    // (1) A visible caret was pushed.
+    const input1 = lastInput(spy);
+    expect(input1).toBeTruthy();
+    expect(input1!.caret).toBeTruthy();
+    expect(input1!.caretVisible).toBe(true);
+
+    // The caret projects onto the text on screen (container px), not the origin.
+    const containerRect = s.container.getBoundingClientRect();
+    const caret1 = input1!.caret!;
+    const mid: readonly [number, number] = [
+      (caret1.top[0] + caret1.bottom[0]) / 2,
+      (caret1.top[1] + caret1.bottom[1]) / 2,
+    ];
+    const screen1 = project(input1!.transform, mid);
+    const box = textEl.getBoundingClientRect();
+    expect(screen1[0]).toBeGreaterThan(box.left - containerRect.left - 4);
+    expect(screen1[0]).toBeLessThan(box.right - containerRect.left + 4);
+
+    // (2) Zoom 4x via the real camera → re-pushed with a larger-scale transform.
+    const callsBefore = spy.mock.calls.length;
+    s.handle.camera.set_zoom(4);
+    expect(spy.mock.calls.length).toBeGreaterThan(callsBefore);
+    const input2 = lastInput(spy)!;
+    expect(Math.abs(input2.transform[0][0])).toBeGreaterThan(
+      Math.abs(input1!.transform[0][0]) * 2
+    );
+
+    // (3) Exit by clicking off the text (commits) → chrome cleared.
+    s.container.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerId: 1,
+        clientX: containerRect.right - 4,
+        clientY: containerRect.bottom - 4,
+        button: 0,
+        buttons: 1,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      })
+    );
+    expect(lastInput(spy)).toBeNull();
+  });
+});

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -29,6 +29,7 @@ import {
   type SelectionShape,
   type SelectionGroup,
   type TapOutcome,
+  type TextEditChromeInput,
 } from "@grida/hud";
 import { cursors as hud_cursors } from "@grida/hud/cursors";
 import { measure, type Measurement } from "@grida/cmath/_measurement";
@@ -86,7 +87,7 @@ import {
   create_attention_tracker,
   type AttentionTracker,
 } from "./util/attention";
-import { SvgTextSurface } from "./text-surface";
+import { SvgTextSurface, type SvgTextEditGeometry } from "./text-surface";
 import {
   PathModel,
   VectorEditSession,
@@ -530,6 +531,10 @@ class DomSurface implements Surface {
   private text_edit: TextEditor | null = null;
   private text_edit_target: NodeId | null = null;
   private text_edit_original: string = "";
+  /** Last text-edit caret/selection geometry (LOCAL svg user-space), kept so a
+   *  camera change can re-project it for the HUD without the surface
+   *  recomputing. `null` when no text edit is active. */
+  private text_edit_geom: SvgTextEditGeometry | null = null;
 
   /** Open insertion bracket for the text tool — set while the inline
    *  content-edit that follows a click-to-place is in flight. When set,
@@ -867,6 +872,11 @@ class DomSurface implements Surface {
         // container space — re-resolve it against the new CTM. The
         // flat-NodeId path (singleton / empty) is a near no-op here.
         this.sync_surface_selection();
+        // Re-project the text-edit chrome against the new camera (the local
+        // geometry is camera-independent; only its local→screen transform
+        // changes). No-op when idle. The `redraw()` below paints it.
+        if (this.text_edit_geom)
+          this.push_text_edit_chrome(this.text_edit_geom);
         this.redraw();
       })
     );
@@ -1495,9 +1505,10 @@ class DomSurface implements Surface {
   }
 
   private render() {
-    // During an active text-edit session the text element and its caret /
-    // selection rect overlays are managed live by `SvgTextSurface`. Replacing
-    // the SVG would yank them out. Skip the re-render until commit/cancel.
+    // During an active text-edit session the live text element is mutated in
+    // place by `SvgTextSurface` (and its caret/selection are drawn on the HUD).
+    // Replacing the SVG would yank the element out. Skip the re-render until
+    // commit/cancel.
     // (`rendered_doc_revision` is deliberately NOT stamped on this early
     // return — the next `flush_dom()` after the session ends re-renders.)
     if (this.text_edit) return;
@@ -3923,7 +3934,12 @@ class DomSurface implements Surface {
 
     const live_el =
       (this.element_index.get(id) as SVGTextContentElement | undefined) ?? el;
-    const text_surface = new SvgTextSurface(live_el);
+    // The surface emits caret/selection geometry in LOCAL svg space; the host
+    // projects + forwards it to the HUD (which draws it above the chrome).
+    const text_surface = new SvgTextSurface(live_el, (geom) => {
+      this.push_text_edit_chrome(geom);
+      this.request_redraw();
+    });
     const is_mac =
       typeof navigator !== "undefined" &&
       /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
@@ -3978,9 +3994,50 @@ class DomSurface implements Surface {
     this.render();
     this.sync_surface_selection();
     this.sync_cursor();
+    // Clear the HUD caret/selection chrome before repainting so it vanishes
+    // on exit (covers commit / cancel / empty-delete — all route here).
+    this.push_text_edit_chrome(null);
     this.redraw();
     this.text_edit = null;
     this.text_edit_target = null;
+  }
+
+  /**
+   * Project the active session's text-edit geometry (LOCAL svg user-space) and
+   * push it to the HUD as text-edit chrome (caret + selection), or clear it on
+   * `null`. The local→container-px transform comes from the live text
+   * element's `getScreenCTM` (which folds in the camera's CSS transform on the
+   * SVG root) minus the container offset — the same projection convention
+   * `vector_of` / `container_box` use. The HUD keeps its own transform at
+   * identity, so this per-chrome transform is the whole projection. Does NOT
+   * redraw — callers own that.
+   */
+  private push_text_edit_chrome(geom: SvgTextEditGeometry | null): void {
+    this.text_edit_geom = geom;
+    if (!geom) {
+      this.hud.setTextEditChrome(null);
+      return;
+    }
+    const el = this.text_edit_target
+      ? this.element_index.get(this.text_edit_target)
+      : undefined;
+    const ctm =
+      (el as SVGGraphicsElement | undefined)?.getScreenCTM?.() ?? null;
+    if (!ctm) {
+      this.hud.setTextEditChrome(null);
+      return;
+    }
+    const input: TextEditChromeInput = {
+      transform: ctm_to_container_transform(ctm, this.container_offset()),
+      caret: geom.caret
+        ? { top: geom.caret.top, bottom: geom.caret.bottom }
+        : undefined,
+      caretVisible: geom.caret?.visible ?? false,
+      selectionRects: geom.selection ? [geom.selection] : undefined,
+      // Black caret reads cleanly on top of the (blue) selection box.
+      style: { caretColor: "#000000" },
+    };
+    this.hud.setTextEditChrome(input);
   }
 
   /**
@@ -5272,6 +5329,24 @@ export function project_point_through_ctm(
     ]
   );
   return [sx + container_offset[0], sy + container_offset[1]];
+}
+
+/**
+ * The matrix form of {@link project_point_through_ctm}: the full
+ * `local → container-px` affine for a CTM + container offset, as a
+ * `cmath.Transform`. Use when handing the transform to a downstream projector
+ * (e.g. HUD chrome) instead of projecting a single point.
+ *
+ * Pure function, no DOM types.
+ */
+export function ctm_to_container_transform(
+  ctm: { a: number; b: number; c: number; d: number; e: number; f: number },
+  container_offset: readonly [number, number]
+): cmath.Transform {
+  return [
+    [ctm.a, ctm.c, ctm.e + container_offset[0]],
+    [ctm.b, ctm.d, ctm.f + container_offset[1]],
+  ];
 }
 
 /**

--- a/packages/grida-svg-editor/src/text-surface.ts
+++ b/packages/grida-svg-editor/src/text-surface.ts
@@ -1,40 +1,59 @@
 // `Surface` + `LayoutEngine` adapter that bridges `@grida/text-editor` to a
-// live `SVGTextContentElement` (a `<text>` or leaf `<tspan>`). Caret +
-// selection are SVG `<rect>` siblings of the outer `<text>`.
+// live `SVGTextContentElement` (a `<text>` or leaf `<tspan>`).
+//
+// This is a GEOMETRY PROVIDER, not a renderer. It owns the text-editing DOM
+// mutations (the live text content + edit-time `xml:space` / `pointer-events`)
+// and computes the caret + selection geometry in LOCAL svg user-space, but it
+// does NOT paint them. Instead it emits that geometry to a host `sink`, which
+// the editor (`dom.ts`) projects and hands to `@grida/hud`'s text-edit chrome.
+// The HUD draws caret + selection on its canvas — above the content and the
+// selection box (never occluded) and at a constant on-screen thickness.
 
 import type { LayoutEngine, Surface } from "@grida/text-editor";
 
-const SVG_NS = "http://www.w3.org/2000/svg";
 const XML_NS = "http://www.w3.org/XML/1998/namespace";
+
+/**
+ * Caret + selection geometry in LOCAL svg user-space. `null` = no chrome.
+ * The host projects this to screen space (the local→world transform comes from
+ * the live element's CTM) before handing it to the HUD.
+ */
+export interface SvgTextEditGeometry {
+  /** Caret endpoints (local) + blink visibility; `null` when there's no caret. */
+  caret: {
+    top: [number, number];
+    bottom: [number, number];
+    visible: boolean;
+  } | null;
+  /** Selection highlight rect (local); `null` when the selection is collapsed. */
+  selection: { x: number; y: number; width: number; height: number } | null;
+}
+
+/** Sink the host wires to push geometry into the HUD (and clear it on `null`). */
+export type SvgTextEditChromeSink = (geom: SvgTextEditGeometry | null) => void;
 
 export class SvgTextSurface implements Surface, LayoutEngine {
   private readonly textEl: SVGTextContentElement;
-  private readonly caretRect: SVGRectElement;
-  private readonly selectionRect: SVGRectElement;
+  private readonly sink: SvgTextEditChromeSink;
   private prevXmlSpace: string | null | undefined = undefined;
   private prevPointerEvents: string | null | undefined = undefined;
+  private caret: SvgTextEditGeometry["caret"] = null;
+  private selection: SvgTextEditGeometry["selection"] = null;
   private last_caret_idx = -1;
   private last_caret_visible = false;
   private last_sel_start = -1;
   private last_sel_end = -1;
 
-  constructor(textEl: SVGTextContentElement) {
+  /**
+   * @param textEl the live text element to drive.
+   * @param sink   receives the caret + selection geometry (local space) on
+   *   every change; the host projects + forwards it to the HUD. Called with
+   *   `null` on dispose so the host clears the chrome.
+   */
+  constructor(textEl: SVGTextContentElement, sink: SvgTextEditChromeSink) {
     this.textEl = textEl;
+    this.sink = sink;
     const ownerDoc = textEl.ownerDocument;
-
-    // SVG's text content model rejects `<rect>` as a child of `<text>` —
-    // walk up to the outermost text element to mount the chrome rects as
-    // valid siblings.
-    let mountAnchor: SVGElement = textEl;
-    while (
-      mountAnchor.parentElement instanceof SVGElement &&
-      (mountAnchor.localName === "tspan" ||
-        mountAnchor.localName === "textPath")
-    ) {
-      mountAnchor = mountAnchor.parentElement;
-    }
-    const parent = mountAnchor.parentNode;
-    if (!parent) throw new Error("text element has no parent");
 
     const computedWhitespace =
       ownerDoc.defaultView?.getComputedStyle(textEl).whiteSpace;
@@ -53,23 +72,6 @@ export class SvgTextSurface implements Surface, LayoutEngine {
     // between characters land on the text for caret positioning.
     this.prevPointerEvents = textEl.getAttribute("pointer-events");
     textEl.setAttribute("pointer-events", "bounding-box");
-
-    const selection = ownerDoc.createElementNS(SVG_NS, "rect");
-    selection.setAttribute("fill", "#2563eb");
-    selection.setAttribute("fill-opacity", "0.25");
-    selection.setAttribute("pointer-events", "none");
-    selection.setAttribute("data-svg-text-edit-selection", "");
-    selection.style.display = "none";
-    parent.insertBefore(selection, mountAnchor);
-    this.selectionRect = selection;
-
-    const caret = ownerDoc.createElementNS(SVG_NS, "rect");
-    caret.setAttribute("fill", "#2563eb");
-    caret.setAttribute("pointer-events", "none");
-    caret.setAttribute("data-svg-text-edit-caret", "");
-    caret.style.display = "none";
-    parent.insertBefore(caret, mountAnchor.nextSibling);
-    this.caretRect = caret;
   }
 
   // ─── Surface ─────────────────────────────────────────────────────────────
@@ -83,17 +85,14 @@ export class SvgTextSurface implements Surface, LayoutEngine {
       return;
     this.last_caret_idx = index;
     this.last_caret_visible = visible;
-    if (!visible) {
-      this.caretRect.style.display = "none";
-      return;
-    }
     const m = this.metrics();
     const x = this.charX(index);
-    this.caretRect.setAttribute("x", String(x - 0.75));
-    this.caretRect.setAttribute("y", String(m.top));
-    this.caretRect.setAttribute("width", "1.5");
-    this.caretRect.setAttribute("height", String(m.height));
-    this.caretRect.style.display = "block";
+    this.caret = {
+      top: [x, m.top],
+      bottom: [x, m.top + m.height],
+      visible,
+    };
+    this.emit();
   }
 
   setSelection(start: number, end: number): void {
@@ -101,22 +100,28 @@ export class SvgTextSurface implements Surface, LayoutEngine {
     this.last_sel_start = start;
     this.last_sel_end = end;
     if (start === end) {
-      this.selectionRect.style.display = "none";
+      this.selection = null;
+      this.emit();
       return;
     }
     const m = this.metrics();
     const x1 = this.charX(start);
     const x2 = this.charX(end);
-    this.selectionRect.setAttribute("x", String(Math.min(x1, x2)));
-    this.selectionRect.setAttribute("y", String(m.top));
-    this.selectionRect.setAttribute("width", String(Math.abs(x2 - x1)));
-    this.selectionRect.setAttribute("height", String(m.height));
-    this.selectionRect.style.display = "block";
+    this.selection = {
+      x: Math.min(x1, x2),
+      y: m.top,
+      width: Math.abs(x2 - x1),
+      height: m.height,
+    };
+    this.emit();
+  }
+
+  private emit(): void {
+    this.sink({ caret: this.caret, selection: this.selection });
   }
 
   dispose(keepEditMutations = false): void {
-    this.caretRect.remove();
-    this.selectionRect.remove();
+    this.sink(null);
     if (this.prevXmlSpace !== undefined && !keepEditMutations) {
       if (this.prevXmlSpace === null) {
         this.textEl.removeAttributeNS(XML_NS, "space");


### PR DESCRIPTION
## What

Make **`@grida/hud` the home** for inline-text-edit chrome (caret + selection). Both are now drawn on the HUD canvas, composited with all other chrome in one place.

## Why

The caret was drawn in a screen-space SVG overlay *above* the HUD, and the selection as an in-content `<rect>` — a **third compositing layer** that existed only to dodge two problems: the caret got occluded by the HUD selection box at the text edge, and it scaled with zoom. Moving both onto the HUD solves these structurally: the caret lives in the `screenRects` band (above the selection box → never occluded) at a constant on-screen thickness. This mirrors how the main canvas editor already draws its caret — a post-scene Skia overlay (`crates/grida/src/overlay/widgets/text_edit_decoration.rs`).

## `@grida/hud` — new `text-edit` named class (`@unstable`)

- `classes/text-edit/` — decoration-only (no gestures/intents/hit regions), thinner than `padding`/`transform-box`.
- `Surface.setTextEditChrome(input | null)` — one atomic setter (caret + selection are one session state; blink re-pushes with a flipped `caretVisible`).
- Input: local caret **endpoints** + local selection rects + a local→world **`transform`** (full affine — places chrome correctly under rotation / nested transforms; anticipates `<textPath>` **without** per-glyph path-following).
- Caret = screen-sized rect (constant px thickness, drawn above the selection box); selection = translucent doc-space fills (composited on top of glyphs, matching the Skia editor).
- svg-editor is the **only** consumer; the canvas editor paints its caret in WASM/Skia and does not consume this.

## svg-editor

`SvgTextSurface` is now a **geometry provider** — it computes caret/selection in LOCAL svg space and emits to a host sink; `dom.ts` projects via the live element's `getScreenCTM` (minus container offset) and pushes to `hud.setTextEditChrome`. The HUD stays at identity (chrome rides the per-input transform). Camera changes re-project the cached geometry; the chrome clears on exit. **Removed** the caret overlay layer, the in-content selection `<rect>`, and the `getScreenCTM`-in-surface draw path.

## Verification

- HUD builder units: zoom-invariant caret width (height tracks zoom), rotation (anchor + angle), selection projection (closed translucent polygon), group propagation.
- svg-editor browser test (real Chromium): drives the real editor + camera — caret pushed + projected onto the text on enter, re-projected on zoom (larger-scale transform), cleared on exit. **Verified to fail when the wiring is broken.**
- `@grida/hud` 575 tests · svg-editor node 1401 · svg-editor browser 66 · `tsc --noEmit` (both) · `oxfmt` · `oxlint` — all clean.

## History

Supersedes the earlier in-PR attempts (`non-scaling-stroke`, `CARET_WIDTH_PX / zoom` counter-scale, then a screen-space SVG overlay above the HUD). All replaced by HUD-owned chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-edit “HUD chrome” rendering for caret and selection on the canvas, with consistent styling and semantic grouping.
  * Introduced a geometry-to-HUD overlay pipeline, including a public builder, default caret sizing, and new caret/selection/style input types.

* **Bug Fixes**
  * Caret/selection now reproject correctly across camera changes and are cleared reliably when exiting edit mode.

* **Tests**
  * Added/expanded unit tests for caret/selection projection and visibility behavior, plus a browser integration test verifying enter/update/clear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->