### PR TITLE
feat(agent): add ask-user `question` tool (#802)

### DIFF
--- a/desktop/src/agent-sidecar.ts
+++ b/desktop/src/agent-sidecar.ts
@@ -102,6 +102,9 @@ async function main() {
     // srt actually confines this process tree. On platforms srt can't wrap
     // (Windows), this is false and the agent gets fs/todos/skills but no shell.
     sandbox_enforced: sandboxEnforced,
+    // A human is at the keyboard — the locked `question` tool pauses for their
+    // answer (RFC `tools` §question) instead of returning the headless refusal.
+    interactive: true,
   });
 
   try {

--- a/docs/wg/ai/agent/queue.md
+++ b/docs/wg/ai/agent/queue.md
@@ -175,8 +175,13 @@ user resolves the block and the turn continues to a **true finish**.
 `idle` alone is therefore not a sufficient drainability test — the
 drain fires only when the session is genuinely ready for a _new_ turn,
 which a blocked turn is not. The block state is authoritative session
-state (a persisted pending approval), so every consumer — a second
-window, a hosted runner, the CLI — honors the pause identically.
+state (a persisted pending approval, or an unanswered
+[`question`](./tools.md#the-question-tool) tool call still at
+`input-available`), so every consumer — a second window, a hosted
+runner, the CLI — honors the pause identically. The drainability
+predicate keys on the _class_ of block, not a single tool: a future
+human-input tool joins the pause by being recognized as one, not by a
+new gate.
 
 ### Stopping with a queue
 

--- a/docs/wg/ai/grida/tools-fundamentals.md
+++ b/docs/wg/ai/grida/tools-fundamentals.md
@@ -33,21 +33,21 @@ execution. The divergence is recorded here, not endorsed — a future
 RFC item should reconcile (see [Adding a new fundamental
 tool](#adding-a-new-fundamental-tool)).
 
-| RFC id        | Grida id                   | Notes                                                                      |
-| ------------- | -------------------------- | -------------------------------------------------------------------------- |
-| `read`        | `read_file`                | Same shape; Grida's name is more specific.                                 |
-| `write`       | `write_file`               | Same shape; Grida adds an optional `version` for stale-check.              |
-| `edit`        | `edit_file`                | Same shape; Grida adds a strict ambiguity rule on multi-match.             |
-| `glob`        | `list_files`               | Today a flat enumerate; promote to glob-shape when needed.                 |
-| `grep`        | `grep_files`               | Same shape; literal substring search (regex is not shipped).               |
-| `bash`        | `run_command`              | Honest name — Grida's host does not always launch a shell.                 |
-| `todo`        | `todo_write`               | Same shape; replace-all semantics.                                         |
-| `task`        | _not yet shipped_          | Subagent spawn surfaced behind editor flows; expose as `task` once stable. |
-| `question`    | _not yet shipped_          | Host-blocking prompt; not yet exposed to agents.                           |
-| `web_search`  | _not yet shipped_          | Host-bound provider; out of scope for the first cut.                       |
-| `web_fetch`   | _not yet shipped_          | As above.                                                                  |
-| `skill`       | _not yet shipped_          | Discovery layer pending.                                                   |
-| `tool_search` | `tool_search` _(proposed)_ | Two-level (literal + semantic) proposed below; not yet implemented.        |
+| RFC id        | Grida id                   | Notes                                                                                                                                                           |
+| ------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `read`        | `read_file`                | Same shape; Grida's name is more specific.                                                                                                                      |
+| `write`       | `write_file`               | Same shape; Grida adds an optional `version` for stale-check.                                                                                                   |
+| `edit`        | `edit_file`                | Same shape; Grida adds a strict ambiguity rule on multi-match.                                                                                                  |
+| `glob`        | `list_files`               | Today a flat enumerate; promote to glob-shape when needed.                                                                                                      |
+| `grep`        | `grep_files`               | Same shape; literal substring search (regex is not shipped).                                                                                                    |
+| `bash`        | `run_command`              | Honest name — Grida's host does not always launch a shell.                                                                                                      |
+| `todo`        | `todo_write`               | Same shape; replace-all semantics.                                                                                                                              |
+| `task`        | _not yet shipped_          | Subagent spawn surfaced behind editor flows; expose as `task` once stable.                                                                                      |
+| `question`    | `question`                 | Shipped. Pauses the run on a human (client-resolved survey card); interactive hosts (desktop, `serve` daemon) answer it, headless hosts return a fixed refusal. |
+| `web_search`  | _not yet shipped_          | Host-bound provider; out of scope for the first cut.                                                                                                            |
+| `web_fetch`   | _not yet shipped_          | As above.                                                                                                                                                       |
+| `skill`       | _not yet shipped_          | Discovery layer pending.                                                                                                                                        |
+| `tool_search` | `tool_search` _(proposed)_ | Two-level (literal + semantic) proposed below; not yet implemented.                                                                                             |
 
 ## Backends
 

--- a/editor/app/(dev)/ui/components/ai-chat/_chat-shell.tsx
+++ b/editor/app/(dev)/ui/components/ai-chat/_chat-shell.tsx
@@ -16,6 +16,9 @@ import {
   ChatMessageView,
   CompactingIndicator,
   PendingTurnIndicator,
+  QuestionCard,
+  findPendingQuestion,
+  type AnswerQuestionHandler,
   type ChatMessage,
   type ChatMessageActions,
 } from "@/kits/agent-chat";
@@ -29,6 +32,7 @@ export function DemoChatShell({
   onDismissError,
   className,
   actions,
+  onAnswerQuestion,
 }: {
   messages: ChatMessage[];
   isStreaming: boolean;
@@ -41,11 +45,16 @@ export function DemoChatShell({
   className?: string;
   /** Per-turn rewind/branch affordances under user bubbles (demo). */
   actions?: ChatMessageActions;
+  /** Commit a `question` answer (demo wires this to `chat.addToolResult`). */
+  onAnswerQuestion?: AnswerQuestionHandler;
 }) {
   // Mirrors the desktop surfaces: a turn is streaming but no assistant turn has
   // begun. The `pending` prop forces it for the static showcase scenario.
   const pendingTurn =
     pending || (isStreaming && messages.at(-1)?.role !== "assistant");
+  // The agent's open question is session-global — pinned above the composer
+  // slot, not rendered in the transcript (mirrors the desktop surfaces).
+  const pendingQuestion = findPendingQuestion(messages);
   return (
     <div
       data-testid="demo-ai-chat-shell"
@@ -69,6 +78,12 @@ export function DemoChatShell({
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
+
+      {pendingQuestion && onAnswerQuestion && (
+        <div className="shrink-0 border-t p-3">
+          <QuestionCard entry={pendingQuestion} onAnswer={onAnswerQuestion} />
+        </div>
+      )}
 
       {error && (
         <div className="flex items-start gap-2 border-t bg-destructive/10 px-3 py-2 text-xs text-destructive">

--- a/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
+++ b/editor/app/(dev)/ui/components/ai-chat/_scenarios.ts
@@ -342,6 +342,140 @@ export const SCENARIOS: Scenario[] = [
     }),
   },
 
+  // --- Question (ask-user survey) ---
+  // The locked `question` tool's interactive card. At `input-available` the run
+  // is paused on the user, so the survey form renders; submit/skip in the demo
+  // calls `chat.addToolResult`, flipping the part to `output-available` (the
+  // read-only summary). Pure UI surface — no model call.
+  {
+    id: "question-single",
+    label: "Single choice",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "input-available",
+      input: {
+        questions: [
+          {
+            question: "Which color scheme should I use for the poster?",
+            header: "Color scheme",
+            options: [
+              {
+                label: "Warm",
+                description: "Reds, oranges, yellows — energetic.",
+              },
+              { label: "Cool", description: "Blues, greens, purples — calm." },
+              { label: "Monochrome", description: "One hue or black & white." },
+            ],
+          },
+        ],
+      },
+    }),
+  },
+  {
+    id: "question-multi",
+    label: "Multi-select",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "input-available",
+      input: {
+        questions: [
+          {
+            question: "Which sections should the landing page include?",
+            header: "Sections",
+            multi_select: true,
+            options: [
+              { label: "Hero" },
+              { label: "Features" },
+              { label: "Pricing" },
+              { label: "Testimonials" },
+              { label: "FAQ" },
+            ],
+          },
+        ],
+      },
+    }),
+  },
+  {
+    id: "question-freetext",
+    label: "Free text only",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "input-available",
+      input: { questions: [{ question: "What should the headline say?" }] },
+    }),
+  },
+  {
+    id: "question-survey",
+    label: "Survey (multiple questions)",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "input-available",
+      input: {
+        questions: [
+          {
+            question: "Which color scheme?",
+            header: "Color",
+            options: [
+              { label: "Warm" },
+              { label: "Cool" },
+              { label: "Monochrome" },
+            ],
+          },
+          {
+            question: "Which sections to include?",
+            header: "Sections",
+            multi_select: true,
+            options: [
+              { label: "Hero" },
+              { label: "Features" },
+              { label: "Pricing" },
+            ],
+          },
+          { question: "Any other requirements?" },
+        ],
+      },
+    }),
+  },
+  {
+    id: "question-answered",
+    label: "Answered (summary)",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "output-available",
+      input: {
+        questions: [
+          {
+            question: "Which color scheme?",
+            options: [{ label: "Warm" }, { label: "Cool" }],
+          },
+        ],
+      },
+      output: { answers: [["Cool"]] },
+    }),
+  },
+  {
+    id: "question-skipped",
+    label: "Skipped",
+    group: "Question",
+    chunks: toolCall({
+      toolCallId: "q1",
+      toolName: "question",
+      state: "output-available",
+      input: { questions: [{ question: "Which color scheme?" }] },
+      output: { answers: [], skipped: true },
+    }),
+  },
+
   // --- C. Grouping ---
   {
     id: "group-reads",

--- a/editor/app/(dev)/ui/components/ai-chat/page.tsx
+++ b/editor/app/(dev)/ui/components/ai-chat/page.tsx
@@ -169,6 +169,17 @@ export default function AiChatDemoPage() {
               onFork: (id) => console.log("[demo] fork", id),
               disabled: isStreaming,
             }}
+            onAnswerQuestion={(toolCallId, output) => {
+              // Commit the answer into the mock Chat — the `question` part flips
+              // to `output-available` and the card swaps to its read-only
+              // summary. No model call (no sendAutomaticallyWhen on this Chat).
+              console.log("[demo] question answer", toolCallId, output);
+              void chat.addToolResult({
+                tool: "question",
+                toolCallId,
+                output,
+              });
+            }}
           />
         </ComponentDemo>
       </div>

