### PR TITLE
feat(svg-editor): accept image insertions via resolvable href (#885)

### DIFF
--- a/docs/wg/feat-svg-editor/image-insertion.md
+++ b/docs/wg/feat-svg-editor/image-insertion.md
@@ -1,0 +1,383 @@
+---
+title: "Image insertion — resolvable href, host-owned I/O"
+description: "FRD for inserting <image> elements into the SVG editor. The editor accepts an image insertion at a point given a resolvable href and host-supplied intrinsic size; turning a local file into a usable URL, and loading bytes to learn a natural size, are host-owned I/O. Specifies the insertion contract, the responsibility boundary, drop/paste transport ownership, href authoring, and the P1 round-trip guarantee for the inserted element."
+keywords:
+  - svg
+  - svg-editor
+  - image
+  - insertion
+  - href
+  - data-uri
+  - drop
+  - paste
+tags:
+  - internal
+  - svg
+  - wg
+  - images
+format: md
+---
+
+# Image insertion — resolvable href, host-owned I/O
+
+**Status:** Proposed — v1 design. The insertion contract (a designed
+image-insertion command, host-supplied intrinsic size, SVG 2 `href`
+authoring) is specified here for implementation; the named deferrals
+(§ Out of scope) remain open. Written so a second implementer could
+honor the contract without reading the current implementation.
+
+This document specifies how an `<image>` element is inserted into an
+open document: what the editor accepts, what it refuses, who resolves a
+local file or a bare URL into something insertable, and what survives the
+round-trip. It is a sibling of [`clipboard.md`](./clipboard.md) — both
+divide a transport problem along the same seam, and both inherit the
+editor's foundational stance that the SVG file is sovereign.
+
+## Thesis: the editor inserts a reference, never reads a file
+
+`<image>` is already a first-class element in the editor — existing
+`<image>` nodes are selected, translated, resized, grouped, and
+round-tripped today. The single missing capability is **insertion**: a
+designed path to add a new `<image>` to the document.
+
+The defining decision is where the responsibility line falls:
+
+> **The editor accepts an image insertion at a point given a _resolvable_
+> href. Turning a local file into a usable URL — and loading bytes to
+> learn a natural size — is host-owned I/O, not the editor's job.**
+
+A **resolvable href** is one the rendering context can already fetch: a
+remote URL, a `data:` URI, or any URL the host serves. Given one, the
+editor places the element, sizes it, and guarantees the round-trip.
+Everything that produces a resolvable href from something that is _not_
+one — a dropped `File`, a pasted `image/*` blob, a path on disk — is the
+host's concern, because it is file I/O, and file I/O is a host-owned seam
+(P2). The editor never reaches into the local filesystem, never reads a
+`File`, never decodes bytes.
+
+This is the same cut [`clipboard.md`](./clipboard.md) makes: _what the
+payload is_ is core; _how text reaches the OS clipboard_ is the host's.
+Here: _placing and authoring the `<image>`_ is core; _producing a
+resolvable href, and measuring it_ is the host's.
+
+The cut is not arbitrary. The editor core is headless by construction —
+it owns the document model, accepts commands, and emits state, but
+imports no rendering context, no window, no image decoder, no network.
+"Resolve this href to pixels and tell me its natural size" is precisely
+the work the core _cannot_ do without an I/O capability it does not have.
+The host has that capability already: it had to, to turn the user's
+dropped file into a URL in the first place.
+
+## Vocabulary
+
+- **Resolvable href** — a reference the rendering context can fetch as-is:
+  a remote URL, a `data:` URI, or a host-served URL. The unit the editor
+  accepts.
+- **Intrinsic size** — the natural width and height an image declares in
+  its own bytes (a raster's pixel dimensions; an SVG image's viewport).
+  Knowable only by loading the bytes — an I/O act.
+- **Placement point** — a document-space coordinate at which the inserted
+  image is positioned. The transport's contribution to insertion.
+- **Resolution (file → href)** — the host act of turning a local `File`
+  or blob into a resolvable href (object URL, `data:` URI, or an upload
+  to a served URL). Not the editor's act.
+
+## The responsibility boundary
+
+Two questions hide inside "insert this image," and they belong to
+different owners.
+
+- **The first question — "what `<image>` element should exist, and
+  where?"** Authoring the element, choosing its representation, placing
+  it, and keeping the document round-trippable. This is **core**: it
+  touches the file-sovereignty invariant (P1), and no view of the
+  editor's state lets a consumer build it themselves.
+- **The second question — "how do I get a resolvable href, and how big is
+  it?"** Turning a local file into a URL; decoding the bytes to learn the
+  intrinsic size. This is **host-owned I/O** (P2): the same class of
+  concern as clipboard and file-open, and a kind of work the host has a
+  rendering or decode context for and the headless editor structurally
+  does not.
+
+The editor answers the first question and refuses the second. A host that
+already holds a resolvable href and a size finds insertion is the only
+thing missing — and it is supplied.
+
+## Requirements
+
+- **R1 — The editor inserts from a resolvable href, never from a file.**
+  The insertion contract accepts a resolvable href (and a placement
+  point, and a size). It never accepts, reads, or decodes a local `File`
+  or an `image/*` blob. Producing a resolvable href from a non-resolvable
+  source is outside the contract.
+- **R2 — Intrinsic size is host-supplied in v1.** Because measuring an
+  image is an I/O act the headless core cannot perform, the size travels
+  _into_ the insertion as caller-supplied dimensions. The insertion
+  command is therefore **synchronous** — it holds no in-flight load, and
+  editor state never sits in a pending-resolve limbo. (A host-owned
+  resolver provider that would let the editor _orchestrate_ resolution is
+  a named enhancement; see § Intrinsic size.)
+- **R3 — A size is always written, with a defined fallback.** An inserted
+  `<image>` always carries explicit `width` and `height` so it is
+  immediately selectable and resizable and its bounds are well-defined.
+  When the caller supplies a size, that size is used. When it does not, a
+  default placeholder size is written — explicitly _not_ intrinsic, and
+  named as such. The fallback is deliberate, not a strict-surface
+  refusal: insertion corrupts nothing (unlike, say, ungrouping a stateful
+  group, where refusal is the honest answer), so a missing size degrades
+  to a resizable placeholder rather than rejecting the gesture; a host
+  that knows the size supplies it. (An `<image>` without width/height has
+  implementation-defined bounds across renderers — SVG 1.1 treats a
+  missing dimension as zero and disables rendering, SVG 2 uses the
+  intrinsic size — so the editor writes a size always rather than inherit
+  that ambiguity.)
+- **R4 — The inserted element round-trips clean (P1).** After insertion,
+  the document's only delta is one `<image>` element. It is authored with
+  SVG 2 `href` (§ Round-trip), no namespace declaration is forced, and
+  serialize → reparse is byte-stable.
+- **R5 — Insertion is one history step.** Adding an image is a single
+  undoable gesture; undo restores the document byte-equal to before, redo
+  re-inserts and re-selects, matching the existing insertion contract.
+- **R6 — The editor imposes no content policy on the href.** No size cap
+  on `data:` URIs, no scheme allowlist, no fetch, no validation of what
+  the href points at. The href is written verbatim and round-trips
+  verbatim (P1 — content is sovereign). Whether to inline a large `data:`
+  URI or upload to a served URL is the host's choice, made before the
+  href reaches the editor.
+- **R7 — Transport is host-owned.** How a user's drop, paste, or file
+  pick becomes a resolvable href and a placement point is the host's
+  concern. The editor supplies the document-space projection a host needs
+  to turn a screen-space drop into a placement point; it does not install
+  drop, drag, or image-paste listeners of its own (§ Transport).
+
+## The insertion contract
+
+Insertion is a **designed command** that takes a resolvable href and
+optional placement and sizing, authors one `<image>`, places it, selects
+it, and records one history step. It is distinct from the generic
+element-insertion command in three ways that justify a dedicated surface:
+
+1. **It carries content.** A rectangle is defined by its geometry; an
+   image is defined by its href. The href is the payload, and the command
+   names it as a first-class argument rather than as an opaque attribute
+   bag.
+2. **It has an intrinsic size.** Geometry-only shapes have none — their
+   size is whatever the user draws. An image's natural size is a real
+   quantity the contract must have an answer for (R3).
+3. **It authors the reference cleanly.** `href` vs. legacy `xlink:href`,
+   and the no-namespace-declaration guarantee, are round-trip decisions
+   the contract owns (§ Round-trip), not caller responsibilities.
+
+### Not a drag-to-size tool tag
+
+The editor's drag-to-size insertion subsystem is a closed set of tags
+whose members have **no intrinsic size** — the user's drag _is_ the size.
+`<image>` is the opposite: it _has_ an intrinsic size and carries href
+content. Forcing it into the drag-to-size set would misrepresent both
+properties, exactly as text was kept out of that set for the mirror
+reason (text also has no intrinsic size, but is placed by click, not
+drag). Image insertion is its own command, driven by the host's
+transport, not a member of the drag-to-size vocabulary.
+
+A pointer-driven place gesture — a tool where the user, having already
+chosen an image, clicks the canvas to drop it at intrinsic size — is a
+plausible future surface (the mirror of the click-to-place text tool).
+It is **deferred**: the drop, paste, and programmatic flows all drive the
+command directly, supplying their own point, so no host yet needs a
+canvas tool to place an already-chosen image. It graduates when a host
+does, under the same "public only after a second consumer shapes it"
+discipline that governs every other surface in this package.
+
+### Placement
+
+The placement point is a document-space coordinate. The inserted image is
+centered on it — the same convention the shape insertions use for their
+click-no-drag fallback, so a drop lands centered under the pointer. With
+no point supplied, the element is anchored at the document origin (its
+top-left at the origin, not centered on it); the host is expected to
+supply a point for any pointer-driven flow.
+
+The transport's only geometric contribution is that point. Projecting a
+screen-space drop or paste location into document space is a query the
+editor already answers for its own gestures, and the host reuses it; the
+editor does not need to observe the drop itself to provide it.
+
+## Intrinsic size: host-owned I/O
+
+Learning an image's natural size means loading its bytes — a network
+fetch and a decode, or a rendering-context measurement. The headless core
+has none of those capabilities. So the capability lives where the I/O
+lives: with the host.
+
+This mirrors the shape of the editor's declared font seam: the editor
+owns the _need_ for a measurement (font metrics there, intrinsic size
+here), but the _resolution_ is delegated to the host, because resolution
+is I/O the headless core cannot perform. (The font seam is declared in
+the construction surface but not yet exercised by an awaited flow; it is
+cited here for its shape, not as a proven async precedent.)
+
+**v1: the host supplies the size.** The argument is impossibility, not
+mere preference. Learning a natural size means **decoding** the image —
+running a raster decoder, or measuring an SVG image's viewport in a
+rendering context. The headless core has no such context by construction;
+it _cannot_ decode, at all. The host can — it is the party with the DOM
+or the server-side image library — and it is already the party that
+produced the resolvable href. So the decode must happen on the host. Note
+honestly that this decode is a _distinct_ act from producing the URL:
+creating an object URL does not read pixels, and encoding a `data:` URI
+does not decode dimensions, so the host performs one decode it would not
+otherwise need. But that decode is unavoidable wherever it lives, only
+the host can do it, and doing it host-side keeps the editor's command
+**synchronous and headless** (R2). For a bare remote URL with no size,
+the host decodes once and passes both href and size in.
+
+**Named enhancement — an image resolver provider.** A host-owned resolver
+that maps a resolvable href to its intrinsic size, mirroring the font
+resolver, would let the editor _orchestrate_ resolution: a caller could
+insert from a bare href and let the editor await the size. It is deferred,
+for two reasons. First, it has one prospective consumer; a provider seam
+shaped against a single host ossifies around that host's quirks, and the
+package's discipline is to let a second consumer shape a contract before
+it is promoted. Second, it drags asynchrony into a command model that is
+otherwise synchronous, which raises real questions — what the document may
+do mid-resolve, how undo interacts with a pending insert — that a
+single-consumer design has no pressure to answer well. When a host needs
+editor-orchestrated resolution, the resolver is the promotion path, and
+those questions get answered then.
+
+## Transport: drop, paste, and the P2 boundary
+
+A user inserts an image by dropping a file, pasting a blob, or picking a
+file. Each starts from a **non-resolvable** source — a local `File` or an
+`image/*` clipboard blob — and each therefore lands on the host's side of
+the boundary (R1, R7).
+
+**The editor does not install drop, drag, or image-paste listeners.** The
+reasons compound:
+
+- **The source is non-resolvable.** A dropped `File` is not an href; a
+  pasted `image/*` blob is not an href. Turning either into one is the
+  resolution act the editor refuses (R1). An editor listener would have
+  nothing to do but hand the file back to the host.
+- **The host already owns the surrounding surface.** The rendering
+  container is exclusively the editor's, but the host renders its own
+  chrome — and its own drop affordance — around it. A host that wants
+  drop-to-insert already has a drop target and already computes a drop
+  point. A second drop listener inside the container would split that
+  ownership for no gain.
+- **The point is already available.** The one thing the editor uniquely
+  knows — how to project a screen location into document space — is
+  exposed for the host to call. The host owns the file; the editor owns
+  the projection; insertion composes them.
+
+So the v1 transport is: the host's drop/paste/pick handler resolves the
+source to a resolvable href (and a size), projects the location to a
+placement point, and calls the insertion command. The editor's existing
+native-clipboard handling, which consumes SVG markup as text, continues
+to ignore non-markup payloads — an `image/*`-only paste is not SVG text
+and is left for the host, consistent with the clipboard FRD already
+naming raster-image paste as deferred host work.
+
+**Named enhancement — a drop observation.** The editor could, instead,
+_observe_ drops the way it observes taps: report a drop's items and
+document-space point on a dedicated channel, leaving the host to resolve
+and insert. This keeps the editor out of file I/O (it reports a drop that
+happened; it never reads the file) while sparing the host its own drop
+plumbing. It is deferred under the same discipline as every observation
+seam — it ships when a host needs editor-routed drops and a second
+consumer pins its shape. It is explicitly _not_ an input-interception
+hook: like the tap observation, it would report a drop that already
+happened and could neither veto nor replace the host's handling. One
+asymmetry that design must confront, and the tap observation does not: a
+drop carries a browser default action that has to be suppressed to accept
+the drop at all, so "purely passive observation" is not quite achievable
+the way it is for a tap — who suppresses the default, and under what
+gate, is part of what a second consumer would pin.
+
+## Round-trip
+
+**New images author SVG 2 `href`.** A freshly inserted `<image>` is
+written with the namespace-free `href` attribute. This needs no namespace
+declaration, matches the editor's no-proprietary-noise stance, and is
+honored by every modern renderer. The legacy `xlink:href` form — the only
+form some older renderers read — is **preserved** on images that already
+use it: an edit to an existing `xlink:href` image keeps that form, which
+is exactly why legacy targets are not stranded. But `xlink:href` is never
+_authored_ for a new image, because doing so would force an `xmlns:xlink`
+declaration onto the document root for no benefit on a modern target.
+
+**No content policy.** The href is written verbatim, whatever it is —
+a multi-megabyte `data:` URI, a remote URL, a fragment reference. The
+editor imposes no size cap, no scheme filter, no fetch-to-validate. P1
+makes content sovereign; policing it would be exactly the kind of silent
+mutation the editor exists to refuse. A host with a reason to bound
+payload size (to keep documents small, say) makes that choice on its side
+of the boundary — by uploading large images to a served URL instead of
+inlining them — before the href reaches the editor.
+
+The result is locked by the round-trip invariant (R4): insert an image,
+serialize, and the document gains exactly one well-formed `<image>` with
+its href, position, and size; reparse is byte-stable.
+
+## Trust model
+
+**Inserting an image is load-equivalent in trust.** Writing an `<image
+href>` into the model admits exactly what loading a document with the
+same element admits: the editor stores the reference verbatim and
+executes nothing by storing it. A `data:` URI is inert bytes in an
+attribute; a remote URL is a reference the model does not dereference.
+
+The honest boundary, as for paste and load, is the **rendering surface**.
+A surface that mounts document markup into a privileged interpreter can
+fetch a remote href (a tracking/privacy vector) or render hostile image
+content; that exposure exists for any `<image>` the surface renders,
+whether authored, loaded, pasted, or inserted. Insertion changes the
+_likelihood_ of hostile input reaching the surface — a drop now suffices
+where a file open was required — not the mechanism. The surface's
+hardening posture is the subject of
+[`rendering-hardening.md`](./rendering-hardening.md); insertion adds no
+new obligation beyond the ones that document already carries for rendered
+references.
+
+## Rejected alternatives
+
+- **Editor reads the dropped file.** Rejected by R1. The headless core
+  has no file or decode capability, and reaching for one would dissolve
+  the boundary that keeps the package testable without a rendering
+  context. The host is the party with that capability; the editor
+  accepting the resolvable href it produces is the whole interface.
+- **`<image>` joins the drag-to-size tool set.** Rejected: that set is
+  defined by the absence of intrinsic size, which `<image>` has, and its
+  members carry no content payload, which `<image>` does. Membership would
+  misrepresent both, the mirror of why text was excluded.
+- **A required resolver provider in v1.** Rejected by the second-consumer
+  discipline and by R2. A provider shaped against a single host ossifies,
+  and an async resolver imposes a pending-resolve state on an otherwise
+  synchronous command for no v1 caller that needs it. Named as the
+  promotion path instead (§ Intrinsic size).
+- **No size written, relying on intrinsic rendering.** Rejected by R3. An
+  `<image>` without explicit width/height has renderer-dependent bounds
+  and is not cleanly selectable or resizable the instant it is placed. The
+  editor writes a size always — the supplied one, or a named placeholder.
+- **Editor-owned drop/paste-image listeners.** Rejected by R7 and the
+  non-resolvable-source argument: the editor would receive a file it
+  refuses to read and could only hand it back. The host owns the surface
+  around the container and the file I/O; the editor owns the projection
+  and the insertion. A drop _observation_ (not a file read) remains a
+  named future seam.
+- **An href content policy (size cap, scheme allowlist).** Rejected by R6
+  and P1. Content is sovereign; bounding it is a host decision made before
+  the href arrives, not a silent editor behavior.
+
+## Out of scope (v1)
+
+Adjacent work this design names but does not include: the **image
+resolver provider** that would let the editor orchestrate intrinsic-size
+resolution from a bare href (§ Intrinsic size); the **pointer-driven
+place tool** for dropping an already-chosen image by clicking the canvas
+(§ The insertion contract); the **drop observation** channel that would
+report drops for the host to resolve (§ Transport); **editor-side
+ingestion** of local files or `image/*` clipboard blobs (permanently
+host-owned by R1, not a deferral); and **aspect-ratio-constrained or
+fit-to-viewport sizing** beyond center-on-point placement and the
+supplied-or-default size.

--- a/docs/wg/feat-svg-editor/index.md
+++ b/docs/wg/feat-svg-editor/index.md
@@ -82,6 +82,15 @@ preserving the author's source on round-trip.
   rather than hidden. Also: command/history semantics, in-place
   appended placement, transport ownership and the engine floor for
   native clipboard events, and the paste-is-load trust model.
+- [`image-insertion.md`](./image-insertion.md) — FRD for inserting
+  `<image>` elements. The editor accepts an insertion at a point given a
+  _resolvable_ href (remote URL, `data:` URI, host-served URL) and a
+  host-supplied intrinsic size; turning a local file into a usable URL,
+  and loading bytes to learn a natural size, are host-owned I/O — the
+  same seam clipboard draws for transport. Covers the insertion contract
+  (why it is a dedicated command, not a drag-to-size tag), placement,
+  SVG 2 `href` authoring, the no-content-policy round-trip, and the
+  deferred resolver-provider / drop-observation seams.
 - [`durable-node-identity.md`](./durable-node-identity.md) — the open
   problem behind #775: `NodeId` is parse-ephemeral, so no reference
   survives a `load()`, let alone an external rewrite of the file. Frames

--- a/editor/app/(canvas)/svg/examples/default/page.tsx
+++ b/editor/app/(canvas)/svg/examples/default/page.tsx
@@ -137,37 +137,34 @@ function SvgEditorDevPageBody() {
     [insertFromSrc, handle]
   );
 
-  // Raster image drop/pick: resolve the File to a data: URI and decode its
-  // intrinsic size (host I/O, P2), then hand the resolved href + size to the
-  // editor's `insert_image` command as ONE history step. The editor centers
-  // the <image> on `at` (anchors at origin when null).
+  // Raster image drop: resolve the File to a data: URI and decode its intrinsic
+  // size (host I/O, P2), then hand the resolved href + size to the editor's
+  // `insert_image` command as ONE history step. The editor centers the <image>
+  // on `at` (anchors at origin when null).
   // (see test/svg-editor-image-insertion.md)
   const insertImageFile = useCallback(
-    (file: File, at: { x: number; y: number } | null) => {
-      const task = (async () => {
-        const href = await readFileAsDataURL(file);
-        const { width, height } = await imageIntrinsicSize(href);
-        cmd.insert_image(href, at ? { at, width, height } : { width, height });
-      })();
-      toast.promise(task, {
-        loading: "Inserting image...",
-        success: "Image inserted",
-        error: "Failed to insert image",
-      });
+    async (file: File, at: { x: number; y: number } | null) => {
+      // SvgRouteShell keys the provider by activeId, so switching the active
+      // doc mid-decode remounts (detaches) this editor — the captured `cmd`
+      // would then strand the insertion in a stale instance while still
+      // toasting success. Capture the doc and bail if it changed before we
+      // write.
+      const docAtStart = store.getActiveId();
+      let href: string;
+      let size: { width: number; height: number };
+      try {
+        href = await readFileAsDataURL(file);
+        size = await imageIntrinsicSize(href);
+      } catch {
+        toast.error("Failed to insert image");
+        return;
+      }
+      if (store.getActiveId() !== docAtStart) return;
+      cmd.insert_image(href, at ? { at, ...size } : size);
+      toast.success("Image inserted");
     },
-    [cmd]
+    [cmd, store]
   );
-
-  // A dropped/picked file is one of two kinds: an SVG *document* (load it as a
-  // page) or a raster *image* (insert it as an <image> into the open doc).
-  // `image/svg+xml` is an image MIME but is a document — route it to load.
-  const handleFile = (file: File, at: { x: number; y: number } | null) => {
-    if (file.type.startsWith("image/") && file.type !== "image/svg+xml") {
-      insertImageFile(file, at);
-      return;
-    }
-    loadSvgFile(file);
-  };
 
   const dragKind = (dt: DataTransfer | null): "file" | "library" | null => {
     if (dt?.types?.includes(datatransfer.key)) return "library";
@@ -205,7 +202,15 @@ function SvgEditorDevPageBody() {
       return;
     }
     const file = e.dataTransfer?.files?.[0];
-    if (file) handleFile(file, at);
+    if (!file) return;
+    // A dropped raster image is inserted as an <image> at the drop point; an
+    // SVG file loads as a document. `image/svg+xml` is an image MIME but is a
+    // document, so it routes to load.
+    if (file.type.startsWith("image/") && file.type !== "image/svg+xml") {
+      insertImageFile(file, at);
+    } else {
+      loadSvgFile(file);
+    }
   };
 
   return (
@@ -215,7 +220,7 @@ function SvgEditorDevPageBody() {
       handle={handle}
       sourceName={sourceName ?? activeDoc?.name ?? null}
       loadError={loadError}
-      onPickFile={(file) => handleFile(file, handle?.camera.center ?? null)}
+      onPickFile={loadSvgFile}
       onReset={() => {
         setLoadError(null);
         setSourceName(null);

--- a/editor/app/(canvas)/svg/examples/default/page.tsx
+++ b/editor/app/(canvas)/svg/examples/default/page.tsx
@@ -27,6 +27,37 @@ import { useSvgAgentHydrated } from "../../_ai/provider";
 // bundle (canvas.json + <id>.svg) via dotcanvas. Old data is dropped.
 const OPFS_BASE = ["grida-svg-demo", "v4", "default"] as const;
 
+// ─── Host-owned image I/O (the P2 boundary) ────────────────────────────────
+// Turning a local File into a *resolvable* href, and decoding it to learn its
+// intrinsic size, is host work — `@grida/svg-editor` never reads a File. The
+// editor only accepts the resolved href + size via `commands.insert_image`.
+// See docs/wg/feat-svg-editor/image-insertion.md.
+//
+// We resolve to a `data:` URI rather than `URL.createObjectURL`: a `blob:` URL
+// is ephemeral (it dies on reload and cannot be persisted to the .canvas
+// bundle), whereas a data: URI embeds the bytes and round-trips + persists.
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function imageIntrinsicSize(
+  src: string
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () =>
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    img.onerror = () => reject(new Error("Failed to decode image"));
+    img.src = src;
+  });
+}
+
 export default function SvgEditorDevPage() {
   return (
     <SvgRouteShell opfsBase={OPFS_BASE} defaultSvg={SAMPLE_SVG}>
@@ -106,6 +137,38 @@ function SvgEditorDevPageBody() {
     [insertFromSrc, handle]
   );
 
+  // Raster image drop/pick: resolve the File to a data: URI and decode its
+  // intrinsic size (host I/O, P2), then hand the resolved href + size to the
+  // editor's `insert_image` command as ONE history step. The editor centers
+  // the <image> on `at` (anchors at origin when null).
+  // (see test/svg-editor-image-insertion.md)
+  const insertImageFile = useCallback(
+    (file: File, at: { x: number; y: number } | null) => {
+      const task = (async () => {
+        const href = await readFileAsDataURL(file);
+        const { width, height } = await imageIntrinsicSize(href);
+        cmd.insert_image(href, at ? { at, width, height } : { width, height });
+      })();
+      toast.promise(task, {
+        loading: "Inserting image...",
+        success: "Image inserted",
+        error: "Failed to insert image",
+      });
+    },
+    [cmd]
+  );
+
+  // A dropped/picked file is one of two kinds: an SVG *document* (load it as a
+  // page) or a raster *image* (insert it as an <image> into the open doc).
+  // `image/svg+xml` is an image MIME but is a document — route it to load.
+  const handleFile = (file: File, at: { x: number; y: number } | null) => {
+    if (file.type.startsWith("image/") && file.type !== "image/svg+xml") {
+      insertImageFile(file, at);
+      return;
+    }
+    loadSvgFile(file);
+  };
+
   const dragKind = (dt: DataTransfer | null): "file" | "library" | null => {
     if (dt?.types?.includes(datatransfer.key)) return "library";
     if (dt?.types?.includes("Files")) return "file";
@@ -125,23 +188,24 @@ function SvgEditorDevPageBody() {
   const onDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragging(null);
+    // Drop point → world space, so dropped content lands centered under the
+    // pointer. Same screen-space convention as the surface's gestures; shared
+    // by the library, raster-image, and (origin-only) SVG paths.
+    const cr = e.currentTarget.getBoundingClientRect();
+    const at =
+      handle?.camera.screen_to_world({
+        x: e.clientX - cr.left,
+        y: e.clientY - cr.top,
+      }) ?? null;
     const known = e.dataTransfer?.getData(datatransfer.key);
     if (known) {
       const data = datatransfer.decode(known);
       if (data.type !== "svg") return;
-      // Drop point → world space, so the icon lands centered under the
-      // pointer. Same screen-space convention as the surface's gestures.
-      const cr = e.currentTarget.getBoundingClientRect();
-      const at =
-        handle?.camera.screen_to_world({
-          x: e.clientX - cr.left,
-          y: e.clientY - cr.top,
-        }) ?? null;
       insertFromSrc(data.src, at);
       return;
     }
     const file = e.dataTransfer?.files?.[0];
-    if (file) loadSvgFile(file);
+    if (file) handleFile(file, at);
   };
 
   return (
@@ -151,7 +215,7 @@ function SvgEditorDevPageBody() {
       handle={handle}
       sourceName={sourceName ?? activeDoc?.name ?? null}
       loadError={loadError}
-      onPickFile={loadSvgFile}
+      onPickFile={(file) => handleFile(file, handle?.camera.center ?? null)}
       onReset={() => {
         setLoadError(null);
         setSourceName(null);
@@ -178,7 +242,9 @@ function SvgEditorDevPageBody() {
           </PathToolbarPosition>
           {dragging && (
             <div className="absolute inset-0 flex items-center justify-center bg-primary/5 text-primary text-sm font-semibold pointer-events-none">
-              {dragging === "file" ? "Drop SVG to load" : "Drop to insert"}
+              {dragging === "file"
+                ? "Drop SVG to load, or an image to insert"
+                : "Drop to insert"}
             </div>
           )}
         </div>

--- a/packages/grida-svg-editor/CHANGELOG.md
+++ b/packages/grida-svg-editor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @grida/svg-editor
 
+## 1.1.0
+
+### Minor Changes
+
+- Image insertion ([#885](https://github.com/gridaco/grida/issues/885)). New `commands.insert_image(href, opts?)` — a designed, **synchronous, headless** command that adds one `<image>` to the open document from a **resolvable href** (a remote URL, a `data:` URI, or a host-served URL). It authors SVG 2 `href` (never `xlink:href`, so no `xmlns:xlink` is forced onto the root), always writes an explicit `width`/`height` (the supplied intrinsic size, or a named `DEFAULT_IMAGE_SIZE` placeholder when omitted), centers the element on `opts.at` (anchors at the document origin when absent), imposes **no** content policy on the href (no `data:` size cap, no scheme filter, no fetch), and records one undoable step.
+
+  The boundary is the point: the editor inserts a _reference_ and never reads a file. Turning a local `File` or an `image/*` blob into a resolvable href, and decoding bytes to learn an intrinsic size, is host-owned I/O — the host resolves and measures, then calls this command. `<image>` is deliberately **not** an `InsertableTag` (it has an intrinsic size and carries content — the mirror of why `<text>` is excluded). An async resolver provider, a pointer-driven place tool, and a passive drop-observation channel are named deferrals. Design: [`docs/wg/feat-svg-editor/image-insertion.md`](https://github.com/gridaco/grida/blob/main/docs/wg/feat-svg-editor/image-insertion.md).
+
+  Also: the DOM surface's native paste handler now calls `preventDefault()` only when it actually consumed `text/plain` SVG markup, so an `image/*`-only paste is left unclaimed for the host to handle.
+
 ## 1.0.0
 
 ### Minor Changes

--- a/packages/grida-svg-editor/README.md
+++ b/packages/grida-svg-editor/README.md
@@ -731,6 +731,24 @@ editor.commands.{
   // undo step, no placement opt.
   insert_fragment(svg: string, opts?: { parent?: NodeId; index?: number; select?: boolean }): NodeId[];
   insert_preview(tag: string, initial?: Readonly<Record<string, string>>): InsertPreviewSession;
+  // image insertion — designed, synchronous, headless. `href` is a
+  // RESOLVABLE href (remote URL / data: URI / host-served URL); the host
+  // supplies the intrinsic size. The editor authors SVG 2 `href` (never
+  // `xlink:href`, no forced `xmlns:xlink`), always writes explicit
+  // width/height (supplied or a named default), centers on `at` (anchors
+  // at origin when absent), and never reads/decodes/fetches. See the
+  // "Image insertion" subsection below.
+  insert_image(
+    href: string,
+    opts?: {
+      at?: Vec2;
+      width?: number;
+      height?: number;
+      parent?: NodeId;
+      index?: number;
+      select?: boolean;
+    },
+  ): NodeId;
 
   // content
   set_text(value: string): void;
@@ -763,6 +781,34 @@ All commands operate on `state.selection` unless they take an explicit target. C
 `transform` composes a general 2×3 affine onto the selection **relative** and **in world space about a pivot** (default: the selection union-bbox center) — `E = T(pivot) · matrix · T(-pivot)` — so a bare `[-1, 0, 0, 1, 0, 0]` is an in-place horizontal flip and `[1, 0, 0, -1, 0, 0]` a vertical one. The editor owns the round-trip: `E` is folded onto each member's transform list as a **single leading `matrix` op** (existing `rotate`/`translate` tokens are preserved after it; repeated applies collapse into one matrix; a net-identity leading matrix is dropped). It refuses (returns `false`, no history) on empty selection, no attached surface, or any member that isn't rotatable (matrix / scale / skew / `<text rotate>` / CSS-property / animated transforms — same gate as `rotate`; Flatten Transform is the recovery path). Flat-doc only: nested transformed ancestors are out of scope.
 
 (Naming convention for the API surface is `snake_case` to match the SVG / CSS property naming the editor already echoes — `set_property("stroke-width", …)` reads cleanly next to `set_paint("fill", …)`. JavaScript identifiers use `snake_case`; user-facing strings that mirror SVG attribute names stay `kebab-case` exactly as the spec writes them.)
+
+#### Image insertion
+
+`insert_image` adds one `<image>` to the open document from a **resolvable href** — a reference the rendering context can already fetch as-is: a remote URL, a `data:` URI, or a host-served URL. It is a **designed, synchronous, headless** command, distinct from the generic `insert(tag, attrs)` primitive because an image carries content (the href is its payload, a first-class argument) and has an intrinsic size the contract must answer for. Design: [`docs/wg/feat-svg-editor/image-insertion.md`](https://grida.co/docs/wg/feat-svg-editor/image-insertion).
+
+```ts
+editor.commands.insert_image(href, {
+  at,        // document-space placement point; the element is CENTERED on it.
+             //   omit → anchored at the document origin (top-left at 0,0).
+  width,     // intrinsic width  — HOST-SUPPLIED (see "the boundary" below).
+  height,    // intrinsic height
+  parent,    // default: root, like the other insert commands.
+  index,     // position among parent's element-children; default: append.
+  select,    // default: true.
+}): NodeId;
+```
+
+What it guarantees:
+
+- **SVG 2 `href`, never `xlink:href`.** A new image is authored with the namespace-free `href` attribute, so no `xmlns:xlink` is forced onto the root (P1 — no proprietary noise). Existing `xlink:href` images are still preserved verbatim on edit; the legacy form is just never _authored_.
+- **An explicit size, always.** The inserted `<image>` always carries explicit `width`/`height` so it is immediately selectable and resizable. When you supply a size it is used; when you omit it, a named placeholder (`DEFAULT_IMAGE_SIZE`, explicitly **not** intrinsic) is written. This is a deliberate fallback, not a refusal — insertion corrupts nothing, so a missing size degrades to a resizable placeholder rather than rejecting the gesture.
+- **Center-on-point placement.** With `at`, the element is centered on the point (an `<image>`'s `x`/`y` are its top-left, so top-left = `at − size/2`). Without it, the element is anchored at the document origin.
+- **No content policy.** The href is written and round-trips **verbatim** — no size cap on a `data:` URI, no scheme allowlist, no fetch-to-validate (P1 — content is sovereign). Whether to inline a large `data:` URI or upload to a served URL is the host's choice, made before the href reaches the editor.
+- **One history step.** Insertion is a single undoable gesture; undo restores the document byte-equal, redo re-inserts and re-selects.
+
+**The boundary — the editor inserts a reference, never reads a file.** Turning a local `File` or an `image/*` blob into a resolvable href, and **decoding bytes to learn an intrinsic size**, is host-owned I/O (P2): the headless core has no decoder, no network, no rendering context, by construction. The host already holds those — it had to, to produce the href — so it resolves and measures, then calls this command synchronously. The editor never installs drop / dragover / image-paste listeners of its own; transport is the host's. The pieces the editor uniquely owns (document-space projection for a screen-space drop point, and the insertion itself) are exposed for the host to compose. An async resolver provider, a pointer-driven place tool, and a passive drop-observation channel are **named deferrals** ([`TODO.md`](./TODO.md) → Insertion subsystem follow-ups), each gated on a second consumer (P6).
+
+`<image>` is deliberately **not** an `InsertableTag` (the drag-to-size set). That set's members have no intrinsic size — the user's drag _is_ the size — and carry no content. `<image>` is the mirror: it _has_ an intrinsic size and _is_ content, exactly the pair of reasons `<text>` is also excluded. So it is its own command, not a tool tag.
 
 ### Providers
 
@@ -1007,7 +1053,8 @@ If a consumer needs any of the above, the right answer is "this is the wrong too
 ## Status
 
 - `v0.x` — selection, transform, insert (rect / ellipse / line), inline text
-  edit, and the click-to-place text tool. Experimental.
+  edit, the click-to-place text tool, and `insert_image` (designed
+  `<image>` insertion). Experimental.
 
 The shape of the API, the mental model, the file-format guarantees, and the scope are all unsettled. Nothing here is stable — public types still in flux include the `Tool` union (a planned axis split, see `TODO.md` F2). Do not depend on it from production code.
 

--- a/packages/grida-svg-editor/TODO.md
+++ b/packages/grida-svg-editor/TODO.md
@@ -46,6 +46,30 @@ alpha.10. Open items:
   different stickiness, different size, different keymap letters), a
   preset graduates — same shape as `keynote` graduated from the camera
   system. Not in v1.
+- **Image insertion follow-ups.** `commands.insert_image(href, opts?)`
+  shipped (synchronous + headless: SVG 2 `href`, explicit size with the
+  `insertions.DEFAULT_IMAGE_SIZE` fallback, center-on-`at` placement, one
+  history step). Design:
+  [`docs/wg/feat-svg-editor/image-insertion.md`](../../docs/wg/feat-svg-editor/image-insertion.md).
+  Named deferrals from the FRD § Out of scope (each ships only when a
+  second consumer pins its shape — P6):
+  - **Image resolver provider.** A host-owned `href → intrinsic size`
+    resolver (mirroring the font resolver) that would let the editor
+    _orchestrate_ resolution from a bare href and `await` the size. The
+    promotion path for editor-orchestrated sizing; deferred because it has
+    one prospective consumer and drags asynchrony into an otherwise
+    synchronous command. v1 keeps the host supplying the size.
+  - **Pointer-driven place tool.** A canvas tool where the user, having
+    chosen an image, clicks to drop it at intrinsic size (the mirror of
+    the click-to-place text tool). Deferred: every v1 flow (drop, paste,
+    programmatic) drives `insert_image` directly with its own point.
+  - **Drop observation channel.** A passive `subscribe`-style channel that
+    reports a drop's items + document-space point for the host to resolve
+    and insert (the mirror of `subscribe_pick`). Deferred; note the FRD's
+    open asymmetry — a drop carries a default action that must be
+    suppressed to accept it, so it is not _purely_ passive the way a tap
+    is. Editor-side ingestion of `File` / `image/*` blobs is **permanently
+    host-owned** (FRD R1), not a deferral.
 
 ### HUD routing migration (defer until N≥2 insertion tools)
 

--- a/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
@@ -175,4 +175,25 @@ describe("paste over the focused canvas", () => {
     expect(s.editor.serialize()).toBe(baseline);
     expect(s.editor.state.can_undo).toBe(false);
   });
+
+  it("an image-only paste (no text/plain) is left unclaimed for the host", () => {
+    // The editor transports SVG markup as text; raster-image paste is
+    // host-owned (clipboard FRD + image-insertion FRD § Transport). With no
+    // text/plain to consider, the handler must NOT preventDefault — else it
+    // swallows a paste the host's own listener wants (resolve the blob to an
+    // href and call commands.insert_image).
+    const s = mount();
+    const baseline = s.editor.serialize();
+    s.container.focus();
+    const dt = new DataTransfer();
+    dt.items.add(
+      new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "a.png", {
+        type: "image/png",
+      })
+    );
+    const { e } = dispatch_clipboard(s.container, "paste", dt);
+    expect(e.defaultPrevented).toBe(false);
+    expect(s.editor.serialize()).toBe(baseline);
+    expect(s.editor.state.can_undo).toBe(false);
+  });
 });

--- a/packages/grida-svg-editor/__tests__/image-insertion.test.ts
+++ b/packages/grida-svg-editor/__tests__/image-insertion.test.ts
@@ -117,7 +117,10 @@ describe("commands.insert_image — one history step (FRD R5)", () => {
 
   it("does not auto-select when opts.select === false", () => {
     const editor = createSvgEditor({ svg: EMPTY });
-    const before = editor.state.selection;
+    // Snapshot by value: a "selection did not change" assertion must not
+    // alias the live array, or an in-place mutation would compare equal to
+    // itself and pass falsely.
+    const before = [...editor.state.selection];
     editor.commands.insert_image(PNG_DATA_URI, { select: false });
     expect(editor.state.selection).toEqual(before);
   });

--- a/packages/grida-svg-editor/__tests__/image-insertion.test.ts
+++ b/packages/grida-svg-editor/__tests__/image-insertion.test.ts
@@ -1,0 +1,161 @@
+// Headless producer tests for the designed `<image>` insertion command.
+//
+// Contract: docs/wg/feat-svg-editor/image-insertion.md. Same idiom as
+// `insertions.test.ts` — create an editor, call `commands.insert_image`,
+// assert document state + a serialize round-trip + undo/redo. No surface is
+// attached: the command is synchronous and headless by construction, so
+// every test here runs in plain node (no getBBox / getScreenCTM needed).
+//
+// Each test NAME states the locked behavior as a spec sentence.
+
+import { describe, expect, it } from "vitest";
+import { insertions } from "../src/core/insertions";
+import { createSvgEditor } from "../src/index";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const EMPTY = `<svg xmlns="${SVG_NS}" viewBox="0 0 100 100"/>`;
+
+const PNG_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+describe("commands.insert_image — href authoring (P1 / FRD R4)", () => {
+  it("authors an SVG 2 href, never xlink:href, and forces no xmlns:xlink on the root", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image("https://example.com/a.png");
+
+    // SVG 2 namespace-free href is the authored form.
+    expect(editor.document.get_attr(id, "href")).toBe(
+      "https://example.com/a.png"
+    );
+    // The legacy form is never authored.
+    expect(editor.document.get_attr(id, "xlink:href")).toBeNull();
+
+    // And no xmlns:xlink declaration is forced onto the root for it.
+    const out = editor.serialize();
+    expect(out).not.toContain("xlink:href");
+    expect(out).not.toContain("xmlns:xlink");
+    expect(out).toContain("<image");
+    expect(out).toContain('href="https://example.com/a.png"');
+  });
+});
+
+describe("commands.insert_image — explicit size (FRD R3)", () => {
+  it("with a supplied size, writes that exact width/height", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI, {
+      width: 320,
+      height: 240,
+    });
+    expect(editor.document.get_attr(id, "width")).toBe("320");
+    expect(editor.document.get_attr(id, "height")).toBe("240");
+  });
+
+  it("with no supplied size, falls back to the named default placeholder size", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI);
+    const expected = String(insertions.DEFAULT_IMAGE_SIZE);
+    // Always written — never absent (an <image> with no size has
+    // renderer-dependent bounds; the editor refuses that ambiguity).
+    expect(editor.document.get_attr(id, "width")).toBe(expected);
+    expect(editor.document.get_attr(id, "height")).toBe(expected);
+  });
+});
+
+describe("commands.insert_image — placement (FRD § Placement)", () => {
+  it("centers the element on the supplied point (an image's x/y is its top-left)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI, {
+      at: { x: 50, y: 60 },
+      width: 20,
+      height: 10,
+    });
+    // top-left = at − size/2  →  (50 − 10, 60 − 5) = (40, 55)
+    expect(editor.document.get_attr(id, "x")).toBe("40");
+    expect(editor.document.get_attr(id, "y")).toBe("55");
+  });
+
+  it("anchors at the document origin when no point is supplied (top-left at 0,0)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI, {
+      width: 20,
+      height: 10,
+    });
+    expect(editor.document.get_attr(id, "x")).toBe("0");
+    expect(editor.document.get_attr(id, "y")).toBe("0");
+  });
+});
+
+describe("commands.insert_image — one history step (FRD R5)", () => {
+  it("inserts at root, selects the new node, and is one undoable step (undo restores byte-equal)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const baseline = editor.serialize();
+
+    const id = editor.commands.insert_image(PNG_DATA_URI, {
+      at: { x: 10, y: 10 },
+    });
+    expect(editor.state.selection).toEqual([id]);
+    expect(editor.tree().nodes.get(id)?.tag).toBe("image");
+    expect(editor.state.can_undo).toBe(true);
+
+    // Exactly one undo restores the document byte-for-byte.
+    editor.commands.undo();
+    expect(editor.serialize()).toBe(baseline);
+    expect(editor.state.can_undo).toBe(false);
+  });
+
+  it("redo re-inserts and re-selects the same node", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI);
+    const after_insert = editor.serialize();
+
+    editor.commands.undo();
+    editor.commands.redo();
+
+    expect(editor.state.selection).toEqual([id]);
+    expect(editor.serialize()).toBe(after_insert);
+  });
+
+  it("does not auto-select when opts.select === false", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    const before = editor.state.selection;
+    editor.commands.insert_image(PNG_DATA_URI, { select: false });
+    expect(editor.state.selection).toEqual(before);
+  });
+});
+
+describe("commands.insert_image — round-trip & content policy (FRD R4 / R6)", () => {
+  it("insert → serialize → reparse is byte-stable", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    editor.commands.insert_image(PNG_DATA_URI, { at: { x: 50, y: 50 } });
+    const once = editor.serialize();
+    // Reparsing the editor's own output and re-serializing must be a
+    // fixpoint — the inserted <image> round-trips like any authored node.
+    const twice = createSvgEditor({ svg: once }).serialize();
+    expect(twice).toBe(once);
+  });
+
+  it("writes a large data: URI href verbatim — no cap, no rewrite (content is sovereign)", () => {
+    const editor = createSvgEditor({ svg: EMPTY });
+    // A multi-megabyte-class href: far past any size a policing editor
+    // would cap. The editor imposes no content policy.
+    const big_href = `data:image/png;base64,${"A".repeat(2_000_000)}`;
+    const id = editor.commands.insert_image(big_href);
+
+    // Stored verbatim in the model …
+    expect(editor.document.get_attr(id, "href")).toBe(big_href);
+    // … and round-tripped verbatim through serialize.
+    expect(editor.serialize()).toContain(big_href);
+  });
+});
+
+describe("commands.insert_image — headless (FRD R2)", () => {
+  it("runs with no surface attached (synchronous, no DOM, no decode)", () => {
+    // No `editor.attach(...)` — geometry_provider is null. A command that
+    // tried to decode the image or measure it would need a rendering
+    // context; this one must not. It returns a real NodeId synchronously.
+    const editor = createSvgEditor({ svg: EMPTY });
+    const id = editor.commands.insert_image(PNG_DATA_URI);
+    expect(typeof id).toBe("string");
+    expect(editor.tree().nodes.get(id)?.tag).toBe("image");
+  });
+});

