### PR TITLE
perf: wrap auth.uid() in the user_project_access_state policy (per-statement)

### DIFF
--- a/supabase/schemas/project.sql
+++ b/supabase/schemas/project.sql
@@ -88,7 +88,7 @@ create table public.user_project_access_state (
 ) TABLESPACE pg_default;
 
 ALTER TABLE public.user_project_access_state ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "Allow all based on user_id" ON public.user_project_access_state USING ((user_id = auth.uid())) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Allow all based on user_id" ON public.user_project_access_state USING ((user_id = (select auth.uid()))) WITH CHECK (user_id = (select auth.uid()));
 
 
 


### PR DESCRIPTION
Addresses item 2 of #873.

The `user_project_access_state` policy compared `user_id = auth.uid()` directly, so Postgres re-evaluates `auth.uid()` per candidate row. This wraps it in a scalar subquery so it's evaluated once per statement (an InitPlan) — the [documented Supabase RLS perf pattern](https://supabase.com/docs/guides/troubleshooting/rls-performance-and-best-practices-Z5Jjwv). Predicate-equivalent (a scalar subquery returns the same single value); one line, in the declarative schema source.

Scoped deliberately to this one safe change. The other two items from #873 I left for your judgment rather than PR blindly:
- **FORCE RLS** — interacts with the owner-bypass your `SECURITY DEFINER` functions rely on (FORCE subjects the owner to RLS), so it's a call only you can make safely.
- **`search_path` consistency** — needs a per-function check that each body fully-qualifies its references.

Found with [pgrls](https://github.com/pgrls/pgrls) (disclosure: I maintain it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user access validation in the database layer to ensure proper permission checks are applied when users access their project data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->