### PR TITLE
refactor(cmath): consolidate triplicated ResizeDirection + add cardinalComponents

### DIFF
--- a/packages/grida-canvas-hud/event/cursor.ts
+++ b/packages/grida-canvas-hud/event/cursor.ts
@@ -1,5 +1,9 @@
-/** 8 cardinal/diagonal resize directions. */
-export type ResizeDirection = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
+import type cmath from "@grida/cmath";
+
+/** 8 cardinal/diagonal resize directions. Aliased from the cmath single
+ *  source of truth (`cmath.compass.ResizeDirection`); re-exported here so
+ *  existing consumers keep their import path. */
+export type ResizeDirection = cmath.compass.ResizeDirection;
 
 /** 4 corner positions for rotation handles. */
 export type RotationCorner = "nw" | "ne" | "se" | "sw";

--- a/packages/grida-canvas-hud/event/gesture.ts
+++ b/packages/grida-canvas-hud/event/gesture.ts
@@ -485,10 +485,12 @@ function applyResizeRect(
   // origin so the center is preserved. `k === 1` reproduces the legacy
   // opposite-anchored math exactly.
   const k = fromCenter ? 2 : 1;
-  const hasN = direction === "n" || direction === "ne" || direction === "nw";
-  const hasS = direction === "s" || direction === "se" || direction === "sw";
-  const hasE = direction === "e" || direction === "ne" || direction === "se";
-  const hasW = direction === "w" || direction === "nw" || direction === "sw";
+  const {
+    north: hasN,
+    south: hasS,
+    east: hasE,
+    west: hasW,
+  } = cmath.compass.cardinalComponents(direction);
 
   if (hasE) {
     width += k * dx;

--- a/packages/grida-canvas-hud/primitives/cursor.ts
+++ b/packages/grida-canvas-hud/primitives/cursor.ts
@@ -1,16 +1,21 @@
 // Cursor icons — value types and pure helpers.
 //
-// Bedrock primitives. Self-contained: no imports beyond the standard
-// library. `CursorIcon` is the logical name a `HUDObject.cursor` field
-// carries; rendering to a CSS `cursor` string (or to a custom SVG
-// renderer) is a host concern wired by the deferred orchestrator.
+// Bedrock primitives: the only external dependency permitted is the
+// `@grida/cmath` type vocabulary (per the `primitives/bedrock.ts` layering
+// contract, enforced by `__tests__/api/import-graph.test.ts`). `CursorIcon`
+// is the logical name a `HUDObject.cursor` field carries; rendering to a CSS
+// `cursor` string (or to a custom SVG renderer) is a host concern wired by
+// the deferred orchestrator.
 //
 // Mirrors `event/cursor.ts`; the legacy file remains in place until the
 // orchestrator follow-up dissolves it. While both files exist, this
 // copy is the canonical bedrock form.
 
-/** 8 cardinal/diagonal resize directions. */
-export type ResizeDirection = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
+import type cmath from "@grida/cmath";
+
+/** 8 cardinal/diagonal resize directions. Aliased from the cmath single
+ *  source of truth (`cmath.compass.ResizeDirection`). */
+export type ResizeDirection = cmath.compass.ResizeDirection;
 
 /** 4 corner positions for rotation handles. */
 export type RotationCorner = "nw" | "ne" | "se" | "sw";

--- a/packages/grida-cmath/__tests__/cmath.compass.test.ts
+++ b/packages/grida-cmath/__tests__/cmath.compass.test.ts
@@ -1,0 +1,75 @@
+import cmath from "..";
+
+describe("cmath.compass.cardinalComponents", () => {
+  it("decomposes orthogonal directions into a single component", () => {
+    expect(cmath.compass.cardinalComponents("n")).toEqual({
+      north: true,
+      south: false,
+      east: false,
+      west: false,
+    });
+    expect(cmath.compass.cardinalComponents("s")).toEqual({
+      north: false,
+      south: true,
+      east: false,
+      west: false,
+    });
+    expect(cmath.compass.cardinalComponents("e")).toEqual({
+      north: false,
+      south: false,
+      east: true,
+      west: false,
+    });
+    expect(cmath.compass.cardinalComponents("w")).toEqual({
+      north: false,
+      south: false,
+      east: false,
+      west: true,
+    });
+  });
+
+  it("decomposes diagonal directions into two components", () => {
+    expect(cmath.compass.cardinalComponents("ne")).toEqual({
+      north: true,
+      south: false,
+      east: true,
+      west: false,
+    });
+    expect(cmath.compass.cardinalComponents("se")).toEqual({
+      north: false,
+      south: true,
+      east: true,
+      west: false,
+    });
+    expect(cmath.compass.cardinalComponents("sw")).toEqual({
+      north: false,
+      south: true,
+      east: false,
+      west: true,
+    });
+    expect(cmath.compass.cardinalComponents("nw")).toEqual({
+      north: true,
+      south: false,
+      east: false,
+      west: true,
+    });
+  });
+
+  it("never reports opposite components together", () => {
+    const dirs: cmath.compass.ResizeDirection[] = [
+      "n",
+      "e",
+      "s",
+      "w",
+      "ne",
+      "se",
+      "sw",
+      "nw",
+    ];
+    for (const dir of dirs) {
+      const c = cmath.compass.cardinalComponents(dir);
+      expect(c.north && c.south).toBe(false);
+      expect(c.east && c.west).toBe(false);
+    }
+  });
+});

--- a/packages/grida-cmath/index.ts
+++ b/packages/grida-cmath/index.ts
@@ -1361,6 +1361,48 @@ namespace cmath {
           return "left";
       }
     }
+
+    /**
+     * The 8 cardinal/diagonal directions of a resize handle.
+     *
+     * Structurally identical to {@link CardinalDirection} — this alias is
+     * the single source of truth for the resize-handle direction union that
+     * `@grida/hud` and `@grida/svg-editor` previously each re-declared. Named
+     * for the resize-handle context at the call sites.
+     */
+    export type ResizeDirection = CardinalDirection;
+
+    /**
+     * Decompose a cardinal direction into its N/S/E/W membership.
+     *
+     * A diagonal belongs to two components (`"ne"` → north + east); an
+     * orthogonal direction to one. This is the shared primitive behind
+     * resize-handle math — the HUD's preview rect and svg-editor's
+     * direction mask both build on it instead of re-deriving the four
+     * boolean ORs.
+     *
+     * Derived from {@link cardinal_direction_vector} so the direction set
+     * has a single source of truth: the unit vector's sign *is* the axis
+     * membership (`x > 0` → east, `y < 0` → north).
+     *
+     * @example
+     * cmath.compass.cardinalComponents("ne");
+     * // { north: true, south: false, east: true, west: false }
+     */
+    export function cardinalComponents(dir: CardinalDirection): {
+      north: boolean;
+      south: boolean;
+      east: boolean;
+      west: boolean;
+    } {
+      const [x, y] = cardinal_direction_vector[dir];
+      return {
+        north: y < 0,
+        south: y > 0,
+        east: x > 0,
+        west: x < 0,
+      };
+    }
   }
 
   export namespace rect {

--- a/packages/grida-svg-editor/src/core/resize-capability.ts
+++ b/packages/grida-svg-editor/src/core/resize-capability.ts
@@ -9,6 +9,7 @@
 // Editor-agnostic — no document, DOM, or editor type. Operates on the
 // `ResizeBaseline` already captured by `intents.ts`.
 
+import cmath from "@grida/cmath";
 import type { Rect, Vec2 } from "../types";
 import type {
   ResizeBaseline,
@@ -65,10 +66,12 @@ export type EffectiveResize = {
 
 export namespace resize_capability {
   export function direction_mask(dir: ResizeDirection): DirectionMask {
-    const has_n = dir === "n" || dir === "ne" || dir === "nw";
-    const has_s = dir === "s" || dir === "se" || dir === "sw";
-    const has_e = dir === "e" || dir === "ne" || dir === "se";
-    const has_w = dir === "w" || dir === "nw" || dir === "sw";
+    const {
+      north: has_n,
+      south: has_s,
+      east: has_e,
+      west: has_w,
+    } = cmath.compass.cardinalComponents(dir);
     return {
       affects_x: has_e || has_w,
       affects_y: has_n || has_s,

--- a/packages/grida-svg-editor/src/core/resize-pipeline/orchestrator.ts
+++ b/packages/grida-svg-editor/src/core/resize-pipeline/orchestrator.ts
@@ -42,9 +42,11 @@ function sign_adjust(
   dx_world: number,
   dy_world: number
 ): { dx: number; dy: number } {
-  const dx = dir === "w" || dir === "nw" || dir === "sw" ? -dx_world : dx_world;
-  const dy = dir === "n" || dir === "ne" || dir === "nw" ? -dy_world : dy_world;
-  return { dx, dy };
+  const { north, west } = cmath.compass.cardinalComponents(dir);
+  return {
+    dx: west ? -dx_world : dx_world,
+    dy: north ? -dy_world : dy_world,
+  };
 }
 
 /** Stable, order-independent key for an id set — used by `is_active_for`

--- a/packages/grida-svg-editor/src/core/resize-pipeline/resize-pipeline.ts
+++ b/packages/grida-svg-editor/src/core/resize-pipeline/resize-pipeline.ts
@@ -37,7 +37,10 @@ import type { SnapSession } from "../snap";
 
 const XLINK_NS = "http://www.w3.org/1999/xlink";
 
-export type ResizeDirection = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+/** The 8 resize-handle directions — aliased from the cmath single source
+ *  of truth (`cmath.compass.ResizeDirection`). Re-exported here so existing
+ *  `resize-pipeline` consumers keep their import path. */
+export type ResizeDirection = cmath.compass.ResizeDirection;
 
 export type ResizeAttrs =
   | { kind: "rect"; x: number; y: number; w: number; h: number }


### PR DESCRIPTION
Closes #860.

## What

`ResizeDirection` (the 8-member `"n" | "ne" | … | "nw"` union) was declared **independently in three places** with no shared source of truth, and the **cardinal decomposition** into N/S/E/W membership was duplicated across packages. This consolidates both into `@grida/cmath`, which already owns the direction vocabulary (`CardinalDirection`, `cardinal_direction_vector`, `invertDirection`, …) and which both consumers already depend on.

## Changes

**`@grida/cmath` (`cmath.compass`)**
- Add `ResizeDirection` — an alias of the existing `CardinalDirection`, the single source of truth, named for the resize-handle context at call sites.
- Add `cardinalComponents(dir) → { north, south, east, west }`. Derived from `cardinal_direction_vector` (the unit vector's sign *is* the axis membership), so the direction set stays single-sourced.

**Consumers re-export / build on the cmath primitives** (the public `ResizeDirection` name is unchanged everywhere, so no downstream import changed):
- `@grida/hud` `event/cursor.ts` + `primitives/cursor.ts` — declarations → re-export of `cmath.compass.ResizeDirection`.
- `@grida/hud` `applyResizeRect` (`event/gesture.ts`) — uses the `cardinalComponents` booleans directly.
- `@grida/svg-editor` `resize-pipeline.ts` — declaration → re-export.
- `@grida/svg-editor` `direction_mask` (`resize-capability.ts`) — derives its richer `{ affects_x, affects_y, x_edge, y_edge }` mask from `cardinalComponents`.
- `@grida/svg-editor` `sign_adjust` (`resize-pipeline/orchestrator.ts`) — 4th copy of the decomposition in the same folder, also migrated.

## Reviewer notes

- **Bedrock layering:** `primitives/cursor.ts` is a bedrock primitive. Its new `@grida/cmath` import is **type-only** and explicitly permitted by the layering contract in `primitives/bedrock.ts`, enforced by `__tests__/api/import-graph.test.ts` (which allows `@grida/cmath` as the sole external). The file's stale "no imports beyond the standard library" comment was corrected to reflect the real contract.
- **Type-preserving:** every site keeps the identical 8-member union, just sourced from one place.
- **Follow-up (out of scope):** two more copies of the same decomposition live in the main canvas reducers (`editor/grida-canvas/.../scale.ts`, `.../snap-resize.ts`); left for a separate change to keep this PR scoped to the packages.

## Tests

- New `packages/grida-cmath/__tests__/cmath.compass.test.ts` covering `cardinalComponents` across all 8 directions + the opposite-components invariant.
- Full suites green: cmath 580, `@grida/hud` 597, `@grida/svg-editor` 1476. Typecheck clean on all three packages; oxlint + oxfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated resize direction type definitions across canvas and editor components by centralizing them in a shared utilities library, improving code maintainability and consistency without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->