### PR TITLE
fix(www): downloads page dark mode + image CLS

### DIFF
--- a/editor/app/(www)/(downloads)/downloads/page.tsx
+++ b/editor/app/(www)/(downloads)/downloads/page.tsx
@@ -31,7 +31,7 @@ export default async function DownloadsPage() {
       <main className="container items-center">
         <section className="container bg-background max-w-xl lg:max-w-7xl mx-auto py-8 px-12 lg:px-16 lg:py-10 xl:py-2 text-left border rounded-lg flex flex-col-reverse lg:flex-row items-center justify-between overflow-hidden">
           <div className="max-w-lg text-center lg:text-left">
-            <h1 className="text-black text-4xl md:text-6xl font-bold mb-16 lg:mb-24">
+            <h1 className="text-4xl md:text-6xl font-bold mb-16 lg:mb-24">
               Download <br />
               Grida for Desktop
             </h1>
@@ -56,10 +56,12 @@ export default async function DownloadsPage() {
           </div>
 
           <div className="w-full h-full md:w-1/2 flex justify-center md:justify-end mt-10 md:mt-0">
+            {/* width/height match the artwork's true aspect ratio (2645x2264) so
+                the reserved box equals the loaded box — no layout shift on load. */}
             <Image
               src="/images/download.png"
               width={600}
-              height={400}
+              height={513}
               alt="download"
               className="object-contain hover:scale-110 transition-all duration-300"
             />


### PR DESCRIPTION
## What

Fixes the **Downloads** page (`/downloads`) in dark mode — it had never been QA-ed there.

- **Heading was invisible in dark mode.** The hero `<h1>` hardcoded `text-black`, which rendered black-on-black against the dark `bg-background`. Removed the override so it inherits the theme `foreground` (set on `body` in `@app/ui` globals), which renders dark-on-light and light-on-dark correctly. No `dark:` variant needed.
- **Card height shifted as the artwork loaded (CLS).** The `<Image>` declared `height={400}`, but the artwork's real ratio is `2645x2264` (about `600x513`). The browser reserved a 3:2 box, then grew to ~1.17:1 once the image loaded, jumping the card height. Corrected the declared height to `513` so the reserved box equals the loaded box — stable height from first paint.

## Why

Dark mode was broken on a public landing page: the main heading disappeared and the hero card visibly jumped on load.

## Notes for reviewer

- Two-line diff in a single file: `editor/app/(www)/(downloads)/downloads/page.tsx`.
- We considered backing the (white-background) install artwork with a light gradient so its dark labels stay legible in dark mode, but decided against shipping a custom gradient. The artwork renders as a transparent PNG over the dark theme as-is.
- Verified the heading color in both themes in the local dev preview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated downloads page hero heading styling and refined artwork image sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->