--- a/packages/grida-svg-editor/package.json
+++ b/packages/grida-svg-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grida/svg-editor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Headless SVG editor (experimental).",
   "keywords": [
     "bezier",

--- a/packages/grida-svg-editor/src/core/editor.ts
+++ b/packages/grida-svg-editor/src/core/editor.ts
@@ -547,6 +547,63 @@ export type Commands = {
     initial: Readonly<Record<string, string>>,
     opts?: { parent?: NodeId; index?: number }
   ): InsertPreviewSession;
+  /**
+   * Insert one `<image>` from a **resolvable href** — a designed,
+   * synchronous, headless image-insertion command. Design:
+   * `docs/wg/feat-svg-editor/image-insertion.md`.
+   *
+   * A "resolvable href" is a reference the rendering context can already
+   * fetch as-is: a remote URL, a `data:` URI, or a host-served URL. The
+   * editor authors the element, places it, sizes it, selects it, and
+   * records ONE history step — it NEVER reads a `File`, decodes bytes, or
+   * fetches the href. Turning a local file into a URL, and decoding it to
+   * learn an intrinsic size, is host-owned I/O (P2); the host does that
+   * first and hands the result here.
+   *
+   * Distinct from {@link insert} (the generic tag + attrs primitive) by
+   * design (FRD § The insertion contract): the href is a first-class,
+   * named argument (it is the payload, not an opaque attr); the size has a
+   * defined answer (R3); and the href-form decision (SVG 2 `href`, no
+   * forced `xmlns:xlink`) is the command's to own, not the caller's.
+   *
+   * Behavior:
+   *  - **SVG 2 `href`** is authored, never `xlink:href` — so no
+   *    `xmlns:xlink` is forced onto the root (R4). `xlink:href` on a
+   *    pre-existing image is still preserved on edit; it is just never
+   *    AUTHORED for a new one.
+   *  - **Explicit `width`/`height` always** (R3). `opts.width`/`height`
+   *    when supplied; otherwise a named placeholder
+   *    (`insertions.DEFAULT_IMAGE_SIZE`, explicitly NOT intrinsic) so the
+   *    node is immediately selectable / resizable. The fallback is
+   *    deliberate, not a refusal — insertion corrupts nothing.
+   *  - **Placement** centers the element on `opts.at` (an `<image>`'s
+   *    `x`/`y` are top-left, so top-left = `at − size/2`); with no `at`
+   *    the element anchors at the document origin (top-left at `(0, 0)`).
+   *  - **No content policy** (R6): the href is written and round-trips
+   *    verbatim — no length cap on a `data:` URI, no scheme filter, no
+   *    fetch-to-validate (P1 — content is sovereign).
+   *
+   * `opts.parent` defaults to root; `opts.index` defaults to append;
+   * `opts.select` defaults to `true`. Returns the new node id. One undo
+   * step (undo restores byte-equal; redo re-inserts and re-selects).
+   *
+   * The pointer-driven "place an already-chosen image by clicking the
+   * canvas" tool, an async intrinsic-size resolver provider, and a drop
+   * observation channel are all NAMED DEFERRALS (FRD § Out of scope) —
+   * every v1 flow (drop, paste, programmatic) drives this command directly
+   * with its own point and size.
+   */
+  insert_image(
+    href: string,
+    opts?: {
+      at?: Vec2;
+      width?: number;
+      height?: number;
+      parent?: NodeId;
+      index?: number;
+      select?: boolean;
+    }
+  ): NodeId;
   // content
   set_text(value: string): void;
   /**
@@ -2131,6 +2188,43 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
   }
 
   /**
+   * Designed `<image>` insertion — contract in {@link Commands.insert_image}
+   * (design: `docs/wg/feat-svg-editor/image-insertion.md`).
+   *
+   * Synchronous and headless: no byte read, no decode, no fetch. The href
+   * is the payload; the host supplies the intrinsic size (or the named
+   * placeholder is written). Composes the atomic `insert` primitive so it
+   * inherits the one-history-step / select / undo-redo-byte-equal semantics
+   * — this command's own job is purely to author the clean attr set
+   * (`insertions.image_attrs`: SVG 2 `href`, explicit size, center-on-point
+   * placement). `<image>` carries no default paint
+   * (`default_paint_attrs_for` returns `{}` for it), so what lands is
+   * exactly the authored attrs and nothing else (R4 — one-element delta).
+   */
+  function insert_image(
+    href: string,
+    opts?: {
+      at?: Vec2;
+      width?: number;
+      height?: number;
+      parent?: NodeId;
+      index?: number;
+      select?: boolean;
+    }
+  ): NodeId {
+    const attrs = insertions.image_attrs(href, {
+      at: opts?.at,
+      width: opts?.width,
+      height: opts?.height,
+    });
+    return insert("image", attrs, {
+      parent: opts?.parent,
+      index: opts?.index,
+      select: opts?.select,
+    });
+  }
+
+  /**
    * Atomic fragment insertion — contract in {@link Commands.insert_fragment}.
    * Parses + adopts via `doc.create_fragment` (subtrees registered but
    * detached, like `create_element` — history.redo finds them via
@@ -2696,6 +2790,7 @@ function _create_svg_editor_internal(opts: CreateSvgEditorOptions) {
     insert,
     insert_fragment,
     insert_preview,
+    insert_image,
     set_text,
     set_vector_selection,
     delete_vector_selection,

--- a/packages/grida-svg-editor/src/core/insertions.ts
+++ b/packages/grida-svg-editor/src/core/insertions.ts
@@ -180,6 +180,60 @@ export namespace insertions {
     };
   }
 
+  /** Named placeholder size for an inserted `<image>` whose caller supplied
+   *  no intrinsic dimensions (FRD R3 — a size is ALWAYS written, with a
+   *  defined fallback). Explicitly NOT the image's intrinsic size: the
+   *  headless core cannot decode bytes, so a host that knows the real size
+   *  passes it in (`width`/`height`); when it does not, the node still lands
+   *  selectable and resizable at this square. Distinct constant from
+   *  `DEFAULT_SIZE` (the drag-to-size click-no-drag default) because this is
+   *  a content-bearing placeholder, not a shape default — they may diverge.
+   *  CSS px in world space. */
+  export const DEFAULT_IMAGE_SIZE = 100;
+
+  /**
+   * Attrs for an `<image>` insert (FRD: image-insertion). Authors the
+   * SVG 2 namespace-free `href` (never `xlink:href` — that would force an
+   * `xmlns:xlink` declaration onto the root for no modern-renderer benefit;
+   * see FRD § Round-trip) and an EXPLICIT `width`/`height` always (FRD R3).
+   *
+   * `<image>`'s `x`/`y` are its TOP-LEFT (like `<rect>`, unlike `<ellipse>`'s
+   * center), so:
+   *  - with `at`     → centered on the point: top-left = at − size/2.
+   *  - without `at`  → anchored at the document origin: top-left = (0, 0).
+   *
+   * `width`/`height` default to {@link DEFAULT_IMAGE_SIZE} per axis when the
+   * caller omits them. The href is written verbatim — no length cap, no
+   * scheme filter, no fetch (FRD R6: content is sovereign).
+   *
+   * `<image>` is intentionally NOT an {@link InsertableTag}: that closed set
+   * is the drag-to-size vocabulary, whose members have NO intrinsic size (the
+   * user's drag IS the size) and carry NO content payload. `<image>` is the
+   * mirror — it HAS an intrinsic size and its href IS its content — exactly
+   * the pair of reasons `<text>` is also excluded. So it lives outside the
+   * per-tag switches above as its own factory, driven by the dedicated
+   * `commands.insert_image` command rather than the insert tool.
+   */
+  export function image_attrs(
+    href: string,
+    opts?: { at?: Vec2; width?: number; height?: number }
+  ): Record<string, string> {
+    const w = opts?.width ?? DEFAULT_IMAGE_SIZE;
+    const h = opts?.height ?? DEFAULT_IMAGE_SIZE;
+    // Center on `at`; anchor at origin when absent.
+    const x = opts?.at ? opts.at.x - w / 2 : 0;
+    const y = opts?.at ? opts.at.y - h / 2 : 0;
+    return {
+      x: fmt(x),
+      y: fmt(y),
+      width: fmt(w),
+      height: fmt(h),
+      // SVG 2 href LAST so attribute order reads geometry-then-content; the
+      // raw string is written verbatim (P1) — no encoding, no length cap.
+      href,
+    };
+  }
+
   // ─── Per-tag drag math ───────────────────────────────────────────────
 
   function rect_attrs(

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -2635,16 +2635,30 @@ class DomSurface implements Surface {
   }
 
   /**
-   * Claim-then-act (mirrors the keydown claim doctrine: swallow when the
-   * gesture is aimed at the editor, not just when a handler consumed):
-   * a refused paste — junk text — still claims; the suppressed default is
-   * a no-op on a div anyway.
+   * Claim-then-act, gated on the presence of a `text/plain` payload:
+   * mirrors the keydown claim doctrine (swallow when the gesture is aimed
+   * at the editor, not just when a handler consumed) for the channel the
+   * editor actually transports. When the clipboard carries `text/plain`,
+   * the editor claims it even if the text is junk — a refused paste still
+   * `preventDefault()`s, and the suppressed default is a no-op on a div
+   * anyway.
+   *
+   * But when there is NO `text/plain` at all — e.g. an `image/*`-only paste
+   * — the editor has nothing to transport (it consumes SVG markup as text;
+   * raster-image paste is host-owned per the clipboard FRD and the
+   * image-insertion FRD § Transport). It must NOT `preventDefault()` there,
+   * or it would swallow a paste a host's own listener wants to handle (turn
+   * the blob into a resolvable href and call `commands.insert_image`). So
+   * the default is suppressed only when text was present to consider.
    */
   private on_paste(e: ClipboardEvent): void {
     if (!this.claims_clipboard("paste")) return;
-    e.preventDefault();
     const text = e.clipboardData?.getData("text/plain");
-    if (text) this.editor.commands.paste(text);
+    // No text payload (image-only paste, empty clipboard) → leave the
+    // event for the host. The editor transports text; it has nothing here.
+    if (!text) return;
+    e.preventDefault();
+    this.editor.commands.paste(text);
   }
 
   /**

--- a/test/svg-editor-image-insertion.md
+++ b/test/svg-editor-image-insertion.md
@@ -38,7 +38,7 @@ the headless core has no decoder, no network, no rendering context. So the
 host resolves and measures, then calls the command synchronously. Spec:
 `docs/wg/feat-svg-editor/image-insertion.md`.
 
-The `/svg/examples/default` demo is the host here. Its drop/pick handler
+The `/svg/examples/default` demo is the host here. Its **drop** handler
 branches on file kind:
 
 - A **raster image** (`image/png`, `image/jpeg`, … — anything
@@ -50,6 +50,10 @@ branches on file kind:
   bundle, and reload.
 - An **SVG file** (`image/svg+xml` or `.svg`) keeps the existing
   behavior: it loads as a new document/page, not as an embedded `<image>`.
+
+The **Open-file** picker is SVG-only — the shared file input filters to
+`.svg,image/svg+xml`, so a raster cannot be selected there. Raster image
+insertion is a **drop-only** affordance in this demo.
 
 The editor authors SVG 2 `href` (never `xlink:href`, so no `xmlns:xlink`
 is forced onto the root), always writes an explicit `width`/`height`
@@ -82,9 +86,10 @@ consume.
 7. Drag an **`.svg`** file onto the canvas. Expected: it loads as a new
    document/page (the pre-existing behavior), **not** as an embedded
    `<image>`.
-8. Pick a raster image via the file-open affordance instead of dropping.
-   Expected: it inserts as an `<image>` at the **viewport center** (no
-   drop point), same as the drop path otherwise.
+8. While a large image is still decoding (e.g. a multi-MB photo), switch
+   the active document before it lands. Expected: the insertion is silently
+   abandoned (no success toast, nothing inserted into the now-detached
+   editor), rather than landing in a stale instance.
 
 ## Notes
 
@@ -95,7 +100,8 @@ consume.
   serialize round-trip with a large `data:` URI, headless/synchronous) is
   fully covered headlessly by `image-insertion.test.ts`; this TC exists
   for the **host-side transport** (file → `data:` URI → decode → insert,
-  the drop/pick branch, persistence) that is impractical to automate.
+  the drop branch, the active-doc guard, persistence) that is impractical
+  to automate.
 - The image-only-paste carve-out (editor leaves an `image/*`-only paste
   for the host) is pinned by `clipboard.browser.test.ts`.
 - Named deferrals (not part of this TC): an async resolver provider, a

--- a/test/svg-editor-image-insertion.md
+++ b/test/svg-editor-image-insertion.md
@@ -1,0 +1,102 @@
+---
+id: TC-SVGEDITOR-IMAGE-001
+title: Dropping (or picking) a raster image inserts an <image> at the drop point; SVG files still load as documents
+module: svg-editor
+area: image-insertion
+tags:
+  [
+    image,
+    insert,
+    insert_image,
+    drop,
+    drag-drop,
+    data-uri,
+    transport,
+    host-owned,
+    round-trip,
+    history,
+    undo,
+  ]
+status: untested
+severity: high
+date: 2026-06-23
+updated: 2026-06-23
+automatable: false
+covered_by:
+  - packages/grida-svg-editor/__tests__/image-insertion.test.ts
+  - packages/grida-svg-editor/__tests__/clipboard.browser.test.ts
+---
+
+## Behavior
+
+The editor accepts an image insertion at a point given a **resolvable
+href** (a remote URL, a `data:` URI, or a host-served URL) via
+`commands.insert_image`, and guarantees the round-trip of the resulting
+`<image>`. Turning a local `File` into a usable href — and decoding it to
+learn its intrinsic size — is **host-owned I/O**, not the editor's job:
+the headless core has no decoder, no network, no rendering context. So the
+host resolves and measures, then calls the command synchronously. Spec:
+`docs/wg/feat-svg-editor/image-insertion.md`.
+
+The `/svg/examples/default` demo is the host here. Its drop/pick handler
+branches on file kind:
+
+- A **raster image** (`image/png`, `image/jpeg`, … — anything
+  `image/*` except `image/svg+xml`) is read into a `data:` URI and
+  decoded for its natural width/height (host work), then inserted as one
+  `<image>` into the **open document** at the drop point, centered under
+  the pointer. A `data:` URI (not a `blob:` object URL) is used so the
+  inserted reference survives serialization, persistence to the `.canvas`
+  bundle, and reload.
+- An **SVG file** (`image/svg+xml` or `.svg`) keeps the existing
+  behavior: it loads as a new document/page, not as an embedded `<image>`.
+
+The editor authors SVG 2 `href` (never `xlink:href`, so no `xmlns:xlink`
+is forced onto the root), always writes an explicit `width`/`height`
+(the decoded size, or a default placeholder when the host omits it),
+imposes no content policy on the href (a large `data:` URI is inlined
+verbatim), and records exactly one undo step.
+
+The editor installs **no** drop / dragover / image-paste listeners of its
+own — the demo owns the drop affordance and computes the drop point via
+the surface camera's `screen_to_world`. Pasting an `image/*`-only
+clipboard payload (no `text/plain` SVG) is left for the host: the editor's
+native paste handler no longer `preventDefault()`s a paste it cannot
+consume.
+
+## Steps
+
+1. Open `/svg/examples/default` and let the canvas hydrate.
+2. Drag a **PNG/JPEG** file from the OS onto the canvas. The drop overlay
+   reads "Drop SVG to load, or an image to insert."
+3. Drop it over a specific spot on the canvas.
+4. Expected: a toast ("Inserting image…" → "Image inserted"), and the
+   image appears as a selectable `<image>` **centered on the drop point**,
+   at its natural pixel dimensions. It is the current selection.
+5. Press undo (⌘Z): the image is removed and the document returns to its
+   prior state in one step. Redo (⌘⇧Z) re-inserts and re-selects it.
+6. Open the document source (or serialize): the new element is
+   `<image href="data:image/...;base64,…" x=… y=… width=… height=…>`,
+   with **no** `xlink:href` and **no** `xmlns:xlink` on the root. Reload
+   the page — the image persists (the `data:` URI survived persistence).
+7. Drag an **`.svg`** file onto the canvas. Expected: it loads as a new
+   document/page (the pre-existing behavior), **not** as an embedded
+   `<image>`.
+8. Pick a raster image via the file-open affordance instead of dropping.
+   Expected: it inserts as an `<image>` at the **viewport center** (no
+   drop point), same as the drop path otherwise.
+
+## Notes
+
+- Issue: [#885](https://github.com/gridaco/grida/issues/885). Design FRD:
+  `docs/wg/feat-svg-editor/image-insertion.md`.
+- The core insertion contract (href authoring, explicit size + default
+  fallback, center-on-point vs anchor-at-origin, one history step,
+  serialize round-trip with a large `data:` URI, headless/synchronous) is
+  fully covered headlessly by `image-insertion.test.ts`; this TC exists
+  for the **host-side transport** (file → `data:` URI → decode → insert,
+  the drop/pick branch, persistence) that is impractical to automate.
+- The image-only-paste carve-out (editor leaves an `image/*`-only paste
+  for the host) is pinned by `clipboard.browser.test.ts`.
+- Named deferrals (not part of this TC): an async resolver provider, a
+  pointer-driven place tool, and a passive drop-observation channel.


### PR DESCRIPTION
Ships the **SDK** side of #885: image insertion for `@grida/svg-editor`.

## What changed

`commands.insert_image(href, opts?)` — a designed, **synchronous, headless** command that adds one `<image>` to the open document from a **resolvable href** (a remote URL, a `data:` URI, or a host-served URL) plus a host-supplied size.

- Authors **SVG 2 `href`** — never `xlink:href`, so no `xmlns:xlink` is forced onto the root (P1). Existing `xlink:href` images are still preserved on edit; it's just never *authored* for a new one.
- Always writes an **explicit `width`/`height`** — the supplied intrinsic size, or a named `DEFAULT_IMAGE_SIZE` placeholder when omitted (a graceful fallback, not a refusal).
- **Center-on-point** placement (`opts.at`), anchors at the document origin when absent.
- **No content policy** on the href — no `data:` size cap, no scheme filter, no fetch (content is sovereign).
- One undo step; returns the new `NodeId`.

`<image>` is deliberately **not** an `InsertableTag` (the drag-to-size set): it *has* an intrinsic size and *carries* content — the mirror of why `<text>` is excluded.

Also: the DOM surface's native paste handler now `preventDefault()`s **only** when it actually consumed `text/plain` SVG markup, so an `image/*`-only paste is left unclaimed for the host.

## Why this shape (the responsibility boundary)

Turning a local `File` into a resolvable href, and **decoding it to learn its intrinsic size**, is host-owned I/O (P2) — the headless core has no decoder, no network, no rendering context, by construction. The editor accepts a *reference* and never reads a file. The browser demo (`/svg/examples/default`) wires the host side (`File → data:` URI → `new Image()` decode → `insert_image`); the editor itself installs no drop/dragover/image-paste listeners.

Full design rationale (the A/B/C/D design questions from #885, resolved via the deciding table): [`docs/wg/feat-svg-editor/image-insertion.md`](https://github.com/gridaco/grida/blob/feat/svg-editor-image-insertion/docs/wg/feat-svg-editor/image-insertion.md).

## Reviewer notes

- **Tests:** 11 new headless spec-named tests (`__tests__/image-insertion.test.ts`) lock the contract — href authoring, explicit-size + default fallback, center-vs-anchor placement, one-step undo/redo byte-equal, serialize round-trip + large `data:` URI verbatim, headless. Plus one browser test pinning the image-only-paste carve-out. Full package suite green (1559), typecheck clean.
- **Manual TC:** `test/svg-editor-image-insertion.md` covers the host-side drop/pick transport that's impractical to automate.
- **Version:** bumps `@grida/svg-editor` **1.0.0 → 1.1.0** (minor) with CHANGELOG; the changeset is consumed in this PR.
- **Scope:** SDK + the browser reference demo only. The SDK is host-agnostic and complete; wiring the **desktop** hosts (and the `.canvas` asset-storage question the clean desktop path needs) is split to **#890**.

Closes #885.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added synchronous, headless `insert_image(href, opts?)` to insert SVG `<image>` elements from resolvable `href` with explicit `width`/`height`, centered placement, and a single undo step.
  * Demo now supports dragging or picking raster images to insert into documents, positioning them in world coordinates.

* **Bug Fixes**
  * Improved paste handling to only prevent default when consuming `text/plain` SVG markup; image-only pastes are left unclaimed.

* **Documentation / Tests**
  * Added image insertion design documentation and automated/manual image insertion tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->