--- a/editor/kits/agent-chat/README.md
+++ b/editor/kits/agent-chat/README.md
@@ -25,14 +25,47 @@ messages.map((m, i) => (
 - **Tool** parts → a compact `Task` row each; a run of consecutive tool calls
   collapses into one summary `Task` (label from `toolDisplay.summarize`). Each row
   expands to its input/output JSON.
+- **`question` tool** parts → only a passive record in the transcript ("asked you
+  …" + the answered summary). The interactive prompt is **session-global**, not a
+  transcript card — see below.
+
+Transcript-level indicators (rendered by the surface around the turn list, not
+per message): `PendingTurnIndicator` (pre-first-token), `CompactingIndicator`
+(in-flight compaction), `ForkedNotice`.
+
+## The agent's question (session-global)
+
+The locked `question` tool **asks** — the run pauses on a human. The kit models
+this like a supervised-approval bar, NOT a tool card: the surface finds the one
+open question and pins the form above its composer.
+
+```tsx
+const pending = findPendingQuestion(messages);
+{
+  pending && <QuestionCard entry={pending} onAnswer={onAnswerQuestion} />;
+}
+```
+
+`QuestionCard` owns its in-progress form selections (the same kind of transient
+UI state as the collapsibles); the **committed** answer leaves through `onAnswer`
+— the surface owns the `Chat` and calls `addToolResult`. The kit never touches
+the transport. `AnsweredQuestionSummary` is the read-only echo the transcript
+shows once answered.
 
 ## Contract (kit rules)
 
 - **Render-only / consumer-stateless**: you pass `message` + `isStreaming`; the kit
-  owns only the stock collapsibles' open/close state. No global stores, no IPC, no
-  route imports.
-- **Public API** (`index.ts`): `ChatMessageView` plus the `ChatMessage` /
-  `ToolCallEntry` types. `toolDisplay` (label/summary formatting) is internal.
+  owns only transient UI state (collapsibles' open/close, a `QuestionCard`'s
+  in-progress selections). No global stores, no IPC, no route imports; committed
+  outcomes leave through callbacks (`onAnswer`).
+- **Public API** (`index.ts`):
+  - `ChatMessageView` + the transcript indicators (`PendingTurnIndicator`,
+    `CompactingIndicator`, `ForkedNotice`).
+  - The session-global question prompt: `findPendingQuestion`, `QuestionCard`,
+    `AnsweredQuestionSummary`, and the `AnswerQuestionHandler` /
+    `QuestionAnswerOutput` types.
+  - The `ChatMessage` / `ToolCallEntry` types. `toolDisplay` (label/summary
+    formatting) is internal.
 - Shared message/tool types live in `@/lib/agent-chat` (the bridge transport +
   session helpers use them too); the kit imports them type-only.
 
@@ -44,6 +77,7 @@ Promoted out of the desktop scaffolds (was render-mis-filed there):
 - `tool-display.ts` / `tool-display.test.ts` ← `lib/agent-chat/`
 
 Reasoning rendering was added during the move (the scaffold version dropped
-reasoning parts). Consumers: the desktop AI sidebar (`scaffolds/desktop/ai-sidebar/`),
-the workspace pane (`scaffolds/desktop/workspace/`), and the
+reasoning parts). Consumers (each also pins `QuestionCard` above its composer):
+the desktop AI sidebar (`scaffolds/desktop/ai-sidebar/`), the workbench agent
+pane (`scaffolds/desktop/workbench/agent-pane.tsx`), and the
 `/ui/components/ai-chat` demo.

--- a/editor/kits/agent-chat/index.ts
+++ b/editor/kits/agent-chat/index.ts
@@ -5,3 +5,12 @@ export {
   PendingTurnIndicator,
 } from "./message";
 export type { ChatMessage, ChatMessageActions, ToolCallEntry } from "./message";
+export {
+  QuestionCard,
+  AnsweredQuestionSummary,
+  findPendingQuestion,
+} from "./question-card";
+export type {
+  AnswerQuestionHandler,
+  QuestionAnswerOutput,
+} from "./question-card";

--- a/editor/kits/agent-chat/message.tsx
+++ b/editor/kits/agent-chat/message.tsx
@@ -656,6 +656,10 @@ function QuestionToolView({ entry }: { entry: ToolCallEntry }) {
     : description.title;
   if (entry.state === "input-streaming") return null;
   const pending = entry.state === "input-available";
+  // A `question` part can be `output-error` — a headless host's fixed refusal
+  // (RFC §question), or any tool error. Surface its text rather than the empty
+  // answered summary, so the refusal/error isn't silently swallowed.
+  const errored = entry.state === "output-error";
   return (
     <div className="w-full">
       <div className="flex items-center gap-2 text-muted-foreground text-xs">
@@ -666,6 +670,8 @@ function QuestionToolView({ entry }: { entry: ToolCallEntry }) {
         <p className="mt-1 text-xs text-muted-foreground/80">
           Awaiting your answer below.
         </p>
+      ) : errored ? (
+        <ToolOutput output={undefined} errorText={entry.errorText} />
       ) : (
         <AnsweredQuestionSummary entry={entry} />
       )}

--- a/editor/kits/agent-chat/message.tsx
+++ b/editor/kits/agent-chat/message.tsx
@@ -42,6 +42,7 @@ import {
   FolderTreeIcon,
   GitBranchIcon,
   ListTodoIcon,
+  MessageCircleQuestionIcon,
   RotateCcwIcon,
   SearchIcon,
   SquareTerminalIcon,
@@ -76,6 +77,7 @@ import {
 import type { ChatMessage, ToolCallEntry } from "@/lib/agent-chat";
 import { toolDisplay, type ToolDisplayDescription } from "./tool-display";
 import { groupMessageParts } from "./group-parts";
+import { AnsweredQuestionSummary, isQuestionEntry } from "./question-card";
 
 export type { ChatMessage, ToolCallEntry };
 
@@ -590,6 +592,13 @@ function approvalOf(entry: ToolCallEntry) {
 }
 
 function ToolCallView({ entry }: { entry: ToolCallEntry }) {
+  // The `question` tool's INTERACTIVE prompt is session-global (pinned above the
+  // composer by the surface — see `findPendingQuestion` / `QuestionCard`). In
+  // the transcript it's only a passive record of what was asked / answered.
+  if (isQuestionEntry(entry)) {
+    return <QuestionToolView entry={entry} />;
+  }
+
   const description = toolDisplay.describe(entry);
   const title = description.detail
     ? `${description.title} · ${description.detail}`
@@ -635,6 +644,35 @@ function ToolCallView({ entry }: { entry: ToolCallEntry }) {
   );
 }
 
+// The `question` tool's PASSIVE transcript record. The interactive prompt is
+// session-global (the surface pins `QuestionCard` above its composer), so here
+// we only show what was asked — a one-line header — and, once answered, the
+// read-only echo of the answer. While the run is paused on the user the header
+// points them at the prompt; `input-streaming` (partial input) shows nothing.
+function QuestionToolView({ entry }: { entry: ToolCallEntry }) {
+  const description = toolDisplay.describe(entry);
+  const title = description.detail
+    ? `${description.title} · ${description.detail}`
+    : description.title;
+  if (entry.state === "input-streaming") return null;
+  const pending = entry.state === "input-available";
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2 text-muted-foreground text-xs">
+        <MessageCircleQuestionIcon className="size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate">{title}</span>
+      </div>
+      {pending ? (
+        <p className="mt-1 text-xs text-muted-foreground/80">
+          Awaiting your answer below.
+        </p>
+      ) : (
+        <AnsweredQuestionSummary entry={entry} />
+      )}
+    </div>
+  );
+}
+
 // `TaskTrigger` renders `children ?? <default SearchIcon row>`, so a custom
 // child swaps the action-agnostic search glyph for a per-action icon. Must
 // be a single element (the trigger is `asChild`), not a component instance.
@@ -664,6 +702,8 @@ function iconForAction(action: ToolDisplayDescription["action"]): LucideIcon {
       return ListTodoIcon;
     case "command":
       return SquareTerminalIcon;
+    case "question":
+      return MessageCircleQuestionIcon;
     case "tool":
       return WrenchIcon;
   }

--- a/editor/kits/agent-chat/question-card.tsx
+++ b/editor/kits/agent-chat/question-card.tsx
@@ -1,0 +1,391 @@
+/**
+ * `@/kits/agent-chat` — the locked `question` (ask-user) tool's UI.
+ *
+ * Mental model: the agent **asks**. This is NOT a tool card buried in the
+ * transcript — it is a SESSION-GLOBAL prompt the host surface pins above its
+ * composer (exactly like the supervised-approval bar). The run is paused on the
+ * human; {@link findPendingQuestion} finds the one open question for the
+ * session, the surface mounts {@link QuestionCard} above the composer, and the
+ * committed answer leaves through `onAnswer` — the surface owns the `Chat` and
+ * calls `chat.addToolResult({ tool: "question", toolCallId, output })`. The
+ * transcript only shows a passive record of what was asked/answered.
+ *
+ * Per the RFC (`tools` §question) the tool is text-only: each question offers
+ * options to pick (single via radio, many via checkbox when `multi_select`) and
+ * ALWAYS a free-text write-in, so the user can answer in their own words. "Skip"
+ * dismisses the survey with a sentinel result so the model knows it was declined
+ * (distinct from the headless refusal). Answers are `string[][]` — one array per
+ * question.
+ */
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { getToolName } from "ai";
+import { cn } from "@app/ui/lib/utils";
+import { Button } from "@app/ui/components/button";
+import { Checkbox } from "@app/ui/components/checkbox";
+import { Label } from "@app/ui/components/label";
+import { RadioGroup, RadioGroupItem } from "@app/ui/components/radio-group";
+import { Textarea } from "@app/ui/components/textarea";
+import type { ChatMessage, ToolCallEntry } from "@/lib/agent-chat";
+
+/** The `question` tool's result shape (mirrors the package `outputSchema`). */
+export type QuestionAnswerOutput = {
+  answers: string[][];
+  skipped?: boolean;
+};
+
+/**
+ * Commit an answer to the open `question`. The surface wires this to
+ * `chat.addToolResult`, so the human's answer becomes the tool result and the
+ * paused run resumes.
+ */
+export type AnswerQuestionHandler = (
+  toolCallId: string,
+  output: QuestionAnswerOutput
+) => void;
+
+type QuestionOption = { label: string; description?: string };
+type QuestionSpec = {
+  question: string;
+  header?: string;
+  options?: QuestionOption[];
+  multi_select?: boolean;
+};
+
+// The locked tool name is producer-owned vocabulary (`@grida/agent`'s
+// `QUESTION_TOOL_NAME`). It is mirrored here as a one-char-cheap string rather
+// than imported so this render-only kit needn't pull the package's neutral
+// runtime entrypoint for a constant — the same reason `tool-display.ts` matches
+// `run_command` by literal. The wire shape is `tool-<name>` (AI SDK UI parts).
+export const QUESTION_TOOL_NAME = "question";
+const QUESTION_PART_TYPE = `tool-${QUESTION_TOOL_NAME}`;
+
+/** True iff this tool part is the locked `question` tool. */
+export function isQuestionEntry(entry: ToolCallEntry): boolean {
+  return getToolName(entry) === QUESTION_TOOL_NAME;
+}
+
+/** Tolerate the AI SDK's `toolCallId` (live stream) vs the persisted
+ *  `tool_call_id` (rehydrated from the DB on reload). */
+function toolCallIdOf(entry: ToolCallEntry): string {
+  const e = entry as { toolCallId?: string; tool_call_id?: string };
+  return e.toolCallId ?? e.tool_call_id ?? "";
+}
+
+/**
+ * The session's ONE open question, or null. A `question` call pauses the run,
+ * so it lives on the last assistant message at `input-available` (the same
+ * shape rule as the approval bar's `findPendingApproval`). The surface renders
+ * {@link QuestionCard} for it above the composer. Tolerates camelCase (live)
+ * and snake_case (rehydrated) part shapes.
+ */
+export function findPendingQuestion(
+  messages: ChatMessage[]
+): ToolCallEntry | null {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "assistant") return null;
+  for (const part of last.parts) {
+    const p = part as {
+      type?: string;
+      state?: string;
+      toolCallId?: string;
+      tool_call_id?: string;
+    };
+    const toolCallId = p.toolCallId ?? p.tool_call_id;
+    if (
+      p.type === QUESTION_PART_TYPE &&
+      p.state === "input-available" &&
+      toolCallId
+    ) {
+      return part as ToolCallEntry;
+    }
+  }
+  return null;
+}
+
+function readQuestions(entry: ToolCallEntry): QuestionSpec[] {
+  const input = "input" in entry ? entry.input : undefined;
+  const questions = (input as { questions?: unknown })?.questions;
+  if (!Array.isArray(questions)) return [];
+  return questions
+    .filter((q): q is QuestionSpec => Boolean(q) && typeof q === "object")
+    .map((q) => ({
+      question: String(q.question ?? ""),
+      header: typeof q.header === "string" ? q.header : undefined,
+      options: Array.isArray(q.options)
+        ? q.options
+            .filter(
+              (o): o is QuestionOption => Boolean(o) && typeof o === "object"
+            )
+            .map((o) => ({
+              label: String(o.label ?? ""),
+              description:
+                typeof o.description === "string" ? o.description : undefined,
+            }))
+        : undefined,
+      multi_select: Boolean(q.multi_select),
+    }));
+}
+
+/**
+ * The interactive survey form. Rendered while the `question` part is
+ * `input-available` (the run is paused on the user). On submit/skip it calls
+ * `onAnswer(toolCallId, output)`; the host wires that to `addToolResult`.
+ */
+export function QuestionCard({
+  entry,
+  onAnswer,
+  disabled,
+}: {
+  entry: ToolCallEntry;
+  onAnswer: (toolCallId: string, output: QuestionAnswerOutput) => void;
+  disabled?: boolean;
+}) {
+  const questions = useMemo(() => readQuestions(entry), [entry]);
+  // Per question: picked option labels + a free-text write-in.
+  const [picked, setPicked] = useState<string[][]>(() =>
+    questions.map(() => [])
+  );
+  const [writeIns, setWriteIns] = useState<string[]>(() =>
+    questions.map(() => "")
+  );
+  const [submitted, setSubmitted] = useState(false);
+  // A survey of >1 question is a one-at-a-time wizard: step through with
+  // Back/Next, Submit on the last. A single question shows no stepper.
+  const [step, setStep] = useState(0);
+
+  const answers = useMemo(
+    () =>
+      questions.map((q, i) => {
+        const wi = (writeIns[i] ?? "").trim();
+        if (q.multi_select) {
+          return [...(picked[i] ?? []), ...(wi ? [wi] : [])];
+        }
+        // Single-select: a write-in (the user's own words) wins over a pick.
+        if (wi) return [wi];
+        return (picked[i] ?? []).slice(0, 1);
+      }),
+    [questions, picked, writeIns]
+  );
+
+  const canSubmit =
+    questions.length > 0 && answers.every((a) => a.length > 0) && !disabled;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    setSubmitted(true);
+    onAnswer(toolCallIdOf(entry), { answers });
+  };
+
+  const skip = () => {
+    if (disabled) return;
+    setSubmitted(true);
+    onAnswer(toolCallIdOf(entry), { answers: [], skipped: true });
+  };
+
+  const togglePick = (qi: number, label: string, multi: boolean) => {
+    setPicked((prev) => {
+      const next = prev.map((row) => [...row]);
+      if (multi) {
+        const row = next[qi] ?? [];
+        next[qi] = row.includes(label)
+          ? row.filter((l) => l !== label)
+          : [...row, label];
+      } else {
+        next[qi] = [label];
+      }
+      return next;
+    });
+  };
+
+  if (questions.length === 0) return null;
+
+  const busy = disabled || submitted;
+  const multiStep = questions.length > 1;
+  const isLast = step === questions.length - 1;
+  // The current step's question must be answered before advancing; on the last
+  // step Submit additionally requires every question answered (`canSubmit`).
+  const currentAnswered = (answers[step] ?? []).length > 0;
+
+  const renderQuestion = (qi: number) => {
+    const q = questions[qi];
+    return (
+      <div className="flex flex-col gap-2">
+        {q.header && (
+          <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {q.header}
+          </span>
+        )}
+        <p className="text-sm font-medium">{q.question}</p>
+
+        {q.options && q.options.length > 0 && !q.multi_select && (
+          <RadioGroup
+            value={(picked[qi] ?? [])[0] ?? ""}
+            onValueChange={(label) => togglePick(qi, label, false)}
+            disabled={busy}
+            className="gap-1.5"
+          >
+            {q.options.map((opt, oi) => (
+              <Label
+                key={oi}
+                className="flex cursor-pointer items-start gap-2 text-sm font-normal"
+              >
+                <RadioGroupItem value={opt.label} className="mt-0.5" />
+                <span className="flex flex-col">
+                  <span>{opt.label}</span>
+                  {opt.description && (
+                    <span className="text-xs text-muted-foreground">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+              </Label>
+            ))}
+          </RadioGroup>
+        )}
+
+        {q.options && q.options.length > 0 && q.multi_select && (
+          <div className="flex flex-col gap-1.5">
+            {q.options.map((opt, oi) => (
+              <Label
+                key={oi}
+                className="flex cursor-pointer items-start gap-2 text-sm font-normal"
+              >
+                <Checkbox
+                  checked={(picked[qi] ?? []).includes(opt.label)}
+                  onCheckedChange={() => togglePick(qi, opt.label, true)}
+                  disabled={busy}
+                  className="mt-0.5"
+                />
+                <span className="flex flex-col">
+                  <span>{opt.label}</span>
+                  {opt.description && (
+                    <span className="text-xs text-muted-foreground">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+              </Label>
+            ))}
+          </div>
+        )}
+
+        <Textarea
+          value={writeIns[qi] ?? ""}
+          onChange={(e) =>
+            setWriteIns((prev) => {
+              const next = [...prev];
+              next[qi] = e.target.value;
+              return next;
+            })
+          }
+          disabled={busy}
+          rows={2}
+          placeholder={
+            q.options && q.options.length > 0
+              ? "Or write your own answer…"
+              : "Type your answer…"
+          }
+          className="text-sm"
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {renderQuestion(multiStep ? step : 0)}
+
+      <div className="flex items-center gap-2">
+        {multiStep && (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            Question {step + 1} of {questions.length}
+          </span>
+        )}
+        <div className="flex-1" />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={skip}
+          disabled={busy}
+        >
+          Skip
+        </Button>
+        {multiStep && step > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            disabled={busy}
+          >
+            Back
+          </Button>
+        )}
+        {multiStep && !isLast ? (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() =>
+              setStep((s) => Math.min(questions.length - 1, s + 1))
+            }
+            disabled={!currentAnswered || busy}
+          >
+            Next
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            onClick={submit}
+            disabled={!canSubmit || submitted}
+          >
+            Submit
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Read-only echo of an answered (or skipped) survey — rendered once the
+ * `question` part is terminal (`output-available`), so the transcript shows what
+ * was asked and how the user answered.
+ */
+export function AnsweredQuestionSummary({ entry }: { entry: ToolCallEntry }) {
+  const questions = readQuestions(entry);
+  const output = ("output" in entry ? entry.output : undefined) as
+    | QuestionAnswerOutput
+    | undefined;
+  if (questions.length === 0) return null;
+
+  if (output?.skipped) {
+    return (
+      <div
+        className={cn(
+          "mt-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground"
+        )}
+      >
+        You skipped this question.
+      </div>
+    );
+  }
+
+  const answers = output?.answers ?? [];
+  return (
+    <div className="mt-2 flex flex-col gap-2 rounded-md border bg-muted/40 p-3">
+      {questions.map((q, qi) => (
+        <div key={qi} className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">{q.question}</span>
+          <span className="text-sm font-medium">
+            {(answers[qi] ?? []).join(", ") || "—"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/editor/kits/agent-chat/question-card.tsx
+++ b/editor/kits/agent-chat/question-card.tsx
@@ -146,6 +146,7 @@ export function QuestionCard({
   const writeIn = survey.writeInFor(qi);
 
   const finalize = (s: QuestionSurvey) => {
+    if (busy) return;
     setSubmitted(true);
     onAnswer(toolCallId, s.buildOutput());
   };
@@ -179,6 +180,7 @@ export function QuestionCard({
 
         {hasOptions && !q.multi_select && (
           <RadioGroup
+            aria-labelledby={questionId}
             value={survey.pickedFor(qi)[0] ?? ""}
             onValueChange={(label) => setSurvey(survey.togglePick(qi, label))}
             disabled={busy}
@@ -204,7 +206,11 @@ export function QuestionCard({
         )}
 
         {hasOptions && q.multi_select && (
-          <div className="flex flex-col gap-1.5">
+          <div
+            role="group"
+            aria-labelledby={questionId}
+            className="flex flex-col gap-1.5"
+          >
             {q.options!.map((opt, oi) => (
               <Label
                 key={oi}
@@ -286,7 +292,7 @@ export function QuestionCard({
             type="button"
             size="sm"
             onClick={() => finalize(survey)}
-            disabled={!survey.canSubmit || submitted}
+            disabled={!survey.canSubmit || busy}
           >
             Submit
           </Button>

--- a/editor/kits/agent-chat/question-card.tsx
+++ b/editor/kits/agent-chat/question-card.tsx
@@ -10,17 +10,16 @@
  * calls `chat.addToolResult({ tool: "question", toolCallId, output })`. The
  * transcript only shows a passive record of what was asked/answered.
  *
- * Per the RFC (`tools` §question) the tool is text-only: each question offers
- * options to pick (single via radio, many via checkbox when `multi_select`) and
- * ALWAYS a free-text write-in, so the user can answer in their own words. "Skip"
- * dismisses the survey with a sentinel result so the model knows it was declined
- * (distinct from the headless refusal). Answers are `string[][]` — one array per
- * question.
+ * This file is a THIN VIEW. All form logic — per-question selections, write-ins,
+ * per-question skip, the wizard step, answer-building, and validation — lives in
+ * the React-free {@link QuestionSurvey} core (`question-survey.ts`), which is
+ * unit-tested on its own. The component holds one survey in state and swaps it
+ * for the next on each transition.
  */
 
 "use client";
 
-import { useId, useMemo, useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { getToolName } from "ai";
 import { cn } from "@app/ui/lib/utils";
 import { Button } from "@app/ui/components/button";
@@ -29,12 +28,13 @@ import { Label } from "@app/ui/components/label";
 import { RadioGroup, RadioGroupItem } from "@app/ui/components/radio-group";
 import { Textarea } from "@app/ui/components/textarea";
 import type { ChatMessage, ToolCallEntry } from "@/lib/agent-chat";
+import {
+  parseQuestions,
+  QuestionSurvey,
+  type QuestionAnswerOutput,
+} from "./question-survey";
 
-/** The `question` tool's result shape (mirrors the package `outputSchema`). */
-export type QuestionAnswerOutput = {
-  answers: string[][];
-  skipped?: boolean;
-};
+export type { QuestionAnswerOutput };
 
 /**
  * Commit an answer to the open `question`. The surface wires this to
@@ -45,14 +45,6 @@ export type AnswerQuestionHandler = (
   toolCallId: string,
   output: QuestionAnswerOutput
 ) => void;
-
-type QuestionOption = { label: string; description?: string };
-type QuestionSpec = {
-  question: string;
-  header?: string;
-  options?: QuestionOption[];
-  multi_select?: boolean;
-};
 
 // The locked tool name is producer-owned vocabulary (`@grida/agent`'s
 // `QUESTION_TOOL_NAME`). It is mirrored here as a one-char-cheap string rather
@@ -72,6 +64,10 @@ export function isQuestionEntry(entry: ToolCallEntry): boolean {
 function toolCallIdOf(entry: ToolCallEntry): string {
   const e = entry as { toolCallId?: string; tool_call_id?: string };
   return e.toolCallId ?? e.tool_call_id ?? "";
+}
+
+function inputOf(entry: ToolCallEntry): unknown {
+  return "input" in entry ? entry.input : undefined;
 }
 
 /**
@@ -105,34 +101,11 @@ export function findPendingQuestion(
   return null;
 }
 
-function readQuestions(entry: ToolCallEntry): QuestionSpec[] {
-  const input = "input" in entry ? entry.input : undefined;
-  const questions = (input as { questions?: unknown })?.questions;
-  if (!Array.isArray(questions)) return [];
-  return questions
-    .filter((q): q is QuestionSpec => Boolean(q) && typeof q === "object")
-    .map((q) => ({
-      question: String(q.question ?? ""),
-      header: typeof q.header === "string" ? q.header : undefined,
-      options: Array.isArray(q.options)
-        ? q.options
-            .filter(
-              (o): o is QuestionOption => Boolean(o) && typeof o === "object"
-            )
-            .map((o) => ({
-              label: String(o.label ?? ""),
-              description:
-                typeof o.description === "string" ? o.description : undefined,
-            }))
-        : undefined,
-      multi_select: Boolean(q.multi_select),
-    }));
-}
-
 /**
- * The interactive survey form. Rendered while the `question` part is
- * `input-available` (the run is paused on the user). On submit/skip it calls
- * `onAnswer(toolCallId, output)`; the host wires that to `addToolResult`.
+ * The interactive survey form — a thin view over {@link QuestionSurvey}. Rendered
+ * while the `question` part is `input-available` (the run is paused on the user).
+ * On submit/skip it calls `onAnswer(toolCallId, output)`; the host wires that to
+ * `addToolResult`.
  */
 export function QuestionCard({
   entry,
@@ -140,123 +113,62 @@ export function QuestionCard({
   disabled,
 }: {
   entry: ToolCallEntry;
-  onAnswer: (toolCallId: string, output: QuestionAnswerOutput) => void;
+  onAnswer: AnswerQuestionHandler;
   disabled?: boolean;
 }) {
-  const questions = useMemo(() => readQuestions(entry), [entry]);
-  // Stable prefix for `<label>`/`aria-labelledby` ids tying each write-in to its
-  // question text (the form gives screen readers no other accessible name).
+  // Stable prefix for `aria-labelledby` ids tying each write-in to its question
+  // text (the form gives screen readers no other accessible name).
   const labelId = useId();
-  // Per question: picked option labels + a free-text write-in.
-  const [picked, setPicked] = useState<string[][]>(() =>
-    questions.map(() => [])
-  );
-  const [writeIns, setWriteIns] = useState<string[]>(() =>
-    questions.map(() => "")
+  const [survey, setSurvey] = useState(() =>
+    QuestionSurvey.from(inputOf(entry))
   );
   const [submitted, setSubmitted] = useState(false);
-  // A survey of >1 question is a one-at-a-time wizard: step through with
-  // Back/Next, Submit on the last. A single question shows no stepper.
-  const [step, setStep] = useState(0);
 
-  // Reset all in-progress state when the pending tool call changes. A surface
-  // may reuse this instance for a NEW question without unmounting (e.g. two
-  // questions back-to-back in one turn, where `pendingQuestion` goes Q1→Q2
-  // without passing through null), and stale selections / disabled state must
-  // not carry into the next answer. React's guarded "adjust state during render"
-  // pattern — runs once per id change, not every render.
+  // Reset when the pending tool call changes — a surface may reuse this instance
+  // for a NEW question without unmounting (two questions back-to-back in one
+  // turn). React's guarded "adjust state during render" pattern.
   const toolCallId = toolCallIdOf(entry);
   const seenToolCallId = useRef(toolCallId);
   if (seenToolCallId.current !== toolCallId) {
     seenToolCallId.current = toolCallId;
-    setPicked(questions.map(() => []));
-    setWriteIns(questions.map(() => ""));
+    setSurvey(QuestionSurvey.from(inputOf(entry)));
     setSubmitted(false);
-    setStep(0);
   }
 
-  const answers = useMemo(
-    () =>
-      questions.map((q, i) => {
-        const wi = (writeIns[i] ?? "").trim();
-        if (q.multi_select) {
-          return [...(picked[i] ?? []), ...(wi ? [wi] : [])];
-        }
-        // Single-select: a write-in (the user's own words) wins over a pick.
-        if (wi) return [wi];
-        return (picked[i] ?? []).slice(0, 1);
-      }),
-    [questions, picked, writeIns]
-  );
-
-  const canSubmit =
-    questions.length > 0 && answers.every((a) => a.length > 0) && !disabled;
-
-  const submit = () => {
-    if (!canSubmit) return;
-    setSubmitted(true);
-    onAnswer(toolCallId, { answers });
-  };
-
-  const skip = () => {
-    if (disabled) return;
-    setSubmitted(true);
-    onAnswer(toolCallId, { answers: [], skipped: true });
-  };
-
-  const togglePick = (qi: number, label: string, multi: boolean) => {
-    setPicked((prev) => {
-      const next = prev.map((row) => [...row]);
-      if (multi) {
-        const row = next[qi] ?? [];
-        next[qi] = row.includes(label)
-          ? row.filter((l) => l !== label)
-          : [...row, label];
-      } else {
-        next[qi] = [label];
-      }
-      return next;
-    });
-    // Picking an option and writing your own are mutually exclusive — picking
-    // clears the custom text so the option wins.
-    setWriteIns((prev) =>
-      prev[qi] ? prev.map((v, i) => (i === qi ? "" : v)) : prev
-    );
-  };
-
-  // The custom write-in is exclusive: focusing or typing it makes it THE answer
-  // and deselects any picked option(s) for that question ("when custom, it's
-  // always custom"). No-op once the picks are already empty.
-  const selectCustom = (qi: number) => {
-    setPicked((prev) =>
-      (prev[qi] ?? []).length
-        ? prev.map((row, i) => (i === qi ? [] : row))
-        : prev
-    );
-  };
-
-  if (questions.length === 0) return null;
+  if (survey.count === 0) return null;
 
   const busy = disabled || submitted;
-  const multiStep = questions.length > 1;
-  const isLast = step === questions.length - 1;
-  // The current step's question must be answered before advancing; on the last
-  // step Submit additionally requires every question answered (`canSubmit`).
-  const currentAnswered = (answers[step] ?? []).length > 0;
+  const qi = survey.multiStep ? survey.step : 0;
+  const q = survey.questions[qi];
+  if (!q) return null;
+  const questionId = `${labelId}-q${qi}`;
+  const hasOptions = (q.options?.length ?? 0) > 0;
+  const writeIn = survey.writeInFor(qi);
 
-  const renderQuestion = (qi: number) => {
-    const q = questions[qi];
-    const questionId = `${labelId}-q${qi}`;
-    return (
+  const finalize = (s: QuestionSurvey) => {
+    setSubmitted(true);
+    onAnswer(toolCallId, s.buildOutput());
+  };
+  // Skip is PER QUESTION: skip the current one (its answer becomes empty) and
+  // advance, or finalize if it's the last/only question.
+  const onSkip = () => {
+    if (busy) return;
+    const skipped = survey.skipCurrent();
+    if (survey.multiStep && !survey.isLast) setSurvey(skipped.next());
+    else finalize(skipped);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
-        {(q.header || multiStep) && (
+        {(q.header || survey.multiStep) && (
           <div className="flex items-center justify-between gap-2">
             <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
               {q.header}
             </span>
-            {multiStep && (
+            {survey.multiStep && (
               <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
-                Question {step + 1} of {questions.length}
+                Question {survey.step + 1} of {survey.count}
               </span>
             )}
           </div>
@@ -265,14 +177,14 @@ export function QuestionCard({
           {q.question}
         </p>
 
-        {q.options && q.options.length > 0 && !q.multi_select && (
+        {hasOptions && !q.multi_select && (
           <RadioGroup
-            value={(picked[qi] ?? [])[0] ?? ""}
-            onValueChange={(label) => togglePick(qi, label, false)}
+            value={survey.pickedFor(qi)[0] ?? ""}
+            onValueChange={(label) => setSurvey(survey.togglePick(qi, label))}
             disabled={busy}
             className="gap-1.5"
           >
-            {q.options.map((opt, oi) => (
+            {q.options!.map((opt, oi) => (
               <Label
                 key={oi}
                 className="flex cursor-pointer items-start gap-2 text-sm font-normal"
@@ -291,16 +203,18 @@ export function QuestionCard({
           </RadioGroup>
         )}
 
-        {q.options && q.options.length > 0 && q.multi_select && (
+        {hasOptions && q.multi_select && (
           <div className="flex flex-col gap-1.5">
-            {q.options.map((opt, oi) => (
+            {q.options!.map((opt, oi) => (
               <Label
                 key={oi}
                 className="flex cursor-pointer items-start gap-2 text-sm font-normal"
               >
                 <Checkbox
-                  checked={(picked[qi] ?? []).includes(opt.label)}
-                  onCheckedChange={() => togglePick(qi, opt.label, true)}
+                  checked={survey.pickedFor(qi).includes(opt.label)}
+                  onCheckedChange={() =>
+                    setSurvey(survey.togglePick(qi, opt.label))
+                  }
                   disabled={busy}
                   className="mt-0.5"
                 />
@@ -319,45 +233,30 @@ export function QuestionCard({
 
         <Textarea
           aria-labelledby={questionId}
-          value={writeIns[qi] ?? ""}
-          onFocus={() => selectCustom(qi)}
-          onChange={(e) => {
-            selectCustom(qi);
-            setWriteIns((prev) => {
-              const next = [...prev];
-              next[qi] = e.target.value;
-              return next;
-            });
-          }}
+          value={writeIn}
+          onFocus={() => setSurvey(survey.selectCustom(qi))}
+          onChange={(e) => setSurvey(survey.setWriteIn(qi, e.target.value))}
           disabled={busy}
           rows={2}
           placeholder={
-            q.options && q.options.length > 0
-              ? "Or write your own answer…"
-              : "Type your answer…"
+            hasOptions ? "Or write your own answer…" : "Type your answer…"
           }
-          // Highlight the custom field while it holds the answer (its picks are
+          // Highlight the custom field while it holds the answer (its options are
           // cleared), so "custom is selected" reads visually.
           className={cn(
             "text-sm",
-            (writeIns[qi] ?? "").trim().length > 0 && "ring-1 ring-ring"
+            writeIn.trim().length > 0 && "ring-1 ring-ring"
           )}
         />
       </div>
-    );
-  };
-
-  return (
-    <div className="flex flex-col gap-4">
-      {renderQuestion(multiStep ? step : 0)}
 
       <div className="flex items-center gap-2">
-        {multiStep && step > 0 && (
+        {survey.multiStep && survey.step > 0 && (
           <Button
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            onClick={() => setSurvey(survey.back())}
             disabled={busy}
           >
             Back
@@ -368,19 +267,17 @@ export function QuestionCard({
           type="button"
           variant="ghost"
           size="sm"
-          onClick={skip}
+          onClick={onSkip}
           disabled={busy}
         >
           Skip
         </Button>
-        {multiStep && !isLast ? (
+        {survey.multiStep && !survey.isLast ? (
           <Button
             type="button"
             size="sm"
-            onClick={() =>
-              setStep((s) => Math.min(questions.length - 1, s + 1))
-            }
-            disabled={!currentAnswered || busy}
+            onClick={() => setSurvey(survey.next())}
+            disabled={!survey.currentAnswered || busy}
           >
             Next
           </Button>
@@ -388,8 +285,8 @@ export function QuestionCard({
           <Button
             type="button"
             size="sm"
-            onClick={submit}
-            disabled={!canSubmit || submitted}
+            onClick={() => finalize(survey)}
+            disabled={!survey.canSubmit || submitted}
           >
             Submit
           </Button>
@@ -400,12 +297,14 @@ export function QuestionCard({
 }
 
 /**
- * Read-only echo of an answered (or skipped) survey — rendered once the
- * `question` part is terminal (`output-available`), so the transcript shows what
- * was asked and how the user answered.
+ * Read-only echo of an answered survey — rendered once the `question` part is
+ * terminal (`output-available`), so the transcript shows what was asked and how
+ * the user answered. Per-question: an answered question shows its answer; a
+ * skipped one shows "Skipped". The `skipped` sentinel (the user declined the
+ * WHOLE survey) shows a single line.
  */
 export function AnsweredQuestionSummary({ entry }: { entry: ToolCallEntry }) {
-  const questions = readQuestions(entry);
+  const questions = parseQuestions(inputOf(entry));
   const output = ("output" in entry ? entry.output : undefined) as
     | QuestionAnswerOutput
     | undefined;
@@ -413,12 +312,8 @@ export function AnsweredQuestionSummary({ entry }: { entry: ToolCallEntry }) {
 
   if (output?.skipped) {
     return (
-      <div
-        className={cn(
-          "mt-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground"
-        )}
-      >
-        You skipped this question.
+      <div className="mt-2 rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+        You skipped this.
       </div>
     );
   }
@@ -426,14 +321,22 @@ export function AnsweredQuestionSummary({ entry }: { entry: ToolCallEntry }) {
   const answers = output?.answers ?? [];
   return (
     <div className="mt-2 flex flex-col gap-2 rounded-md border bg-muted/40 p-3">
-      {questions.map((q, qi) => (
-        <div key={qi} className="flex flex-col gap-0.5">
-          <span className="text-xs text-muted-foreground">{q.question}</span>
-          <span className="text-sm font-medium">
-            {(answers[qi] ?? []).join(", ") || "—"}
-          </span>
-        </div>
-      ))}
+      {questions.map((q, qi) => {
+        const a = answers[qi] ?? [];
+        return (
+          <div key={qi} className="flex flex-col gap-0.5">
+            <span className="text-xs text-muted-foreground">{q.question}</span>
+            <span
+              className={cn(
+                "text-sm font-medium",
+                a.length === 0 && "text-muted-foreground italic"
+              )}
+            >
+              {a.length ? a.join(", ") : "Skipped"}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/editor/kits/agent-chat/question-card.tsx
+++ b/editor/kits/agent-chat/question-card.tsx
@@ -217,6 +217,22 @@ export function QuestionCard({
       }
       return next;
     });
+    // Picking an option and writing your own are mutually exclusive — picking
+    // clears the custom text so the option wins.
+    setWriteIns((prev) =>
+      prev[qi] ? prev.map((v, i) => (i === qi ? "" : v)) : prev
+    );
+  };
+
+  // The custom write-in is exclusive: focusing or typing it makes it THE answer
+  // and deselects any picked option(s) for that question ("when custom, it's
+  // always custom"). No-op once the picks are already empty.
+  const selectCustom = (qi: number) => {
+    setPicked((prev) =>
+      (prev[qi] ?? []).length
+        ? prev.map((row, i) => (i === qi ? [] : row))
+        : prev
+    );
   };
 
   if (questions.length === 0) return null;
@@ -233,10 +249,17 @@ export function QuestionCard({
     const questionId = `${labelId}-q${qi}`;
     return (
       <div className="flex flex-col gap-2">
-        {q.header && (
-          <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            {q.header}
-          </span>
+        {(q.header || multiStep) && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {q.header}
+            </span>
+            {multiStep && (
+              <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                Question {step + 1} of {questions.length}
+              </span>
+            )}
+          </div>
         )}
         <p id={questionId} className="text-sm font-medium">
           {q.question}
@@ -297,13 +320,15 @@ export function QuestionCard({
         <Textarea
           aria-labelledby={questionId}
           value={writeIns[qi] ?? ""}
-          onChange={(e) =>
+          onFocus={() => selectCustom(qi)}
+          onChange={(e) => {
+            selectCustom(qi);
             setWriteIns((prev) => {
               const next = [...prev];
               next[qi] = e.target.value;
               return next;
-            })
-          }
+            });
+          }}
           disabled={busy}
           rows={2}
           placeholder={
@@ -311,7 +336,12 @@ export function QuestionCard({
               ? "Or write your own answer…"
               : "Type your answer…"
           }
-          className="text-sm"
+          // Highlight the custom field while it holds the answer (its picks are
+          // cleared), so "custom is selected" reads visually.
+          className={cn(
+            "text-sm",
+            (writeIns[qi] ?? "").trim().length > 0 && "ring-1 ring-ring"
+          )}
         />
       </div>
     );
@@ -322,21 +352,6 @@ export function QuestionCard({
       {renderQuestion(multiStep ? step : 0)}
 
       <div className="flex items-center gap-2">
-        {multiStep && (
-          <span className="text-xs text-muted-foreground tabular-nums">
-            Question {step + 1} of {questions.length}
-          </span>
-        )}
-        <div className="flex-1" />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={skip}
-          disabled={busy}
-        >
-          Skip
-        </Button>
         {multiStep && step > 0 && (
           <Button
             type="button"
@@ -348,6 +363,16 @@ export function QuestionCard({
             Back
           </Button>
         )}
+        <div className="flex-1" />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={skip}
+          disabled={busy}
+        >
+          Skip
+        </Button>
         {multiStep && !isLast ? (
           <Button
             type="button"

--- a/editor/kits/agent-chat/question-card.tsx
+++ b/editor/kits/agent-chat/question-card.tsx
@@ -20,7 +20,7 @@
 
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import { getToolName } from "ai";
 import { cn } from "@app/ui/lib/utils";
 import { Button } from "@app/ui/components/button";
@@ -144,6 +144,9 @@ export function QuestionCard({
   disabled?: boolean;
 }) {
   const questions = useMemo(() => readQuestions(entry), [entry]);
+  // Stable prefix for `<label>`/`aria-labelledby` ids tying each write-in to its
+  // question text (the form gives screen readers no other accessible name).
+  const labelId = useId();
   // Per question: picked option labels + a free-text write-in.
   const [picked, setPicked] = useState<string[][]>(() =>
     questions.map(() => [])
@@ -155,6 +158,22 @@ export function QuestionCard({
   // A survey of >1 question is a one-at-a-time wizard: step through with
   // Back/Next, Submit on the last. A single question shows no stepper.
   const [step, setStep] = useState(0);
+
+  // Reset all in-progress state when the pending tool call changes. A surface
+  // may reuse this instance for a NEW question without unmounting (e.g. two
+  // questions back-to-back in one turn, where `pendingQuestion` goes Q1→Q2
+  // without passing through null), and stale selections / disabled state must
+  // not carry into the next answer. React's guarded "adjust state during render"
+  // pattern — runs once per id change, not every render.
+  const toolCallId = toolCallIdOf(entry);
+  const seenToolCallId = useRef(toolCallId);
+  if (seenToolCallId.current !== toolCallId) {
+    seenToolCallId.current = toolCallId;
+    setPicked(questions.map(() => []));
+    setWriteIns(questions.map(() => ""));
+    setSubmitted(false);
+    setStep(0);
+  }
 
   const answers = useMemo(
     () =>
@@ -176,13 +195,13 @@ export function QuestionCard({
   const submit = () => {
     if (!canSubmit) return;
     setSubmitted(true);
-    onAnswer(toolCallIdOf(entry), { answers });
+    onAnswer(toolCallId, { answers });
   };
 
   const skip = () => {
     if (disabled) return;
     setSubmitted(true);
-    onAnswer(toolCallIdOf(entry), { answers: [], skipped: true });
+    onAnswer(toolCallId, { answers: [], skipped: true });
   };
 
   const togglePick = (qi: number, label: string, multi: boolean) => {
@@ -211,6 +230,7 @@ export function QuestionCard({
 
   const renderQuestion = (qi: number) => {
     const q = questions[qi];
+    const questionId = `${labelId}-q${qi}`;
     return (
       <div className="flex flex-col gap-2">
         {q.header && (
@@ -218,7 +238,9 @@ export function QuestionCard({
             {q.header}
           </span>
         )}
-        <p className="text-sm font-medium">{q.question}</p>
+        <p id={questionId} className="text-sm font-medium">
+          {q.question}
+        </p>
 
         {q.options && q.options.length > 0 && !q.multi_select && (
           <RadioGroup
@@ -273,6 +295,7 @@ export function QuestionCard({
         )}
 
         <Textarea
+          aria-labelledby={questionId}
           value={writeIns[qi] ?? ""}
           onChange={(e) =>
             setWriteIns((prev) => {

--- a/editor/kits/agent-chat/question-survey.test.ts
+++ b/editor/kits/agent-chat/question-survey.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { parseQuestions, QuestionSurvey } from "./question-survey";
+
+const SINGLE = {
+  questions: [
+    {
+      question: "Which color scheme?",
+      options: [{ label: "Warm" }, { label: "Cool" }],
+    },
+  ],
+};
+
+const SURVEY = {
+  questions: [
+    { question: "Color?", options: [{ label: "Warm" }, { label: "Cool" }] },
+    {
+      question: "Sections?",
+      multi_select: true,
+      options: [{ label: "Hero" }, { label: "Pricing" }],
+    },
+    { question: "Anything else?" },
+  ],
+};
+
+describe("parseQuestions", () => {
+  it("drops malformed entries and coerces shapes", () => {
+    const qs = parseQuestions({
+      questions: [
+        { question: "ok", options: [{ label: "A", description: "d" }, null] },
+        null,
+        42,
+        { multi_select: true },
+      ],
+    });
+    expect(qs).toHaveLength(2);
+    expect(qs[0]).toEqual({
+      question: "ok",
+      header: undefined,
+      options: [{ label: "A", description: "d" }],
+      multi_select: false,
+    });
+    expect(qs[1].question).toBe(""); // coerced; no `question` field
+  });
+
+  it("is empty for non-array / missing input", () => {
+    expect(parseQuestions(undefined)).toEqual([]);
+    expect(parseQuestions({})).toEqual([]);
+    expect(parseQuestions({ questions: "nope" })).toEqual([]);
+  });
+});
+
+describe("QuestionSurvey — answer building", () => {
+  it("single-select: a pick is the answer", () => {
+    const s = QuestionSurvey.from(SINGLE).togglePick(0, "Warm");
+    expect(s.answersFor(0)).toEqual(["Warm"]);
+    expect(s.buildOutput()).toEqual({ answers: [["Warm"]] });
+  });
+
+  it("single-select: a second pick replaces the first", () => {
+    const s = QuestionSurvey.from(SINGLE)
+      .togglePick(0, "Warm")
+      .togglePick(0, "Cool");
+    expect(s.answersFor(0)).toEqual(["Cool"]);
+  });
+
+  it("multi-select: picks accumulate and toggle off", () => {
+    const s = QuestionSurvey.from(SURVEY)
+      .togglePick(1, "Hero")
+      .togglePick(1, "Pricing")
+      .togglePick(1, "Hero");
+    expect(s.answersFor(1)).toEqual(["Pricing"]);
+  });
+
+  it("custom write-in WINS over a pick (mutually exclusive)", () => {
+    const picked = QuestionSurvey.from(SINGLE).togglePick(0, "Warm");
+    const custom = picked.setWriteIn(0, "Pastel");
+    expect(custom.pickedFor(0)).toEqual([]); // pick cleared
+    expect(custom.answersFor(0)).toEqual(["Pastel"]);
+  });
+
+  it("picking after a write-in clears the custom text", () => {
+    const s = QuestionSurvey.from(SINGLE)
+      .setWriteIn(0, "Pastel")
+      .togglePick(0, "Cool");
+    expect(s.writeInFor(0)).toBe("");
+    expect(s.answersFor(0)).toEqual(["Cool"]);
+  });
+
+  it("selectCustom deselects options for that question", () => {
+    const s = QuestionSurvey.from(SINGLE).togglePick(0, "Warm").selectCustom(0);
+    expect(s.pickedFor(0)).toEqual([]);
+    expect(s.answersFor(0)).toEqual([]); // nothing typed yet
+  });
+});
+
+describe("QuestionSurvey — skip semantics", () => {
+  it("skipping the ONLY question declines the whole survey (skipped sentinel)", () => {
+    const s = QuestionSurvey.from(SINGLE).skipCurrent();
+    expect(s.buildOutput()).toEqual({ answers: [], skipped: true });
+  });
+
+  it("THE BUG: answer Q1/Q2, skip only Q3 → kept answers + empty Q3, NOT a decline", () => {
+    // Step through the wizard exactly like the UI: answer 1, answer 2, skip 3.
+    const s = QuestionSurvey.from(SURVEY)
+      .togglePick(0, "Warm")
+      .next()
+      .togglePick(1, "Hero")
+      .next()
+      .skipCurrent(); // step is now 2 (the last) → skip it
+    expect(s.buildOutput()).toEqual({ answers: [["Warm"], ["Hero"], []] });
+    expect(s.buildOutput().skipped).toBeUndefined();
+  });
+
+  it("skipping every question declines the whole survey", () => {
+    const s = QuestionSurvey.from(SURVEY)
+      .skipCurrent()
+      .next()
+      .skipCurrent()
+      .next()
+      .skipCurrent();
+    expect(s.buildOutput()).toEqual({ answers: [], skipped: true });
+  });
+
+  it("a skipped question can be un-skipped by answering it", () => {
+    const s = QuestionSurvey.from(SINGLE).skipCurrent();
+    expect(s.isSkipped(0)).toBe(true);
+    const back = s.togglePick(0, "Warm");
+    expect(back.isSkipped(0)).toBe(false);
+    expect(back.answersFor(0)).toEqual(["Warm"]);
+  });
+});
+
+describe("QuestionSurvey — validation & stepping", () => {
+  it("canSubmit requires every question RESOLVED (answered or skipped)", () => {
+    let s = QuestionSurvey.from(SURVEY);
+    expect(s.canSubmit).toBe(false);
+    s = s.togglePick(0, "Warm");
+    expect(s.canSubmit).toBe(false); // Q2/Q3 unresolved
+    s = s.next().togglePick(1, "Hero").next().skipCurrent();
+    expect(s.canSubmit).toBe(true); // all answered-or-skipped
+  });
+
+  it("currentAnswered tracks the active step", () => {
+    const s = QuestionSurvey.from(SURVEY);
+    expect(s.currentAnswered).toBe(false);
+    expect(s.togglePick(0, "Warm").currentAnswered).toBe(true);
+  });
+
+  it("next / back clamp to range and isLast is correct", () => {
+    const s = QuestionSurvey.from(SURVEY);
+    expect(s.back().step).toBe(0); // clamped
+    const mid = s.next();
+    expect(mid.step).toBe(1);
+    expect(mid.isLast).toBe(false);
+    const last = mid.next();
+    expect(last.step).toBe(2);
+    expect(last.isLast).toBe(true);
+    expect(last.next().step).toBe(2); // clamped
+  });
+
+  it("multiStep is false for a single question", () => {
+    expect(QuestionSurvey.from(SINGLE).multiStep).toBe(false);
+    expect(QuestionSurvey.from(SURVEY).multiStep).toBe(true);
+  });
+});

--- a/editor/kits/agent-chat/question-survey.test.ts
+++ b/editor/kits/agent-chat/question-survey.test.ts
@@ -162,4 +162,12 @@ describe("QuestionSurvey — validation & stepping", () => {
     expect(QuestionSurvey.from(SINGLE).multiStep).toBe(false);
     expect(QuestionSurvey.from(SURVEY).multiStep).toBe(true);
   });
+
+  it("an empty survey (defensive parse) keeps step in range and isLast false", () => {
+    const s = QuestionSurvey.from({ questions: "nope" });
+    expect(s.count).toBe(0);
+    expect(s.isLast).toBe(false);
+    expect(s.next().step).toBe(0); // not -1
+    expect(s.next().isLast).toBe(false);
+  });
 });

--- a/editor/kits/agent-chat/question-survey.ts
+++ b/editor/kits/agent-chat/question-survey.ts
@@ -64,7 +64,7 @@ export class QuestionSurvey {
     return this.count > 1;
   }
   get isLast(): boolean {
-    return this.step === this.count - 1;
+    return this.count > 0 && this.step === this.count - 1;
   }
 
   pickedFor(qi: number): readonly string[] {
@@ -154,6 +154,9 @@ export class QuestionSurvey {
   }
 
   next(): QuestionSurvey {
+    // Guard the defensive-parse empty case so `step` never goes below 0
+    // (`Math.min(-1, …)` would otherwise produce -1 and corrupt `isLast`).
+    if (this.count === 0) return this;
     return this.withStep(Math.min(this.count - 1, this.step + 1));
   }
   back(): QuestionSurvey {

--- a/editor/kits/agent-chat/question-survey.ts
+++ b/editor/kits/agent-chat/question-survey.ts
@@ -1,0 +1,223 @@
+/**
+ * `QuestionSurvey` — the pure, React-free core of the ask-user `question` tool's
+ * form. It owns the per-question option selections, the free-text write-ins,
+ * the per-question skip flags, the wizard step, and ALL derived semantics
+ * (answer-building, validation, skip-vs-decline). The React `QuestionCard` is a
+ * thin view: it holds one of these in state and swaps it for the next on each
+ * transition. Immutable — every transition returns a NEW survey — so the view's
+ * update is just `setSurvey(survey.next())` and the logic is testable on its own
+ * with zero rendering.
+ *
+ * ## Answer model (the subtle part)
+ *
+ * The tool returns `{ answers: string[][] }` — one array per question. A question
+ * is answered by picking option(s) and/or writing a custom answer; picking and
+ * writing are MUTUALLY EXCLUSIVE (when there's custom text, it IS the answer).
+ *
+ * "Skip" is **per question**, not per survey. Skipping the last question of a
+ * three-question survey you answered the first two of yields
+ * `{ answers: [a, b, []] }` — the kept answers plus an empty array for the
+ * skipped one. The `skipped: true` sentinel is reserved for the case where the
+ * user resolved NOTHING (declined the entire survey); the model reads that as
+ * "the user passed on the whole thing" — distinct from the headless refusal.
+ */
+
+export type QuestionOption = { label: string; description?: string };
+
+export type QuestionSpec = {
+  question: string;
+  header?: string;
+  options?: QuestionOption[];
+  multi_select?: boolean;
+};
+
+/** The `question` tool's result shape (mirrors the package `outputSchema`). */
+export type QuestionAnswerOutput = { answers: string[][]; skipped?: boolean };
+
+export class QuestionSurvey {
+  private constructor(
+    readonly questions: readonly QuestionSpec[],
+    private readonly picked: readonly (readonly string[])[],
+    private readonly writeIns: readonly string[],
+    private readonly skipped: readonly boolean[],
+    readonly step: number
+  ) {}
+
+  /** Build a fresh survey from a tool call's `input` (defensive parse). */
+  static from(input: unknown): QuestionSurvey {
+    const questions = parseQuestions(input);
+    return new QuestionSurvey(
+      questions,
+      questions.map(() => []),
+      questions.map(() => ""),
+      questions.map(() => false),
+      0
+    );
+  }
+
+  // ── derived ─────────────────────────────────────────────────────────────
+  get count(): number {
+    return this.questions.length;
+  }
+  /** A survey of >1 question is a one-at-a-time wizard. */
+  get multiStep(): boolean {
+    return this.count > 1;
+  }
+  get isLast(): boolean {
+    return this.step === this.count - 1;
+  }
+
+  pickedFor(qi: number): readonly string[] {
+    return this.picked[qi] ?? [];
+  }
+  writeInFor(qi: number): string {
+    return this.writeIns[qi] ?? "";
+  }
+  isSkipped(qi: number): boolean {
+    return this.skipped[qi] === true;
+  }
+
+  /** The committed answer array for question `qi` — empty when skipped or blank.
+   *  A custom write-in wins over a pick (they are mutually exclusive). */
+  answersFor(qi: number): string[] {
+    if (this.skipped[qi]) return [];
+    const wi = (this.writeIns[qi] ?? "").trim();
+    const q = this.questions[qi];
+    if (q?.multi_select) {
+      return [...(this.picked[qi] ?? []), ...(wi ? [wi] : [])];
+    }
+    if (wi) return [wi];
+    return (this.picked[qi] ?? []).slice(0, 1);
+  }
+  isAnswered(qi: number): boolean {
+    return this.answersFor(qi).length > 0;
+  }
+  /** The current step's question is answered — Next / Submit require this. */
+  get currentAnswered(): boolean {
+    return this.isAnswered(this.step);
+  }
+  /** Every question is RESOLVED — answered OR explicitly skipped. */
+  get canSubmit(): boolean {
+    return (
+      this.count > 0 &&
+      this.questions.every((_, i) => this.isAnswered(i) || this.skipped[i])
+    );
+  }
+
+  // ── transitions (each returns a NEW survey) ───────────────────────────────
+  /** Toggle an option for question `qi`. Picking is exclusive with the
+   *  write-in and un-skips the question. */
+  togglePick(qi: number, label: string): QuestionSurvey {
+    const q = this.questions[qi];
+    if (!q) return this;
+    const cur = this.picked[qi] ?? [];
+    const next = q.multi_select
+      ? cur.includes(label)
+        ? cur.filter((l) => l !== label)
+        : [...cur, label]
+      : [label];
+    return this.with({
+      picked: replace(this.picked, qi, next),
+      writeIns: replace(this.writeIns, qi, ""),
+      skipped: replace(this.skipped, qi, false),
+    });
+  }
+
+  /** Make the custom write-in the active answer for `qi` — deselect options and
+   *  un-skip (e.g. on focus). No-op once already exclusive. */
+  selectCustom(qi: number): QuestionSurvey {
+    if ((this.picked[qi] ?? []).length === 0 && !this.skipped[qi]) return this;
+    return this.with({
+      picked: replace(this.picked, qi, []),
+      skipped: replace(this.skipped, qi, false),
+    });
+  }
+
+  /** Set the custom write-in text for `qi` (also makes it exclusive + un-skips). */
+  setWriteIn(qi: number, text: string): QuestionSurvey {
+    return this.with({
+      picked: replace(this.picked, qi, []),
+      writeIns: replace(this.writeIns, qi, text),
+      skipped: replace(this.skipped, qi, false),
+    });
+  }
+
+  /** Skip the CURRENT question: clear its inputs and mark it skipped. Does not
+   *  move the step — the view decides whether to advance or finalize. */
+  skipCurrent(): QuestionSurvey {
+    const qi = this.step;
+    return this.with({
+      picked: replace(this.picked, qi, []),
+      writeIns: replace(this.writeIns, qi, ""),
+      skipped: replace(this.skipped, qi, true),
+    });
+  }
+
+  next(): QuestionSurvey {
+    return this.withStep(Math.min(this.count - 1, this.step + 1));
+  }
+  back(): QuestionSurvey {
+    return this.withStep(Math.max(0, this.step - 1));
+  }
+
+  // ── output ────────────────────────────────────────────────────────────────
+  /** The tool result. Per-question answers (empty for skipped/blank); the
+   *  `skipped` sentinel ONLY when the user resolved nothing (declined the whole
+   *  survey) — a partial answer is NOT a decline. */
+  buildOutput(): QuestionAnswerOutput {
+    const answers = this.questions.map((_, i) => this.answersFor(i));
+    if (answers.every((a) => a.length === 0))
+      return { answers: [], skipped: true };
+    return { answers };
+  }
+
+  // ── internals ───────────────────────────────────────────────────────────
+  private with(p: {
+    picked?: readonly (readonly string[])[];
+    writeIns?: readonly string[];
+    skipped?: readonly boolean[];
+    step?: number;
+  }): QuestionSurvey {
+    return new QuestionSurvey(
+      this.questions,
+      p.picked ?? this.picked,
+      p.writeIns ?? this.writeIns,
+      p.skipped ?? this.skipped,
+      p.step ?? this.step
+    );
+  }
+  private withStep(step: number): QuestionSurvey {
+    return step === this.step ? this : this.with({ step });
+  }
+}
+
+function replace<T>(arr: readonly T[], i: number, value: T): T[] {
+  const next = arr.slice();
+  next[i] = value;
+  return next;
+}
+
+/** Defensive parse of a tool call's `input` into the question list. Tolerates
+ *  malformed entries (the model's JSON is untrusted) — bad items are dropped. */
+export function parseQuestions(input: unknown): QuestionSpec[] {
+  const questions = (input as { questions?: unknown })?.questions;
+  if (!Array.isArray(questions)) return [];
+  return questions
+    .filter((q): q is QuestionSpec => Boolean(q) && typeof q === "object")
+    .map((q) => ({
+      question: String(q.question ?? ""),
+      header: typeof q.header === "string" ? q.header : undefined,
+      options: Array.isArray(q.options)
+        ? q.options
+            .filter(
+              (o): o is QuestionOption => Boolean(o) && typeof o === "object"
+            )
+            .map((o) => ({
+              label: String(o.label ?? ""),
+              description:
+                typeof o.description === "string" ? o.description : undefined,
+            }))
+        : undefined,
+      multi_select: Boolean(q.multi_select),
+    }));
+}

--- a/editor/kits/agent-chat/tool-display.ts
+++ b/editor/kits/agent-chat/tool-display.ts
@@ -137,6 +137,7 @@ export namespace toolDisplay {
     pushClause(clauses, counts, "list", "listed");
     pushClause(clauses, counts, "command", "ran");
     pushClause(clauses, counts, "plan", "updated", "plan update");
+    pushClause(clauses, counts, "question", "asked");
     pushClause(clauses, counts, "tool", "used");
 
     return capitalize(clauses.join(", "));

--- a/editor/kits/agent-chat/tool-display.ts
+++ b/editor/kits/agent-chat/tool-display.ts
@@ -11,6 +11,7 @@ export type ToolDisplayAction =
   | "search"
   | "plan"
   | "command"
+  | "question"
   | "tool";
 
 export type ToolDisplayTone = "running" | "ok" | "warn" | "error";
@@ -91,6 +92,14 @@ export namespace toolDisplay {
           tone,
         };
 
+      case "question":
+        return {
+          action: "question",
+          title: isActive(entry) ? "Asking you" : "Asked you",
+          detail: describeQuestionDetail(entry),
+          tone,
+        };
+
       default:
         return {
           action: "tool",
@@ -165,6 +174,8 @@ function nounForAction(action: ToolDisplayAction): string {
       return "command";
     case "plan":
       return "plan update";
+    case "question":
+      return "question";
     case "tool":
       return "tool call";
   }
@@ -222,6 +233,15 @@ function describeTodosDetail(entry: ToolCallEntry): string | undefined {
     numberValue(result.count) ?? resultTodos?.length ?? argsTodos?.length;
   if (count === undefined) return undefined;
   return `${count} ${pluralize("item", count)}`;
+}
+
+function describeQuestionDetail(entry: ToolCallEntry): string | undefined {
+  const questions = asArray(asRecord(readToolInput(entry)).questions);
+  if (!questions || questions.length === 0) return undefined;
+  if (questions.length === 1) {
+    return stringValue(asRecord(questions[0]).question);
+  }
+  return `${questions.length} questions`;
 }
 
 function describeCommandDetail(entry: ToolCallEntry): string | undefined {

--- a/editor/lib/agent-chat/bridge-transport.ts
+++ b/editor/lib/agent-chat/bridge-transport.ts
@@ -33,6 +33,15 @@ export type DesktopAgentTransportOptions = Partial<
    * panel keeps whatever it hydrated from the DB.
    */
   onResumeStart?: () => void;
+  /**
+   * Live renderer run-context (current `model_id` / `provider_id` / `mode`),
+   * read FRESH on every send — crucially the AI SDK's **body-less** tool/approval
+   * auto-resubmit (`addToolResult` → `sendAutomaticallyWhen`). Without it, answering
+   * a client-resolved tool (e.g. `question`) resumes with no model/mode and the
+   * server clobbers the session's model + posture with defaults. The explicit
+   * per-send `body` still wins; this only backfills what a body-less send omits.
+   */
+  runContext?: () => Partial<Omit<AgentRunOptions, "messages">>;
 };
 
 export namespace desktopAgentTransport {
@@ -55,8 +64,13 @@ export namespace desktopAgentTransport {
       async sendMessages(options) {
         const body = readBodyOptions(options.body);
         if (body.session_id) liveSessionId = body.session_id;
+        // Backfill the live renderer context (model/provider/mode) so a body-less
+        // auto-resubmit still carries them; the explicit `body` overrides it.
+        const { runContext, ...restDefaults } = defaults;
+        const context = runContext?.() ?? {};
         return streamFromBridge({
-          ...defaults,
+          ...restDefaults,
+          ...context,
           ...body,
           // A body-less send (the AI SDK's approval/tool auto-resubmit calls
           // `makeRequest` with no body) would otherwise fall back to the

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -36,6 +36,7 @@ import type { ComposerCatalog } from "@/kits/composer";
 import {
   AGENT_SESSION_AGENT,
   sessions as bridgeSessions,
+  type AgentRunOptions,
 } from "@/lib/desktop/bridge";
 import {
   buildAgentSend,
@@ -128,6 +129,11 @@ export function AISidebarChat({
   // callback mutate the chat's messages once a resume is happening — it can't
   // close over `chat`, which doesn't exist yet at closure-construction time.
   const chatRef = useRef<Chat<UIMessage> | null>(null);
+  // Live run-context (current model/provider) the transport backfills onto
+  // body-less sends — the fs/todos/question auto-resubmit — so a resume keeps
+  // the session's model instead of resetting it. Assigned once the picker
+  // resolves; read fresh per send via the getter.
+  const runContextRef = useRef<Partial<Omit<AgentRunOptions, "messages">>>({});
   const chat = useMemo(() => {
     const todos = new AgentTodos();
     const chat = new Chat<UIMessage>({
@@ -136,6 +142,7 @@ export function AISidebarChat({
       transport: desktopAgentTransport.create({
         workspace_id: workspaceId,
         session_id: chatSession.current_id ?? undefined,
+        runContext: () => runContextRef.current,
         onSessionId: (resolvedId) => {
           chatSession.apply_resolved_session_id(resolvedId);
         },
@@ -283,6 +290,15 @@ export function AISidebarChat({
     sessions: chatSession.sessions,
     endpoints,
   });
+  // Keep the transport's body-less backfill (above) in step with the picker.
+  // The single-file/deck agent has no permission-mode picker, so no `mode`.
+  {
+    const providerId = registered_models.providerIdForModel(modelId, endpoints);
+    runContextRef.current = {
+      model_id: modelId,
+      ...(providerId ? { provider_id: providerId } : {}),
+    };
+  }
 
   // Whether the active model accepts image input — memoized so the
   // registry lookup doesn't re-scan on every render (only when the model

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -56,7 +56,10 @@ import {
   CompactingIndicator,
   ForkedNotice,
   PendingTurnIndicator,
+  QuestionCard,
+  findPendingQuestion,
   type ChatMessageActions,
+  type AnswerQuestionHandler,
 } from "@/kits/agent-chat";
 import { ChatSessionPicker } from "../shared/chat-session-picker";
 import {
@@ -420,6 +423,20 @@ export function AISidebarChat({
     [onCompact, onForkCommand]
   );
 
+  // Commit a `question` (ask-user) answer: the human's answer becomes the tool
+  // result and `sendAutomaticallyWhen` resumes the paused run. Reads `chatRef`
+  // (not `chat`) so it stays stable across the per-session Chat rebuild.
+  const onAnswerQuestion = useCallback<AnswerQuestionHandler>(
+    (toolCallId, output) => {
+      void chatRef.current?.addToolResult({
+        tool: "question",
+        toolCallId,
+        output,
+      });
+    },
+    []
+  );
+
   // Settled history renders independently of the streaming row, so
   // per-chunk updates that touch only `state.streaming` don't
   // re-render these.
@@ -434,6 +451,15 @@ export function AISidebarChat({
         />
       )),
     [messages, isStreaming, messageActions]
+  );
+
+  // The agent ASKS: a pending `question` is a session-global prompt pinned above
+  // the composer (the same model as the supervised-approval bar), not a card in
+  // the transcript. One open question per session. Memoized on `messages` like
+  // the approval bar's `findPendingApproval` — it only changes when they do.
+  const pendingQuestion = useMemo(
+    () => findPendingQuestion(messages),
+    [messages]
   );
 
   const isEmpty = messages.length === 0;
@@ -494,6 +520,17 @@ export function AISidebarChat({
       <QueuedMessages queued={queued} onCancel={cancelQueued} />
 
       <ModelToolCallNotice model_id={modelId} endpoints={endpoints} />
+
+      {/* The agent is asking — session-global prompt above the composer. */}
+      {pendingQuestion && (
+        <div className="shrink-0 border-t p-3">
+          <QuestionCard
+            entry={pendingQuestion}
+            onAnswer={onAnswerQuestion}
+            disabled={busy}
+          />
+        </div>
+      )}
 
       <div className="shrink-0 border-t p-3">
         <AgentComposerInput

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -32,7 +32,10 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Chat, useChat } from "@ai-sdk/react";
-import type { UIMessage } from "ai";
+import {
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type UIMessage,
+} from "ai";
 import {
   Conversation,
   ConversationContent,
@@ -69,7 +72,10 @@ import {
   CompactingIndicator,
   ForkedNotice,
   PendingTurnIndicator,
+  QuestionCard,
+  findPendingQuestion,
   type ChatMessageActions,
+  type AnswerQuestionHandler,
 } from "@/kits/agent-chat";
 import { QueuedMessages } from "../shared/queued-messages";
 import { ChatSessionPicker } from "../shared/chat-session-picker";
@@ -248,6 +254,14 @@ function AgentPaneContent({
             }
           },
         }),
+        // Resume after a CLIENT-resolved tool result lands. fs/todos/command are
+        // server-resolved (the sidecar completes the loop in-stream, ending on
+        // text — never a dangling tool call), so this fires ONLY for the locked
+        // `question` tool: once the user answers (the card calls addToolResult),
+        // the message becomes complete-with-tool-calls and the paused run
+        // resumes. Approval pauses are NOT affected (an approval-requested call
+        // has no result, so it's never "complete").
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
       }),
     // Rebuild ONLY on a real session switch / new chat (or workspace change)
     // — signalled by `initialMessages` changing (hydration). `currentId` is
@@ -575,6 +589,22 @@ function AgentPaneContent({
     [messages]
   );
 
+  // Commit a `question` (ask-user) answer: the human's answer becomes the tool
+  // result and `sendAutomaticallyWhen` resumes the paused run. Unlike the
+  // approval resume (which must use the live `chat` to merge into an in-flight
+  // message), this fires on a click against an already-settled card, so the
+  // post-commit `chatRef` mirror is the right (stable) instance.
+  const onAnswerQuestion = useCallback<AnswerQuestionHandler>(
+    (toolCallId, output) => {
+      void chatRef.current?.addToolResult({
+        tool: "question",
+        toolCallId,
+        output,
+      });
+    },
+    []
+  );
+
   const settledList = useMemo(
     () =>
       messages.map((m, index) => (
@@ -586,6 +616,14 @@ function AgentPaneContent({
         />
       )),
     [messages, isStreaming, messageActions]
+  );
+
+  // The agent ASKS: a pending `question` is a session-global prompt pinned above
+  // the composer (same model as the approval bar), not a transcript card.
+  // Memoized on `messages` to match `pendingApproval` above.
+  const pendingQuestion = useMemo(
+    () => findPendingQuestion(messages),
+    [messages]
   );
 
   // Pre-first-token "Thinking" indicator: a turn is streaming through this
@@ -640,6 +678,17 @@ function AgentPaneContent({
           feedback, no optimistic message mutation needed. */}
       {pendingApproval && !busy && (
         <AgentApprovalBar pending={pendingApproval} onApprove={onApprove} />
+      )}
+
+      {/* The agent is asking — session-global prompt above the composer. */}
+      {pendingQuestion && (
+        <div className="shrink-0 border-t p-3">
+          <QuestionCard
+            entry={pendingQuestion}
+            onAnswer={onAnswerQuestion}
+            disabled={busy}
+          />
+        </div>
       )}
 
       <div className="shrink-0 border-t p-3">

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -46,6 +46,7 @@ import { Button } from "@app/ui/components/button";
 import {
   AGENT_SESSION_AGENT,
   sessions as bridgeSessions,
+  type AgentRunOptions,
   type Workspace,
 } from "@/lib/desktop/bridge";
 import {
@@ -231,6 +232,11 @@ function AgentPaneContent({
   // ("No tool invocation found"), the run never renders, and the approval bar
   // never clears until a hard refresh re-hydrates from the DB.
   const chatRef = useRef<Chat<UIMessage> | null>(null);
+  // Live run-context (current model/provider/mode) the transport backfills onto
+  // body-less sends — the question/tool auto-resubmit — so a resume keeps the
+  // session's model + posture instead of resetting them. Assigned below once the
+  // pickers resolve; read fresh per send via the getter.
+  const runContextRef = useRef<Partial<Omit<AgentRunOptions, "messages">>>({});
   const chat = useMemo(
     () =>
       new Chat<UIMessage>({
@@ -239,6 +245,7 @@ function AgentPaneContent({
         transport: desktopAgentTransport.create({
           workspace_id: workspace.id,
           session_id: chatSession.current_id ?? undefined,
+          runContext: () => runContextRef.current,
           onSessionId: (resolvedId) => {
             chatSession.apply_resolved_session_id(resolvedId);
           },
@@ -422,6 +429,12 @@ function AgentPaneContent({
   // Endpoint provider pin for the active model (issue #806) — rides every
   // run-entering body: normal sends AND approval resumes below.
   const providerId = registered_models.providerIdForModel(modelId, endpoints);
+  // Keep the transport's body-less backfill (above) in step with the pickers.
+  runContextRef.current = {
+    model_id: modelId,
+    mode,
+    ...(providerId ? { provider_id: providerId } : {}),
+  };
 
   const {
     queued,

--- a/packages/grida-ai-agent/src/agent-host.ts
+++ b/packages/grida-ai-agent/src/agent-host.ts
@@ -66,6 +66,14 @@ export type AgentHostOptions = {
    * shell child has no kernel-level fs/network containment.
    */
   allow_unsandboxed_shell?: boolean;
+  /**
+   * Whether a human UI is bound to this host (RFC `tools` §question). When
+   * true, the locked `question` tool pauses for the user's answer; when
+   * false/undefined (fail-closed headless) it refuses with a fixed tool error.
+   * The desktop sidecar sets this true; the CLI leaves it false. Carried into
+   * {@link ServerOptions} by the `...opts` spread below.
+   */
+  interactive?: boolean;
 };
 
 export class AgentHost {

--- a/packages/grida-ai-agent/src/agent/index.ts
+++ b/packages/grida-ai-agent/src/agent/index.ts
@@ -114,6 +114,13 @@ export type CreateAgentOptions = {
    * concatenated AGENTS.md / CLAUDE.md, injected eagerly into the prompt.
    */
   project_instructions?: string;
+  /**
+   * Whether a human UI is bound (RFC `tools` §question). When true the locked
+   * `question` tool is client-resolved (pauses for the user's answer); when
+   * false/undefined it ships with a fixed-refusal `execute` for headless hosts.
+   * The tool is always registered either way (it is locked).
+   */
+  interactive?: boolean;
 };
 
 /**
@@ -135,6 +142,7 @@ export function createAgent(opts: CreateAgentOptions) {
     todos: opts.todos,
     vision: opts.vision,
     command: opts.command,
+    interactive: opts.interactive,
     skill:
       opts.skill_index && opts.skill_load_body
         ? {

--- a/packages/grida-ai-agent/src/cli.ts
+++ b/packages/grida-ai-agent/src/cli.ts
@@ -153,7 +153,9 @@ async function serveCommand(args: string[]): Promise<void> {
       config.user_data_path
     );
   }
-  const host = await createHost(config, flags);
+  // A `serve` daemon is the host the desktop-from-web bridge drives — a human
+  // is present, so the `question` tool pauses for their answer (interactive).
+  const host = await createHost(config, flags, true);
   await host.start();
   process.stdout.write(`PORT=${host.port}\n`);
   process.stderr.write(
@@ -419,7 +421,13 @@ export function parseRunArgs(args: string[]): {
 
 async function createHost(
   config: CliConfig,
-  flags?: Pick<ServeFlags, "allow_origins" | "allow_referer_paths">
+  flags?: Pick<ServeFlags, "allow_origins" | "allow_referer_paths">,
+  // Whether this host serves a human UI (RFC `tools` §question). A long-lived
+  // `serve` daemon is driven by a human client (the desktop-from-web bridge),
+  // so the locked `question` tool pauses for their answer. The throwaway
+  // embedded host behind a one-shot `run` has no client UI → stays headless and
+  // the tool returns the fixed refusal.
+  interactive = false
 ): Promise<AgentHost> {
   const { AgentHost } = await import("./server");
   return new AgentHost({
@@ -439,6 +447,10 @@ async function createHost(
     // deliberately opts into the shell rather than fail-closed. The desktop
     // host, by contrast, only enables shell when srt actually wraps it.
     allow_unsandboxed_shell: true,
+    // The locked `question` tool pauses for a human only when this host serves
+    // a UI (the `serve` daemon driven by the desktop-from-web bridge). A
+    // throwaway embedded host (one-shot `run`) is headless → fixed refusal.
+    interactive,
   });
 }
 

--- a/packages/grida-ai-agent/src/cli.ts
+++ b/packages/grida-ai-agent/src/cli.ts
@@ -323,7 +323,15 @@ export async function runCommand(
     throw new Error('usage: grida-agent run [--session <id>] "message"');
   }
   const handle = await client.agent.run(
-    { messages: [{ role: "user", content: message }], session_id: sessionId },
+    {
+      messages: [{ role: "user", content: message }],
+      session_id: sessionId,
+      // A one-shot `run` has no UI to answer the `question` tool — and it may
+      // target a daemon that IS interactive for a web client. Declare headless
+      // per-run so `question` returns its fixed refusal instead of pausing this
+      // run forever (and leaving the session stuck on `human-input-pending`).
+      interactive: false,
+    },
     (chunk) => writeTextDelta(chunk, out)
   );
   await handle.done;

--- a/packages/grida-ai-agent/src/e2e.test.ts
+++ b/packages/grida-ai-agent/src/e2e.test.ts
@@ -44,6 +44,7 @@ let captured: CapturedTurn[];
 /** When the incoming prompt's last user text contains this, the mock
  *  emits a `skill` tool call instead of plain text. */
 const SKILL_TRIGGER = "USE_ALPHA_SKILL";
+const QUESTION_TRIGGER = "ASK_THE_USER";
 
 const FINISH_USAGE = {
   type: "finish" as const,
@@ -111,6 +112,31 @@ function makeMockModel(): MockLanguageModelV3 {
                 toolCallId: "tc_skill",
                 toolName: "skill",
                 input: JSON.stringify({ name: "alpha" }),
+              },
+              FINISH_USAGE,
+            ],
+          }),
+        };
+      }
+      const wantsQuestion =
+        lastUserText(prompt).includes(QUESTION_TRIGGER) && call === 1;
+      if (wantsQuestion) {
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              {
+                type: "tool-call",
+                toolCallId: "tc_question",
+                toolName: "question",
+                input: JSON.stringify({
+                  questions: [
+                    {
+                      question: "Pick one",
+                      options: [{ label: "A" }, { label: "B" }],
+                    },
+                  ],
+                }),
               },
               FINISH_USAGE,
             ],
@@ -323,6 +349,22 @@ describe("agent system e2e (skills · rewind · fork · compaction)", () => {
       .content;
     expect(content).toContain('<skill_content name="alpha">');
     expect(content).toContain("Step 1: do alpha");
+  });
+
+  it("headless `question`: the tool refuses cleanly (output-error, stream not crashed)", async () => {
+    // This runtime is built WITHOUT `interactive`, so the locked `question`
+    // tool is headless: its `execute` throws the fixed refusal. The flagged
+    // risk is whether a thrown tool execute lowers to a model-readable
+    // output-error or crashes the stream. runTurn asserts status 200 (the
+    // stream completed); we then confirm the persisted question part is a
+    // terminal output-error carrying the refusal — the model can read it and
+    // continue (it does: call 2 returns "done").
+    const sessionId = await runTurn({ text: `please ${QUESTION_TRIGGER}` });
+    const parts = (await store.listMessages(sessionId)).flatMap((m) => m.parts);
+    const questionPart = parts.find((p) => p.type === "tool-question");
+    expect(questionPart).toBeTruthy();
+    expect(questionPart!.tool_state).toBe("output-error");
+    expect(JSON.stringify(questionPart!.data)).toContain("interactive user");
   });
 
   it("is server-authoritative: turn 2 sees turn 1 from the DB, not the client array", async () => {

--- a/packages/grida-ai-agent/src/http/routes/agent.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/agent.test.ts
@@ -225,12 +225,13 @@ describe("HTTP wire — agent routes (run/stream/abort)", () => {
     expect(body.code).toBe("run_in_flight");
   });
 
-  it("POST /agent/run is refused 409 approval-pending while a supervised approval is unanswered (RFC `permission modes`)", async () => {
+  it("POST /agent/run is refused 409 human-input-pending while a supervised approval is unanswered (RFC `permission modes`)", async () => {
     // A session whose last assistant turn left an unanswered approval-requested
     // tool part — the exact state the scheduler's drain refuses to run over
-    // (`session-scheduler.ts` `has_pending_approval`). The HTTP path must refuse
+    // (`session-scheduler.ts` `has_pending_human_input`). The HTTP path must refuse
     // too, or `buildModelMessages` drops the unanswered part and the next message
-    // runs ahead of the blocked command (orphaning the approval).
+    // runs ahead of the blocked command (orphaning the approval). The 409 code is
+    // generalized: the same guard now covers an unanswered `question`.
     const created = await sessionsStore.create({ agent: AGENT_SESSION_AGENT });
     const asst = await sessionsStore.appendMessage(created.id, {
       role: "assistant",
@@ -258,7 +259,7 @@ describe("HTTP wire — agent routes (run/stream/abort)", () => {
     });
     expect(blocked.status).toBe(409);
     expect(((await blocked.json()) as { code?: string }).code).toBe(
-      "approval-pending"
+      "human-input-pending"
     );
     // No turn started; the typed-ahead follow-up was NOT persisted; the approval
     // is still pending and actionable (not orphaned).
@@ -298,6 +299,56 @@ describe("HTTP wire — agent routes (run/stream/abort)", () => {
       );
       expect(hasHi).toBe(true);
     });
+  });
+
+  it("RESUMES a paused `question` when the answer rides the assistant tail (clears the block BEFORE the 409 guard)", async () => {
+    // Regression for the live-daemon resume 409: unlike an approval (a body
+    // field applied before the guard), a `question` answer is a terminal tool
+    // result in the assistant tail. `fillIncomingToolResults` must clear the
+    // human-input block BEFORE `hasPendingHumanInput`, or the very POST carrying
+    // the answer is refused by the guard it resolves.
+    const created = await sessionsStore.create({ agent: AGENT_SESSION_AGENT });
+    const asst = await sessionsStore.appendMessage(created.id, {
+      role: "assistant",
+    });
+    await sessionsStore.upsertPart(asst.id, {
+      index: 0,
+      type: "tool-question",
+      data: {
+        type: "tool-question",
+        state: "input-available",
+        input: { questions: [{ question: "Which color?" }] },
+      },
+      tool_call_id: "q1",
+      tool_state: "input-available",
+    });
+    expect(await sessionsStore.hasPendingHumanInput(created.id)).toBe(true);
+
+    // The resume carries the answer as an output-available tool part in the tail.
+    const resumed = await app.request("/agent/run", {
+      method: "POST",
+      body: JSON.stringify({
+        session_id: created.id,
+        messages: [
+          {
+            id: asst.id,
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-question",
+                toolCallId: "q1",
+                state: "output-available",
+                input: { questions: [{ question: "Which color?" }] },
+                output: { answers: [["Cool"]] },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(resumed.status).toBe(200); // NOT 409 — the answer cleared the block
+    await resumed.text();
+    expect(await sessionsStore.hasPendingHumanInput(created.id)).toBe(false);
   });
 
   it("the CORE drains a queue on a clean idle edge — serial, FIFO, no client re-send (RFC `queue`)", async () => {

--- a/packages/grida-ai-agent/src/http/server.ts
+++ b/packages/grida-ai-agent/src/http/server.ts
@@ -50,6 +50,14 @@ export type ServerOptions = {
   sandbox_enforced?: boolean;
   /** GRIDA-SEC-004 — explicit unsandboxed-shell opt-in (CLI/dev). */
   allow_unsandboxed_shell?: boolean;
+  /**
+   * Whether a human UI is bound to this host — i.e. the locked `question`
+   * tool can pause and be answered by a person. Default (undefined/false) is
+   * FAIL-CLOSED headless: the `question` tool refuses with a fixed tool error
+   * instead of pausing forever (RFC `tools` §question). The desktop sidecar
+   * sets this true; the CLI and hosted/batch paths leave it false.
+   */
+  interactive?: boolean;
 };
 
 /**
@@ -178,6 +186,9 @@ export function buildServer(opts: ServerOptions): BuiltServer {
     // added to the srt deny_read policy — the host itself reads auth.json.
     secrets_root: opts.user_data_path,
     shell_execution_allowed: shellExecutionAllowed,
+    // Whether the locked `question` tool pauses for a human (interactive) or
+    // refuses with a fixed tool error (headless). Fail-closed headless.
+    interactive: opts.interactive === true,
   });
   if (opts.capabilities.agent) registerAgentRoutes(app, runtime);
   if (opts.capabilities.sessions)

--- a/packages/grida-ai-agent/src/index.ts
+++ b/packages/grida-ai-agent/src/index.ts
@@ -102,6 +102,7 @@ export { composeSystemPrompt } from "./agent/prompts";
 export {
   createToolset,
   RUN_COMMAND_TOOL_NAME,
+  QUESTION_TOOL_NAME,
   type AgentToolName,
   type RunCommandOutcome,
   type ToolsetCapabilities,

--- a/packages/grida-ai-agent/src/protocol/run.ts
+++ b/packages/grida-ai-agent/src/protocol/run.ts
@@ -85,6 +85,15 @@ export type AgentRunOptions = {
    */
   mode?: AgentMode;
   /**
+   * Whether the CLIENT making this run has a human UI that can answer the
+   * locked `question` tool (RFC `tools` §question). Declared per run because one
+   * daemon serves both — the desktop-from-web bridge (a human, `true`) and a
+   * one-shot `cli run` (no UI, `false`). Omitted ⇒ falls back to the host's
+   * `interactive` default. When false, `question` returns the fixed headless
+   * refusal instead of pausing the run forever on a client that can't answer.
+   */
+  interactive?: boolean;
+  /**
    * Resume answer for a paused supervised approval (RFC `permission modes`,
    * Phase 2). Present ONLY on the turn that answers an Allow/Deny; the host
    * applies it (`store.answerApproval`) before rebuilding the model view, then

--- a/packages/grida-ai-agent/src/runtime/index.ts
+++ b/packages/grida-ai-agent/src/runtime/index.ts
@@ -69,6 +69,7 @@ import {
   extractFirstUserText,
   extractLastUserText,
   extractLastUserMessageId,
+  fillIncomingToolResults,
   parseRunBody,
   persistIncomingTail,
   type RunRequest,
@@ -172,6 +173,13 @@ export type AgentRuntimeDeps = ResolveDeps & {
    * `createWorkspaceAgentBindings`. No sandbox (or no opt-in) ⇒ no shell.
    */
   shell_execution_allowed?: boolean;
+  /**
+   * Whether a human UI is bound — gates the locked `question` tool. When true
+   * the tool is client-resolved (pauses for the user's answer); when
+   * false/undefined (fail-closed headless) the tool refuses with a fixed tool
+   * error. Threaded from the HTTP-server boundary down to `createToolset`.
+   */
+  interactive?: boolean;
   /**
    * Optional injected registry — the smoke + tests pre-populate entries.
    * Omit to let AgentRuntime allocate its own.
@@ -309,8 +317,8 @@ export class AgentRuntime {
       dequeue: (messageId) =>
         this.deps.sessions_store.dequeueMessage(messageId),
       drain: (sessionId, messageId) => this.drainTurn(sessionId, messageId),
-      has_pending_approval: (sessionId) =>
-        this.deps.sessions_store.hasPendingApproval(sessionId),
+      has_pending_human_input: (sessionId) =>
+        this.deps.sessions_store.hasPendingHumanInput(sessionId),
       drain_cooldown_ms: deps.drain_cooldown_ms,
     });
     // Both observers are detached in dispose(): the registry can be
@@ -682,22 +690,34 @@ export class AgentRuntime {
       );
     }
 
-    // Fail closed on an unanswered supervised approval — the SAME invariant the
-    // scheduler's drain enforces (`session-scheduler.ts` `has_pending_approval`):
-    // never start a NEW turn while an approval is pending. `buildModelMessages`
-    // drops the unanswered `approval-requested` part, so a turn started here would
-    // orphan the blocked command and run the next message ahead of it. A valid
-    // `approval_answer` above clears the block; a missing / forged / stale one
-    // leaves it pending. The client normally queues sends while an approval is
-    // pending (it never POSTs here), so this is the server-authoritative guard for
-    // a direct or forged send. We bail BEFORE persisting the incoming tail so a
-    // typed-ahead follow-up isn't recorded against a refused turn.
-    if (await this.deps.sessions_store.hasPendingApproval(sessionId)) {
+    // Clear a CLIENT-resolved answer that rides the incoming tail BEFORE the
+    // pending-block guard below. A `question` answer is a terminal tool result
+    // on the assistant tail (not a body field like an approval), so without
+    // this the very POST carrying the answer would trip the guard it resolves
+    // (the live-daemon resume 409). Idempotent vs. the later persistIncomingTail.
+    await fillIncomingToolResults(
+      this.deps.sessions_store,
+      sessionId,
+      messages
+    );
+
+    // Fail closed on an unanswered human-in-the-loop block (a supervised
+    // approval, or a `question` paused for the user) — the SAME invariant the
+    // scheduler's drain enforces (`session-scheduler.ts` `has_pending_human_input`):
+    // never start a NEW turn while one is pending. `buildModelMessages` drops the
+    // unanswered blocking part, so a turn started here would orphan the block and
+    // run the next message ahead of it. A valid `approval_answer` above clears an
+    // approval; a question clears when its answer is filled. The client normally
+    // queues sends while a block is pending (it never POSTs here), so this is the
+    // server-authoritative guard for a direct or forged send. We bail BEFORE
+    // persisting the incoming tail so a typed-ahead follow-up isn't recorded
+    // against a refused turn.
+    if (await this.deps.sessions_store.hasPendingHumanInput(sessionId)) {
       return Response.json(
         {
           error:
-            "a supervised approval is pending; resolve it before starting a new turn",
-          code: "approval-pending",
+            "a human-input block (approval or question) is pending; resolve it before starting a new turn",
+          code: "human-input-pending",
           session_id: sessionId,
         },
         { status: 409 }
@@ -839,6 +859,8 @@ export class AgentRuntime {
       workspace_registry: workspaceRegistry,
       secrets_root: secretsRoot,
       shell_execution_allowed: shellExecutionAllowed,
+      // Host-level: gates the `question` tool's execute-or-pause in createAgent.
+      interactive: this.deps.interactive === true,
     };
     // Pump: open the upstream model call, forward each SSE frame into the
     // registry. Doesn't block the caller; a client attaches as another

--- a/packages/grida-ai-agent/src/runtime/index.ts
+++ b/packages/grida-ai-agent/src/runtime/index.ts
@@ -243,6 +243,9 @@ type StartTurnOptions = {
   workspace_root?: string;
   skills?: RunRequest["skills"];
   mode: RunRequest["mode"];
+  /** Whether the requesting client can answer the `question` tool (per-run;
+   *  absent ⇒ the host `interactive` default). A core drain leaves it absent. */
+  interactive?: RunRequest["interactive"];
   /**
    * The user message this turn fires — the fired-message identity the
    * turn-lifecycle wire carries (RFC `turn-authority`; emitted on the
@@ -759,6 +762,9 @@ export class AgentRuntime {
         workspace_root: workspaceRoot,
         skills,
         mode,
+        // Per-run client UI capability (the desktop-from-web bridge sets true; a
+        // headless `cli run` sets false). Absent ⇒ host default downstream.
+        interactive: req.interactive,
         // The fired message of a direct run is the incoming tail's user
         // message (the client resends history; the tail is the new one). An
         // approval-answer resume continues the PRIOR turn's tool call — it
@@ -808,6 +814,7 @@ export class AgentRuntime {
       workspace_root: workspaceRoot,
       skills,
       mode,
+      interactive,
     } = opts;
 
     // Reserve the registry entry; its `modelAbort.signal` (not the request
@@ -950,6 +957,7 @@ export class AgentRuntime {
             workspace_root: workspaceRoot,
             skills,
             mode,
+            interactive,
             skill_index: ctx.skill_index,
             skill_cache: ctx.skill_cache,
             project_instructions: ctx.project_instructions,

--- a/packages/grida-ai-agent/src/runtime/run-agent.ts
+++ b/packages/grida-ai-agent/src/runtime/run-agent.ts
@@ -76,6 +76,13 @@ export type AgentRunRequest = {
    */
   mode?: AgentMode;
   /**
+   * Per-run client UI capability for the `question` tool (RFC `tools`
+   * §question). When set it WINS over the host-level `interactive` deps below
+   * (a `cli run` against an interactive daemon declares `false` to stay
+   * headless). Absent ⇒ the host default applies.
+   */
+  interactive?: boolean;
+  /**
    * Discovered RFC skills (names + descriptions advertised; bodies loaded
    * via the `skill` tool). Session-static — the runtime discovers once and
    * passes the same index every turn.
@@ -180,10 +187,12 @@ export async function runAgent(
     skill_cache: req.skill_cache,
     skill_load_body: req.skill_index ? nodeSkillBodyLoader : undefined,
     project_instructions: req.project_instructions,
-    // Host-level: whether the `question` tool pauses for a human or refuses
-    // headless. Independent of workspace bindings (a person can answer a
-    // standalone-doc session too).
-    interactive: deps.interactive,
+    // Whether the `question` tool pauses for a human or refuses headless. The
+    // per-run client capability (`req.interactive`) WINS over the host default
+    // (`deps.interactive`) — one daemon serves both an interactive web client
+    // and a headless `cli run`. Independent of workspace bindings (a person can
+    // answer a standalone-doc session too).
+    interactive: req.interactive ?? deps.interactive,
   });
 
   return await createAgentUIStreamResponse({

--- a/packages/grida-ai-agent/src/runtime/run-agent.ts
+++ b/packages/grida-ai-agent/src/runtime/run-agent.ts
@@ -148,7 +148,13 @@ function toMessageUsage(u: SdkStepUsage): MessageUsage {
 export async function runAgent(
   provider: ResolvedProvider,
   req: AgentRunRequest,
-  deps: { workspace_registry: WorkspaceRegistry }
+  deps: {
+    workspace_registry: WorkspaceRegistry;
+    /** Host-level: gates the `question` tool (pause vs fixed-refusal). The
+     * runtime threads it down via `runDeps`; `createWorkspaceAgentBindings`
+     * ignores it (it reads only workspace/secret/shell fields). */
+    interactive?: boolean;
+  }
 ): Promise<Response> {
   // Wire bindings only when the request carries workspace context.
   // The "no-bindings" mode preserves the existing SVG-editor flow
@@ -174,6 +180,10 @@ export async function runAgent(
     skill_cache: req.skill_cache,
     skill_load_body: req.skill_index ? nodeSkillBodyLoader : undefined,
     project_instructions: req.project_instructions,
+    // Host-level: whether the `question` tool pauses for a human or refuses
+    // headless. Independent of workspace bindings (a person can answer a
+    // standalone-doc session too).
+    interactive: deps.interactive,
   });
 
   return await createAgentUIStreamResponse({

--- a/packages/grida-ai-agent/src/runtime/run-input.test.ts
+++ b/packages/grida-ai-agent/src/runtime/run-input.test.ts
@@ -282,6 +282,25 @@ describe("parseRunBody", () => {
     });
   });
 
+  it("parses the per-run `interactive` flag (boolean only; else absent)", async () => {
+    // The client declares whether it can answer `question` (a `cli run` sets
+    // false; a UI client true). Only an explicit boolean counts — anything else
+    // is absent so the host's interactive default applies downstream.
+    const msgs = [{ role: "user", parts: [{ type: "text", text: "hi" }] }];
+    const asReq = async (interactive: unknown) => {
+      const p = await parseRunBody(
+        { messages: msgs, interactive },
+        deps as never
+      );
+      if (p instanceof Response) throw new Error("unexpected 400");
+      return p;
+    };
+    expect((await asReq(false)).interactive).toBe(false);
+    expect((await asReq(true)).interactive).toBe(true);
+    expect((await asReq(undefined)).interactive).toBeUndefined();
+    expect((await asReq("yes")).interactive).toBeUndefined();
+  });
+
   it("rejects untyped message parts at the HTTP boundary", async () => {
     const parsed = await parseRunBody(
       {

--- a/packages/grida-ai-agent/src/runtime/run-input.ts
+++ b/packages/grida-ai-agent/src/runtime/run-input.ts
@@ -283,6 +283,33 @@ export async function persistIncomingTail(
  * tool_state = 'input-available'` guard); it cannot inject or rewrite anything
  * else.
  */
+/**
+ * Fill any CLIENT-resolved tool results carried on the incoming tail's
+ * assistant messages — the in-place fill from {@link persistResolvedToolResults}
+ * applied across the whole batch.
+ *
+ * Called BEFORE the pending-human-input guard (`runtime/index.ts`): a
+ * client-resolved answer rides the message tail (unlike a supervised approval,
+ * which arrives as an explicit `approval_answer` body field applied even
+ * earlier). The locked `question` tool is the case that needs this — its answer
+ * is a terminal `output-available` part in the tail, and it must clear the
+ * session's human-input block BEFORE the guard, or the very POST that carries
+ * the answer would be refused by the guard it resolves. Idempotent: the later
+ * {@link persistIncomingTail} re-runs the same fill (a no-op once the row is
+ * already terminal) and still appends any new user message.
+ */
+export async function fillIncomingToolResults(
+  store: SessionsStore,
+  sessionId: string,
+  incoming: NormalizedMessage[]
+): Promise<void> {
+  for (const m of incoming) {
+    if (m.role === "assistant") {
+      await persistResolvedToolResults(store, sessionId, m);
+    }
+  }
+}
+
 async function persistResolvedToolResults(
   store: SessionsStore,
   sessionId: string,

--- a/packages/grida-ai-agent/src/runtime/run-input.ts
+++ b/packages/grida-ai-agent/src/runtime/run-input.ts
@@ -54,6 +54,9 @@ export type RunRequest = {
   skills?: SkillId[];
   /** Permission/supervision posture; defaults to `accept-edits` when absent. */
   mode: AgentMode;
+  /** Whether the requesting client has a human UI for the `question` tool
+   *  (RFC `tools` §question). Absent ⇒ inherit the host's `interactive` default. */
+  interactive?: boolean;
   /** Resume answer for a paused supervised approval; absent on a normal turn. */
   approval_answer?: ApprovalAnswer;
   session_id?: string;
@@ -79,6 +82,7 @@ export async function parseRunBody(
     workspace_id?: unknown;
     skills?: unknown;
     mode?: unknown;
+    interactive?: unknown;
     approval_answer?: unknown;
     session_id?: unknown;
   };
@@ -163,6 +167,9 @@ export async function parseRunBody(
     // string is treated as absent rather than rejected — the supervision
     // posture should fail safe, not 400 the whole turn.
     mode: asAgentMode(b.mode) ?? AGENT_DEFAULT_MODE,
+    // Only an explicit boolean counts; anything else leaves it absent so the
+    // host's `interactive` default applies (the client didn't declare a UI).
+    interactive: typeof b.interactive === "boolean" ? b.interactive : undefined,
     // A malformed approval answer is treated as absent (no resume), never a
     // 400 — and `store.answerApproval` re-validates it against the persisted
     // pending approval regardless, so a forged answer is a no-op.

--- a/packages/grida-ai-agent/src/runtime/session-scheduler.test.ts
+++ b/packages/grida-ai-agent/src/runtime/session-scheduler.test.ts
@@ -52,11 +52,11 @@ function delay(ms: number): Promise<void> {
 }
 
 /** A scheduler wired to the real store with an overridable `drain`. The
- *  `has_pending_approval` gate defaults to "never blocked" so the existing
- *  drain tests are unaffected; the approval-pause test passes a real flag. */
+ *  `has_pending_human_input` gate defaults to "never blocked" so the existing
+ *  drain tests are unaffected; the block-pause tests pass a real flag. */
 function makeScheduler(
   drain?: SessionSchedulerDeps["drain"],
-  hasPendingApproval?: SessionSchedulerDeps["has_pending_approval"]
+  hasPendingHumanInput?: SessionSchedulerDeps["has_pending_human_input"]
 ): {
   scheduler: SessionScheduler;
   calls: string[];
@@ -71,7 +71,7 @@ function makeScheduler(
     list_queued: (sid) => store.listQueuedMessages(sid),
     dequeue: (id) => store.dequeueMessage(id),
     drain: drain ?? defaultDrain,
-    has_pending_approval: hasPendingApproval ?? (async () => false),
+    has_pending_human_input: hasPendingHumanInput ?? (async () => false),
     drain_cooldown_ms: COOLDOWN,
   });
   live.push(scheduler);
@@ -162,8 +162,8 @@ describe("SessionScheduler drain", () => {
     // (RFC queue § drain-pause). An approval-request finishes the run cleanly,
     // so the session reads idle through the pause — but the queued message must
     // NOT fire until the approval resolves. Without the fire-gate's
-    // has_pending_approval check, the cooldown drain would fire `q1` during the
-    // wait (the reported B1 bug): drop that check and this assertion fails.
+    // has_pending_human_input check, the cooldown drain would fire `q1` during
+    // the wait (the reported B1 bug): drop that check and this assertion fails.
     let pendingApproval = true;
     const { scheduler, calls } = makeScheduler(
       undefined,
@@ -207,7 +207,7 @@ describe("SessionScheduler drain", () => {
       list_queued: (sid) => store.listQueuedMessages(sid),
       dequeue: (id) => store.dequeueMessage(id),
       drain,
-      has_pending_approval: async () => false,
+      has_pending_human_input: async () => false,
       drain_cooldown_ms: COOLDOWN,
     });
     live.push(scheduler);
@@ -245,7 +245,7 @@ describe("SessionScheduler drain", () => {
       list_queued: (sid) => store.listQueuedMessages(sid),
       dequeue: (id) => store.dequeueMessage(id),
       drain,
-      has_pending_approval: async () => false,
+      has_pending_human_input: async () => false,
       drain_cooldown_ms: COOLDOWN,
     });
     live.push(scheduler);

--- a/packages/grida-ai-agent/src/runtime/session-scheduler.ts
+++ b/packages/grida-ai-agent/src/runtime/session-scheduler.ts
@@ -24,11 +24,12 @@
  * response. The session is genuinely idle through the cooldown, so the
  * Stop/Send control reads Send and the UI paints Stop→Send→Stop. A hard error
  * PAUSES the drain (queued rows wait for the next fired turn). A turn BLOCKED
- * awaiting a user decision (a pending supervised approval) pauses it the same
- * way: an approval-request finishes the run cleanly so the session reads idle,
- * but it is not a completed turn — the fire-gate consults
- * {@link SessionSchedulerDeps.has_pending_approval} and holds the queue until
- * the user answers and the turn continues to a true finish.
+ * awaiting a user decision (a pending supervised approval, or an unanswered
+ * `question`) pauses it the same way: the blocking request finishes the run
+ * cleanly so the session reads idle, but it is not a completed turn — the
+ * fire-gate consults {@link SessionSchedulerDeps.has_pending_human_input} and
+ * holds the queue until the user answers and the turn continues to a true
+ * finish.
  *
  * Re-entrancy: `onFinish` runs inside the registry's `finish()`; the drain it
  * schedules runs on a fresh task (a timer), never inline inside `finish()`, so
@@ -58,15 +59,16 @@ export type SessionSchedulerDeps = {
    */
   drain: (sessionId: string, messageId: string) => Promise<void>;
   /**
-   * Is this session's current turn BLOCKED awaiting a user decision (an
-   * unanswered supervised approval)? A blocked turn is NOT a completed turn:
-   * the drain stays paused until the user resolves it — like a hard error
-   * pauses it (RFC `queue` § drain-pause). Consulted at the drain fire-gate
-   * against the AUTHORITATIVE persisted approval state (restart-durable, unlike
-   * an in-memory flag). Required so a scheduler cannot silently forget the
-   * block and fire a queued turn before the user answers.
+   * Is this session's current turn BLOCKED awaiting a user decision — an
+   * unanswered supervised approval, OR a human-input tool (e.g. `question`)
+   * paused for the user's answer? A blocked turn is NOT a completed turn: the
+   * drain stays paused until the user resolves it — like a hard error pauses it
+   * (RFC `queue` § drain-pause). Consulted at the drain fire-gate against the
+   * AUTHORITATIVE persisted state (restart-durable, unlike an in-memory flag).
+   * Required so a scheduler cannot silently forget the block and fire a queued
+   * turn before the user answers.
    */
-  has_pending_approval: (sessionId: string) => Promise<boolean>;
+  has_pending_human_input: (sessionId: string) => Promise<boolean>;
   /** Inter-turn settle delay before a drained turn fires (ms). */
   drain_cooldown_ms?: number;
 };
@@ -177,15 +179,15 @@ export class SessionScheduler {
     this.setDrainTimer(sessionId, this.cooldown_ms, async () => {
       if (this.getStatus(sessionId).state !== "idle") return;
       // A turn BLOCKED awaiting a user decision (an unanswered supervised
-      // approval) is not ready for the next turn: pause the drain until the
-      // user resolves it (RFC `queue` § drain-pause — the same class as a hard
-      // error pausing the drain). The session reads `idle` through the pause —
-      // an approval-request finishes the run cleanly — so idle alone is NOT a
-      // sufficient drainability predicate. Checked against the authoritative
-      // persisted approval state. Fail closed: never drain over an unconfirmed
-      // block.
+      // approval, or a `question` paused for the user's answer) is not ready
+      // for the next turn: pause the drain until the user resolves it (RFC
+      // `queue` § drain-pause — the same class as a hard error pausing the
+      // drain). The session reads `idle` through the pause — the blocking
+      // request finishes the run cleanly — so idle alone is NOT a sufficient
+      // drainability predicate. Checked against the authoritative persisted
+      // state. Fail closed: never drain over an unconfirmed block.
       try {
-        if (await this.deps.has_pending_approval(sessionId)) return;
+        if (await this.deps.has_pending_human_input(sessionId)) return;
       } catch {
         return;
       }

--- a/packages/grida-ai-agent/src/session/store.test.ts
+++ b/packages/grida-ai-agent/src/session/store.test.ts
@@ -1077,6 +1077,22 @@ describe("hasPendingHumanInput (drain-pause trait gate)", () => {
     await recordToolPart(s.id, "tc_q", "question", "output-available", msgId);
     expect(await store.hasPendingHumanInput(s.id)).toBe(false);
   });
+
+  it("ignores a rewound (hidden) block — a hidden pending question does not deadlock the gate", async () => {
+    // rewind() only marks `hidden_at`; it does NOT delete the parts. Without a
+    // visibility scope the gate would keep a rewound-past prompt "pending"
+    // forever, returning human-input-pending for a prompt the user can't see.
+    const s = await store.create({ agent: "grida" });
+    // A user turn to rewind back to, then a later assistant turn that pauses.
+    const anchor = await store.appendMessage(s.id, { role: "user" });
+    await recordToolPart(s.id, "tc_q", "question", "input-available");
+    expect(await store.hasPendingHumanInput(s.id)).toBe(true);
+
+    // Rewinding to the anchor hides the assistant question message → no longer
+    // pending, even though its `input-available` part still exists in the DB.
+    await store.rewind(s.id, anchor.id);
+    expect(await store.hasPendingHumanInput(s.id)).toBe(false);
+  });
 });
 
 function delay(ms: number): Promise<void> {

--- a/packages/grida-ai-agent/src/session/store.test.ts
+++ b/packages/grida-ai-agent/src/session/store.test.ts
@@ -1005,6 +1005,80 @@ describe("answerApproval — supervised approval boundary (GRIDA-SEC-004)", () =
   });
 });
 
+describe("hasPendingHumanInput (drain-pause trait gate)", () => {
+  // Write/advance one tool part for a session at a given tool name + state,
+  // mimicking what the recorder persists mid-turn. Reuses `msgId` so a later
+  // call advances the SAME row in place (state migrates by tool_call_id) — the
+  // way `fillToolResult` flips input-available → output-available, not a new row.
+  async function recordToolPart(
+    sessionId: string,
+    tcid: string,
+    name: string,
+    state: string,
+    msgId: string = newMessageId()
+  ): Promise<string> {
+    await store.appendMessageIfAbsent(sessionId, {
+      id: msgId,
+      role: "assistant",
+    });
+    await store.upsertPart(msgId, {
+      index: 0,
+      type: `tool-${name}`,
+      data: {
+        type: `tool-${name}`,
+        tool_call_id: tcid,
+        tool_name: name,
+        state,
+        input: {},
+      },
+      tool_call_id: tcid,
+      tool_state: state,
+      session_id: sessionId,
+    });
+    return msgId;
+  }
+
+  it("is false for a session with no pending block", async () => {
+    const s = await store.create({ agent: "grida" });
+    expect(await store.hasPendingHumanInput(s.id)).toBe(false);
+  });
+
+  it("is true while a supervised approval is unanswered", async () => {
+    const s = await store.create({ agent: "grida" });
+    await recordToolPart(s.id, "tc_a", "run_command", "approval-requested");
+    expect(await store.hasPendingHumanInput(s.id)).toBe(true);
+  });
+
+  it("is true while a `question` is paused at input-available", async () => {
+    const s = await store.create({ agent: "grida" });
+    await recordToolPart(s.id, "tc_q", "question", "input-available");
+    expect(await store.hasPendingHumanInput(s.id)).toBe(true);
+  });
+
+  it("is FALSE for a transient client-fs call at input-available (the trait discriminator)", async () => {
+    // A client-resolved `read_file` sits at `input-available` for the moment
+    // between stream-finish and the renderer filling its result. It is NOT a
+    // human block — the drain must NOT pause on it. This is exactly why the
+    // gate keys on the HUMAN_INPUT_TOOL_NAMES trait, not bare `input-available`.
+    const s = await store.create({ agent: "grida" });
+    await recordToolPart(s.id, "tc_r", "read_file", "input-available");
+    expect(await store.hasPendingHumanInput(s.id)).toBe(false);
+  });
+
+  it("is false once the question is answered (output-available)", async () => {
+    const s = await store.create({ agent: "grida" });
+    const msgId = await recordToolPart(
+      s.id,
+      "tc_q",
+      "question",
+      "input-available"
+    );
+    // Answer arrives → the SAME row advances to output-available (in place).
+    await recordToolPart(s.id, "tc_q", "question", "output-available", msgId);
+    expect(await store.hasPendingHumanInput(s.id)).toBe(false);
+  });
+});
+
 function delay(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }

--- a/packages/grida-ai-agent/src/session/store.ts
+++ b/packages/grida-ai-agent/src/session/store.ts
@@ -1304,14 +1304,22 @@ export class SessionsStore {
    * `input-available` for the moment between the stream finishing and the
    * renderer filling its result, and must NOT pause the drain). Read-only
    * existence check; reads no input/output/args/content.
+   *
+   * Scoped to VISIBLE messages (`hidden_at IS NULL`): a rewind only hides
+   * messages, it does not delete their parts. Without this join, rewinding past
+   * a paused approval/question would leave the block "pending" forever — the
+   * gate would keep returning `human-input-pending` for a prompt the user can no
+   * longer see (the same visibility rule as `listVisibleMessages`).
    */
   async hasPendingHumanInput(sessionId: string): Promise<boolean> {
     const rows = await this.db
       .select({ id: chatParts.id })
       .from(chatParts)
+      .innerJoin(chatMessages, eq(chatMessages.id, chatParts.message_id))
       .where(
         and(
           eq(chatParts.session_id, sessionId),
+          isNull(chatMessages.hidden_at),
           or(
             eq(chatParts.tool_state, "approval-requested"),
             and(

--- a/packages/grida-ai-agent/src/session/store.ts
+++ b/packages/grida-ai-agent/src/session/store.ts
@@ -14,10 +14,23 @@
  * result that arrives long after the input-start can find the same row.
  */
 
-import { and, asc, desc, eq, gt, isNull, like, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  like,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { OpenedSessionsDb } from "./db";
 import { chatMessages, chatParts, chatSessions } from "./schema";
 import { asAgentMode, type AgentMode } from "../protocol/mode";
+import { HUMAN_INPUT_PART_TYPES } from "../tools/names";
 import { newMessageId, newPartId, newSessionId } from "./ids";
 import { session_title } from "./title";
 import { compactionBoundary } from "./boundary";
@@ -1270,6 +1283,42 @@ export class SessionsStore {
         and(
           eq(chatParts.session_id, sessionId),
           eq(chatParts.tool_state, "approval-requested")
+        )
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /**
+   * Does this session have an UNANSWERED human-in-the-loop block? True iff a
+   * persisted tool part is awaiting a person — either a supervised approval
+   * (`approval-requested`) OR a human-input tool (e.g. `question`) paused at
+   * `input-available`. This is the authoritative drain-pause predicate (RFC
+   * `queue` § drain-pause): the queue waits while ANY such block is open, so a
+   * later turn never fires ahead of the user's pending decision.
+   *
+   * The `input-available` leg is keyed on the {@link HUMAN_INPUT_TOOL_NAMES}
+   * *trait*, NOT a literal name — a future richer human-block tool joins by
+   * being added to that set. The trait clause is REQUIRED to distinguish a real
+   * human block from a *transient* client-resolved fs call (which also sits at
+   * `input-available` for the moment between the stream finishing and the
+   * renderer filling its result, and must NOT pause the drain). Read-only
+   * existence check; reads no input/output/args/content.
+   */
+  async hasPendingHumanInput(sessionId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ id: chatParts.id })
+      .from(chatParts)
+      .where(
+        and(
+          eq(chatParts.session_id, sessionId),
+          or(
+            eq(chatParts.tool_state, "approval-requested"),
+            and(
+              eq(chatParts.tool_state, "input-available"),
+              inArray(chatParts.type, HUMAN_INPUT_PART_TYPES)
+            )
+          )
         )
       )
       .limit(1);

--- a/packages/grida-ai-agent/src/tools/index.ts
+++ b/packages/grida-ai-agent/src/tools/index.ts
@@ -41,14 +41,19 @@ import type {
   SkillBodyLoader,
   SkillIndex,
 } from "../skills/types";
-import { RUN_COMMAND_TOOL_NAME, type AgentToolName } from "./names";
+import {
+  RUN_COMMAND_TOOL_NAME,
+  QUESTION_TOOL_NAME,
+  type AgentToolName,
+} from "./names";
 import {
   createRunCommandTool,
   type RunCommandBackend,
   type RunCommandOutcome,
 } from "./run-command";
+import { createQuestionTool } from "./question";
 
-export { RUN_COMMAND_TOOL_NAME, SKILL_TOOL_NAME };
+export { RUN_COMMAND_TOOL_NAME, QUESTION_TOOL_NAME, SKILL_TOOL_NAME };
 export type { AgentToolName, RunCommandBackend, RunCommandOutcome };
 
 export type ToolsetCapabilities = {
@@ -90,6 +95,15 @@ export type ToolsetCapabilities = {
     /** Body reader (server injects `nodeSkillBodyLoader`). */
     load_body: SkillBodyLoader;
   };
+  /**
+   * Whether a human UI is bound (RFC `tools` §question). The locked `question`
+   * tool is ALWAYS registered — when `interactive` is true it is client-resolved
+   * (no `execute`, pauses for the user's answer); when false/undefined it ships
+   * with a fixed-refusal `execute` so a headless host returns a tool error
+   * instead of hanging forever. Unlike the other capabilities, absence does not
+   * drop the tool — the lock guarantees every host advertises it.
+   */
+  interactive?: boolean;
 };
 
 /**
@@ -119,6 +133,12 @@ export function createToolset(caps: ToolsetCapabilities = {}) {
   const base = {
     ...fsTools,
     ...todosTools,
+    // The locked `question` tool is unconditional (every host advertises it).
+    // `interactive` only decides whether it pauses for a human (no execute) or
+    // refuses headless (a fixed-error execute) — see `createQuestionTool`.
+    [QUESTION_TOOL_NAME]: createQuestionTool({
+      interactive: caps.interactive === true,
+    }),
   };
   // Conditional spreads keep each capability's precise tool type in the
   // inferred return (used by `createAgent`'s `ToolLoopAgent<…, typeof

--- a/packages/grida-ai-agent/src/tools/names.ts
+++ b/packages/grida-ai-agent/src/tools/names.ts
@@ -12,6 +12,9 @@ import type { SKILL_TOOL_NAME } from "../skills/skill-tool";
 
 export const RUN_COMMAND_TOOL_NAME = "run_command" as const;
 
+/** The locked `question` (ask-user) tool — RFC `tools` §question. */
+export const QUESTION_TOOL_NAME = "question" as const;
+
 /**
  * Every tool the agent may emit, regardless of which capabilities a
  * given callsite happens to wire. The *maximal* union: the client must
@@ -24,4 +27,31 @@ export type AgentToolName =
   | AgentTodos.ToolName
   | AgentVision.ToolName
   | typeof RUN_COMMAND_TOOL_NAME
+  | typeof QUESTION_TOOL_NAME
   | typeof SKILL_TOOL_NAME;
+
+/**
+ * Tools that **block the turn on a human** — they pause at `input-available`
+ * until a person resolves them (RFC `queue` § drain-pause). This is the
+ * *trait* the drain-pause gate keys on, NOT the literal tool name: the gate
+ * (`store.hasPendingHumanInput`) treats any `input-available` part whose tool
+ * is in this set as a pending human block, so the queue waits exactly as it
+ * does for a supervised approval. A future richer human-block tool (e.g. a
+ * "pick a generated idea" picker) joins the contract by being added here —
+ * no change to the gate. Distinct from a *transient* client-resolved fs call
+ * at `input-available` (which a renderer fills in milliseconds), which must
+ * NOT pause the drain.
+ */
+export const HUMAN_INPUT_TOOL_NAMES = [QUESTION_TOOL_NAME] as const;
+
+/**
+ * Persisted/streamed part `type` values for the {@link HUMAN_INPUT_TOOL_NAMES}
+ * tools. The AI SDK UI-message convention encodes the tool name into the part
+ * type as `tool-<name>`, and the persisted `chat_parts.type` column carries it
+ * verbatim — so the drain-pause gate (`store.hasPendingHumanInput`) filters on
+ * these values. Derived from the name set so adding a human-block tool there
+ * propagates here automatically.
+ */
+export const HUMAN_INPUT_PART_TYPES = HUMAN_INPUT_TOOL_NAMES.map(
+  (name) => `tool-${name}` as const
+);

--- a/packages/grida-ai-agent/src/tools/question.test.ts
+++ b/packages/grida-ai-agent/src/tools/question.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createQuestionTool, QUESTION_HEADLESS_REFUSAL } from "./question";
+
+describe("createQuestionTool", () => {
+  it("is client-resolved (NO execute) in an interactive host", () => {
+    // Interactive: the human's answer IS the result, supplied via addToolResult.
+    // Like the fs tools, the tool must ship without an `execute` so the call
+    // pauses at `input-available` instead of resolving server-side.
+    const tool = createQuestionTool({ interactive: true });
+    expect(tool.execute).toBeUndefined();
+  });
+
+  it("ships a fixed-refusal execute in a headless host", async () => {
+    // Headless (CI / scheduled / batch): no human to answer. The tool refuses
+    // with a fixed tool error so the model gets it next turn and proceeds.
+    const tool = createQuestionTool({ interactive: false });
+    expect(tool.execute).toBeTypeOf("function");
+    await expect(
+      // The AI SDK passes (input, context); the refusal ignores both.
+      (tool.execute as (input: unknown, ctx: unknown) => Promise<unknown>)(
+        { questions: [{ question: "x?" }] },
+        {}
+      )
+    ).rejects.toThrow(QUESTION_HEADLESS_REFUSAL);
+  });
+
+  it("accepts the RFC question shape and rejects an empty survey", () => {
+    const tool = createQuestionTool({ interactive: true });
+    const schema = tool.inputSchema as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(
+      schema.safeParse({
+        questions: [
+          {
+            question: "Pick a color",
+            header: "Color",
+            options: [{ label: "Red", description: "warm" }, { label: "Blue" }],
+            multi_select: false,
+          },
+        ],
+      }).success
+    ).toBe(true);
+    // At least one question is required.
+    expect(schema.safeParse({ questions: [] }).success).toBe(false);
+  });
+});

--- a/packages/grida-ai-agent/src/tools/question.ts
+++ b/packages/grida-ai-agent/src/tools/question.ts
@@ -1,0 +1,145 @@
+/**
+ * The locked `question` (ask-user survey) tool — RFC `tools` §question
+ * (`docs/wg/ai/agent/tools.md`). The agent emits one or more structured
+ * questions; the run **pauses on a human**; the user picks an option or writes
+ * their own answer per question; the turn resumes with the answers.
+ *
+ * Substrate — it is a **client-resolved no-`execute` tool**, exactly like the
+ * fs tools (`fs/index.ts`): in an interactive host the tool ships WITHOUT an
+ * `execute`, so the call streams to `input-available` and the loop pauses there.
+ * The human's answer IS the tool result (`{ answers }`), supplied by the
+ * renderer via `chat.addToolResult` and persisted server-authoritatively
+ * through the existing `fillToolResult` path. There is no question-specific
+ * state machine, store method, wire DTO, or lowering — it rides the same rails
+ * as `read_file`. The only shared rail is the drain-pause gate, which keys on
+ * the {@link HUMAN_INPUT_TOOL_NAMES} trait, not this tool's name.
+ *
+ * Headless hosts (CI, scheduled agents, hosted batch) have no human to answer.
+ * There the tool is constructed WITH an `execute` that throws the fixed refusal
+ * ({@link QUESTION_HEADLESS_REFUSAL}); the model reads the tool error next turn
+ * and falls back to its best assumption. That conditional construction — based
+ * on the host's `interactive` flag — IS the capability gate. The tool is always
+ * registered (it is locked: every host advertises it, so the model's mental
+ * model is identical across hosts).
+ *
+ * Text-only on purpose. Options are `{ label, description? }`; answers are
+ * `string[][]`. It is NOT a rich/visual/artifact picker — that is a separate,
+ * domain tool that sits beside this one. Keeping this schema minimal is what
+ * lets it refuse to grow.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { QUESTION_TOOL_NAME } from "./names";
+
+export { QUESTION_TOOL_NAME };
+export type QuestionToolName = typeof QUESTION_TOOL_NAME;
+
+/**
+ * The fixed tool error a headless host returns when the model calls `question`.
+ * RFC `tools` §question: "Headless hosts MUST treat `question` as a tool error
+ * with a fixed message — the model gets the refusal in its next turn and falls
+ * back to its best guess."
+ */
+export const QUESTION_HEADLESS_REFUSAL =
+  "The question tool is unavailable here: there is no interactive user to " +
+  "answer. Do not ask — proceed with your best assumption and state the " +
+  "assumption you made.";
+
+const questionInputSchema = z.object({
+  questions: z
+    .array(
+      z.object({
+        question: z
+          .string()
+          .min(1)
+          .describe("The question to ask the user. One clear ask."),
+        header: z
+          .string()
+          .optional()
+          .describe(
+            "Optional short label/category for this question (a few words), " +
+              "shown as a heading above it."
+          ),
+        options: z
+          .array(
+            z.object({
+              label: z
+                .string()
+                .min(1)
+                .describe("Short selectable answer text."),
+              description: z
+                .string()
+                .optional()
+                .describe("Optional one-line explanation of this option."),
+            })
+          )
+          .optional()
+          .describe(
+            "Suggested answers the user can pick. The user may always write " +
+              "their own answer instead, so options are hints, not a closed set."
+          ),
+        multi_select: z
+          .boolean()
+          .optional()
+          .describe(
+            "When true, the user may select more than one option for this " +
+              "question. Default false (single choice)."
+          ),
+      })
+    )
+    .min(1)
+    .describe("One or more questions to ask in a single survey."),
+});
+
+const questionOutputSchema = z.object({
+  answers: z
+    .array(z.array(z.string()))
+    .describe(
+      "One array of answer strings per question, in the same order as the " +
+        "questions. A single-select question yields a one-element array; a " +
+        "multi-select question may yield several; a free-text write-in is the " +
+        "user's text verbatim."
+    ),
+  /** Present and true when the user dismissed the survey without answering. */
+  skipped: z
+    .boolean()
+    .optional()
+    .describe("True when the user skipped/dismissed the survey unanswered."),
+});
+
+const DESCRIPTION =
+  "Pause and ask the user one or more structured questions, then wait for " +
+  "their answer before continuing. Use this when a decision genuinely needs " +
+  "the user — an ambiguous requirement, a choice between real alternatives, " +
+  "missing information you cannot infer. Each question may offer options to " +
+  "pick from; the user can also write their own answer. Do NOT use it for " +
+  "things you can decide yourself or look up — asking when you should act is " +
+  "a worse experience than acting. Returns one answer array per question.";
+
+/**
+ * Build the `question` tool. `interactive` decides who resolves it:
+ *
+ *   - interactive (a human UI is bound): NO `execute` — the call pauses at
+ *     `input-available` and the renderer supplies `{ answers }` via
+ *     `addToolResult`.
+ *   - headless: `execute` throws {@link QUESTION_HEADLESS_REFUSAL} so the model
+ *     gets a tool error and proceeds without asking.
+ */
+export function createQuestionTool(opts: { interactive: boolean }) {
+  const base = {
+    description: DESCRIPTION,
+    inputSchema: questionInputSchema,
+    outputSchema: questionOutputSchema,
+  };
+  if (opts.interactive) {
+    // Client-resolved: no execute. The human answer becomes the result.
+    return tool(base);
+  }
+  return tool({
+    ...base,
+    execute: async () => {
+      throw new Error(QUESTION_HEADLESS_REFUSAL);
+    },
+  });
+}


### PR DESCRIPTION
Implements the locked **`question` (ask-user)** tool (#802): the agent emits structured questions, the run **pauses on a human**, the user answers (or skips), and the turn resumes with the answers. RFC: `docs/wg/ai/agent/tools.md` §question.

## Substrate (the key decision)
`question` rides the **existing client-resolved no-`execute` tool path** (the fs tools) — **not** #800's approval machinery. The human's answer *is* the tool result (`{ answers: string[][] }`), delivered via `chat.addToolResult` → the existing `persistIncomingTail`/`fillToolResult` path → the existing `output-available` lowering. So: **no new part states, no new wire DTO, no new lowering**, and only one new store query.

## Core — `packages/grida-ai-agent`
- **`tools/question.ts`** — `createQuestionTool({ interactive })`. Interactive hosts ship it **without `execute`** (client-resolved pause); headless hosts ship a **fixed-refusal `execute`** (the RFC's headless contract). Always registered (it's locked); `interactive` only decides execute-vs-pause.
- **`tools/names.ts`** — `QUESTION_TOOL_NAME` + the **`HUMAN_INPUT_TOOL_NAMES` trait** registry (+ derived `HUMAN_INPUT_PART_TYPES`). The drain gate keys on the **trait**, not the literal name, so a future human-input tool joins for free.
- **`store.hasPendingHumanInput`** — drain-pause gate = `approval-requested` **OR** (`input-available` **AND** tool ∈ trait). The trait clause is what distinguishes a real human block from a *transient* client-fs call sitting at `input-available`.
- **`interactive` flag** threaded host→server→runtime→toolset, mirroring `shell_execution_allowed` exactly. Desktop sidecar + `serve` daemon = interactive; one-shot `run` / headless = false.
- **`fillIncomingToolResults`** runs **before** the pending-block 409 guard — a client-resolved answer rides the message *tail* (unlike approval's body field), so it must clear the block before the guard it resolves. (Fixes a live-daemon resume 409 caught during end-to-end testing.)

## UI — the agent **asks** (`editor`)
The question is a **session-global prompt pinned above the composer** (mirrors the supervised-approval bar), **not** a transcript card. The kit exposes `findPendingQuestion` + `QuestionCard` (radio / checkbox / free-text write-in / skip; a multi-question survey is a **one-at-a-time wizard** with Back/Next, Submit on the last). The transcript shows only a passive record. Wired into **both** desktop surfaces (ai-sidebar + workbench pane) **and** the `/ui/components/ai-chat` dev showcase — no prop-drilling through the kit's per-turn renderer.

## Tests & verification
- **Package:** trait-discriminator unit test (a transient fs call does **not** pause), interactive-vs-headless construction, headless refusal lowers to a model-readable `output-error` (e2e mock model), and a **resume-clears-the-block** regression.
- **Live end-to-end:** verified against a running daemon with a real model — agent asked → run paused → answered → resumed using the answer.
- Editor agent-chat tests pass; typecheck (all package configs incl. browser-safe + editor), oxlint, oxfmt clean.

## Reviewer notes
- **Drain-gate altitude:** the package gate is trait-general (one queue must pause uniformly), while the editor's `findPendingQuestion`/`QuestionCard` are question-specific (each human-input tool needs its own form). That asymmetry is intentional.
- **Not consolidated on purpose:** `findPendingApproval` stays surface-local (workbench-only, resolves via a body field) while `findPendingQuestion` is kit-shared (3 surfaces, resolves via `addToolResult`). Converging them would couple two things that legitimately differ.
- Docs updated: `tools-fundamentals.md` (status → shipped), `queue.md` (names `question` as a drain-pause example), kit `README.md` (public API re-synced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive, session-global “question” flow with a pinned open card, multi-step wizard navigation, and read-only answered/skip summaries.
  * Extended desktop chat, sidebar, and agent panes to render pending question prompts and commit answers.
  * Exposed the `question` tool for hosts with optional human-input interactivity.

* **Bug Fixes**
  * Updated runtime scheduling to pause draining on any pending human-input (including unanswered questions) and resume once answered.
  * Improved headless behavior to fail-closed with a fixed refusal; clarified HTTP 409 as `human-input-pending`.

* **Documentation / Tests**
  * Updated queue/tooling docs and expanded UI scenarios plus HTTP, store, scheduler, e2e, and tool parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->