### PR TITLE
fix(svg-editor): counter-scale HUD canvas under a CSS-transformed ancestor (#892)

### DIFF
--- a/.changeset/svg-editor-hud-ancestor-transform.md
+++ b/.changeset/svg-editor-hud-ancestor-transform.md
@@ -1,0 +1,15 @@
+---
+"@grida/svg-editor": patch
+---
+
+Fix HUD selection chrome double-scaling when the editor is embedded inside a
+CSS-transformed ancestor (#892).
+
+The HUD overlay canvas is a child of the editor container, so an ancestor
+`transform: scale(z)` scaled it a second time on top of chrome positions already
+projected to screen px via `getScreenCTM()` — handles and the size badge drifted
+toward the top-left and shrank by ~z². `sync_canvas_size` now counter-scales the
+canvas by `1/z` (derived as transformed-box ÷ layout-box) so its drawing space
+stays 1:1 with screen px. Identity at 1:1, with a sub-pixel snap so a
+fractional-width container (flex/percentage panes) does not get a spurious
+counter-scale that would blur the otherwise pixel-sharp chrome.

--- a/.changeset/svg-editor-hud-ancestor-transform.md
+++ b/.changeset/svg-editor-hud-ancestor-transform.md
@@ -13,3 +13,7 @@ canvas by `1/z` (derived as transformed-box ÷ layout-box) so its drawing space
 stays 1:1 with screen px. Identity at 1:1, with a sub-pixel snap so a
 fractional-width container (flex/percentage panes) does not get a spurious
 counter-scale that would blur the otherwise pixel-sharp chrome.
+
+The pixel grid is drawn in the camera frame (not the `getScreenCTM` screen-px
+frame the chrome uses), so the ancestor scale is folded back into its transform
+to keep it aligned with content on the counter-scaled canvas.

--- a/packages/grida-svg-editor/__tests__/fold-scale-into-transform.test.ts
+++ b/packages/grida-svg-editor/__tests__/fold-scale-into-transform.test.ts
@@ -1,0 +1,53 @@
+// gridaco/grida#892 — `fold_scale_into_transform` folds the container's
+// ancestor CSS scale into the camera-frame pixel-grid transform, so the grid
+// stays aligned with content on the counter-scaled HUD canvas. The risk this
+// guards is a transposition (scaling the wrong row / axis), so we assert the
+// projected output of a known point, not just the matrix entries.
+import { describe, it, expect } from "vitest";
+import { fold_scale_into_transform } from "../src/dom";
+import cmath from "@grida/cmath";
+
+// out_x = t[0]·(x,y,1), out_y = t[1]·(x,y,1) — see `apply_camera_transform`.
+const project = (t: cmath.Transform, p: cmath.Vector2): cmath.Vector2 =>
+  cmath.vector2.transform(p, t);
+
+describe("#892: fold_scale_into_transform", () => {
+  it("returns the same transform at unit scale (no-op)", () => {
+    const t: cmath.Transform = [
+      [5, 0, 30],
+      [0, 5, 40],
+    ];
+    expect(fold_scale_into_transform(t, 1, 1)).toBe(t);
+  });
+
+  it("scales the projected output per axis: out → (out_x·sx, out_y·sy)", () => {
+    // Camera zoom 5×, pan (30,40): world (100,20) → (530, 140).
+    const t: cmath.Transform = [
+      [5, 0, 30],
+      [0, 5, 40],
+    ];
+    const p: cmath.Vector2 = [100, 20];
+    const base = project(t, p); // [530, 140]
+
+    // Ancestor scale(0.5): the grid output must scale by 0.5 to match content
+    // that the ancestor will render at half size.
+    const folded = fold_scale_into_transform(t, 0.5, 0.5);
+    const out = project(folded, p);
+    expect(out[0]).toBeCloseTo(base[0] * 0.5, 6); // 265
+    expect(out[1]).toBeCloseTo(base[1] * 0.5, 6); // 70
+  });
+
+  it("folds non-uniform scale on the correct axes (catches a row transposition)", () => {
+    const t: cmath.Transform = [
+      [2, 0, 10],
+      [0, 3, 7],
+    ];
+    const p: cmath.Vector2 = [4, 6];
+    const base = project(t, p); // [2*4+10, 3*6+7] = [18, 25]
+
+    const folded = fold_scale_into_transform(t, 0.5, 0.25);
+    const out = project(folded, p);
+    expect(out[0]).toBeCloseTo(base[0] * 0.5, 6); // 9   (x by sx)
+    expect(out[1]).toBeCloseTo(base[1] * 0.25, 6); // 6.25 (y by sy)
+  });
+});

--- a/packages/grida-svg-editor/__tests__/hud-ancestor-transform.browser.test.ts
+++ b/packages/grida-svg-editor/__tests__/hud-ancestor-transform.browser.test.ts
@@ -1,0 +1,136 @@
+// gridaco/grida#892 — the HUD selection chrome double-scales when the editor
+// is mounted inside an ancestor carrying a CSS `transform: scale(z)`.
+//
+// Mechanism: the HUD canvas is a child of the container, and chrome positions
+// are projected to *screen* px via `getScreenCTM()`. Under an ancestor scale,
+// the canvas (living inside the scaled subtree) re-applies `z` at render — so
+// chrome drifts toward the container's top-left and shrinks by ~z². The fix
+// counter-scales the canvas by `1/z` (`sync_canvas_size`) so its drawing space
+// stays 1:1 with screen px; the canvas then overlays the container exactly.
+//
+// Why this needs a real browser: the bug only exists once a layout engine
+// actually applies the ancestor CSS transform to the canvas. jsdom returns an
+// identity layout, so `getBoundingClientRect` ≡ `offsetWidth` and the double
+// scale is invisible. We assert on the canvas's real screen geometry.
+import { describe, it, expect, afterEach } from "vitest";
+import { createSvgEditor } from "../src";
+import { attach_dom_surface, type DomSurfaceHandle } from "../src/dom";
+
+const FIXTURE = `<svg xmlns="http://www.w3.org/2000/svg" width="900" height="650" viewBox="0 0 900 650"><rect id="box" x="100" y="80" width="200" height="150" fill="#f33"/></svg>`;
+
+type Mount = {
+  container: HTMLDivElement;
+  hudCanvas: HTMLCanvasElement;
+  handle: DomSurfaceHandle;
+  dispose: () => void;
+};
+
+/**
+ * Mount the editor inside an optional ancestor wrapper. When `scale` is given,
+ * the wrapper carries `transform: scale(scale)` with `transform-origin: 0 0`,
+ * reproducing the #892 embedding (a zoom-UI / scaled-preview host). `width`
+ * overrides the container's CSS width (a fractional value exercises the
+ * `offsetWidth`-rounding edge — see the fractional-width case below).
+ */
+function mount(scale?: number, width = "900px"): Mount {
+  const wrapper = document.createElement("div");
+  Object.assign(wrapper.style, {
+    position: "fixed",
+    left: "0px",
+    top: "0px",
+    margin: "0",
+    padding: "0",
+    ...(scale !== undefined
+      ? { transform: `scale(${scale})`, transformOrigin: "0 0" }
+      : {}),
+  });
+
+  const container = document.createElement("div");
+  Object.assign(container.style, {
+    position: "relative",
+    width,
+    height: "650px",
+    margin: "0",
+    padding: "0",
+    border: "0",
+    background: "#fff",
+  });
+  wrapper.appendChild(container);
+  document.body.appendChild(wrapper);
+
+  const editor = createSvgEditor({ svg: FIXTURE });
+  const handle = attach_dom_surface(editor, {
+    container,
+    gestures: true,
+    fit: false,
+  });
+  // Select the rect so the HUD actually builds + draws selection chrome.
+  const box = [...editor.tree().nodes.values()].find((n) => n.name === "box");
+  if (box) editor.commands.select(box.id);
+
+  const hudCanvas = container.querySelector("canvas");
+  if (!hudCanvas) throw new Error("no HUD canvas mounted");
+
+  return {
+    container,
+    hudCanvas,
+    handle,
+    dispose: () => {
+      handle.detach();
+      wrapper.remove();
+    },
+  };
+}
+
+let active: Mount | null = null;
+
+afterEach(() => {
+  active?.dispose();
+  active = null;
+  document.body.innerHTML = "";
+});
+
+/** Assert the HUD canvas occupies the same screen box as the container — the
+ *  core #892 invariant. Before the fix the canvas renders at z× (anchored
+ *  top-left), so width/left diverge. */
+function expectCanvasOverlaysContainer(m: Mount): void {
+  const c = m.container.getBoundingClientRect();
+  const h = m.hudCanvas.getBoundingClientRect();
+  expect(h.left).toBeCloseTo(c.left, 0);
+  expect(h.top).toBeCloseTo(c.top, 0);
+  expect(h.width).toBeCloseTo(c.width, 0);
+  expect(h.height).toBeCloseTo(c.height, 0);
+}
+
+describe("#892: HUD chrome under a CSS-transformed ancestor", () => {
+  it("1:1 mount: canvas is not counter-scaled and overlays the container", () => {
+    active = mount();
+    // Empty string (not `scale(1, 1)`) — the common, untransformed mount stays
+    // a true no-op, byte-identical to before the fix.
+    expect(active.hudCanvas.style.transform).toBe("");
+    expectCanvasOverlaysContainer(active);
+  });
+
+  it("scale(0.5) ancestor: canvas counter-scales by 1/z and still overlays the container", () => {
+    active = mount(0.5);
+    expect(active.hudCanvas.style.transform).toBe("scale(2, 2)"); // 1/0.5
+    expectCanvasOverlaysContainer(active);
+    // Guard the test: a 450px screen box from a 900px layout box proves the
+    // ancestor transform genuinely applied (without it the overlay is vacuous).
+    expect(active.container.getBoundingClientRect().width).toBeCloseTo(450, 0);
+  });
+
+  it("fractional-width container, no ancestor transform: stays a no-op (no spurious counter-scale)", () => {
+    // `offsetWidth` is integer-rounded while `getBoundingClientRect` is
+    // fractional, so a non-integer container width (the norm for flex/percentage
+    // panes) yields a ~1.0004x ratio with NO ancestor transform. The fix must
+    // still emit "" — a spurious `scale(0.9996)` would sub-pixel-blur the chrome.
+    active = mount(undefined, "900.4px");
+    // Prove the divergence is real: fractional screen box vs integer offsetWidth.
+    expect(active.container.getBoundingClientRect().width).not.toBe(
+      active.container.offsetWidth
+    );
+    expect(active.hudCanvas.style.transform).toBe("");
+    expectCanvasOverlaysContainer(active);
+  });
+});

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -416,6 +416,10 @@ type PendingInsertCommon = {
 class DomSurface implements Surface {
   private svg_root: SVGSVGElement | null = null;
   private hud_canvas: HTMLCanvasElement;
+  // Cached container ancestor CSS-transform scale (gridaco/grida#892), refreshed
+  // on every `sync_canvas_size`. Read from the camera hot path (pixel-grid
+  // transform) so it must not re-trigger a layout read there.
+  private ancestor_scale: { sx: number; sy: number } = { sx: 1, sy: 1 };
   private hud: HUDSurface;
   private teardown: Array<() => void> = [];
   private element_index = new Map<NodeId, SVGElement>();
@@ -1000,11 +1004,11 @@ class DomSurface implements Surface {
       resolve_bounds: (target) => this.resolve_world_bounds(target),
       initial: options.initial_camera,
     });
-    this.hud.setPixelGridTransform(this.camera.transform);
+    this.push_pixel_grid_transform();
     this.teardown.push(
       this.camera.subscribe(() => {
         this.apply_camera_transform();
-        this.hud.setPixelGridTransform(this.camera.transform);
+        this.push_pixel_grid_transform();
         // Multi-member envelope chrome stores a baked union rect in
         // container space — re-resolve it against the new CTM. The
         // flat-NodeId path (singleton / empty) is a near no-op here.
@@ -1728,13 +1732,37 @@ class DomSurface implements Surface {
     // space 1:1 with screen px — the convention the whole surface assumes — so
     // chrome tracks content instead of drifting toward the top-left at z².
     // Identity (`""`) at 1:1, so this is a no-op for the common mount.
-    const { sx, sy } = this.container_ancestor_scale(cr);
+    this.ancestor_scale = this.container_ancestor_scale(cr);
+    const { sx, sy } = this.ancestor_scale;
     this.hud_canvas.style.transform =
       sx === 1 && sy === 1 ? "" : `scale(${1 / sx}, ${1 / sy})`;
+    // The pixel grid is projected in the camera frame, not the screen-px frame
+    // the counter-scaled canvas now uses — re-fold the (possibly changed)
+    // ancestor scale into it so it stays aligned with content.
+    this.push_pixel_grid_transform();
     // Push viewport size to the camera so `camera.fit`, `bounds`, `center`
     // compute against the live container dimensions.
     this.camera._set_viewport_size(cr.width, cr.height);
     this.redraw();
+  }
+
+  /**
+   * Feed the pixel grid the camera transform folded with the container's
+   * ancestor scale (gridaco/grida#892).
+   *
+   * Unlike the selection chrome — projected to screen px via `getScreenCTM`,
+   * which the canvas's `1/z` counter-scale cancels — the pixel grid is drawn in
+   * the editor *camera* frame (container-local px, the frame the SVG content
+   * lives in). On the counter-scaled canvas that frame is no longer 1:1 with
+   * the rendered content, so without folding the ancestor scale back in the
+   * grid would drift from the content by `1/z`. Identity at 1:1. Uses the cached
+   * `ancestor_scale` so the per-camera-frame path stays off the layout-read path.
+   */
+  private push_pixel_grid_transform(): void {
+    const { sx, sy } = this.ancestor_scale;
+    this.hud.setPixelGridTransform(
+      fold_scale_into_transform(this.camera.transform, sx, sy)
+    );
   }
 
   /**
@@ -6131,6 +6159,27 @@ function sameTangentRefs(
  *
  * Exported for headless test coverage — pure function, no DOM types.
  */
+/**
+ * Pre-multiply a `cmath.Transform`'s output by an axis-aligned scale: row 0
+ * (output x) by `sx`, row 1 (output y) by `sy`. Equivalent to `scale(sx, sy) ∘
+ * t`. Used to fold the container's ancestor CSS scale into the camera-frame
+ * pixel-grid transform so it stays aligned on the counter-scaled HUD canvas
+ * (gridaco/grida#892). Returns `t` unchanged at unit scale.
+ *
+ * Pure function, no DOM types.
+ */
+export function fold_scale_into_transform(
+  t: cmath.Transform,
+  sx: number,
+  sy: number
+): cmath.Transform {
+  if (sx === 1 && sy === 1) return t;
+  return [
+    [t[0][0] * sx, t[0][1] * sx, t[0][2] * sx],
+    [t[1][0] * sy, t[1][1] * sy, t[1][2] * sy],
+  ];
+}
+
 export function project_point_through_ctm(
   px: number,
   py: number,

--- a/packages/grida-svg-editor/src/dom.ts
+++ b/packages/grida-svg-editor/src/dom.ts
@@ -934,6 +934,10 @@ class DomSurface implements Surface {
       position: "absolute",
       left: "0",
       top: "0",
+      // Pin the counter-scale applied in `sync_canvas_size` (gridaco/grida#892)
+      // to the top-left, so it cancels the ancestor transform about the same
+      // origin the chrome projection assumes (the container's top-left).
+      transformOrigin: "0 0",
       pointerEvents: "none",
     });
     container.appendChild(this.hud_canvas);
@@ -1716,10 +1720,55 @@ class DomSurface implements Surface {
   private sync_canvas_size() {
     const cr = this.container.getBoundingClientRect();
     this.hud.setSize(cr.width, cr.height);
+    // Counter the container's ancestor CSS-transform scale (gridaco/grida#892).
+    // The HUD canvas is a child of the container, so an ancestor `transform:
+    // scale(z)` would scale it a *second* time — the chrome is already
+    // projected into screen px via `getScreenCTM`, and so is the pointer path
+    // (`dispatch_pointer`). Counter-scaling by `1/z` keeps the canvas's drawing
+    // space 1:1 with screen px — the convention the whole surface assumes — so
+    // chrome tracks content instead of drifting toward the top-left at z².
+    // Identity (`""`) at 1:1, so this is a no-op for the common mount.
+    const { sx, sy } = this.container_ancestor_scale(cr);
+    this.hud_canvas.style.transform =
+      sx === 1 && sy === 1 ? "" : `scale(${1 / sx}, ${1 / sy})`;
     // Push viewport size to the camera so `camera.fit`, `bounds`, `center`
     // compute against the live container dimensions.
     this.camera._set_viewport_size(cr.width, cr.height);
     this.redraw();
+  }
+
+  /**
+   * The cumulative CSS-transform scale applied to the container by its
+   * ancestors (e.g. a zoom-UI wrapper carrying `transform: scale(z)`), as
+   * transformed-box ÷ layout-box. `1` when the editor is mounted at 1:1.
+   *
+   * `getBoundingClientRect()` reports the post-transform (screen) border box;
+   * `offsetWidth/Height` report the pre-transform (layout) border box, so
+   * their ratio isolates the ancestor scale independent of border/padding.
+   *
+   * `offsetWidth/Height` are integer-rounded while the rect is fractional, so a
+   * sub-pixel container size (the norm for flex/percentage panes) would yield a
+   * spurious ~1.00x ratio with no real ancestor transform. A box delta below
+   * 1px IS that rounding (always <0.5px), not a scale — it snaps to exactly 1,
+   * keeping the untransformed mount a true no-op (and the chrome pixel-sharp,
+   * rather than sub-pixel-blurred by a fractional counter-scale).
+   *
+   * Only re-derived on size sync. A host that *animates* an ancestor transform
+   * should drive zoom through the editor camera instead — an ancestor
+   * `transform` change does not fire `ResizeObserver`, so the counter-scale
+   * would otherwise go stale. (This is the embedding contract gridaco/grida#892
+   * raised; driving zoom via the camera is the recommended pattern regardless.)
+   */
+  private container_ancestor_scale(cr: DOMRect): { sx: number; sy: number } {
+    const snap = (rect: number, layout: number): number => {
+      if (!(layout > 0) || Math.abs(rect - layout) < 1) return 1;
+      const s = rect / layout;
+      return Number.isFinite(s) && s > 0 ? s : 1;
+    };
+    return {
+      sx: snap(cr.width, this.container.offsetWidth),
+      sy: snap(cr.height, this.container.offsetHeight),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #892 — the `@grida/svg-editor` HUD selection chrome (resize handles, size badge, selection outline) double-scales when the editor is mounted inside an ancestor carrying a CSS `transform: scale(z)` (zoom-UI hosts, scaled previews). The SVG content renders correctly; only the HUD overlay drifts toward the container's top-left and shrinks by ~z².

## Root cause

The HUD overlay `<canvas>` is a child of the editor container. Chrome positions are projected to **screen px** via `getScreenCTM()` (and so is the pointer path in `dispatch_pointer`), so the whole surface already works in a screen-px frame and is internally consistent. The one thing that breaks under an ancestor scale is that the canvas — living *inside* the scaled subtree — re-applies `z` at render time, on top of coordinates that already account for it. `sync_canvas_size` also sized the canvas from `getBoundingClientRect().width` (= `Wc·z`), so it rendered at `Wc·z²` — the "factor squared."

## Fix

Counter-scale the HUD canvas by `1/z` in `sync_canvas_size`, where `z` is the ancestor scale derived as **transformed-box ÷ layout-box** (`getBoundingClientRect().width / offsetWidth`) — which isolates the ancestor scale independent of border/padding. This keeps the canvas's drawing space 1:1 with screen px, so **no projection or pointer code changes**. `transform-origin: 0 0` pins the counter-scale to the same origin the chrome projection assumes.

- **No-op at 1:1** — emits `""` (a true no-op, byte-identical to before) for the common, untransformed mount.
- **Sub-pixel snap** — `offsetWidth` is integer-rounded while the rect is fractional, so a non-integer container width (the norm for flex/percentage panes) would otherwise yield a spurious ~1.00x ratio with no real transform and *blur* the pixel-sharp chrome. A `<1px` box delta (always the rounding, `<0.5px`) snaps to exactly `1`.

## Verification

New real-browser regression test (`hud-ancestor-transform.browser.test.ts`) — jsdom returns identity CTMs and literally cannot see this bug, so it runs in headless Chromium and asserts the canvas's true screen geometry:

- **1:1 mount** → `transform` is `""`, canvas overlays container.
- **`scale(0.5)` ancestor** → `transform: scale(2, 2)`, canvas overlays container to the pixel.
- **fractional-width (`900.4px`), no transform** → stays `""` (no spurious counter-scale).

Each was proven non-vacuous (fails with the relevant fix line disabled). Also confirmed live via a throwaway Vite harness: under `scale(0.5)` the HUD canvas measured `450×325` at the container origin (exact overlay) with the fix vs `225×163` (shrunk top-left) without it.

All green: **browser 70**, **node 1556**, `tsc` clean, `oxlint` 0/0.

## Reviewer notes

- The change is scoped to **uniform scale** (rotation/skew out of scope, matching the issue) and is re-derived on size sync. A host that *animates* an ancestor transform should drive zoom via the editor camera instead — an ancestor `transform` change doesn't fire `ResizeObserver`. This embedding contract is documented inline.
- Pre-existing and untouched: `camera._set_viewport_size` is passed screen px under an ancestor scale. Out of scope for this HUD-rendering fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HUD selection chrome in the SVG editor when embedded in a CSS-transformed (scaled) ancestor.
  * Kept HUD overlay drawing in sync with screen pixels to prevent chrome drift and selection badge size shrinkage.
  * Improved alignment of the pixel grid and reduced blur/jitter in fractional-width layouts.

* **Tests**
  * Added browser tests covering scaled and non-scaled embedding scenarios to validate overlay geometry and transforms.
  * Added unit tests for the transform-folding helper used to align the pixel grid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->