### PR TITLE
feat(svg-editor): expose vector sub-selection API in path-edit mode (#790)

### DIFF
--- a/editor/app/(www)/(svg)/svg/_sections/playground-fixtures.ts
+++ b/editor/app/(www)/(svg)/svg/_sections/playground-fixtures.ts
@@ -12,6 +12,14 @@ export type PlaygroundFixture = {
   svg: string;
   /** Open in plain selection instead of path-edit mode. */
   selectOnly?: boolean;
+  /**
+   * Open path-edit with these vertices already selected (gridaco/grida#790's
+   * atomic-entry form, `enter_content_edit(id, { vertices })`). `"all"` derives
+   * the full vertex set from the live path model. The motivating demo: a tile
+   * that lands straight in an *active* sub-selection so editability is obvious,
+   * not just "vertices on display, nothing picked." Ignored when `selectOnly`.
+   */
+  initialVertexSelection?: "all" | readonly number[];
 };
 
 // The Grida brand symbol (from components/grida-logo) — kept monochrome
@@ -32,6 +40,8 @@ const heart = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 export const PLAYGROUND_FIXTURES: PlaygroundFixture[] = [
   { label: "artwork", svg: artwork },
   { label: "illustration", svg: illustration },
-  { label: "heart", svg: heart },
+  // Heart opens with every anchor pre-selected — the clearest "this is live,
+  // editable, and already in an edit state" cue on a simple recognizable shape.
+  { label: "heart", svg: heart, initialVertexSelection: "all" },
   { label: "grida", svg: grida, selectOnly: true },
 ];

--- a/editor/app/(www)/(svg)/svg/_sections/playground.tsx
+++ b/editor/app/(www)/(svg)/svg/_sections/playground.tsx
@@ -7,6 +7,7 @@ import {
   SvgEditorCanvas,
   useSvgEditor,
 } from "@grida/svg-editor/react";
+import { PathModel } from "@grida/svg-editor";
 import type { DomSurfaceHandle } from "@grida/svg-editor/dom";
 import { cn } from "@app/ui/lib/utils";
 import { GridCells } from "./grid";
@@ -27,18 +28,41 @@ const TILE_LAYOUT = [
 ];
 
 /**
+ * Resolve a fixture's `initialVertexSelection` to concrete vertex indices
+ * against the live path. `"all"` derives the count from a `PathModel` built off
+ * the path's authored `d` (read via the editor's property view) — no fragile
+ * hardcoded indices. Returns `undefined` when there's nothing to select, so the
+ * caller falls back to a plain path-edit entry.
+ */
+function resolveInitialVertices(
+  editor: ReturnType<typeof useSvgEditor>,
+  pathId: string,
+  sel: "all" | readonly number[]
+): number[] | undefined {
+  if (sel !== "all") return sel.length > 0 ? [...sel] : undefined;
+  const d = editor.node_properties(pathId, ["d"])["d"]?.declared;
+  if (!d) return undefined;
+  const count = PathModel.fromSvgPathD(d).vertexCount();
+  return count > 0 ? Array.from({ length: count }, (_, i) => i) : undefined;
+}
+
+/**
  * The canvas + its auto-edit wiring. The select / enter-edit must run *after*
  * the DOM surface attaches (it installs the content-edit driver), so it's done
  * in `onAttach`, not a mount effect — opening each tile straight into path-edit
- * mode on its primary <path> with the vector vertices on display. Falls back to
- * selecting all top-level elements when the fixture has no path.
+ * mode on its primary <path> with the vector vertices on display. A fixture
+ * carrying `initialVertexSelection` lands with those anchors already selected
+ * (gridaco/grida#790's atomic entry — one step, no unselected flash). Falls
+ * back to selecting all top-level elements when the fixture has no path.
  */
 function TileCanvas({
   active,
   selectOnly,
+  initialVertexSelection,
 }: {
   active: boolean;
   selectOnly?: boolean;
+  initialVertexSelection?: "all" | readonly number[];
 }) {
   const editor = useSvgEditor();
   const onAttach = useCallback(
@@ -57,14 +81,21 @@ function TileCanvas({
         }
         if (pathId) {
           editor.commands.select(pathId);
-          editor.enter_content_edit(pathId);
+          // Atomic entry: open AND seed the sub-selection in one step (#790).
+          const vertices = initialVertexSelection
+            ? resolveInitialVertices(editor, pathId, initialVertexSelection)
+            : undefined;
+          editor.enter_content_edit(
+            pathId,
+            vertices ? { vertices } : undefined
+          );
           return;
         }
       }
       const children = tree.nodes.get(tree.root)?.children ?? [];
       if (children.length > 0) editor.commands.select([...children]);
     },
-    [editor, selectOnly]
+    [editor, selectOnly, initialVertexSelection]
   );
   return (
     <SvgEditorCanvas
@@ -87,12 +118,14 @@ function PlaygroundTile({
   index,
   className,
   selectOnly,
+  initialVertexSelection,
 }: {
   svg: string;
   label: string;
   index: number;
   className?: string;
   selectOnly?: boolean;
+  initialVertexSelection?: "all" | readonly number[];
 }) {
   const [active, setActive] = useState(false);
   return (
@@ -104,7 +137,11 @@ function PlaygroundTile({
       className={cn("group relative bg-background", className)}
     >
       <SvgEditorProvider initialSvg={svg}>
-        <TileCanvas active={active} selectOnly={selectOnly} />
+        <TileCanvas
+          active={active}
+          selectOnly={selectOnly}
+          initialVertexSelection={initialVertexSelection}
+        />
       </SvgEditorProvider>
       <span className="pointer-events-none absolute left-3 top-3 z-10 font-mono text-[10px] text-muted-foreground/50">
         {label}.svg
@@ -136,6 +173,7 @@ export default function Playground() {
           index={i}
           className={TILE_LAYOUT[i]}
           selectOnly={f.selectOnly}
+          initialVertexSelection={f.initialVertexSelection}
         />
       ))}
     </GridCells>

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -333,6 +333,26 @@ The point is document-space and always the pointer-**down** point — so it stay
 
 > **Status:** `@unstable` — shipped against one consumer; the shape is open until a second click-driven tool exercises it (P6).
 
+### Observation — vector sub-selection
+
+While a path is open in vector content-edit, the **sub-selection** (which vertices / segments / tangents are selected) is its own piece of state, distinct from `state.selection` (which names the whole node under edit). It is exposed as a designed read view — the read half of [#790](https://github.com/gridaco/grida/issues/790), paired with the `set_vector_selection` command.
+
+```ts
+type VectorSubSelection = {
+  node_id: NodeId;
+  vertices: readonly number[]; // ordinal vertex indices (PathModel order)
+  segments: readonly number[]; // ordinal segment indices
+  tangents: readonly (readonly [number, 0 | 1])[]; // [vertexIndex, 0=ta | 1=tb]
+};
+
+editor.vector_subselection(): VectorSubSelection | null; // null = no session
+editor.subscribe_vector_subselection(
+  fn: (sel: VectorSubSelection | null) => void,
+): Unsubscribe;
+```
+
+The channel fires on every sub-selection change (click, marquee, lasso, programmatic `set_vector_selection`, undo/redo) and on session enter/exit (`null` on exit). Like pick and surface-hover it is kept **off `state.version`** — sub-selection changes at pointer rate during marquee/lasso, so folding it into the version stream would re-render the whole app per knob (P4). Subscribe to this channel instead of polling `state`.
+
 ### Observation — properties
 
 This section is about **property semantics on a single node**, following the CSS / SVG spec. Multi-selection ("mixed values") is a separate concern; see the [Multi-selection](#multi-selection-mixed-values) section below. The two are kept apart on purpose: property semantics is defined by the spec; mixed semantics is an aggregation layer the editor adds because it supports multi-select.
@@ -714,7 +734,16 @@ editor.commands.{
 
   // content
   set_text(value: string): void;
-  enter_content_edit(target?: NodeId): boolean;
+  enter_content_edit(target?: NodeId, opts?: VectorSubSelectionInput): boolean;
+  // vector content-edit — set the vertex / segment / tangent sub-selection
+  // while a path is open in content-edit (the write half of #790). `mode`
+  // defaults to "replace"; "add"/"toggle" fold into the existing selection.
+  // One undoable step, like a knob click. Returns false (no-op) when no vector
+  // session is active, no surface is attached, the input is out of range, or
+  // it resolves to the current selection — a strict surface refuses rather
+  // than silently mishandling. To open a path with an initial sub-selection in
+  // ONE step, pass the same input as `enter_content_edit`'s `opts`.
+  set_vector_selection(input: VectorSubSelectionInput, mode?: SelectMode): boolean;
 
   // file
   load_svg(svg: string): void;

--- a/packages/grida-svg-editor/__tests__/internal-surface.test.ts
+++ b/packages/grida-svg-editor/__tests__/internal-surface.test.ts
@@ -40,8 +40,10 @@ type Internal = {
   set_surface_hover_override_driver: (fn: unknown) => void;
   push_surface_hover: (id: unknown) => void;
   push_pick: (e: unknown) => void;
+  push_vector_subselection: (sel: unknown) => void;
   set_computed_resolver: (fn: unknown) => void;
   set_geometry: (p: unknown) => void;
+  set_vector_subselect_driver: (fn: unknown) => void;
   register_command: (id: string, handler: unknown) => () => void;
 };
 
@@ -64,12 +66,14 @@ describe("editor._internal contract", () => {
         "notify_translate_commit",
         "push_pick",
         "push_surface_hover",
+        "push_vector_subselection",
         "register_command",
         "seed_duplication",
         "set_computed_resolver",
         "set_content_edit_driver",
         "set_geometry",
         "set_surface_hover_override_driver",
+        "set_vector_subselect_driver",
         "subscribe_translate_commit",
       ].sort()
     );

--- a/packages/grida-svg-editor/__tests__/vector-subselection.test.ts
+++ b/packages/grida-svg-editor/__tests__/vector-subselection.test.ts
@@ -1,0 +1,263 @@
+// Vector sub-selection write/read API (gridaco/grida#790).
+//
+// Two layers are exercised here, both headless (no DOM surface — see
+// __tests__/README.md):
+//
+//   1. The pure core (`apply_subselection` / `validate_subselection`):
+//      validation + session mutation against a real `VectorEditSession` +
+//      `PathModel`. This is where the load-bearing logic lives, so this is
+//      where the bugs must reproduce (core-first testing doctrine).
+//   2. The editor wiring (`commands.set_vector_selection`,
+//      `enter_content_edit(id, opts)`, and the read channel
+//      `subscribe_vector_subselection` / `vector_subselection()`): the
+//      surface-private session can't be mounted headlessly, so we stub the
+//      drivers and assert the editor delegates / fans out correctly. The
+//      end-to-end surface path is a manual case in `test/`.
+
+import { describe, expect, it, vi } from "vitest";
+import { createSvgEditor } from "../src/index";
+import {
+  PathModel,
+  VectorEditSession,
+  apply_subselection,
+  validate_subselection,
+} from "../src/core/vector-edit";
+import type { VectorSubSelection, VectorSubSelectionInput } from "../src/types";
+
+// 3 vertices, 3 segments (closed triangle).
+const D = "M0,0 L10,0 L10,10 Z";
+
+function session(): VectorEditSession {
+  return new VectorEditSession("p1", { kind: "path", d: D }, D);
+}
+function model(): PathModel {
+  return PathModel.fromSvgPathD(D);
+}
+
+describe("validate_subselection — strict range check", () => {
+  const m = model();
+
+  it("accepts in-range vertices / segments / tangents", () => {
+    expect(validate_subselection({ vertices: [0, 1, 2] }, m)).toBe(true);
+    expect(validate_subselection({ segments: [0, 1, 2] }, m)).toBe(true);
+    expect(
+      validate_subselection(
+        {
+          tangents: [
+            [0, 0],
+            [2, 1],
+          ],
+        },
+        m
+      )
+    ).toBe(true);
+  });
+
+  it("accepts an empty input (clears in replace mode)", () => {
+    expect(validate_subselection({}, m)).toBe(true);
+  });
+
+  it("rejects an out-of-range vertex", () => {
+    expect(validate_subselection({ vertices: [3] }, m)).toBe(false);
+    expect(validate_subselection({ vertices: [-1] }, m)).toBe(false);
+  });
+
+  it("rejects an out-of-range segment", () => {
+    expect(validate_subselection({ segments: [3] }, m)).toBe(false);
+  });
+
+  it("rejects a bad tangent ref (vertex out of range or side not 0/1)", () => {
+    expect(validate_subselection({ tangents: [[9, 0]] }, m)).toBe(false);
+    expect(validate_subselection({ tangents: [[0, 2 as 0 | 1]] }, m)).toBe(
+      false
+    );
+  });
+
+  it("rejects non-integer indices", () => {
+    expect(validate_subselection({ vertices: [1.5] }, m)).toBe(false);
+  });
+
+  it("refuses the WHOLE input if any one index is out of range", () => {
+    // Strict: a partially-valid input is rejected, not partially applied.
+    expect(validate_subselection({ vertices: [0, 1, 99] }, m)).toBe(false);
+  });
+});
+
+describe("apply_subselection — mutation semantics", () => {
+  it("replace swaps in the whole triple and clears omitted tracks", () => {
+    const s = session();
+    s.set_selection({ vertices: [2], segments: [2], tangents: [[2, 1]] });
+    const changed = apply_subselection(
+      s,
+      model(),
+      { vertices: [0, 1] },
+      "replace"
+    );
+    expect(changed).toBe(true);
+    expect(s.selected_vertices).toEqual([0, 1]);
+    expect(s.selected_segments).toEqual([]); // omitted track cleared
+    expect(s.selected_tangents).toEqual([]);
+  });
+
+  it("add folds into the existing selection, leaving omitted tracks intact", () => {
+    const s = session();
+    s.set_selection({ vertices: [0], segments: [1], tangents: [] });
+    apply_subselection(s, model(), { vertices: [2] }, "add");
+    expect(s.selected_vertices).toEqual([0, 2]);
+    expect(s.selected_segments).toEqual([1]); // intact — not in input
+  });
+
+  it("toggle removes an already-selected vertex", () => {
+    const s = session();
+    s.set_selection({ vertices: [0, 1], segments: [], tangents: [] });
+    apply_subselection(s, model(), { vertices: [0] }, "toggle");
+    expect(s.selected_vertices).toEqual([1]);
+  });
+
+  it("returns false (no mutation) on out-of-range input — strict refusal", () => {
+    const s = session();
+    s.set_selection({ vertices: [0], segments: [], tangents: [] });
+    const changed = apply_subselection(
+      s,
+      model(),
+      { vertices: [99] },
+      "replace"
+    );
+    expect(changed).toBe(false);
+    expect(s.selected_vertices).toEqual([0]); // untouched
+  });
+
+  it("returns false when the write resolves to the current selection", () => {
+    const s = session();
+    s.set_selection({ vertices: [0, 1], segments: [], tangents: [] });
+    const changed = apply_subselection(
+      s,
+      model(),
+      { vertices: [0, 1] },
+      "replace"
+    );
+    expect(changed).toBe(false);
+  });
+});
+
+// ─── Editor wiring (headless, driver-stubbed) ────────────────────────────────
+
+type Internal = {
+  set_vector_subselect_driver: (
+    fn: ((input: VectorSubSelectionInput, mode?: string) => boolean) | null
+  ) => void;
+  set_content_edit_driver: (
+    fn: ((id: string, opts?: VectorSubSelectionInput) => boolean) | null
+  ) => void;
+  push_vector_subselection: (sel: VectorSubSelection | null) => void;
+};
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path id="p" d="M0,0 L10,0 L10,10 Z"/>
+</svg>`;
+
+function pathId(editor: ReturnType<typeof createSvgEditor>): string {
+  for (const [id, node] of editor.tree().nodes) {
+    if (node.tag === "path") return id;
+  }
+  throw new Error("no <path>");
+}
+
+function internal(editor: ReturnType<typeof createSvgEditor>): Internal {
+  return (editor as unknown as { _internal: Internal })._internal;
+}
+
+describe("commands.set_vector_selection — delegates to the surface driver", () => {
+  it("forwards input + mode and returns the driver's result", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const driver = vi.fn<
+      (input: VectorSubSelectionInput, mode?: string) => boolean
+    >(() => true);
+    internal(editor).set_vector_subselect_driver(driver);
+
+    const input = { vertices: [0, 2] };
+    expect(editor.commands.set_vector_selection(input, "add")).toBe(true);
+    expect(driver).toHaveBeenCalledWith(input, "add");
+  });
+
+  it("is a no-op returning false when no surface (driver) is attached", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    expect(editor.commands.set_vector_selection({ vertices: [0] })).toBe(false);
+  });
+
+  it("propagates a driver refusal (false)", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    internal(editor).set_vector_subselect_driver(() => false);
+    expect(editor.commands.set_vector_selection({ vertices: [99] })).toBe(
+      false
+    );
+  });
+});
+
+describe("enter_content_edit(id, opts) — threads the initial sub-selection", () => {
+  it("forwards opts to the content-edit driver", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const id = pathId(editor);
+    const driver = vi.fn<
+      (id: string, opts?: VectorSubSelectionInput) => boolean
+    >(() => true);
+    internal(editor).set_content_edit_driver(driver);
+
+    const opts = { vertices: [1] };
+    expect(editor.enter_content_edit(id, opts)).toBe(true);
+    expect(driver).toHaveBeenCalledWith(id, opts);
+  });
+
+  it("still works with no opts (back-compat)", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const id = pathId(editor);
+    const driver = vi.fn<
+      (id: string, opts?: VectorSubSelectionInput) => boolean
+    >(() => true);
+    internal(editor).set_content_edit_driver(driver);
+    expect(editor.enter_content_edit(id)).toBe(true);
+    expect(driver).toHaveBeenCalledWith(id, undefined);
+  });
+});
+
+describe("vector sub-selection read channel", () => {
+  it("subscribe fires with the pushed value, accessor reflects it", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const seen: (VectorSubSelection | null)[] = [];
+    const unsub = editor.subscribe_vector_subselection((s) => seen.push(s));
+
+    const sel: VectorSubSelection = {
+      node_id: pathId(editor),
+      vertices: [0, 1],
+      segments: [],
+      tangents: [],
+    };
+    internal(editor).push_vector_subselection(sel);
+    expect(seen).toEqual([sel]);
+    expect(editor.vector_subselection()).toBe(sel);
+
+    internal(editor).push_vector_subselection(null);
+    expect(editor.vector_subselection()).toBe(null);
+
+    unsub();
+    internal(editor).push_vector_subselection(sel);
+    expect(seen.length).toBe(2); // no further fire after unsubscribe
+  });
+
+  it("does NOT bump state.version (off the version stream — P4)", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    const v0 = editor.state.version;
+    internal(editor).push_vector_subselection({
+      node_id: pathId(editor),
+      vertices: [0],
+      segments: [],
+      tangents: [],
+    });
+    expect(editor.state.version).toBe(v0);
+  });
+
+  it("starts null", () => {
+    const editor = createSvgEditor({ svg: SVG });
+    expect(editor.vector_subselection()).toBe(null);
+  });
+});

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -53,6 +53,8 @@ import type {
   Tool,
   Unsubscribe,
   Vec2,
+  VectorSubSelection,
+  VectorSubSelectionInput,
 } from "../types";
 import { DEFAULT_STYLE, TOOL_CURSOR } from "../types";
 import { array_shallow_equal } from "../util/equal";
@@ -547,6 +549,25 @@ export type Commands = {
   ): InsertPreviewSession;
   // content
   set_text(value: string): void;
+  /**
+   * Set the vertex / segment / tangent sub-selection while a vector
+   * content-edit session is open (gridaco/grida#790). Returns `true` when the
+   * sub-selection changed, `false` (no-op) when no vector session is active,
+   * no DOM surface is attached, the input is out of range, or it resolves to
+   * the current selection.
+   *
+   * `mode` defaults to `"replace"` (the input becomes the whole sub-selection;
+   * omitted tracks are cleared). `"add"` / `"toggle"` fold the input into the
+   * existing sub-selection per track, leaving omitted tracks intact. The write
+   * is one undoable step, like a knob click. Indices are validated against the
+   * path under edit; an out-of-range index or tangent ref refuses the whole
+   * call. To open a path with an initial sub-selection in one step, pass the
+   * same input to {@link SvgEditor.enter_content_edit}.
+   */
+  set_vector_selection(
+    input: VectorSubSelectionInput,
+    mode?: SelectMode
+  ): boolean;
   // file
   load_svg(svg: string): void;
   serialize_svg(): string;
@@ -2478,7 +2499,15 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     });
   }
 
-  let content_edit_driver: ((target: NodeId) => boolean) | null = null;
+  let content_edit_driver:
+    | ((target: NodeId, opts?: VectorSubSelectionInput) => boolean)
+    | null = null;
+  // Editor → surface driver for vector sub-selection writes. The session is
+  // surface-owned, so `commands.set_vector_selection` reaches it only through
+  // this slot (symmetric to `content_edit_driver`). Null without a surface.
+  let vector_subselect_driver:
+    | ((input: VectorSubSelectionInput, mode?: SelectMode) => boolean)
+    | null = null;
   let computed_resolver: DomComputedResolver | null = null;
 
   function dom_computed_property(id: NodeId, name: string): string | null {
@@ -2520,18 +2549,52 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     for (const cb of pick_listeners) cb(e);
   }
 
-  function enter_content_edit(target?: NodeId): boolean {
+  // Vector sub-selection channel — the surface publishes the live vertex /
+  // segment / tangent sub-selection here. Like surface-hover and pick, kept
+  // out of EditorState and off the `version` stream: it changes at pointer
+  // rate during marquee / lasso, so a `version` bump per knob would re-render
+  // the whole app (P4 — subscribe to outcomes). `null` when no session.
+  let current_vector_subselection: VectorSubSelection | null = null;
+  const vector_subselection_listeners = new Set<
+    (sel: VectorSubSelection | null) => void
+  >();
+  function notify_vector_subselection() {
+    for (const cb of vector_subselection_listeners) {
+      cb(current_vector_subselection);
+    }
+  }
+  function _set_current_vector_subselection(sel: VectorSubSelection | null) {
+    current_vector_subselection = sel;
+    notify_vector_subselection();
+  }
+
+  function enter_content_edit(
+    target?: NodeId,
+    opts?: VectorSubSelectionInput
+  ): boolean {
     const id = target ?? (selection.length === 1 ? selection[0] : null);
     if (!id) return false;
     // Accept text (`<text>`/`<tspan>` leaf) OR vector (`<path>`/`<line>`/
     // `<polyline>`/`<polygon>`). The vector predicate widens what was
     // previously a path-only gate (see core/document.ts
     // `is_vector_edit_target`). The driver (DOM surface) routes by tag
-    // inside `dom.ts:enter_content_edit`.
+    // inside `dom.ts:enter_content_edit`. `opts` carries an optional initial
+    // vector sub-selection (gridaco/grida#790) — ignored for text targets.
     if (!doc.is_text_edit_target(id) && doc.is_vector_edit_target(id) === null)
       return false;
     if (!content_edit_driver) return false;
-    return content_edit_driver(id);
+    return content_edit_driver(id, opts);
+  }
+
+  function set_vector_selection(
+    input: VectorSubSelectionInput,
+    mode?: SelectMode
+  ): boolean {
+    // The vector session lives on the surface; reach it through the driver
+    // (no surface ⇒ no session ⇒ no-op). The driver owns validation, the
+    // session mutation, and the undoable history step.
+    if (!vector_subselect_driver) return false;
+    return vector_subselect_driver(input, mode);
   }
 
   function load_svg(svg: string) {
@@ -2607,6 +2670,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     insert_fragment,
     insert_preview,
     set_text,
+    set_vector_selection,
     load_svg,
     serialize_svg,
     undo,
@@ -2676,6 +2740,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     geometry_listeners.clear();
     translate_commit_listeners.clear();
     pick_listeners.clear();
+    vector_subselection_listeners.clear();
   }
 
   function set_style(partial: Partial<EditorStyle>) {
@@ -2818,6 +2883,33 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     },
 
     /**
+     * The current vector sub-selection (vertices / segments / tangents) inside
+     * an open vector content-edit session, or `null` when no such session is
+     * active (gridaco/grida#790). The read counterpart to
+     * `commands.set_vector_selection`. See {@link VectorSubSelection}.
+     */
+    vector_subselection(): VectorSubSelection | null {
+      return current_vector_subselection;
+    },
+
+    /**
+     * Subscribe to vector sub-selection changes — fires whenever the live
+     * vertex / segment / tangent selection changes (click, marquee, lasso,
+     * programmatic `set_vector_selection`, undo/redo) and on session
+     * enter/exit (`null` on exit). The callback receives the new value, also
+     * readable via {@link vector_subselection}. Cheap channel — does NOT bump
+     * `state.version`.
+     */
+    subscribe_vector_subselection(
+      cb: (sel: VectorSubSelection | null) => void
+    ): Unsubscribe {
+      vector_subselection_listeners.add(cb);
+      return () => {
+        vector_subselection_listeners.delete(cb);
+      };
+    },
+
+    /**
      * Subscribe to bounds-affecting changes. Fires when any document
      * mutation advances `state.geometry_version` — drag, resize, text
      * edit, structural insert/remove. Skips presentation-only writes
@@ -2900,8 +2992,20 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
       seed_duplication(record: subtree.DuplicationRecord) {
         active_duplication = record;
       },
-      set_content_edit_driver(fn: ((target: NodeId) => boolean) | null) {
+      set_content_edit_driver(
+        fn: ((target: NodeId, opts?: VectorSubSelectionInput) => boolean) | null
+      ) {
         content_edit_driver = fn;
+      },
+      set_vector_subselect_driver(
+        fn:
+          | ((input: VectorSubSelectionInput, mode?: SelectMode) => boolean)
+          | null
+      ) {
+        vector_subselect_driver = fn;
+      },
+      push_vector_subselection(sel: VectorSubSelection | null) {
+        _set_current_vector_subselection(sel);
       },
       set_surface_hover_override_driver(
         fn: ((id: NodeId | null) => void) | null

--- a/packages/grida-svg-editor/src/core/surface-bridge.ts
+++ b/packages/grida-svg-editor/src/core/surface-bridge.ts
@@ -13,7 +13,14 @@
 //     a fact or open a history bracket.
 
 import type { Preview } from "@grida/history";
-import type { NodeId, PickEvent, Unsubscribe } from "../types";
+import type { SelectMode } from "@grida/hud";
+import type {
+  NodeId,
+  PickEvent,
+  Unsubscribe,
+  VectorSubSelection,
+  VectorSubSelectionInput,
+} from "../types";
 import type { CommandHandler, CommandId } from "../commands/registry";
 import type { DomComputedResolver } from "./editor";
 import type { GeometryProvider } from "./geometry";
@@ -93,9 +100,30 @@ export interface SurfaceBridge {
 
   /** editor → surface: register the driver that mounts inline content
    *  editing (text-edit, vector-edit) on a target node. The editor calls
-   *  `editor.enter_content_edit(id)` and routes here. Pass `null` to
+   *  `editor.enter_content_edit(id, opts?)` and routes here. `opts` carries an
+   *  optional initial vector sub-selection (gridaco/grida#790) applied as part
+   *  of the entry transition — ignored for text targets. Pass `null` to
    *  unregister on detach. */
-  set_content_edit_driver(fn: ((target: NodeId) => boolean) | null): void;
+  set_content_edit_driver(
+    fn: ((target: NodeId, opts?: VectorSubSelectionInput) => boolean) | null
+  ): void;
+
+  /** editor → surface: register the driver that applies a vector
+   *  sub-selection write while a vector content-edit session is open
+   *  (`commands.set_vector_selection`, gridaco/grida#790). Returns `false`
+   *  when no session is active, the input is out of range, or the surface
+   *  refuses; `true` when the sub-selection changed. Pass `null` to unregister
+   *  on detach. The session is surface-owned, so this is the only write path
+   *  the headless command has into it — symmetric to the content-edit driver. */
+  set_vector_subselect_driver(
+    fn: ((input: VectorSubSelectionInput, mode?: SelectMode) => boolean) | null
+  ): void;
+
+  /** surface → editor: publish the current vector sub-selection. Goes to
+   *  `editor.subscribe_vector_subselection()` listeners and updates
+   *  `editor.vector_subselection()`; does NOT bump `state.version` (it changes
+   *  at pointer rate during marquee / lasso — P4). `null` on session exit. */
+  push_vector_subselection(sel: VectorSubSelection | null): void;
 
   /** editor → surface: register the driver that pushes a hover override
    *  (e.g. from a layers panel) into the HUD. Invoked immediately on

--- a/packages/grida-svg-editor/src/core/vector-edit/index.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/index.ts
@@ -30,3 +30,6 @@ export {
 
 export { marquee } from "./marquee";
 export type { SubpathSelectCandidates } from "./marquee";
+
+export { apply_subselection, validate_subselection } from "./subselection";
+export type { SubSelectionInput } from "./subselection";

--- a/packages/grida-svg-editor/src/core/vector-edit/subselection.ts
+++ b/packages/grida-svg-editor/src/core/vector-edit/subselection.ts
@@ -1,0 +1,90 @@
+// Programmatic vector sub-selection writes (gridaco/grida#790).
+//
+// The pure core behind `commands.set_vector_selection` and the atomic-entry
+// `enter_content_edit(id, opts)` form. Kept here — not in the DOM surface —
+// so the validation + apply rules are headlessly unit-testable against a
+// `VectorEditSession` + `PathModel` (the surface can't be mounted in jsdom;
+// see `__tests__/README.md`). The surface (`dom.ts`) is a thin shell that
+// resolves the live session/model, calls these, then syncs the mirror and
+// pushes the undoable history step.
+//
+// Boundary: imports only `./model` and `./session` (no `@grida/vn`, no DOM).
+
+import type { PathModel, TangentRef } from "./model";
+import type { SelectMode, VectorEditSession } from "./session";
+import { sub_selection_equal } from "./session";
+
+/**
+ * Write triple for a sub-selection. Structurally identical to the package's
+ * public `VectorSubSelectionInput` (`../../types`) — kept local so this
+ * low-level module stays decoupled from the root public types.
+ */
+export type SubSelectionInput = {
+  readonly vertices?: ReadonlyArray<number>;
+  readonly segments?: ReadonlyArray<number>;
+  readonly tangents?: ReadonlyArray<readonly [number, 0 | 1]>;
+};
+
+/**
+ * Validate a sub-selection write against the live path model. Vertex /
+ * segment indices must be integers in `[0, count)`; a tangent ref must be
+ * `[vertexInRange, 0 | 1]`. Returns `false` if ANY track is out of range —
+ * callers refuse the whole write rather than silently dropping offending
+ * indices (a strict surface rejects wrong contents). An empty input is valid
+ * (it clears the selection in `replace` mode).
+ */
+export function validate_subselection(
+  input: SubSelectionInput,
+  model: PathModel
+): boolean {
+  const vcount = model.vertexCount();
+  const scount = model.segmentCount();
+  const in_range = (n: unknown, count: number): boolean =>
+    Number.isInteger(n) && (n as number) >= 0 && (n as number) < count;
+  for (const v of input.vertices ?? []) {
+    if (!in_range(v, vcount)) return false;
+  }
+  for (const s of input.segments ?? []) {
+    if (!in_range(s, scount)) return false;
+  }
+  for (const t of input.tangents ?? []) {
+    if (!in_range(t?.[0], vcount)) return false;
+    if (t[1] !== 0 && t[1] !== 1) return false;
+  }
+  return true;
+}
+
+/**
+ * Validate `input` against `model` and apply it to `session`.
+ *
+ * - `replace` (default elsewhere) swaps `input` in as the WHOLE sub-selection;
+ *   omitted tracks are cleared.
+ * - `add` / `toggle` fold each track into the existing selection (each
+ *   per-item call preserves the other tracks — Figma-like), so omitted tracks
+ *   are left intact.
+ *
+ * Returns `true` when the selection actually changed (and was valid), `false`
+ * when the input is out of range OR resolves to the current sub-selection (a
+ * no-op the caller should not record as a history step). Pure session
+ * mutation — no mirror sync, no history; the caller owns those.
+ */
+export function apply_subselection(
+  session: VectorEditSession,
+  model: PathModel,
+  input: SubSelectionInput,
+  mode: SelectMode
+): boolean {
+  if (!validate_subselection(input, model)) return false;
+  const before = session.snapshot_selection();
+  const vertices = input.vertices ?? [];
+  const segments = input.segments ?? [];
+  const tangents: ReadonlyArray<TangentRef> = input.tangents ?? [];
+  if (mode === "replace") {
+    session.set_selection({ vertices, segments, tangents });
+  } else {
+    for (const v of vertices) session.select_vertex(v, mode);
+    for (const s of segments) session.select_segment(s, mode);
+    for (const t of tangents) session.select_tangent(t, mode);
+  }
+  return !sub_selection_equal(before, session.snapshot_selection());
+}

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -98,6 +98,7 @@ import {
   vector_apply,
   vector_revert,
   apply_subselection,
+  validate_subselection,
   type SubSelectionSnapshot,
 } from "./core/vector-edit";
 import type { RetypeRecord } from "./core/document";
@@ -1460,6 +1461,11 @@ class DomSurface implements Surface {
       this.vector_edit = null;
       this.vector_edit_region_baseline = null;
       this.hud.setVectorSelection(null);
+      // Clear the editor read channel too (gridaco/grida#790): disposing the
+      // surface ends the session, so `vector_subselection()` must drop to null
+      // and subscribers must see it — this detach/unmount path bypasses
+      // `_do_exit_vector_edit`, which is where the normal-exit null push lives.
+      this.editor_internal().push_vector_subselection(null);
     }
     this.scene_marquee_baseline = null;
     this.gestures._dispose();
@@ -4159,12 +4165,21 @@ class DomSurface implements Surface {
     opts?: VectorSubSelectionInput
   ): boolean {
     if (this.vector_edit) return false;
+    // Honor the `VectorSubSelectionInput` contract for the atomic-entry form:
+    // an out-of-range initial sub-selection refuses the WHOLE call (no entry,
+    // no history) — the same strict semantics as `set_vector_selection`, so a
+    // bad index can't masquerade as a successful preselect (gridaco/grida#790).
+    // Validate against the path BEFORE entering, so refusal leaves zero trace
+    // (no transient session, no read-channel blip).
+    if (opts) {
+      const source = this.editor_internal().doc.is_vector_edit_target(id);
+      if (!source) return false;
+      const model = PathModel.fromSvgPathD(source_to_session_d(source));
+      if (!validate_subselection(opts, model)) return false;
+    }
     if (!this._do_enter_vector_edit(id)) return false;
-    // Apply the optional initial sub-selection (gridaco/grida#790) as part of
-    // THIS entry — one history step, no intermediate empty-selection frame.
-    // `apply_subselection_to_session` self-validates against the live model;
-    // invalid opts are ignored and entry still succeeds with an empty
-    // selection (entry eligibility and sub-selection validity are separate).
+    // Apply the (now-validated) initial sub-selection as part of THIS entry —
+    // one history step, no intermediate empty-selection frame.
     if (opts) this.apply_subselection_to_session(opts, "replace");
     // Capture the post-opts selection so REDO of this entry restores it —
     // symmetric to how `exit_vector_edit`'s revert restores `final_selection`.

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -4165,25 +4165,28 @@ class DomSurface implements Surface {
     opts?: VectorSubSelectionInput
   ): boolean {
     if (this.vector_edit) return false;
-    // Honor the `VectorSubSelectionInput` contract for the atomic-entry form:
-    // an out-of-range initial sub-selection refuses the WHOLE call (no entry,
-    // no history) — the same strict semantics as `set_vector_selection`, so a
-    // bad index can't masquerade as a successful preselect (gridaco/grida#790).
-    // Validate against the path BEFORE entering, so refusal leaves zero trace
-    // (no transient session, no read-channel blip).
+    // Resolve + validate the optional initial sub-selection BEFORE entering, so
+    // (a) an out-of-range opts refuses the WHOLE call (the
+    // `VectorSubSelectionInput` contract, matching `set_vector_selection`) — a
+    // bad index can't masquerade as a successful preselect — and (b) entry can
+    // install it before the session's first mirror push, so the public read
+    // channel never sees a transient empty frame (gridaco/grida#790). Atomic
+    // entry is always "replace": the validated opts ARE the selection.
+    let initial: SubSelectionSnapshot | undefined;
     if (opts) {
       const source = this.editor_internal().doc.is_vector_edit_target(id);
       if (!source) return false;
       const model = PathModel.fromSvgPathD(source_to_session_d(source));
       if (!validate_subselection(opts, model)) return false;
+      initial = {
+        vertices: opts.vertices ?? [],
+        segments: opts.segments ?? [],
+        tangents: (opts.tangents ?? []).map((t) => [t[0], t[1]] as const),
+      };
     }
-    if (!this._do_enter_vector_edit(id)) return false;
-    // Apply the (now-validated) initial sub-selection as part of THIS entry —
-    // one history step, no intermediate empty-selection frame.
-    if (opts) this.apply_subselection_to_session(opts, "replace");
-    // Capture the post-opts selection so REDO of this entry restores it —
+    if (!this._do_enter_vector_edit(id, initial)) return false;
+    // Capture the installed selection so REDO of this entry restores it —
     // symmetric to how `exit_vector_edit`'s revert restores `final_selection`.
-    // (Empty when no opts, so the no-opts path keeps its old behavior.)
     const initial_selection = this.vector_edit!.snapshot_selection();
     // Apply succeeded — push a delta so undo can reverse it. Use
     // preview+set+commit (the surface seam exposes `preview()` only).
@@ -4194,7 +4197,9 @@ class DomSurface implements Surface {
     preview.set({
       providerId: "svg-editor",
       descriptor: { kind: "vector-mode-enter" },
-      apply: () => this.reenter_vector_session(node_id, initial_selection),
+      apply: () => {
+        this._do_enter_vector_edit(node_id, initial_selection);
+      },
       revert: () => {
         this._do_exit_vector_edit();
       },
@@ -4226,40 +4231,31 @@ class DomSurface implements Surface {
       apply: () => {
         this._do_exit_vector_edit();
       },
-      revert: () => this.reenter_vector_session(node_id, final_selection),
+      revert: () => {
+        this._do_enter_vector_edit(node_id, final_selection);
+      },
     });
     preview.commit();
   }
 
   /**
-   * Re-enter the vector session on `node_id` and reinstate a captured
-   * sub-selection. The shared tail of two history closures that must land
-   * back in the same path with the same anchors picked: the enter-delta's
-   * REDO (gridaco/grida#790's atomic entry) and the exit-delta's UNDO. No-op
-   * if re-entry fails.
-   *
-   * Indices may have drifted under collab/AI mutations; the HUD's `vectorOf`
-   * provider tolerates stale indices (chrome simply doesn't render for missing
-   * vertices), and the next user click rebuilds a valid selection.
-   */
-  private reenter_vector_session(
-    node_id: NodeId,
-    selection: SubSelectionSnapshot
-  ): void {
-    if (!this._do_enter_vector_edit(node_id)) return;
-    this.vector_edit?.restore_selection(selection);
-    this.sync_selection_mirror();
-    this.redraw();
-  }
-
-  /**
    * Unchecked enter — performs the mode flip + HUD wiring without
    * pushing to history. Called by {@link enter_vector_edit} (user-facing,
-   * which pushes the delta) and by the exit-delta's revert (history-
-   * driven re-entry on undo). Returns `false` if the node has no usable
-   * `d` attribute, leaving editor state untouched.
+   * which pushes the delta), by the enter-delta's redo, and by the
+   * exit-delta's revert (history-driven re-entry on undo). Returns `false`
+   * if the node has no usable `d` attribute, leaving editor state untouched.
+   *
+   * `initialSelection` installs a sub-selection BEFORE the first mirror push,
+   * so the session publishes its final state ONCE — atomic entry and undo/redo
+   * re-entry never leak a transient empty selection through the public read
+   * channel (gridaco/grida#790). Indices may have drifted under collab/AI
+   * mutation; the HUD's `vectorOf` provider tolerates stale ones (chrome just
+   * doesn't render missing vertices) and the next click rebuilds a valid set.
    */
-  private _do_enter_vector_edit(id: NodeId): boolean {
+  private _do_enter_vector_edit(
+    id: NodeId,
+    initialSelection?: SubSelectionSnapshot
+  ): boolean {
     if (this.vector_edit) return false;
     const internal = this.editor_internal();
     const doc = internal.doc;
@@ -4276,6 +4272,7 @@ class DomSurface implements Surface {
     // first gesture commit calls apply_session_d to project back.
     const session_d = source_to_session_d(source);
     this.vector_edit = new VectorEditSession(id, source, session_d);
+    if (initialSelection) this.vector_edit.restore_selection(initialSelection);
     this.editor.commands.set_mode("edit-content");
     this.sync_selection_mirror();
     this.sync_surface_selection();
@@ -4445,14 +4442,18 @@ class DomSurface implements Surface {
    */
   private sync_selection_mirror(): void {
     if (!this.vector_edit) return;
-    // The session reassigns (never mutates-in-place) its selection arrays, so
-    // sharing them by reference is safe — a held reference is a stable
-    // snapshot. Build one value for both sinks.
+    // Detach the published value from the session's live arrays. TS `readonly`
+    // is compile-time only, and the same value feeds the PUBLIC read channel —
+    // so a stray runtime mutation by a consumer must not be able to poison the
+    // session's own selection state. Copy all three tracks (one value, both
+    // sinks).
     const sel: VectorSubSelection = {
       node_id: this.vector_edit.node_id,
-      vertices: this.vector_edit.selected_vertices,
-      segments: this.vector_edit.selected_segments,
-      tangents: this.vector_edit.selected_tangents,
+      vertices: [...this.vector_edit.selected_vertices],
+      segments: [...this.vector_edit.selected_segments],
+      tangents: this.vector_edit.selected_tangents.map(
+        (t) => [t[0], t[1]] as const
+      ),
     };
     this.hud.setVectorSelection(sel);
     // Mirror to the editor's public read channel (gridaco/grida#790). Off the
@@ -4618,8 +4619,9 @@ class DomSurface implements Surface {
    * headlessly testable). Returns `false` (no mutation) when no session is
    * active, the input is out of range, or it resolves to the current
    * sub-selection. Syncs the mirror + redraws on change, but does NOT push a
-   * history step — callers wrap it (`apply_vector_subselection_command`) or
-   * fold it into a larger delta (atomic entry via `enter_vector_edit`).
+   * history step — the caller (`apply_vector_subselection_command`) wraps it in
+   * one. (Atomic entry installs its selection directly via
+   * `_do_enter_vector_edit`, not through here.)
    */
   private apply_subselection_to_session(
     input: VectorSubSelectionInput,
@@ -4649,6 +4651,11 @@ class DomSurface implements Surface {
     mode: SelectMode = "replace"
   ): boolean {
     if (!this.vector_edit) return false;
+    // Refuse mid-gesture: this records a history step, and landing it inside an
+    // open gesture bracket (a vector preview drag, or a HUD marquee/lasso)
+    // would break undo order — the same class of bug the keyboard path avoids
+    // by dropping non-Escape keys during a gesture.
+    if (this.active_preview || this.hud.gesture().kind !== "idle") return false;
     const before = this.vector_edit.snapshot_selection();
     if (!this.apply_subselection_to_session(input, mode)) return false;
     this.record_vector_selection_change(before, "set vector selection");

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -22,6 +22,7 @@ import {
   type HUDLine,
   type HUDRect,
   type Intent,
+  type SelectMode,
   type SurfaceEvent,
   type SurfaceResponse,
   type Modifiers,
@@ -96,6 +97,7 @@ import {
   source_to_session_d,
   vector_apply,
   vector_revert,
+  apply_subselection,
   type SubSelectionSnapshot,
 } from "./core/vector-edit";
 import type { RetypeRecord } from "./core/document";
@@ -106,6 +108,8 @@ import type {
   Rect,
   Tool,
   Vec2,
+  VectorSubSelection,
+  VectorSubSelectionInput,
 } from "./types";
 import { TOOL_CURSOR } from "./types";
 import { array_shallow_equal } from "./util/equal";
@@ -1080,8 +1084,18 @@ class DomSurface implements Surface {
     // Surface-side handlers for editor-registered drivers.
     const internal = editor._internal;
     this.editor_hover_internal = internal;
-    internal.set_content_edit_driver((id) => this.enter_content_edit(id));
+    internal.set_content_edit_driver((id, opts) =>
+      this.enter_content_edit(id, opts)
+    );
     this.teardown.push(() => internal.set_content_edit_driver(null));
+
+    // Programmatic vector sub-selection write (gridaco/grida#790). The
+    // session is surface-private, so `commands.set_vector_selection` reaches
+    // it only through this driver — symmetric to the content-edit driver.
+    internal.set_vector_subselect_driver((input, mode) =>
+      this.apply_vector_subselection_command(input, mode)
+    );
+    this.teardown.push(() => internal.set_vector_subselect_driver(null));
 
     // Arrow-key nudge: in vector content-edit, route to the path sub-
     // selection (vertices / segments / tangents) instead of leaking to a
@@ -3874,10 +3888,15 @@ class DomSurface implements Surface {
    * editor has already gated on text-OR-path eligibility; this method
    * routes on the actual tag.
    */
-  private enter_content_edit(id: NodeId): boolean {
+  private enter_content_edit(
+    id: NodeId,
+    opts?: VectorSubSelectionInput
+  ): boolean {
     if (this.text_edit || this.vector_edit) return false;
     const tag = this.tag_of(id);
     if (tag === "text" || tag === "tspan") {
+      // `opts` is a vector-only affordance — text content-edit has no
+      // sub-selection. Ignore it rather than refusing the entry.
       return this.enter_text_edit(id);
     }
     // Vector-edit: the doc-side `is_vector_edit_target` predicate is the
@@ -3888,7 +3907,7 @@ class DomSurface implements Surface {
     // eligibility change lands in one place. (`<image>` / `<use>` stay
     // ineligible there.)
     if (this.editor_internal().doc.is_vector_edit_target(id) !== null) {
-      return this.enter_vector_edit(id);
+      return this.enter_vector_edit(id, opts);
     }
     return false;
   }
@@ -4135,9 +4154,22 @@ class DomSurface implements Surface {
    * {@link _do_exit_vector_edit} helpers; the public wrappers below own
    * the history side, the unchecked helpers own the state mutation.
    */
-  private enter_vector_edit(id: NodeId): boolean {
+  private enter_vector_edit(
+    id: NodeId,
+    opts?: VectorSubSelectionInput
+  ): boolean {
     if (this.vector_edit) return false;
     if (!this._do_enter_vector_edit(id)) return false;
+    // Apply the optional initial sub-selection (gridaco/grida#790) as part of
+    // THIS entry — one history step, no intermediate empty-selection frame.
+    // `apply_subselection_to_session` self-validates against the live model;
+    // invalid opts are ignored and entry still succeeds with an empty
+    // selection (entry eligibility and sub-selection validity are separate).
+    if (opts) this.apply_subselection_to_session(opts, "replace");
+    // Capture the post-opts selection so REDO of this entry restores it —
+    // symmetric to how `exit_vector_edit`'s revert restores `final_selection`.
+    // (Empty when no opts, so the no-opts path keeps its old behavior.)
+    const initial_selection = this.vector_edit!.snapshot_selection();
     // Apply succeeded — push a delta so undo can reverse it. Use
     // preview+set+commit (the surface seam exposes `preview()` only).
     // Apply (= redo) re-runs the unchecked enter; revert undoes it.
@@ -4147,9 +4179,7 @@ class DomSurface implements Surface {
     preview.set({
       providerId: "svg-editor",
       descriptor: { kind: "vector-mode-enter" },
-      apply: () => {
-        this._do_enter_vector_edit(node_id);
-      },
+      apply: () => this.reenter_vector_session(node_id, initial_selection),
       revert: () => {
         this._do_exit_vector_edit();
       },
@@ -4181,20 +4211,30 @@ class DomSurface implements Surface {
       apply: () => {
         this._do_exit_vector_edit();
       },
-      revert: () => {
-        if (this._do_enter_vector_edit(node_id)) {
-          // Restore the sub-selection the user had when they left.
-          // Indices may have drifted under collab/AI mutations; the
-          // HUD's vectorOf provider tolerates stale indices (chrome
-          // simply doesn't render for missing vertices), and the next
-          // user click will rebuild a valid selection.
-          this.vector_edit?.restore_selection(final_selection);
-          this.sync_selection_mirror();
-          this.redraw();
-        }
-      },
+      revert: () => this.reenter_vector_session(node_id, final_selection),
     });
     preview.commit();
+  }
+
+  /**
+   * Re-enter the vector session on `node_id` and reinstate a captured
+   * sub-selection. The shared tail of two history closures that must land
+   * back in the same path with the same anchors picked: the enter-delta's
+   * REDO (gridaco/grida#790's atomic entry) and the exit-delta's UNDO. No-op
+   * if re-entry fails.
+   *
+   * Indices may have drifted under collab/AI mutations; the HUD's `vectorOf`
+   * provider tolerates stale indices (chrome simply doesn't render for missing
+   * vertices), and the next user click rebuilds a valid selection.
+   */
+  private reenter_vector_session(
+    node_id: NodeId,
+    selection: SubSelectionSnapshot
+  ): void {
+    if (!this._do_enter_vector_edit(node_id)) return;
+    this.vector_edit?.restore_selection(selection);
+    this.sync_selection_mirror();
+    this.redraw();
   }
 
   /**
@@ -4252,6 +4292,9 @@ class DomSurface implements Surface {
     // bypasses the per-gesture commit / cancel clears.
     this.point_snap_guide = undefined;
     this.hud.setVectorSelection(null);
+    // Clear the public read channel too (gridaco/grida#790): no session ⇒
+    // no sub-selection. Off the `version` stream.
+    this.editor_internal().push_vector_subselection(null);
     if (
       this.current_tool.type === "lasso" ||
       this.current_tool.type === "bend"
@@ -4387,12 +4430,19 @@ class DomSurface implements Surface {
    */
   private sync_selection_mirror(): void {
     if (!this.vector_edit) return;
-    this.hud.setVectorSelection({
+    // The session reassigns (never mutates-in-place) its selection arrays, so
+    // sharing them by reference is safe — a held reference is a stable
+    // snapshot. Build one value for both sinks.
+    const sel: VectorSubSelection = {
       node_id: this.vector_edit.node_id,
       vertices: this.vector_edit.selected_vertices,
       segments: this.vector_edit.selected_segments,
       tangents: this.vector_edit.selected_tangents,
-    });
+    };
+    this.hud.setVectorSelection(sel);
+    // Mirror to the editor's public read channel (gridaco/grida#790). Off the
+    // `version` stream — `subscribe_vector_subselection` consumers only.
+    this.editor_internal().push_vector_subselection(sel);
   }
 
   /**
@@ -4545,6 +4595,49 @@ class DomSurface implements Surface {
       },
     });
     preview.commit();
+  }
+
+  /**
+   * Apply a sub-selection write to the open vector session via the pure
+   * `apply_subselection` core (validation + mutation live there so they're
+   * headlessly testable). Returns `false` (no mutation) when no session is
+   * active, the input is out of range, or it resolves to the current
+   * sub-selection. Syncs the mirror + redraws on change, but does NOT push a
+   * history step — callers wrap it (`apply_vector_subselection_command`) or
+   * fold it into a larger delta (atomic entry via `enter_vector_edit`).
+   */
+  private apply_subselection_to_session(
+    input: VectorSubSelectionInput,
+    mode: SelectMode
+  ): boolean {
+    const ses = this.vector_edit;
+    if (!ses) return false;
+    const model = this.session_model();
+    if (!model) return false;
+    if (!apply_subselection(ses, model, input, mode)) return false;
+    this.sync_selection_mirror();
+    this.redraw();
+    return true;
+  }
+
+  /**
+   * Driver behind `commands.set_vector_selection` (gridaco/grida#790). Applies
+   * a programmatic sub-selection write as one undoable step — the same shape
+   * as a knob click (mutate, mirror, record). Returns `false` (no-op) when no
+   * vector session is active, the input is out of range, or it resolves to the
+   * current sub-selection.
+   *
+   * (see test/svg-editor-vector-subselection-api.md)
+   */
+  private apply_vector_subselection_command(
+    input: VectorSubSelectionInput,
+    mode: SelectMode = "replace"
+  ): boolean {
+    if (!this.vector_edit) return false;
+    const before = this.vector_edit.snapshot_selection();
+    if (!this.apply_subselection_to_session(input, mode)) return false;
+    this.record_vector_selection_change(before, "set vector selection");
+    return true;
   }
 
   /** Resolve the in-flight `PathModel` for the named node id when a

--- a/packages/grida-svg-editor/src/index.ts
+++ b/packages/grida-svg-editor/src/index.ts
@@ -49,6 +49,8 @@ export type {
   Tool,
   Unsubscribe,
   Vec2,
+  VectorSubSelection,
+  VectorSubSelectionInput,
 } from "./types";
 
 export { DEFAULT_STYLE, TOOL_CURSOR } from "./types";

--- a/packages/grida-svg-editor/src/types.ts
+++ b/packages/grida-svg-editor/src/types.ts
@@ -395,6 +395,48 @@ export type EditorState = {
 
 export type Unsubscribe = () => void;
 
+// ─── Vector sub-selection ────────────────────────────────────────────────────
+
+/**
+ * The current vertex / segment / tangent sub-selection inside a vector
+ * content-edit session. This is a **read** view — the outcome emitted on the
+ * transient `editor.subscribe_vector_subselection` channel and returned by
+ * `editor.vector_subselection()`. `null` when no vector content-edit session
+ * is active.
+ *
+ * Indices are ordinal positions into the path under edit — the same ordinals
+ * `PathModel` exposes (vertex 0 is the first authored vertex, etc.). A tangent
+ * ref is `[vertexIndex, 0 | 1]`: `0` = the tangent entering that vertex (`ta`),
+ * `1` = the tangent leaving it (`tb`).
+ *
+ * Kept off `EditorState` on purpose: it changes at pointer rate during marquee
+ * / lasso, so folding it into the `version` stream would re-render the whole
+ * app per knob. Subscribe to this channel instead (P4 — subscribe to outcomes).
+ */
+export type VectorSubSelection = {
+  readonly node_id: NodeId;
+  readonly vertices: ReadonlyArray<number>;
+  readonly segments: ReadonlyArray<number>;
+  readonly tangents: ReadonlyArray<readonly [number, 0 | 1]>;
+};
+
+/**
+ * Write triple for `commands.set_vector_selection(input, mode?)` and the
+ * atomic-entry form `enter_content_edit(id, input)`. Every track is optional.
+ * In `"replace"` mode an omitted track is treated as empty (cleared); in
+ * `"add"` / `"toggle"` mode an omitted track means "nothing to add/toggle on
+ * that track" (the existing sub-selection there is left intact).
+ *
+ * Indices follow the same ordinal convention as {@link VectorSubSelection}.
+ * Out-of-range indices or refs cause the whole call to refuse (no-op): a
+ * strict surface rejects wrong contents rather than silently mishandling them.
+ */
+export type VectorSubSelectionInput = {
+  readonly vertices?: ReadonlyArray<number>;
+  readonly segments?: ReadonlyArray<number>;
+  readonly tangents?: ReadonlyArray<readonly [number, 0 | 1]>;
+};
+
 // ─── Commands ──────────────────────────────────────────────────────────────
 
 export type ReorderDirection =

--- a/test/svg-editor-vector-subselection-api.md
+++ b/test/svg-editor-vector-subselection-api.md
@@ -1,0 +1,81 @@
+---
+id: TC-SVGEDITOR-VECTOR-002
+title: Programmatic vector sub-selection (set + read) in path-edit mode
+module: svg-editor
+area: vector
+tags: [vector, content-edit, sub-selection, api, history, undo, observation]
+status: untested
+severity: medium
+date: 2026-06-19
+updated: 2026-06-19
+automatable: false
+covered_by:
+  - packages/grida-svg-editor/__tests__/vector-subselection.test.ts
+---
+
+## Behavior
+
+A host can programmatically drive the **vertex / segment / tangent
+sub-selection** of a path open in vector content-edit, and observe it — the
+write + read halves of [#790](https://github.com/gridaco/grida/issues/790).
+
+- **Write, mid-session:** `editor.commands.set_vector_selection(input, mode?)`
+  applies a sub-selection while a vector session is open. `mode` defaults to
+  `"replace"` (the input becomes the whole sub-selection; omitted tracks
+  cleared); `"add"` / `"toggle"` fold into the existing selection per track. It
+  is **one undoable step**, exactly like a knob click.
+- **Write, atomic entry:** `editor.enter_content_edit(id, { vertices, … })`
+  opens the path AND applies the initial sub-selection as a single transition —
+  no intermediate "open with nothing selected" frame, one undo step.
+- **Read:** `editor.vector_subselection()` returns the current selection (or
+  `null` outside a session); `editor.subscribe_vector_subselection(fn)` fires on
+  every change and on enter/exit. The read channel is **off `state.version`**.
+- **Strict refusal:** an out-of-range index/ref refuses the whole call (no-op,
+  returns `false`) rather than selecting a phantom vertex.
+
+The pure validation + mutation core and the editor-side delegation/read wiring
+are unit-covered (`covered_by`). This TC covers what only manifests in a mounted
+editor: that the HUD actually renders the programmatically-set anchors as
+selected, that undo restores the prior sub-selection visibly, and that the
+atomic-entry path shows no unselected flash.
+
+## Steps
+
+1. Mount the editor on a document containing
+   `<path id="p" d="M0,0 L40,0 L40,40 L0,40 Z"/>` and select the path.
+2. **Atomic entry.** Call
+   `editor.enter_content_edit(p, { vertices: [1] })`.
+   - Expected: the path enters content-edit with vertex **1** already drawn as
+     selected (filled knob), no flash of an all-unselected overlay first.
+   - Expected: `editor.vector_subselection()` returns
+     `{ node_id: p, vertices: [1], segments: [], tangents: [] }`.
+3. **Mid-session replace.** Call
+   `editor.commands.set_vector_selection({ vertices: [0, 2] })`.
+   - Expected: returns `true`; the HUD now shows vertices 0 and 2 selected, 1
+     deselected; a `subscribe_vector_subselection` listener fired with the new
+     value; `state.version` did **not** change as a result of this read channel.
+4. **Add mode.** Call
+   `editor.commands.set_vector_selection({ vertices: [3] }, "add")`.
+   - Expected: vertices 0, 2, 3 selected (folded in, not replaced).
+5. **Undo.** Press Cmd/Ctrl+Z once.
+   - Expected: a single undo restores the step-3 sub-selection (vertices 0, 2),
+     visible in the HUD — selection is history-coherent, like a click.
+6. **Out-of-range refusal.** Call
+   `editor.commands.set_vector_selection({ vertices: [99] })`.
+   - Expected: returns `false`; the HUD selection is unchanged (no phantom
+     knob, no exception).
+7. **No session.** Exit content-edit (Escape), then call
+   `editor.commands.set_vector_selection({ vertices: [0] })`.
+   - Expected: returns `false` (no-op); `editor.vector_subselection()` is
+     `null`; a subscriber fired with `null` on the Escape exit.
+
+## Notes
+
+- Paradigm: commands-only (the editor exposes a write command + a read view;
+  there is no construction-time `initialState`). The document is the only
+  declarative extern state — interaction state is reached by replaying commands.
+- The session is surface-owned; the headless command reaches it through the
+  `set_vector_subselect_driver` seam (symmetric to the content-edit driver), so
+  with no surface attached the command is a clean no-op.
+- Read channel parity: like `subscribe_pick` / surface-hover, it never bumps
+  `state.version` (P4) — it changes at pointer rate during marquee/lasso.

--- a/test/svg-editor-vector-subselection-api.md
+++ b/test/svg-editor-vector-subselection-api.md
@@ -60,14 +60,26 @@ atomic-entry path shows no unselected flash.
 5. **Undo.** Press Cmd/Ctrl+Z once.
    - Expected: a single undo restores the step-3 sub-selection (vertices 0, 2),
      visible in the HUD — selection is history-coherent, like a click.
-6. **Out-of-range refusal.** Call
+6. **Out-of-range refusal (mid-session).** Call
    `editor.commands.set_vector_selection({ vertices: [99] })`.
    - Expected: returns `false`; the HUD selection is unchanged (no phantom
      knob, no exception).
-7. **No session.** Exit content-edit (Escape), then call
+7. **Out-of-range refusal (atomic entry).** From `select` mode, call
+   `editor.enter_content_edit(p, { vertices: [99] })`.
+   - Expected: returns `false`; the path does **not** enter content-edit (no
+     vertices shown), and `editor.vector_subselection()` stays `null`. A bad
+     index refuses the whole call — it cannot masquerade as a successful
+     preselect or open the path with an empty selection.
+8. **No session.** Exit content-edit (Escape), then call
    `editor.commands.set_vector_selection({ vertices: [0] })`.
    - Expected: returns `false` (no-op); `editor.vector_subselection()` is
      `null`; a subscriber fired with `null` on the Escape exit.
+9. **Detach / unmount while editing.** Re-enter path-edit (step 2), then unmount
+   the tile / call `handle.detach()`.
+   - Expected: a `subscribe_vector_subselection` listener on the (still-alive)
+     editor receives `null`, and `editor.vector_subselection()` returns `null` —
+     surface disposal ends the session, so the read channel must drop, not go
+     stale.
 
 ## Notes
 


### PR DESCRIPTION
Closes #790

## Problem

A host could put the editor into vector content-edit on a `<path>` (`enter_content_edit(id)`), but every vertex knob opened **unselected** and there was no public way to pre-select one or several. The sub-selection lived entirely in the surface-private `VectorEditSession` — neither writable nor readable through the public surface. The only workaround was synthesizing a `pointerdown` at the knob's screen coordinate (fragile).

## Approach — commands-only (Paradigm B)

The document is the only declarative extern state; interaction state is reached by replaying commands (no construction-time `initialState`). New public surface:

- **`commands.set_vector_selection(input, mode?)`** — full-triple write (`{ vertices?, segments?, tangents? }`), mid-session, **one undoable step** like a knob click. `mode` defaults to `"replace"`; `"add"` / `"toggle"` fold into the existing selection per track.
- **`enter_content_edit(id, opts?)`** — atomic entry: opens the path with the initial sub-selection in **one transition** (no unselected flash, one history step).
- **`editor.vector_subselection()` + `editor.subscribe_vector_subselection(fn)`** — designed read view on a transient channel, kept **off `state.version`** (P4 — it changes at pointer rate during marquee/lasso).
- New public types `VectorSubSelection` / `VectorSubSelectionInput`.

## Design notes for reviewers

- **Strict refusal:** an out-of-range index / tangent ref refuses the whole call (`false`, no-op) — a strict surface rejects wrong contents rather than selecting a phantom vertex.
- **Surface-owned session:** the write reaches the surface-private session through a `set_vector_subselect_driver` seam, symmetric to the existing `content_edit_driver` (not the keymap registry — keyboard isn't the ask). The read mirror pushes via `push_vector_subselection`, matching the existing pick / surface-hover channels.
- **Core-first testing:** validation + mutation live in a pure `core/vector-edit/subselection.ts` (`validate_subselection` / `apply_subselection`) so the load-bearing logic is headlessly unit-testable against a real `VectorEditSession` + `PathModel` — the DOM surface can't mount in jsdom.
- The enter-delta redo and exit-delta undo share one `reenter_vector_session` helper (no duplicated re-entry logic).
- `enter_content_edit`'s `opts` is ignored for text targets (vector-only affordance); the no-opts path is byte-identical to prior behavior.

## Demo

The `/svg` landing playground's **heart** tile now opens straight into path-edit with all anchors pre-selected via the atomic-entry form — the exact use case the issue cites. Vertices are derived from the live `PathModel` (no hardcoded indices), resolved at the page layer (host convenience, not SDK).

## Tests

- 20 new tests (`__tests__/vector-subselection.test.ts`): pure validate/apply + replace/add/toggle modes + strict refusal; command delegation; `opts` threading through `enter_content_edit`; read channel fires + no `state.version` bump.
- Updated the `_internal` seam-contract guard for the two new bridge methods.
- Manual case `TC-SVGEDITOR-VECTOR-002` for the surface-integrated path (jsdom can't mount the surface).
- Full suite green (1476 tests), `tsc --noEmit` clean, `oxlint` clean, package builds.

## Docs

README: `set_vector_selection` added to the closed Commands list; `enter_content_edit(id, opts?)` documented; new "Observation — vector sub-selection" section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vector sub-selection for path editing (vertices, segments, tangents), including programmatic updates during active sessions.
  * Added observation APIs to read the current vector sub-selection and subscribe to changes; the value clears on exit.
  * Enabled fixture-driven initial pre-selection when entering path-edit mode for an atomic “enter with selection” experience.
* **Documentation**
  * Updated the vector sub-selection API reference and extended related command signatures.
* **Tests**
  * Added coverage for strict validation, refusal/no-op behavior, subscription semantics, and undo/redo correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->