### PR TITLE
fix(svg): trivia-preserving inline-style editing (#823)

### DIFF
--- a/packages/grida-svg-editor/__tests__/inline-style-trivia.test.ts
+++ b/packages/grida-svg-editor/__tests__/inline-style-trivia.test.ts
@@ -1,0 +1,52 @@
+// Editor-level wiring for inline-style editing (issue #823).
+//
+// The trivia-preserving declaration grammar itself is owned and spec'd by
+// `@grida/svg` (`inline_style`, see its `parse/__tests__/inline-style.test.ts`).
+// These tests only prove the editor plumbs the `style` attribute through it:
+// `set_style` writes a minimal diff into the document, `get_style` /
+// `get_all_styles` read it back, and a non-style edit leaves the authored
+// `style` bytes verbatim (the README's P1 letter).
+
+import { describe, expect, it } from "vitest";
+import { createSvgEditor } from "../src/index";
+import { first_rect } from "./_helpers";
+
+function editorWith(style: string) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" style="${style}"/></svg>`;
+  const editor = createSvgEditor({ svg });
+  return { editor, id: first_rect(editor) };
+}
+
+describe("editor inline-style wiring (#823)", () => {
+  it("set_style writes a minimal diff and the document round-trips byte-equal", () => {
+    const src = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" style="fill:red;stroke:blue"/></svg>`;
+    const editor = createSvgEditor({ svg: src });
+    editor.document.set_style(first_rect(editor), "fill", "green");
+    expect(editor.serialize()).toBe(
+      `<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" style="fill:green;stroke:blue"/></svg>`
+    );
+  });
+
+  it("get_style / get_all_styles read the authored declarations back", () => {
+    const { editor, id } = editorWith("fill: red ; stroke:blue");
+    expect(editor.document.get_style(id, "stroke")).toBe("blue");
+    expect(editor.document.get_all_styles(id)).toEqual([
+      { property: "fill", value: "red" },
+      { property: "stroke", value: "blue" },
+    ]);
+  });
+
+  it("removing the last declaration drops the style attribute", () => {
+    const { editor, id } = editorWith("fill:red");
+    editor.document.set_style(id, "fill", null);
+    expect(editor.document.get_attr(id, "style")).toBe(null);
+  });
+
+  it("a non-style edit leaves authored style bytes verbatim (P1 letter)", () => {
+    const { editor, id } = editorWith("fill: red ; stroke: blue;");
+    editor.document.set_attr(id, "width", "20");
+    expect(editor.document.get_attr(id, "style")).toBe(
+      "fill: red ; stroke: blue;"
+    );
+  });
+});

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -533,10 +533,9 @@ export class SvgDocument implements DocumentEvents {
   get_style(id: NodeId, property: string): string | null {
     const style = this.get_attr(id, "style");
     if (!style) return null;
-    for (const d of inline_style.declarations(style)) {
-      if (d.property === property) return d.value;
-    }
-    return null;
+    // `inline_style.get` returns the cascade winner (last declaration) — the
+    // CSS last-one-wins rule stays owned by `@grida/svg`, not reimplemented here.
+    return inline_style.get(style, property);
   }
 
   set_style(id: NodeId, property: string, value: string | null): void {

--- a/packages/grida-svg-editor/src/core/document.ts
+++ b/packages/grida-svg-editor/src/core/document.ts
@@ -24,7 +24,7 @@ import {
   XMLNS_NS,
   XML_NS,
 } from "@grida/svg/parser";
-import { svg_parse } from "@grida/svg/parse";
+import { inline_style, svg_parse } from "@grida/svg/parse";
 import type { NodeId } from "../types";
 
 /**
@@ -533,33 +533,27 @@ export class SvgDocument implements DocumentEvents {
   get_style(id: NodeId, property: string): string | null {
     const style = this.get_attr(id, "style");
     if (!style) return null;
-    const decls = parse_inline_style(style);
-    for (const d of decls) {
+    for (const d of inline_style.declarations(style)) {
       if (d.property === property) return d.value;
     }
     return null;
   }
 
   set_style(id: NodeId, property: string, value: string | null): void {
+    // The trivia-preserving declaration-list surgery lives in `@grida/svg`
+    // (`inline_style.set`) — the editor only plumbs the `style` attribute
+    // through it. `set` returns the input unchanged on a no-op (e.g. removing
+    // an absent property), so skipping the write keeps history clean.
     const style = this.get_attr(id, "style") ?? "";
-    const decls = parse_inline_style(style);
-    const idx = decls.findIndex((d) => d.property === property);
-    if (value === null) {
-      if (idx === -1) return;
-      decls.splice(idx, 1);
-    } else if (idx === -1) {
-      decls.push({ property, value });
-    } else {
-      decls[idx].value = value;
-    }
-    const next = decls.map((d) => `${d.property}: ${d.value}`).join("; ");
+    const next = inline_style.set(style, property, value);
+    if (next === style) return;
     this.set_attr(id, "style", next === "" ? null : next);
   }
 
-  get_all_styles(id: NodeId): Array<{ property: string; value: string }> {
+  get_all_styles(id: NodeId): inline_style.Declaration[] {
     const style = this.get_attr(id, "style");
     if (!style) return [];
-    return parse_inline_style(style);
+    return inline_style.declarations(style);
   }
 
   // ─── Text content ────────────────────────────────────────────────────────
@@ -1261,25 +1255,6 @@ export class SvgDocument implements DocumentEvents {
       a.quote
     )}${a.quote}`;
   }
-}
-
-// ─── Inline style helpers ──────────────────────────────────────────────────
-
-function parse_inline_style(
-  s: string
-): Array<{ property: string; value: string }> {
-  // Very small CSS declaration list parser. Doesn't handle comments / nested
-  // parens precisely; SVG editors don't usually need that. Sufficient for v0.
-  const out: Array<{ property: string; value: string }> = [];
-  const decls = s.split(";");
-  for (const decl of decls) {
-    const colon = decl.indexOf(":");
-    if (colon === -1) continue;
-    const property = decl.slice(0, colon).trim();
-    const value = decl.slice(colon + 1).trim();
-    if (property) out.push({ property, value });
-  }
-  return out;
 }
 
 /**

--- a/packages/grida-svg/package.json
+++ b/packages/grida-svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "Grida-owned SVG tooling for parsing, transforming, and authoring SVG data.",
   "keywords": [

--- a/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
+++ b/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
@@ -1,0 +1,113 @@
+// Spec for the inline-`style` declaration grammar: trivia-preserving authoring
+// (Grida svg-editor issue #823). Editing one declaration must not churn the
+// formatting of untouched siblings, and a removed property must leave the
+// survivors byte-equal. The token model is private; these tests pin the two
+// public functions (`declarations` read view, `set` edit).
+
+import { describe, expect, it } from "vitest";
+import { inline_style } from "../inline-style";
+
+describe("inline_style.declarations (read projection)", () => {
+  it("returns trimmed property/value pairs in source order", () => {
+    expect(inline_style.declarations("fill: red ; stroke:blue")).toEqual([
+      { property: "fill", value: "red" },
+      { property: "stroke", value: "blue" },
+    ]);
+  });
+
+  it("returns [] for an empty string", () => {
+    expect(inline_style.declarations("")).toEqual([]);
+  });
+
+  it("skips colon-less and empty-property fragments", () => {
+    expect(
+      inline_style.declarations("fill:red;garbage;:orphan;stroke:blue")
+    ).toEqual([
+      { property: "fill", value: "red" },
+      { property: "stroke", value: "blue" },
+    ]);
+  });
+
+  it("keeps the first colon as the split, so values may contain colons", () => {
+    expect(inline_style.declarations("background:url(a:b)")).toEqual([
+      { property: "background", value: "url(a:b)" },
+    ]);
+  });
+});
+
+describe("inline_style.set (trivia-preserving edit)", () => {
+  it("editing one declaration leaves untouched siblings byte-equal (compact)", () => {
+    expect(inline_style.set("fill:red;stroke:blue", "fill", "green")).toBe(
+      "fill:green;stroke:blue"
+    );
+  });
+
+  it("preserves authored spacing and trailing semicolon on the untouched sibling", () => {
+    expect(inline_style.set("fill: red ; stroke: blue;", "fill", "green")).toBe(
+      "fill: green ; stroke: blue;"
+    );
+  });
+
+  it("preserves the touched declaration's own colon / value spacing", () => {
+    expect(inline_style.set("fill  :  red;stroke:blue", "fill", "green")).toBe(
+      "fill  :  green;stroke:blue"
+    );
+  });
+
+  it("keeps a value with internal whitespace and parens intact when editing a sibling", () => {
+    expect(
+      inline_style.set(
+        "fill:url(#g);stroke-dasharray:4 2 4;stroke:blue",
+        "stroke",
+        "black"
+      )
+    ).toBe("fill:url(#g);stroke-dasharray:4 2 4;stroke:black");
+  });
+
+  it("editing a value that itself contains a colon only swaps the value", () => {
+    expect(
+      inline_style.set(
+        "background:url(a:b);stroke:blue",
+        "background",
+        "url(c:d)"
+      )
+    ).toBe("background:url(c:d);stroke:blue");
+  });
+
+  it("set + restore round-trips to the byte-equal authored string", () => {
+    const src = "fill: red ; stroke: blue;";
+    const edited = inline_style.set(src, "fill", "green");
+    expect(inline_style.set(edited, "fill", "red")).toBe(src);
+  });
+
+  it("removing a declaration keeps surviving declarations byte-equal", () => {
+    expect(inline_style.set("fill:red;stroke:blue", "fill", null)).toBe(
+      "stroke:blue"
+    );
+  });
+
+  it("removing the last declaration yields an empty string", () => {
+    expect(inline_style.set("fill:red", "fill", null)).toBe("");
+  });
+
+  it("removing an absent property returns the input unchanged", () => {
+    expect(inline_style.set("fill:red", "stroke", null)).toBe("fill:red");
+    expect(inline_style.set("", "stroke", null)).toBe("");
+  });
+
+  it("appending a new declaration leaves existing ones byte-equal", () => {
+    expect(inline_style.set("fill:red", "stroke", "blue")).toBe(
+      "fill:red;stroke: blue"
+    );
+  });
+
+  it("appending preserves an authored trailing semicolon", () => {
+    expect(inline_style.set("fill:red;", "stroke", "blue")).toBe(
+      "fill:red;stroke: blue;"
+    );
+  });
+
+  it("adds the first declaration to an empty style with no leading separator", () => {
+    expect(inline_style.set("", "fill", "red")).toBe("fill: red");
+  });
+});

--- a/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
+++ b/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
@@ -90,6 +90,20 @@ describe("inline_style.set (trivia-preserving edit)", () => {
     expect(inline_style.set("fill:red", "fill", null)).toBe("");
   });
 
+  it("removing the last declaration drops authored trailing separators / whitespace", () => {
+    // The leftover raw tail (`" "`, `";"`, `" ;"`) must not survive as the
+    // whole style value — otherwise the caller can't drop the attribute.
+    expect(inline_style.set("fill:red; ", "fill", null)).toBe("");
+    expect(inline_style.set("fill:red;;", "fill", null)).toBe("");
+    expect(inline_style.set("fill:red ;", "fill", null)).toBe("");
+  });
+
+  it("removing a non-last declaration keeps the surviving declaration's trailing trivia", () => {
+    expect(inline_style.set("fill:red;stroke:blue; ", "stroke", null)).toBe(
+      "fill:red; "
+    );
+  });
+
   it("removing an absent property returns the input unchanged", () => {
     expect(inline_style.set("fill:red", "stroke", null)).toBe("fill:red");
     expect(inline_style.set("", "stroke", null)).toBe("");

--- a/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
+++ b/packages/grida-svg/src/parse/__tests__/inline-style.test.ts
@@ -1,8 +1,9 @@
 // Spec for the inline-`style` declaration grammar: trivia-preserving authoring
 // (Grida svg-editor issue #823). Editing one declaration must not churn the
 // formatting of untouched siblings, and a removed property must leave the
-// survivors byte-equal. The token model is private; these tests pin the two
-// public functions (`declarations` read view, `set` edit).
+// survivors byte-equal. The token model is private; these tests pin the three
+// public functions (`declarations` read view, `get` cascade winner, `set`
+// edit) — including CSS last-one-wins for duplicate properties.
 
 import { describe, expect, it } from "vitest";
 import { inline_style } from "../inline-style";
@@ -32,6 +33,28 @@ describe("inline_style.declarations (read projection)", () => {
     expect(inline_style.declarations("background:url(a:b)")).toEqual([
       { property: "background", value: "url(a:b)" },
     ]);
+  });
+
+  it("preserves duplicate properties in source order (read view, not cascade)", () => {
+    expect(inline_style.declarations("fill:red;fill:blue")).toEqual([
+      { property: "fill", value: "red" },
+      { property: "fill", value: "blue" },
+    ]);
+  });
+});
+
+describe("inline_style.get (cascade winner)", () => {
+  it("returns the sole declaration's value", () => {
+    expect(inline_style.get("fill: red ;stroke:blue", "fill")).toBe("red");
+  });
+
+  it("returns null for an absent property and empty input", () => {
+    expect(inline_style.get("fill:red", "stroke")).toBe(null);
+    expect(inline_style.get("", "fill")).toBe(null);
+  });
+
+  it("returns the LAST declaration when a property is duplicated (last-one-wins)", () => {
+    expect(inline_style.get("fill:red;fill:blue", "fill")).toBe("blue");
   });
 });
 
@@ -123,5 +146,21 @@ describe("inline_style.set (trivia-preserving edit)", () => {
 
   it("adds the first declaration to an empty style with no leading separator", () => {
     expect(inline_style.set("", "fill", "red")).toBe("fill: red");
+  });
+
+  it("editing a duplicated property edits the LAST (cascade-winning) occurrence", () => {
+    // The earlier shadowed `fill:red` stays byte-equal; the edit lands on the
+    // declaration that actually wins, so it isn't silently ineffective.
+    expect(inline_style.set("fill:red;fill:blue", "fill", "green")).toBe(
+      "fill:red;fill:green"
+    );
+  });
+
+  it("removing a duplicated property drops EVERY occurrence", () => {
+    // A surviving duplicate would keep the property in the cascade.
+    expect(inline_style.set("fill:red;fill:blue", "fill", null)).toBe("");
+    expect(
+      inline_style.set("fill:red;stroke:blue;fill:green", "fill", null)
+    ).toBe("stroke:blue");
   });
 });

--- a/packages/grida-svg/src/parse/index.ts
+++ b/packages/grida-svg/src/parse/index.ts
@@ -1,1 +1,2 @@
 export { svg_parse } from "./svg-parse.js";
+export { inline_style } from "./inline-style.js";

--- a/packages/grida-svg/src/parse/inline-style.ts
+++ b/packages/grida-svg/src/parse/inline-style.ts
@@ -1,0 +1,163 @@
+// Inline-style (`style="…"`) declaration-list parsing + trivia-preserving
+// authoring.
+//
+// The `style` attribute value is an SVG attribute string whose content is a
+// CSS declaration list (`prop: value; prop: value`). Per the `svg_parse` rule
+// — every lexical parse of SVG content lives in this package, callers MUST NOT
+// roll their own — this module is the single owner of that sub-grammar.
+//
+// It exists so an edit to ONE declaration rewrites only that declaration's
+// value and re-emits every untouched sibling byte-for-byte. That is the
+// minimal-diff round-trip invariant one syntax level below the attribute
+// grammar's trivia model (`AttrToken`): editing `fill` must not churn the
+// formatting of `stroke`.
+//
+// Scope (deliberate): this is NOT a full CSS tokenizer. CSS comments, and
+// `;` / `:` nested inside parens or strings, are not modeled — a `;` inside a
+// value still splits the list. Malformed or unmodeled segments are preserved
+// verbatim (as `raw`) rather than rewritten, never matched by `set`.
+
+/**
+ * One `;`-delimited segment of a `style` value, retaining enough source trivia
+ * to re-emit it byte-for-byte.
+ *
+ * A `decl` is a `property : value` pair split at its first colon. Any other
+ * segment — the empty tail after a trailing `;`, a whitespace-only run, or a
+ * colon-less / empty-property fragment — is preserved verbatim as `raw`.
+ */
+type Segment =
+  | {
+      kind: "decl";
+      /** Whitespace before the property name. */
+      pre: string;
+      /** Property name, verbatim (no surrounding whitespace). Matched against
+       *  on edit; projected by {@link inline_style.declarations}. */
+      property: string;
+      /** Verbatim bytes between the property name and the value — the `:` plus
+       *  any whitespace around it. Opaque: only ever re-emitted, never read,
+       *  so the colon/space form survives untouched. */
+      sep: string;
+      /** Value, verbatim middle (no surrounding whitespace). The only field an
+       *  edit rewrites. */
+      value: string;
+      /** Whitespace after the value, before the separator / end. */
+      post: string;
+    }
+  | { kind: "raw"; text: string };
+
+/** Splits a string into (leading ws, middle, trailing ws). The middle is
+ *  non-greedy so trailing whitespace lands in group 3; every part is optional,
+ *  so this matches any input and the `!` on `.exec` is sound. */
+const STYLE_TRIM = /^(\s*)([\s\S]*?)(\s*)$/;
+
+/** `[leading ws, trimmed middle, trailing ws]` — the verbatim split a `decl`
+ *  segment needs on both sides of its colon. */
+function trim3(s: string): [string, string, string] {
+  const [, pre, mid, post] = STYLE_TRIM.exec(s)!;
+  return [pre, mid, post];
+}
+
+function tokenize(s: string): Segment[] {
+  // The empty string is zero declarations — distinct from `";"`, which is one
+  // empty trailing segment. Returning [] keeps add-to-empty from emitting a
+  // spurious leading separator.
+  if (s === "") return [];
+  return s.split(";").map((seg): Segment => {
+    const colon = seg.indexOf(":");
+    if (colon === -1) return { kind: "raw", text: seg };
+    const [pre, property, name_trailing] = trim3(seg.slice(0, colon));
+    // A colon with no property name (`:value`) is not an editable declaration;
+    // keep it verbatim so it round-trips and never matches `set`.
+    if (property === "") return { kind: "raw", text: seg };
+    const [value_leading, value, post] = trim3(seg.slice(colon + 1));
+    return {
+      kind: "decl",
+      pre,
+      property,
+      sep: `${name_trailing}:${value_leading}`,
+      value,
+      post,
+    };
+  });
+}
+
+function emit(segs: Segment[]): string {
+  return segs
+    .map((seg) =>
+      seg.kind === "raw"
+        ? seg.text
+        : `${seg.pre}${seg.property}${seg.sep}${seg.value}${seg.post}`
+    )
+    .join(";");
+}
+
+export namespace inline_style {
+  /** A single CSS declaration projected from a `style` value: the trimmed
+   *  property name and value, with all formatting trivia dropped. */
+  export type Declaration = { property: string; value: string };
+
+  /**
+   * The declaration list of a `style` attribute value, in source order.
+   *
+   * Trimmed projection — colon-less and empty-property fragments are skipped
+   * (they are not editable declarations). Returns `[]` for empty input. This
+   * is the read view the cascade engine / inspector consume; it is derived
+   * from the same tokenizer that {@link set} edits, so reads and writes can't
+   * disagree about what a declaration is.
+   */
+  export function declarations(style: string): Declaration[] {
+    const out: Declaration[] = [];
+    for (const seg of tokenize(style)) {
+      if (seg.kind === "decl")
+        out.push({ property: seg.property, value: seg.value });
+    }
+    return out;
+  }
+
+  /**
+   * Return `style` with `property` set to `value`, or removed when `value` is
+   * `null`. Trivia-preserving: the touched declaration's own colon/space form
+   * and every untouched sibling re-emit byte-for-byte.
+   *
+   *  - Edit: only the matched declaration's value changes.
+   *  - Add (property absent): a canonical `property: value` is appended,
+   *    inserted before a trailing empty segment so an authored trailing `;`
+   *    stays trailing.
+   *  - Remove: the matched declaration is spliced; surviving declarations stay
+   *    byte-equal. Returns `""` when the last declaration is removed.
+   *  - Remove of an absent property: returns the input unchanged.
+   */
+  export function set(
+    style: string,
+    property: string,
+    value: string | null
+  ): string {
+    const segs = tokenize(style);
+    const idx = segs.findIndex(
+      (s) => s.kind === "decl" && s.property === property
+    );
+    if (value === null) {
+      if (idx === -1) return style;
+      segs.splice(idx, 1);
+    } else if (idx === -1) {
+      const decl: Segment = {
+        kind: "decl",
+        pre: "",
+        property,
+        sep: ": ",
+        value,
+        post: "",
+      };
+      const tail = segs.length > 0 ? segs[segs.length - 1] : null;
+      if (tail && tail.kind === "raw" && tail.text.trim() === "") {
+        segs.splice(segs.length - 1, 0, decl);
+      } else {
+        segs.push(decl);
+      }
+    } else {
+      const seg = segs[idx];
+      if (seg.kind === "decl") seg.value = value;
+    }
+    return emit(segs);
+  }
+}

--- a/packages/grida-svg/src/parse/inline-style.ts
+++ b/packages/grida-svg/src/parse/inline-style.ts
@@ -139,6 +139,13 @@ export namespace inline_style {
     if (value === null) {
       if (idx === -1) return style;
       segs.splice(idx, 1);
+      // Once the last declaration is gone, any leftover segments are pure
+      // separators / whitespace (or unmodeled `raw` fragments) — never
+      // declarations worth preserving. Collapse to "" so the caller drops the
+      // attribute, matching the prior parser and this function's last-removal
+      // contract; otherwise `fill:red; ` / `fill:red;;` would re-emit a stray
+      // `" "` / `";"` and leave an empty `style` behind.
+      if (!segs.some((s) => s.kind === "decl")) return "";
     } else if (idx === -1) {
       const decl: Segment = {
         kind: "decl",

--- a/packages/grida-svg/src/parse/inline-style.ts
+++ b/packages/grida-svg/src/parse/inline-style.ts
@@ -115,16 +115,36 @@ export namespace inline_style {
   }
 
   /**
+   * The effective declared value of `property`, or `null` if absent.
+   *
+   * Returns the **last** matching declaration: CSS resolves declarations of
+   * equal weight last-one-wins (CSS 2.1 §6.4.1), so for `fill:red;fill:blue`
+   * the winner is `blue`. Keeps the cascade rule co-located with {@link set}
+   * (which edits that same winner) so reads and writes agree.
+   */
+  export function get(style: string, property: string): string | null {
+    let value: string | null = null;
+    for (const seg of tokenize(style)) {
+      if (seg.kind === "decl" && seg.property === property) value = seg.value;
+    }
+    return value;
+  }
+
+  /**
    * Return `style` with `property` set to `value`, or removed when `value` is
    * `null`. Trivia-preserving: the touched declaration's own colon/space form
    * and every untouched sibling re-emit byte-for-byte.
    *
-   *  - Edit: only the matched declaration's value changes.
+   *  - Edit: only the **effective** (last, per CSS last-one-wins) declaration's
+   *    value changes; any earlier shadowed duplicate is left byte-equal, so the
+   *    edit is the one that actually wins the cascade.
    *  - Add (property absent): a canonical `property: value` is appended,
    *    inserted before a trailing empty segment so an authored trailing `;`
    *    stays trailing.
-   *  - Remove: the matched declaration is spliced; surviving declarations stay
-   *    byte-equal. Returns `""` when the last declaration is removed.
+   *  - Remove: **every** declaration of `property` is dropped — a surviving
+   *    duplicate would keep the property in the cascade. Other declarations
+   *    stay byte-equal. Returns `""` when no declaration remains (so the caller
+   *    can drop the attribute rather than emit a stray separator tail).
    *  - Remove of an absent property: returns the input unchanged.
    */
   export function set(
@@ -133,20 +153,27 @@ export namespace inline_style {
     value: string | null
   ): string {
     const segs = tokenize(style);
-    const idx = segs.findIndex(
-      (s) => s.kind === "decl" && s.property === property
-    );
     if (value === null) {
-      if (idx === -1) return style;
-      segs.splice(idx, 1);
-      // Once the last declaration is gone, any leftover segments are pure
-      // separators / whitespace (or unmodeled `raw` fragments) — never
-      // declarations worth preserving. Collapse to "" so the caller drops the
-      // attribute, matching the prior parser and this function's last-removal
-      // contract; otherwise `fill:red; ` / `fill:red;;` would re-emit a stray
-      // `" "` / `";"` and leave an empty `style` behind.
-      if (!segs.some((s) => s.kind === "decl")) return "";
-    } else if (idx === -1) {
+      const kept = segs.filter(
+        (s) => s.kind !== "decl" || s.property !== property
+      );
+      if (kept.length === segs.length) return style; // nothing matched
+      // Only separators / whitespace left (no declaration): collapse so the
+      // caller drops the attribute instead of emitting a stray `" "` / `";"`.
+      if (!kept.some((s) => s.kind === "decl")) return "";
+      return emit(kept);
+    }
+    // Edit / add target the LAST occurrence — the cascade winner — so the edit
+    // is the effective one even when the property is authored more than once.
+    let idx = -1;
+    for (let i = segs.length - 1; i >= 0; i--) {
+      const s = segs[i];
+      if (s.kind === "decl" && s.property === property) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) {
       const decl: Segment = {
         kind: "decl",
         pre: "",


### PR DESCRIPTION
## What

Editing one inline-`style` declaration used to rewrite the formatting of every **untouched** sibling. `set_style` reparsed the whole `style` value and re-emitted it canonically:

```
src : <rect style="fill:red;stroke:blue" …/>
edit: set fill → green
was : <rect style="fill: green; stroke: blue" …/>   ← stroke's spacing churned
now : <rect style="fill:green;stroke:blue" …/>      ← only fill's value changes
```

This violated the editor's central promise (README P1 — *"the diff should be exactly the change you made — nothing more"*), one syntax level below the attribute grammar's `AttrToken` trivia model. Fixes #823.

## How

Introduce **`inline_style`** in **`@grida/svg/parse`** — the package that already owns all SVG lexical parsing (`svg_parse`'s rule: *"every lexical parse of SVG content lives here; callers MUST NOT roll their own"*) — as the single owner of the `style` declaration-list sub-grammar:

- A trivia-preserving token model (`Segment` / `tokenize` / `emit`) kept **file-private**.
- Two pure functions on the public surface:
  - `inline_style.declarations(style)` — trimmed `{property, value}[]` read projection.
  - `inline_style.set(style, property, value)` — trivia-preserving edit / add / remove. An edit rewrites only the touched declaration's value and re-emits every sibling byte-for-byte; the touched declaration's own colon/space form is preserved too.

The editor's `get_style` / `set_style` / `get_all_styles` become thin plumbing over the package, **deleting** the editor-local hand-rolled parser that was both lossy and a violation of the `svg_parse` rule. `set_style` keeps an `if (next === style) return` guard so a no-op write (e.g. removing an absent property) doesn't emit.

## Why this layer

The `style` attribute value is an SVG attribute string, and its CSS declaration list is SVG syntax — it belongs next to `svg_parse.parse_points` / `parse_leading_translate` (lenient, non-throwing value parsers), **not** in the throwing `@grida/svg/parser` markup tokenizer, and **not** editor-local. This resolves #823's open "where does the declaration-token model live?" question.

## Tests

- **`@grida/svg`**: 16 unit tests spec the grammar (trivia preservation, colon-in-value, trailing `;`, add/remove/restore byte-equality, projection parity). Spec lives with the logic.
- **`@grida/svg-editor`**: 4 integration tests for the wiring (`set_style` → `serialize` minimal diff, `get_style`/`get_all_styles` read-back, remove-last drops the attr, non-style edit leaves `style` bytes verbatim).
- Full suites green: `@grida/svg` 384 tests, `@grida/svg-editor` 1456 tests; `tsc`, `oxfmt`, `oxlint` clean across both packages.

## Reviewer notes

- Public surface of `@grida/svg` grows by exactly `inline_style.declarations` + `set` + the `Declaration` type; the token model stays internal.
- Scope is deliberately **not** a full CSS tokenizer (comments and `;`/`:` nested in parens/strings are unmodeled — same tolerance as the prior parser); malformed/unmodeled segments are preserved verbatim, never rewritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced support for reading and editing SVG inline `style` declarations with correct cascade behavior (last-one-wins).
* **Bug Fixes**
  * Inline `style` edits now preserve original formatting/trivia and make minimal document changes.
  * Removing a property correctly updates the `style` attribute (including removing it entirely when the last declaration is deleted).
* **Refactor**
  * Unified inline-style parsing/editing across the SVG editor for consistent results.
* **Tests**
  * Expanded automated coverage for parsing, get/set/removal/appending, and round-trip byte-identical output.
* **Chores**
  * Updated package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->