### PR TITLE
chore(refig): add changeset to release #867 render-fidelity fix

### DIFF
--- a/.changeset/refig-figma-rest-render-fidelity.md
+++ b/.changeset/refig-figma-rest-render-fidelity.md
@@ -1,0 +1,12 @@
+---
+"@grida/refig": patch
+---
+
+Fix Figma REST API render fidelity: layer opacity, image `CROP` scale mode,
+gradient transform flip, image sampling quality, and text line-height (#867).
+
+The opacity / sampling / line-height fixes live in the Rust painter
+(`crates/grida`) and reach `@grida/refig` only through a rebuilt
+`@grida/canvas-wasm`. `0.91.0-canary.21` and earlier predate #867 and do **not**
+contain them — this release must be paired with a `canvas-wasm` canary built
+_after_ #867. See the PR for the required release order.


### PR DESCRIPTION
## What

Adds the missing changeset for **@grida/refig** so the render-fidelity fixes from gridaco/grida#867 can ship to npm. Bumps `@grida/refig` `0.0.5 → 0.0.6` (patch) on the next `changeset version`.

This PR adds **only** the changeset file — no version bump or dependency repin (those are release-time steps, kept out so the publish smoke test stays green in CI).

## Why

gridaco/grida#867 *"fix(refig): Figma REST render fidelity (opacity, image CROP, gradient flip, sampling, line-height)"* merged into `main` on 2026-06-21 (`5b96cdb`), but it was never released:

- **@grida/refig** — npm `latest` is still `0.0.5` (published 2026-04-04, *before* the merge). `main` still says `0.0.5`. No changeset was added in gridaco/grida#867.
- **@grida/canvas-wasm** — latest canary is `0.91.0-canary.21` (2026-04-20), also *before* the merge.

Both packages have had no publish since April 2026, so npm consumers of `@grida/refig` are missing the entire gridaco/grida#867 fix. As an outside contributor I can't run the publishes myself — this PR sets up the changeset and documents the release order so a maintainer can take it the rest of the way. 🙏

## Important: release order (the painter fixes need a wasm rebuild first)

The opacity / image-sampling / line-height fixes live in the **Rust painter** (`crates/grida/src/painter/{image,paint}.rs`, `crates/grida/src/text/text_style.rs`). `@grida/canvas-wasm` compiles `crates/grida`, so those fixes reach `@grida/refig` **only through a rebuilt + republished wasm**. `0.91.0-canary.21` and earlier predate gridaco/grida#867 and do **not** contain them. refig currently pins `@grida/canvas-wasm@0.91.0-canary.17`.

Suggested order for whoever has npm publish rights:

1. **Get gridaco/grida#867 into the wasm-build source.** The real `publish-canvas-wasm` workflow lives on the `canary` branch, and `canary` does **not** yet contain gridaco/grida#867 (its `crates/grida` painter is ~224 lines behind `main`). Either merge `main → canary`, or build wasm locally from `main`.
2. **Rebuild + republish `@grida/canvas-wasm`** as a new canary (e.g. `0.91.0-canary.22`) — `just build canvas wasm`, then dispatch `publish-canvas-wasm` (tag `canary`). This is the step that actually ships the Rust painter fixes.
3. **Repin** `@grida/refig` → `@grida/canvas-wasm@0.91.0-canary.22` (done after step 2 so the smoke test can install it).
4. **Version + publish refig** — `changeset version` (→ `0.0.6` + changelog), build, run `__tests__/refig.cli.smoke.test.ts`, then publish per `packages/grida-canvas-sdk-render-figma/AGENTS.md` (manual prepack/postpack flow).

## Scope notes

- **@grida/canvas-wasm** is intentionally left out of the changeset — it's on a manual `-canary.N` track, and a changeset would bump it to a stable `0.91.x`/`0.92.0` and break that flow. The repin in step 3 is manual.
- **@grida/io-figma** (private, unpublished, no `version` field) is bundled into refig at build time, so its gridaco/grida#867 changes ship via the refig publish — no separate changeset entry.

## Ask

Could a maintainer with npm publish rights for `@grida/canvas-wasm` and `@grida/refig` run the wasm rebuild + the two publishes above? I'm happy to do the repin / `changeset version` commits if that helps — just can't run the publishes myself. Thank you!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering fidelity issues with layer opacity, image CROP scale modes, gradient transforms, image sampling quality, and text line-height in Figma REST API exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->