### PR TITLE
feat: BYOK image & video generation (desktop) — model→provider bindings (#908)

### DIFF
--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -510,6 +510,14 @@ const bridge: DesktopBridge = {
     detect_claude: () => agentClient.providers.detect_claude(),
   },
 
+  images: {
+    generate: (req) => agentClient.images.generate(req),
+  },
+
+  video: {
+    generate: (req) => agentClient.video.generate(req),
+  },
+
   agent: {
     run: (opts, onChunk) =>
       // Fresh runs always return a stream (only `reconnect` may return

--- a/editor/app/desktop/images/page.tsx
+++ b/editor/app/desktop/images/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { DesktopPageShell } from "@/scaffolds/desktop/chrome/page-shell";
+import { DesktopImagePlayground } from "@/scaffolds/desktop/image-gen/image-playground";
+
+/**
+ * Desktop image-generation page (#908) — the dedicated home for BYOK image
+ * generation. A `?model=<id>` query (set by "Try this model" in Settings)
+ * preselects a model. Generation runs in the agent sidecar against the user's
+ * connected provider key; the key never reaches this renderer (GRIDA-SEC-004).
+ */
+export default function DesktopImagesPage() {
+  return (
+    <DesktopPageShell>
+      <Suspense>
+        <PlaygroundWithQuery />
+      </Suspense>
+    </DesktopPageShell>
+  );
+}
+
+function PlaygroundWithQuery() {
+  const model = useSearchParams().get("model") ?? undefined;
+  return <DesktopImagePlayground initialModelId={model} />;
+}

--- a/editor/app/desktop/settings/page.tsx
+++ b/editor/app/desktop/settings/page.tsx
@@ -14,11 +14,14 @@ import {
   CardTitle,
 } from "@app/ui/components/card";
 import { Skeleton } from "@app/ui/components/skeleton";
+import { models } from "@grida/ai-models";
 import {
   BYOK_PROVIDER_LABELS,
   DesktopBridgeMissingError,
   OLLAMA_ENDPOINT_PRESET,
   app,
+  images,
+  video,
   mergeProbedModels,
   providers,
   resolveEndpointModel,
@@ -27,6 +30,7 @@ import {
   type EndpointModelEntry,
   type EndpointProviderConfig,
 } from "@/lib/desktop/bridge";
+import Link from "next/link";
 import {
   DesktopPageContent,
   DesktopPageShell,
@@ -59,6 +63,8 @@ export default function DesktopSettingsPage() {
         </header>
 
         <ByokSection />
+        <ImageModelsSection />
+        <VideoModelsSection />
         <LocalModelsSection />
         <AboutSection />
       </DesktopPageContent>
@@ -282,6 +288,147 @@ function StatusPill({ kind }: { kind: "loading" | "empty" | "configured" }) {
       />
       Not configured
     </span>
+  );
+}
+
+/* ───────────────────────────── Models ───────────────────────────── */
+
+/** Image providers, by precedence — one connected key serves the whole list. */
+const IMAGE_PROVIDER_IDS: ByokProviderId[] = ["openrouter", "vercel", "fal"];
+
+/**
+ * Image-generation models (#908). Shows the curated, provider-agnostic list and
+ * a readiness line. Provider is hidden by design — connecting any one image
+ * provider key (above) unlocks every model here. The agent host resolves the
+ * provider per request; the renderer never sees the key (GRIDA-SEC-004).
+ */
+function ImageModelsSection() {
+  const [ready, setReady] = useState<boolean | null>(null);
+  const supported = images.isSupported();
+  const listed = models.image.listed_models();
+
+  useEffect(() => {
+    if (!supported) return;
+    let live = true;
+    (async () => {
+      const present = await Promise.all(
+        IMAGE_PROVIDER_IDS.map((id) => secrets.hasKey(id).catch(() => false))
+      );
+      if (live) setReady(present.some(Boolean));
+    })();
+    return () => {
+      live = false;
+    };
+  }, [supported]);
+
+  if (!supported) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Image models</CardTitle>
+        <CardDescription>
+          {ready === null
+            ? "Checking your connected providers…"
+            : ready
+              ? "Ready — you can generate images with any model below."
+              : "Connect one provider key above (OpenRouter, Vercel, or fal) to use these."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {listed.map((card) => (
+          <div
+            key={card.id}
+            className="flex items-center justify-between gap-4 text-sm"
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="font-medium">{card.label}</span>
+              <span className="truncate text-xs text-muted-foreground">
+                {card.short_description}
+              </span>
+            </div>
+            {ready && (
+              <Button asChild variant="outline" size="sm" className="shrink-0">
+                <Link
+                  href={`/desktop/images?model=${encodeURIComponent(card.id)}`}
+                >
+                  Try this model
+                </Link>
+              </Button>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Video providers, by precedence. OpenRouter serves Veo + Seedance; Vercel
+ *  serves every listed model; fal serves a subset (image-to-video). */
+const VIDEO_PROVIDER_IDS: ByokProviderId[] = ["openrouter", "vercel", "fal"];
+
+/**
+ * Video-generation models (#908). Same provider-hidden treatment as image —
+ * connecting a provider key above (Vercel covers every model) unlocks the list.
+ */
+function VideoModelsSection() {
+  const [ready, setReady] = useState<boolean | null>(null);
+  const supported = video.isSupported();
+  const listed = models.video.listed_models();
+
+  useEffect(() => {
+    if (!supported) return;
+    let live = true;
+    (async () => {
+      const present = await Promise.all(
+        VIDEO_PROVIDER_IDS.map((id) => secrets.hasKey(id).catch(() => false))
+      );
+      if (live) setReady(present.some(Boolean));
+    })();
+    return () => {
+      live = false;
+    };
+  }, [supported]);
+
+  if (!supported) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Video models</CardTitle>
+        <CardDescription>
+          {ready === null
+            ? "Checking your connected providers…"
+            : ready
+              ? "Ready — you can generate video with the models below."
+              : "Connect an OpenRouter, Vercel, or fal key above to use these."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {listed.map((card) => (
+          <div
+            key={card.id}
+            className="flex items-center justify-between gap-4 text-sm"
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="font-medium">{card.label}</span>
+              <span className="truncate text-xs text-muted-foreground">
+                {card.short_description}
+              </span>
+            </div>
+            {ready && (
+              <Button asChild variant="outline" size="sm" className="shrink-0">
+                <Link
+                  href={`/desktop/video?model=${encodeURIComponent(card.id)}`}
+                >
+                  Try this model
+                </Link>
+              </Button>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/editor/app/desktop/video/page.tsx
+++ b/editor/app/desktop/video/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { DesktopPageShell } from "@/scaffolds/desktop/chrome/page-shell";
+import { DesktopVideoPlayground } from "@/scaffolds/desktop/video-gen/video-playground";
+
+/**
+ * Desktop video-generation page (#908) — the dedicated home for BYOK video
+ * generation, the sibling of `/desktop/images`. A `?model=<id>` query (set by
+ * "Try this model" in Settings) preselects a model. Generation runs in the
+ * agent sidecar against the user's connected provider key; the key never
+ * reaches this renderer (GRIDA-SEC-004).
+ */
+export default function DesktopVideoPage() {
+  return (
+    <DesktopPageShell>
+      <Suspense>
+        <PlaygroundWithQuery />
+      </Suspense>
+    </DesktopPageShell>
+  );
+}
+
+function PlaygroundWithQuery() {
+  const model = useSearchParams().get("model") ?? undefined;
+  return <DesktopVideoPlayground initialModelId={model} />;
+}

--- a/editor/lib/desktop/bridge.test.ts
+++ b/editor/lib/desktop/bridge.test.ts
@@ -45,7 +45,8 @@ describe("desktop bridge client contract", () => {
 
   it("uses producer-owned BYOK provider metadata for settings", () => {
     expect(secrets.byokProviderMetadata()).toBe(BYOK_PROVIDER_METADATA);
-    expect(secrets.byokProviders()).toEqual(["openrouter", "vercel"]);
+    // fal joined the BYOK set for image/video generation (#908).
+    expect(secrets.byokProviders()).toEqual(["openrouter", "vercel", "fal"]);
   });
 
   it("rejects empty keys before calling the bridge", async () => {

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -38,6 +38,10 @@ import {
   type EndpointModelSpec,
   type EndpointProviderConfig,
   type ProbedEndpointModel,
+  type ImageGenerateRequest,
+  type ImageGenerateResult,
+  type VideoGenerateRequest,
+  type VideoGenerateResult,
   type PatchSessionOptions,
   type RewindResult,
   type SessionListFilter,
@@ -78,6 +82,12 @@ export {
   type EndpointModelSpec,
   type EndpointProviderConfig,
   type ProbedEndpointModel,
+  type ImageGenProvider,
+  type ImageGenerateRequest,
+  type ImageGenerateResult,
+  type VideoGenProvider,
+  type VideoGenerateRequest,
+  type VideoGenerateResult,
   type AgentMode,
   type AgentUIMessageChunk,
   type AgentRunOptions,
@@ -435,6 +445,50 @@ export namespace providers {
       cancel_id: 1,
     });
     return choice === 0;
+  }
+}
+
+/* ─────────────────────── images namespace ───────────────────── */
+
+/**
+ * BYOK image generation (#908). Desktop-only: the request resolves the user's
+ * connected provider key inside the agent sidecar and returns base64 image
+ * bytes — the key never crosses the bridge (GRIDA-SEC-004). Feature-detect
+ * with {@link isSupported}; old binaries lack the surface.
+ */
+export namespace images {
+  export function isSupported(): boolean {
+    return getDesktopBridge()?.images != null;
+  }
+
+  export async function generate(
+    req: ImageGenerateRequest
+  ): Promise<ImageGenerateResult> {
+    const bridge = bridgeOrThrow().images;
+    if (!bridge) throw new DesktopBridgeMissingError();
+    return await bridge.generate(req);
+  }
+}
+
+/* ─────────────────────── video namespace ────────────────────── */
+
+/**
+ * BYOK video generation (#908). Same posture as {@link images}: the request
+ * resolves the user's key in the sidecar and returns a provider URL (or base64)
+ * — the key never crosses the bridge (GRIDA-SEC-004). Feature-detect with
+ * {@link isSupported}.
+ */
+export namespace video {
+  export function isSupported(): boolean {
+    return getDesktopBridge()?.video != null;
+  }
+
+  export async function generate(
+    req: VideoGenerateRequest
+  ): Promise<VideoGenerateResult> {
+    const bridge = bridgeOrThrow().video;
+    if (!bridge) throw new DesktopBridgeMissingError();
+    return await bridge.generate(req);
   }
 }
 

--- a/editor/lib/desktop/csp.ts
+++ b/editor/lib/desktop/csp.ts
@@ -19,6 +19,15 @@ const DESKTOP_CSP_SCRIPT_TAIL = IS_DEV
 
 const DESKTOP_CSP_PREFIX = `default-src 'self'; script-src 'self' 'nonce-`;
 
+//   connect-src allows:
+//   - 'self'              — grida.co (prod) / localhost:3000 (dev)
+//   - http://127.0.0.1:*  — the agent sidecar
+//   - localhost/ws(s)     — Next.js dev HMR ONLY; gated out of prod so a
+//                          renderer/XSS bug can't probe arbitrary local services
+const DESKTOP_CSP_CONNECT_SRC = IS_DEV
+  ? `connect-src 'self' http://127.0.0.1:* http://localhost:* ws://localhost:* wss://localhost:*; `
+  : `connect-src 'self' http://127.0.0.1:*; `;
+
 const DESKTOP_CSP_SUFFIX =
   `${DESKTOP_CSP_SCRIPT_TAIL}; ` +
   // Tailwind's runtime classes still flow through `<style>` tags Next.js emits
@@ -31,12 +40,7 @@ const DESKTOP_CSP_SUFFIX =
   // external origin (same trust level as img-src; no provider hosts added).
   `media-src 'self' data: blob:; ` +
   `font-src 'self' data:; ` +
-  //   connect-src allows:
-  //   - 'self'              — grida.co (prod) / localhost:3000 (dev)
-  //   - http://127.0.0.1:*  — the agent sidecar
-  //   - ws: http: localhost — Next.js dev HMR (harmless in prod, no
-  //                          localhost service to attack)
-  `connect-src 'self' http://127.0.0.1:* http://localhost:* ws://localhost:* wss://localhost:*; ` +
+  DESKTOP_CSP_CONNECT_SRC +
   `frame-ancestors 'none'; ` +
   `object-src 'none'; ` +
   `base-uri 'self'; ` +

--- a/editor/lib/desktop/csp.ts
+++ b/editor/lib/desktop/csp.ts
@@ -1,0 +1,53 @@
+/**
+ * GRIDA-SEC-004 — desktop Content-Security-Policy template.
+ *
+ * Lives outside `proxy.ts` because Next.js 16 only permits the proxy handler
+ * and an optional `config` export there; any extra export (this helper) trips
+ * route-export validation. `proxy.ts` and the CSP contract test
+ * (`proxy.test.ts`) both import `buildDesktopCsp` from here.
+ *
+ * The template is hoisted so each `/desktop/*` request only interpolates the
+ * per-request nonce (one concat) instead of rebuilding a 10-directive string.
+ * The `'unsafe-eval'` tail is dev-only — pinned at module load.
+ */
+
+const IS_DEV = process.env.NODE_ENV === "development";
+
+const DESKTOP_CSP_SCRIPT_TAIL = IS_DEV
+  ? "' 'strict-dynamic' 'wasm-unsafe-eval' 'unsafe-eval'"
+  : "' 'strict-dynamic' 'wasm-unsafe-eval'";
+
+const DESKTOP_CSP_PREFIX = `default-src 'self'; script-src 'self' 'nonce-`;
+
+const DESKTOP_CSP_SUFFIX =
+  `${DESKTOP_CSP_SCRIPT_TAIL}; ` +
+  // Tailwind's runtime classes still flow through `<style>` tags Next.js emits
+  // at build/SSR — keep `'unsafe-inline'` for now; tightening style-src is a
+  // separate change.
+  `style-src 'self' 'unsafe-inline'; ` +
+  `img-src 'self' data: blob:; ` +
+  // media-src for BYOK video (#908): clips are downloaded by the sidecar and
+  // handed to the renderer as base64 `data:`/`blob:` — never streamed from an
+  // external origin (same trust level as img-src; no provider hosts added).
+  `media-src 'self' data: blob:; ` +
+  `font-src 'self' data:; ` +
+  //   connect-src allows:
+  //   - 'self'              — grida.co (prod) / localhost:3000 (dev)
+  //   - http://127.0.0.1:*  — the agent sidecar
+  //   - ws: http: localhost — Next.js dev HMR (harmless in prod, no
+  //                          localhost service to attack)
+  `connect-src 'self' http://127.0.0.1:* http://localhost:* ws://localhost:* wss://localhost:*; ` +
+  `frame-ancestors 'none'; ` +
+  `object-src 'none'; ` +
+  `base-uri 'self'; ` +
+  `form-action 'self'`;
+
+/**
+ * Build the desktop CSP header for a given per-request nonce. The contract test
+ * pins the directive set so a new renderer-loaded resource type (e.g. another
+ * media modality) can't silently fall back to `default-src` and break at
+ * runtime — the way video did before `media-src` was added (#908).
+ */
+export function buildDesktopCsp(nonce: string): string {
+  return DESKTOP_CSP_PREFIX + nonce + DESKTOP_CSP_SUFFIX;
+}

--- a/editor/proxy.test.ts
+++ b/editor/proxy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildDesktopCsp } from "./proxy";
+
+/**
+ * GRIDA-SEC-004 — desktop CSP contract.
+ *
+ * Pins the directive set so the failure mode that broke BYOK video (#908)
+ * can't recur: a renderer-loaded resource type with no matching directive
+ * silently falls back to `default-src 'self'` and is blocked at runtime, with
+ * no compile/test signal. Any directive change is a conscious edit here.
+ *
+ * Rule this encodes: every kind of content the desktop renderer loads has an
+ * explicit directive. Generated media (image/video) is returned by the sidecar
+ * as bytes and played from `data:`/`blob:` — never an external origin — so
+ * `img-src` and `media-src` must allow `data:`/`blob:` and NOT list provider
+ * hosts.
+ */
+describe("desktop CSP (GRIDA-SEC-004)", () => {
+  const csp = buildDesktopCsp("test-nonce");
+
+  const directive = (name: string): string => {
+    const found = csp
+      .split(";")
+      .map((d) => d.trim())
+      .find((d) => d === name || d.startsWith(`${name} `));
+    if (!found) throw new Error(`CSP missing directive: ${name}`);
+    return found;
+  };
+
+  it("locks the base to self", () => {
+    expect(directive("default-src")).toBe("default-src 'self'");
+    expect(directive("object-src")).toBe("object-src 'none'");
+    expect(directive("frame-ancestors")).toBe("frame-ancestors 'none'");
+    expect(directive("base-uri")).toBe("base-uri 'self'");
+  });
+
+  it("carries the per-request script nonce", () => {
+    expect(directive("script-src")).toContain("'nonce-test-nonce'");
+  });
+
+  // Generated media is sidecar-downloaded → played as data:/blob:. Both image
+  // AND video must be covered, or one modality silently breaks (the #908 bug).
+  it.each(["img-src", "media-src"])(
+    "%s allows data: and blob: (sidecar-bytes contract)",
+    (name) => {
+      const d = directive(name);
+      expect(d).toContain("'self'");
+      expect(d).toContain("data:");
+      expect(d).toContain("blob:");
+    }
+  );
+
+  it("does NOT allowlist external provider media origins", () => {
+    // Generated media never streams from a provider CDN — it's bytes from the
+    // sidecar. If someone adds a provider host here, this is the wrong fix.
+    for (const host of ["fal.media", "openrouter.ai", "vercel", "googleapis"]) {
+      expect(directive("media-src")).not.toContain(host);
+      expect(directive("img-src")).not.toContain(host);
+    }
+  });
+
+  it("connect-src reaches the loopback agent sidecar", () => {
+    expect(directive("connect-src")).toContain("http://127.0.0.1:*");
+  });
+});

--- a/editor/proxy.test.ts
+++ b/editor/proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildDesktopCsp } from "./proxy";
+import { buildDesktopCsp } from "./lib/desktop/csp";
 
 /**
  * GRIDA-SEC-004 — desktop CSP contract.

--- a/editor/proxy.test.ts
+++ b/editor/proxy.test.ts
@@ -62,4 +62,10 @@ describe("desktop CSP (GRIDA-SEC-004)", () => {
   it("connect-src reaches the loopback agent sidecar", () => {
     expect(directive("connect-src")).toContain("http://127.0.0.1:*");
   });
+
+  it("connect-src does NOT allow localhost in prod (dev-HMR only)", () => {
+    // Tests run with NODE_ENV !== "development" → the production CSP. A
+    // renderer/XSS bug must not be able to probe arbitrary localhost services.
+    expect(directive("connect-src")).not.toContain("localhost");
+  });
 });

--- a/editor/proxy.ts
+++ b/editor/proxy.ts
@@ -14,6 +14,7 @@ import { get } from "@vercel/edge-config";
 import type { NextRequest } from "next/server";
 import { TenantMiddleware } from "./lib/tenant/middleware";
 import { updateSession } from "./lib/supabase/proxy";
+import { buildDesktopCsp } from "./lib/desktop/csp";
 
 const IS_PROD = process.env.NODE_ENV === "production";
 const IS_DEV = process.env.NODE_ENV === "development";
@@ -24,44 +25,9 @@ if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
   );
 }
 
-// GRIDA-SEC-004 — desktop CSP template, hoisted so we only interpolate the
-// per-request nonce (one concat) instead of rebuilding a 10-directive array
-// on every `/desktop/*` request. The `'unsafe-eval'` tail is dev-only —
-// pinned at module load so it's not recomputed per request either.
-const DESKTOP_CSP_SCRIPT_TAIL = IS_DEV
-  ? "' 'strict-dynamic' 'wasm-unsafe-eval' 'unsafe-eval'"
-  : "' 'strict-dynamic' 'wasm-unsafe-eval'";
-const DESKTOP_CSP_PREFIX = `default-src 'self'; script-src 'self' 'nonce-`;
-const DESKTOP_CSP_SUFFIX =
-  `${DESKTOP_CSP_SCRIPT_TAIL}; ` +
-  // Tailwind's runtime classes still flow through `<style>` tags
-  // Next.js emits at build/SSR — keep `'unsafe-inline'` for now;
-  // tightening style-src is a separate change.
-  `style-src 'self' 'unsafe-inline'; ` +
-  `img-src 'self' data: blob:; ` +
-  // media-src for BYOK video (#908): clips are downloaded by the sidecar and
-  // handed to the renderer as base64 `data:`/`blob:` — never streamed from an
-  // external origin (same trust level as img-src; no provider hosts added).
-  `media-src 'self' data: blob:; ` +
-  `font-src 'self' data:; ` +
-  //   connect-src allows:
-  //   - 'self'              — grida.co (prod) / localhost:3000 (dev)
-  //   - http://127.0.0.1:*  — the agent sidecar
-  //   - ws: http: localhost — Next.js dev HMR (harmless in prod, no
-  //                          localhost service to attack)
-  `connect-src 'self' http://127.0.0.1:* http://localhost:* ws://localhost:* wss://localhost:*; ` +
-  `frame-ancestors 'none'; ` +
-  `object-src 'none'; ` +
-  `base-uri 'self'; ` +
-  `form-action 'self'`;
-
-// Exported for the CSP contract test (proxy.test.ts). The test pins the
-// directive set so a new renderer-loaded resource type (e.g. another media
-// modality) can't silently fall back to `default-src` and break at runtime —
-// the way video did before `media-src` was added (#908).
-export function buildDesktopCsp(nonce: string): string {
-  return DESKTOP_CSP_PREFIX + nonce + DESKTOP_CSP_SUFFIX;
-}
+// GRIDA-SEC-004 — desktop CSP lives in ./lib/desktop/csp (Next.js 16 forbids
+// extra exports from this proxy entrypoint). `buildDesktopCsp` interpolates the
+// per-request nonce into a hoisted template.
 
 type DesktopHeaderState = {
   isDesktop: boolean;

--- a/editor/proxy.ts
+++ b/editor/proxy.ts
@@ -39,6 +39,10 @@ const DESKTOP_CSP_SUFFIX =
   // tightening style-src is a separate change.
   `style-src 'self' 'unsafe-inline'; ` +
   `img-src 'self' data: blob:; ` +
+  // media-src for BYOK video (#908): clips are downloaded by the sidecar and
+  // handed to the renderer as base64 `data:`/`blob:` — never streamed from an
+  // external origin (same trust level as img-src; no provider hosts added).
+  `media-src 'self' data: blob:; ` +
   `font-src 'self' data:; ` +
   //   connect-src allows:
   //   - 'self'              — grida.co (prod) / localhost:3000 (dev)
@@ -51,7 +55,11 @@ const DESKTOP_CSP_SUFFIX =
   `base-uri 'self'; ` +
   `form-action 'self'`;
 
-function buildDesktopCsp(nonce: string): string {
+// Exported for the CSP contract test (proxy.test.ts). The test pins the
+// directive set so a new renderer-loaded resource type (e.g. another media
+// modality) can't silently fall back to `default-src` and break at runtime —
+// the way video did before `media-src` was added (#908).
+export function buildDesktopCsp(nonce: string): string {
   return DESKTOP_CSP_PREFIX + nonce + DESKTOP_CSP_SUFFIX;
 }
 

--- a/editor/scaffolds/desktop/image-gen/image-model-picker.tsx
+++ b/editor/scaffolds/desktop/image-gen/image-model-picker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { models } from "@grida/ai-models";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@app/ui/components/select";
+
+/**
+ * Provider-hidden image-model picker (#908). Lists only the curated
+ * (`listed: true`) models by their friendly label and what they're good for —
+ * never by provider. The provider is implied by the user's connected key and
+ * resolved per request by the agent host.
+ */
+export function ImageModelPicker({
+  value,
+  onValueChange,
+  disabled,
+}: {
+  value: string;
+  onValueChange: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const listed = models.image.listed_models();
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger
+        size="sm"
+        className="w-fit gap-1 border-0 bg-transparent px-2 shadow-none focus-visible:ring-0"
+      >
+        <SelectValue placeholder="Choose a model" />
+      </SelectTrigger>
+      <SelectContent>
+        {listed.map((card) => (
+          <SelectItem key={card.id} value={card.id}>
+            {card.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/editor/scaffolds/desktop/image-gen/image-playground.tsx
+++ b/editor/scaffolds/desktop/image-gen/image-playground.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Download, Sparkles, SlidersHorizontal, X } from "lucide-react";
+import { models } from "@grida/ai-models";
+import { Skeleton } from "@app/ui/components/skeleton";
+import { Dialog, DialogContent, DialogTitle } from "@app/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@app/ui/components/dropdown-menu";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputButton,
+  PromptInputFooter,
+  PromptInputProvider,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
+  usePromptInputController,
+  type PromptInputMessage,
+} from "@app/ui/ai-elements/prompt-input";
+import { images } from "@/lib/desktop/bridge";
+import { ImageModelPicker } from "./image-model-picker";
+
+/** Named prompt templates — pick one from the composer menu to fill the input.
+ *  Design-tool flavored starters; original to Grida. */
+const PROMPT_TEMPLATES: { name: string; prompt: string }[] = [
+  {
+    name: "App Icon",
+    prompt:
+      "A modern app icon on a rounded squircle, bold simple glyph, soft gradient, subtle inner shadow, centered",
+  },
+  {
+    name: "Product Hero Shot",
+    prompt:
+      "Clean studio product photo on a seamless pastel backdrop, soft shadows, crisp reflections, centered composition",
+  },
+  {
+    name: "Gradient Wallpaper",
+    prompt:
+      "Smooth abstract mesh gradient wallpaper, soft blended colors, gentle grain, no text",
+  },
+  {
+    name: "Isometric Workspace",
+    prompt:
+      "Cute isometric 3D illustration of a tidy desk workspace, pastel palette, soft lighting, miniature diorama",
+  },
+  {
+    name: "Flat Vector Mascot",
+    prompt:
+      "Friendly flat-vector mascot character, bold outlines, limited palette, playful, on a plain background",
+  },
+  {
+    name: "Hand-drawn Doodles",
+    prompt:
+      "A neat sheet of black-ink hand-drawn doodle icons, consistent line weight, on white paper",
+  },
+  {
+    name: "Brand Pattern",
+    prompt:
+      "Seamless geometric brand pattern, two-color minimal shapes, evenly spaced, tileable",
+  },
+  {
+    name: "Sticker Sheet",
+    prompt:
+      "A sheet of glossy die-cut stickers with white borders, vibrant cartoon style, drop shadows",
+  },
+];
+
+const DEFAULT_MODEL_ID = models.image.listed_models()[0]?.id ?? "";
+
+/** Always render at least this many cells so the gallery grid is visible even
+ *  when empty. Extra slots beyond the images are blank placeholders. */
+const MIN_CELLS = 20;
+
+type SizeOption = { label: string; width?: number; height?: number };
+const AUTO_SIZE: SizeOption = { label: "Auto" };
+const QUALITY_OPTIONS = ["auto", "high", "medium", "low"] as const;
+
+/** Size options for a model — 2K/4K only when its constraints allow. */
+function sizeOptionsFor(
+  card: models.image.ImageModelCard | undefined
+): SizeOption[] {
+  const maxEdge = card?.constraints?.max_edge;
+  const opts: SizeOption[] = [
+    AUTO_SIZE,
+    { label: "Square (1024×1024)", width: 1024, height: 1024 },
+    { label: "Portrait (1024×1536)", width: 1024, height: 1536 },
+    { label: "Landscape (1536×1024)", width: 1536, height: 1024 },
+  ];
+  if (!maxEdge || maxEdge >= 2560)
+    opts.push({ label: "2K (2560×1440)", width: 2560, height: 1440 });
+  if (!maxEdge || maxEdge >= 3840)
+    opts.push({ label: "4K (3840×2160)", width: 3840, height: 2160 });
+  return opts;
+}
+
+/** Quality tiers only apply to per-image-tiered models (e.g. GPT Image). */
+function supportsQuality(
+  card: models.image.ImageModelCard | undefined
+): boolean {
+  return card?.pricing.type === "per_image_tiered";
+}
+
+type Tile = {
+  id: string;
+  prompt: string;
+  model_id: string;
+  status: "generating" | "done" | "error";
+  src?: string;
+  error?: string;
+};
+
+/**
+ * Desktop image generation playground (#908). A clean, full-bleed gallery: a
+ * hairline grid that's always visible (even empty), a minimal header, and a
+ * single floating prompt composer. Each submit prepends a shimmering cell that
+ * fills in when its image resolves — one at a time. Generation runs in the
+ * agent sidecar against the user's connected provider key; the key never
+ * reaches this renderer (GRIDA-SEC-004).
+ */
+export function DesktopImagePlayground({
+  initialModelId,
+}: {
+  initialModelId?: string;
+} = {}) {
+  const [modelId, setModelId] = useState(
+    initialModelId && models.image.models[initialModelId]?.listed
+      ? initialModelId
+      : DEFAULT_MODEL_ID
+  );
+  const [tiles, setTiles] = useState<Tile[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [size, setSize] = useState<SizeOption>(AUTO_SIZE);
+  const [quality, setQuality] = useState<string>("auto");
+
+  const card = models.image.models[modelId];
+  const active = tiles.find((t) => t.id === activeId && t.status === "done");
+
+  const remove = (id: string) =>
+    setTiles((prev) => prev.filter((t) => t.id !== id));
+
+  const onSubmit = (message: PromptInputMessage) => {
+    void runGenerate(message.text);
+  };
+
+  const runGenerate = async (rawPrompt: string) => {
+    const prompt = rawPrompt.trim();
+    if (!prompt) return;
+    const id = crypto.randomUUID();
+    const model_id = modelId;
+    setTiles((prev) => [
+      { id, prompt, model_id, status: "generating" },
+      ...prev,
+    ]);
+    try {
+      const res = await images.generate({
+        model_id,
+        prompt,
+        ...(size.width && size.height
+          ? { width: size.width, height: size.height }
+          : {}),
+        ...(quality !== "auto" ? { quality } : {}),
+      });
+      const first = res.images[0];
+      const src = first
+        ? `data:${first.media_type};base64,${first.base64}`
+        : undefined;
+      setTiles((prev) =>
+        prev.map((t) =>
+          t.id === id
+            ? src
+              ? { ...t, status: "done", src }
+              : { ...t, status: "error", error: "No image returned" }
+            : t
+        )
+      );
+    } catch (e) {
+      setTiles((prev) =>
+        prev.map((t) =>
+          t.id === id ? { ...t, status: "error", error: String(e) } : t
+        )
+      );
+    }
+  };
+
+  const cellCount = Math.max(MIN_CELLS, Math.ceil(tiles.length / 5) * 5);
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      {/* Header */}
+      <header className="flex shrink-0 items-center justify-between px-6 py-4">
+        <h1 className="text-2xl font-bold tracking-tight">Images</h1>
+      </header>
+
+      {/* Gallery — a real hairline grid, visible even when empty. Cells are
+          transparent; the borders (cell right/bottom + grid left/top) draw a
+          single crisp line everywhere. */}
+      <div className="min-h-0 flex-1 overflow-y-auto pb-40">
+        <div className="grid grid-cols-2 border-l border-t border-border sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          {Array.from({ length: cellCount }, (_, i) => {
+            const tile = tiles[i];
+            return tile ? (
+              <GalleryCell
+                key={tile.id}
+                tile={tile}
+                onOpen={() => setActiveId(tile.id)}
+                onRemove={() => remove(tile.id)}
+              />
+            ) : (
+              <div
+                key={`empty-${i}`}
+                className="aspect-square border-b border-r border-border"
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Floating composer — a single pill. The pill IS the InputGroup
+          (PromptInput's child div); we style it directly via `[&>div]` so its
+          focus ring renders unclipped (no `overflow-hidden` ancestor). */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-4">
+        {/* Provider lifts the text state so the template menu can fill it. */}
+        <PromptInputProvider>
+          <PromptInput
+            onSubmit={onSubmit}
+            className="pointer-events-auto w-full max-w-2xl [&>div]:rounded-2xl [&>div]:bg-background/90 [&>div]:shadow-lg [&>div]:backdrop-blur"
+          >
+            <PromptInputBody>
+              <PromptInputTextarea placeholder="Describe what you want to see…" />
+            </PromptInputBody>
+            <PromptInputFooter>
+              <PromptInputTools>
+                <TemplateMenu />
+                <SettingsMenu
+                  card={card}
+                  size={size}
+                  onSize={setSize}
+                  quality={quality}
+                  onQuality={setQuality}
+                />
+                <ImageModelPicker value={modelId} onValueChange={setModelId} />
+              </PromptInputTools>
+              <PromptInputSubmit />
+            </PromptInputFooter>
+          </PromptInput>
+        </PromptInputProvider>
+      </div>
+
+      {/* Fullscreen viewer */}
+      <Dialog
+        open={active != null}
+        onOpenChange={(o) => !o && setActiveId(null)}
+      >
+        <DialogContent className="max-w-[90vw] overflow-hidden p-0 sm:max-w-3xl">
+          <DialogTitle className="sr-only">
+            {active?.prompt ?? "Generated image"}
+          </DialogTitle>
+          {active?.src && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={active.src}
+              alt={active.prompt}
+              className="max-h-[85vh] w-full object-contain"
+            />
+          )}
+          {active && (
+            <p className="px-4 pb-4 text-sm text-muted-foreground">
+              {active.prompt}
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+/** Composer toolbar menu of named prompt templates. Clicking one fills the
+ *  input (does not generate) via the lifted PromptInput controller. */
+function TemplateMenu() {
+  const { textInput } = usePromptInputController();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <PromptInputButton
+          aria-label="Prompt templates"
+          title="Prompt templates"
+        >
+          <Sparkles className="size-4" />
+        </PromptInputButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        className="max-h-80 overflow-y-auto"
+      >
+        {PROMPT_TEMPLATES.map((t) => (
+          <DropdownMenuItem
+            key={t.name}
+            onSelect={() => textInput.setInput(t.prompt)}
+          >
+            {t.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Composer toolbar menu of model-aware generation controls (size + quality). */
+function SettingsMenu({
+  card,
+  size,
+  onSize,
+  quality,
+  onQuality,
+}: {
+  card: models.image.ImageModelCard | undefined;
+  size: SizeOption;
+  onSize: (s: SizeOption) => void;
+  quality: string;
+  onQuality: (q: string) => void;
+}) {
+  const sizeOptions = sizeOptionsFor(card);
+  const showQuality = supportsQuality(card);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <PromptInputButton aria-label="Image settings" title="Image settings">
+          <SlidersHorizontal className="size-4" />
+        </PromptInputButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        className="max-h-96 w-56 overflow-y-auto"
+      >
+        <DropdownMenuLabel>Size</DropdownMenuLabel>
+        {sizeOptions.map((opt) => (
+          <DropdownMenuItem
+            key={opt.label}
+            onSelect={() => onSize(opt)}
+            className="justify-between"
+          >
+            {opt.label}
+            {opt.label === size.label && <Check className="size-4" />}
+          </DropdownMenuItem>
+        ))}
+        {showQuality && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Quality</DropdownMenuLabel>
+            {QUALITY_OPTIONS.map((q) => (
+              <DropdownMenuItem
+                key={q}
+                onSelect={() => onQuality(q)}
+                className="justify-between capitalize"
+              >
+                {q}
+                {q === quality && <Check className="size-4" />}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const CELL = "relative aspect-square border-b border-r border-border";
+const CELL_BTN =
+  "flex size-7 items-center justify-center rounded-full bg-black/60 text-white backdrop-blur transition hover:bg-black/80";
+
+function GalleryCell({
+  tile,
+  onOpen,
+  onRemove,
+}: {
+  tile: Tile;
+  onOpen: () => void;
+  onRemove: () => void;
+}) {
+  if (tile.status === "generating") {
+    return (
+      <div className={`${CELL} overflow-hidden`}>
+        <Skeleton className="size-full rounded-none" />
+        {/* Show the prompt while generating so the user knows what's coming. */}
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-3">
+          <p className="line-clamp-4 text-center text-xs text-muted-foreground">
+            {tile.prompt}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (tile.status === "error") {
+    return (
+      <div
+        className={`group flex flex-col items-center justify-center gap-1 bg-destructive/5 p-3 text-center text-destructive ${CELL}`}
+      >
+        <span className="text-xs font-medium">Failed to generate</span>
+        <span
+          className="line-clamp-4 text-[11px] leading-tight opacity-80"
+          title={tile.error}
+        >
+          {tile.error}
+        </span>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          title="Dismiss"
+          onClick={onRemove}
+          className={`${CELL_BTN} absolute right-1 top-1 opacity-0 group-hover:opacity-100`}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`group overflow-hidden ${CELL}`}>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="absolute inset-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        aria-label="Open image"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={tile.src}
+          alt={tile.prompt}
+          className="size-full object-cover transition duration-200 group-hover:scale-[1.02]"
+        />
+      </button>
+
+      {/* Hover: prompt overlay (non-interactive) */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2 opacity-0 transition group-hover:opacity-100">
+        <p className="line-clamp-2 text-xs text-white">{tile.prompt}</p>
+      </div>
+
+      {/* Hover: actions (siblings of the open button, on top) */}
+      <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition group-hover:opacity-100">
+        <a
+          href={tile.src}
+          download={`grida-image-${tile.id}.png`}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Download"
+          title="Download"
+          className={CELL_BTN}
+        >
+          <Download className="size-3.5" />
+        </a>
+        <button
+          type="button"
+          aria-label="Remove"
+          title="Remove"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className={CELL_BTN}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/editor/scaffolds/desktop/image-gen/image-playground.tsx
+++ b/editor/scaffolds/desktop/image-gen/image-playground.tsx
@@ -108,12 +108,27 @@ function supportsQuality(
   return card?.pricing.type === "per_image_tiered";
 }
 
+/** File extension for a download, from the returned media type. */
+function imageExtension(mediaType?: string): string {
+  switch (mediaType) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
+  }
+}
+
 type Tile = {
   id: string;
   prompt: string;
   model_id: string;
   status: "generating" | "done" | "error";
   src?: string;
+  media_type?: string;
   error?: string;
 };
 
@@ -176,7 +191,7 @@ export function DesktopImagePlayground({
         prev.map((t) =>
           t.id === id
             ? src
-              ? { ...t, status: "done", src }
+              ? { ...t, status: "done", src, media_type: first?.media_type }
               : { ...t, status: "error", error: "No image returned" }
             : t
         )
@@ -246,7 +261,16 @@ export function DesktopImagePlayground({
                   quality={quality}
                   onQuality={setQuality}
                 />
-                <ImageModelPicker value={modelId} onValueChange={setModelId} />
+                <ImageModelPicker
+                  value={modelId}
+                  onValueChange={(next) => {
+                    // Reset model-scoped options — a size/quality the new model
+                    // doesn't expose would otherwise be sent and rejected.
+                    setModelId(next);
+                    setSize(AUTO_SIZE);
+                    setQuality("auto");
+                  }}
+                />
               </PromptInputTools>
               <PromptInputSubmit />
             </PromptInputFooter>
@@ -451,7 +475,7 @@ function GalleryCell({
       <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition group-hover:opacity-100">
         <a
           href={tile.src}
-          download={`grida-image-${tile.id}.png`}
+          download={`grida-image-${tile.id}.${imageExtension(tile.media_type)}`}
           onClick={(e) => e.stopPropagation()}
           aria-label="Download"
           title="Download"

--- a/editor/scaffolds/desktop/video-gen/video-model-picker.tsx
+++ b/editor/scaffolds/desktop/video-gen/video-model-picker.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { models } from "@grida/ai-models";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@app/ui/components/select";
+
+/**
+ * Provider-hidden video-model picker (#908). Lists only the curated
+ * (`listed: true`) video models by friendly label — never by provider. The
+ * agent host resolves the provider per request from the user's connected key.
+ */
+export function VideoModelPicker({
+  value,
+  onValueChange,
+  disabled,
+}: {
+  value: string;
+  onValueChange: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const listed = models.video.listed_models();
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Choose a model" />
+      </SelectTrigger>
+      <SelectContent>
+        {listed.map((card) => (
+          <SelectItem key={card.id} value={card.id}>
+            {card.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/editor/scaffolds/desktop/video-gen/video-playground.tsx
+++ b/editor/scaffolds/desktop/video-gen/video-playground.tsx
@@ -89,12 +89,25 @@ function durationOptionsFor(
   return opts;
 }
 
+/** File extension for a download, from the returned media type. */
+function videoExtension(mediaType?: string): string {
+  switch (mediaType) {
+    case "video/webm":
+      return "webm";
+    case "video/quicktime":
+      return "mov";
+    default:
+      return "mp4";
+  }
+}
+
 type Tile = {
   id: string;
   prompt: string;
   model_id: string;
   status: "generating" | "done" | "error";
   src?: string;
+  media_type?: string;
   error?: string;
 };
 
@@ -152,13 +165,13 @@ export function DesktopVideoPlayground({
       });
       const first = res.videos[0];
       const src = first
-        ? (first.url ?? `data:${first.media_type};base64,${first.base64 ?? ""}`)
+        ? `data:${first.media_type};base64,${first.base64}`
         : undefined;
       setTiles((prev) =>
         prev.map((t) =>
           t.id === id
             ? src
-              ? { ...t, status: "done", src }
+              ? { ...t, status: "done", src, media_type: first?.media_type }
               : { ...t, status: "error", error: "No video returned" }
             : t
         )
@@ -220,7 +233,16 @@ export function DesktopVideoPlayground({
                   duration={duration}
                   onDuration={setDuration}
                 />
-                <VideoModelPicker value={modelId} onValueChange={setModelId} />
+                <VideoModelPicker
+                  value={modelId}
+                  onValueChange={(next) => {
+                    // Model-scoped options don't carry over — a stale aspect
+                    // ratio / duration the new model doesn't offer would fail.
+                    setModelId(next);
+                    setAspect(AUTO);
+                    setDuration({ label: AUTO });
+                  }}
+                />
               </PromptInputTools>
               <PromptInputSubmit />
             </PromptInputFooter>
@@ -418,7 +440,7 @@ function GalleryCell({
       <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition group-hover:opacity-100">
         <a
           href={tile.src}
-          download={`grida-video-${tile.id}.mp4`}
+          download={`grida-video-${tile.id}.${videoExtension(tile.media_type)}`}
           onClick={(e) => e.stopPropagation()}
           aria-label="Download"
           title="Download"

--- a/editor/scaffolds/desktop/video-gen/video-playground.tsx
+++ b/editor/scaffolds/desktop/video-gen/video-playground.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Download, Sparkles, SlidersHorizontal, X } from "lucide-react";
+import { models } from "@grida/ai-models";
+import { Skeleton } from "@app/ui/components/skeleton";
+import { Dialog, DialogContent, DialogTitle } from "@app/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@app/ui/components/dropdown-menu";
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputButton,
+  PromptInputFooter,
+  PromptInputProvider,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
+  usePromptInputController,
+  type PromptInputMessage,
+} from "@app/ui/ai-elements/prompt-input";
+import { video } from "@/lib/desktop/bridge";
+import { VideoModelPicker } from "./video-model-picker";
+
+/** Named prompt templates — motion-flavored starters, original to Grida. */
+const PROMPT_TEMPLATES: { name: string; prompt: string }[] = [
+  {
+    name: "Product Spin",
+    prompt:
+      "A sleek product rotating slowly on a seamless studio backdrop, soft cinematic lighting, shallow depth of field",
+  },
+  {
+    name: "Drone Flyover",
+    prompt:
+      "Aerial drone shot flying over a misty mountain range at golden hour, smooth forward motion, cinematic",
+  },
+  {
+    name: "Liquid Macro",
+    prompt:
+      "Extreme macro of colorful ink swirling in water, slow motion, soft light, abstract and mesmerizing",
+  },
+  {
+    name: "City Timelapse",
+    prompt:
+      "Timelapse of a city skyline transitioning from day to night, streaking car lights, clouds drifting",
+  },
+  {
+    name: "Character Walk",
+    prompt:
+      "A stylized cartoon mascot walking toward camera on a plain background, looping, playful, smooth motion",
+  },
+  {
+    name: "Nature Loop",
+    prompt:
+      "Seamless looping shot of tall grass swaying gently in the breeze, warm sunlight, calm and serene",
+  },
+];
+
+const DEFAULT_MODEL_ID = models.video.listed_models()[0]?.id ?? "";
+
+/** Always render at least this many cells so the gallery grid is visible. */
+const MIN_CELLS = 12;
+
+const AUTO = "Auto";
+
+/** Duration options bounded by the model's min/max (seconds). */
+function durationOptionsFor(
+  card: models.video.VideoModelCard | undefined
+): { label: string; value?: number }[] {
+  const opts: { label: string; value?: number }[] = [{ label: AUTO }];
+  if (!card) return opts;
+  const seen = new Set<number>();
+  for (const v of [
+    card.min_duration,
+    card.default.duration,
+    card.max_duration,
+  ]) {
+    if (v != null && !seen.has(v)) {
+      seen.add(v);
+      opts.push({ label: `${v}s`, value: v });
+    }
+  }
+  return opts;
+}
+
+type Tile = {
+  id: string;
+  prompt: string;
+  model_id: string;
+  status: "generating" | "done" | "error";
+  src?: string;
+  error?: string;
+};
+
+/**
+ * Desktop video generation playground (#908) — the video sibling of the image
+ * playground. A hairline gallery (visible even empty), a minimal header, and a
+ * floating prompt composer. Each submit prepends a shimmering cell that fills in
+ * with a playable clip when the video resolves. Generation runs in the agent
+ * sidecar against the user's connected provider key; the key never reaches this
+ * renderer (GRIDA-SEC-004). v1 is text-to-video (served by a connected Vercel
+ * key for every listed model).
+ */
+export function DesktopVideoPlayground({
+  initialModelId,
+}: {
+  initialModelId?: string;
+} = {}) {
+  const [modelId, setModelId] = useState(
+    initialModelId && models.video.models[initialModelId]?.listed
+      ? initialModelId
+      : DEFAULT_MODEL_ID
+  );
+  const [tiles, setTiles] = useState<Tile[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [aspect, setAspect] = useState<string>(AUTO);
+  const [duration, setDuration] = useState<{ label: string; value?: number }>({
+    label: AUTO,
+  });
+
+  const card = models.video.models[modelId];
+  const active = tiles.find((t) => t.id === activeId && t.status === "done");
+
+  const remove = (id: string) =>
+    setTiles((prev) => prev.filter((t) => t.id !== id));
+
+  const onSubmit = (message: PromptInputMessage) => {
+    void runGenerate(message.text);
+  };
+
+  const runGenerate = async (rawPrompt: string) => {
+    const prompt = rawPrompt.trim();
+    if (!prompt) return;
+    const id = crypto.randomUUID();
+    const model_id = modelId;
+    setTiles((prev) => [
+      { id, prompt, model_id, status: "generating" },
+      ...prev,
+    ]);
+    try {
+      const res = await video.generate({
+        model_id,
+        prompt,
+        ...(aspect !== AUTO ? { aspect_ratio: aspect } : {}),
+        ...(duration.value != null ? { duration: duration.value } : {}),
+      });
+      const first = res.videos[0];
+      const src = first
+        ? (first.url ?? `data:${first.media_type};base64,${first.base64 ?? ""}`)
+        : undefined;
+      setTiles((prev) =>
+        prev.map((t) =>
+          t.id === id
+            ? src
+              ? { ...t, status: "done", src }
+              : { ...t, status: "error", error: "No video returned" }
+            : t
+        )
+      );
+    } catch (e) {
+      setTiles((prev) =>
+        prev.map((t) =>
+          t.id === id ? { ...t, status: "error", error: String(e) } : t
+        )
+      );
+    }
+  };
+
+  const cellCount = Math.max(MIN_CELLS, Math.ceil(tiles.length / 4) * 4);
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <header className="flex shrink-0 items-center justify-between px-6 py-4">
+        <h1 className="text-2xl font-bold tracking-tight">Video</h1>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto pb-40">
+        <div className="grid grid-cols-1 border-l border-t border-border sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: cellCount }, (_, i) => {
+            const tile = tiles[i];
+            return tile ? (
+              <GalleryCell
+                key={tile.id}
+                tile={tile}
+                onOpen={() => setActiveId(tile.id)}
+                onRemove={() => remove(tile.id)}
+              />
+            ) : (
+              <div
+                key={`empty-${i}`}
+                className="aspect-video border-b border-r border-border"
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-4">
+        <PromptInputProvider>
+          <PromptInput
+            onSubmit={onSubmit}
+            className="pointer-events-auto w-full max-w-2xl [&>div]:rounded-2xl [&>div]:bg-background/90 [&>div]:shadow-lg [&>div]:backdrop-blur"
+          >
+            <PromptInputBody>
+              <PromptInputTextarea placeholder="Describe the video you want to create…" />
+            </PromptInputBody>
+            <PromptInputFooter>
+              <PromptInputTools>
+                <TemplateMenu />
+                <SettingsMenu
+                  card={card}
+                  aspect={aspect}
+                  onAspect={setAspect}
+                  duration={duration}
+                  onDuration={setDuration}
+                />
+                <VideoModelPicker value={modelId} onValueChange={setModelId} />
+              </PromptInputTools>
+              <PromptInputSubmit />
+            </PromptInputFooter>
+          </PromptInput>
+        </PromptInputProvider>
+      </div>
+
+      <Dialog
+        open={active != null}
+        onOpenChange={(o) => !o && setActiveId(null)}
+      >
+        <DialogContent className="max-w-[90vw] overflow-hidden p-0 sm:max-w-3xl">
+          <DialogTitle className="sr-only">
+            {active?.prompt ?? "Generated video"}
+          </DialogTitle>
+          {active?.src && (
+            <video
+              src={active.src}
+              controls
+              autoPlay
+              className="max-h-[85vh] w-full object-contain"
+            />
+          )}
+          {active && (
+            <p className="px-4 pb-4 text-sm text-muted-foreground">
+              {active.prompt}
+            </p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TemplateMenu() {
+  const { textInput } = usePromptInputController();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <PromptInputButton
+          aria-label="Prompt templates"
+          title="Prompt templates"
+        >
+          <Sparkles className="size-4" />
+        </PromptInputButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        className="max-h-80 overflow-y-auto"
+      >
+        {PROMPT_TEMPLATES.map((t) => (
+          <DropdownMenuItem
+            key={t.name}
+            onSelect={() => textInput.setInput(t.prompt)}
+          >
+            {t.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Model-aware generation controls (aspect ratio + duration). */
+function SettingsMenu({
+  card,
+  aspect,
+  onAspect,
+  duration,
+  onDuration,
+}: {
+  card: models.video.VideoModelCard | undefined;
+  aspect: string;
+  onAspect: (a: string) => void;
+  duration: { label: string; value?: number };
+  onDuration: (d: { label: string; value?: number }) => void;
+}) {
+  const aspectOptions = [AUTO, ...(card?.aspect_ratios ?? [])];
+  const durationOptions = durationOptionsFor(card);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <PromptInputButton aria-label="Video settings" title="Video settings">
+          <SlidersHorizontal className="size-4" />
+        </PromptInputButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        className="max-h-96 w-56 overflow-y-auto"
+      >
+        <DropdownMenuLabel>Aspect ratio</DropdownMenuLabel>
+        {aspectOptions.map((opt) => (
+          <DropdownMenuItem
+            key={opt}
+            onSelect={() => onAspect(opt)}
+            className="justify-between"
+          >
+            {opt}
+            {opt === aspect && <Check className="size-4" />}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Duration</DropdownMenuLabel>
+        {durationOptions.map((opt) => (
+          <DropdownMenuItem
+            key={opt.label}
+            onSelect={() => onDuration(opt)}
+            className="justify-between"
+          >
+            {opt.label}
+            {opt.label === duration.label && <Check className="size-4" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const CELL = "relative aspect-video border-b border-r border-border";
+const CELL_BTN =
+  "flex size-7 items-center justify-center rounded-full bg-black/60 text-white backdrop-blur transition hover:bg-black/80";
+
+function GalleryCell({
+  tile,
+  onOpen,
+  onRemove,
+}: {
+  tile: Tile;
+  onOpen: () => void;
+  onRemove: () => void;
+}) {
+  if (tile.status === "generating") {
+    return (
+      <div className={`${CELL} overflow-hidden`}>
+        <Skeleton className="size-full rounded-none" />
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-3">
+          <p className="line-clamp-4 text-center text-xs text-muted-foreground">
+            {tile.prompt}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (tile.status === "error") {
+    return (
+      <div
+        className={`group flex flex-col items-center justify-center gap-1 bg-destructive/5 p-3 text-center text-destructive ${CELL}`}
+      >
+        <span className="text-xs font-medium">Failed to generate</span>
+        <span
+          className="line-clamp-4 text-[11px] leading-tight opacity-80"
+          title={tile.error}
+        >
+          {tile.error}
+        </span>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          title="Dismiss"
+          onClick={onRemove}
+          className={`${CELL_BTN} absolute right-1 top-1 opacity-0 group-hover:opacity-100`}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`group overflow-hidden ${CELL}`}>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="absolute inset-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        aria-label="Open video"
+      >
+        <video
+          src={tile.src}
+          muted
+          loop
+          playsInline
+          className="size-full object-cover transition duration-200 group-hover:scale-[1.02]"
+          onMouseEnter={(e) => void e.currentTarget.play().catch(() => {})}
+          onMouseLeave={(e) => e.currentTarget.pause()}
+        />
+      </button>
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2 opacity-0 transition group-hover:opacity-100">
+        <p className="line-clamp-2 text-xs text-white">{tile.prompt}</p>
+      </div>
+
+      <div className="absolute right-1 top-1 flex gap-1 opacity-0 transition group-hover:opacity-100">
+        <a
+          href={tile.src}
+          download={`grida-video-${tile.id}.mp4`}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Download"
+          title="Download"
+          className={CELL_BTN}
+        >
+          <Download className="size-3.5" />
+        </a>
+        <button
+          type="button"
+          aria-label="Remove"
+          title="Remove"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className={CELL_BTN}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/grida-ai-agent/package.json
+++ b/packages/grida-ai-agent/package.json
@@ -133,7 +133,7 @@
     "@agentclientprotocol/sdk": "0.25.0",
     "@ai-sdk/gateway": "3.0.125",
     "@ai-sdk/openai-compatible": "2.0.48",
-    "@ai-sdk/provider": "^3.0.0",
+    "@ai-sdk/provider": "3.0.10",
     "@grida/ai-models": "workspace:*",
     "@grida/home": "workspace:*",
     "@hono/node-server": "^1.13.7",

--- a/packages/grida-ai-agent/package.json
+++ b/packages/grida-ai-agent/package.json
@@ -133,6 +133,7 @@
     "@agentclientprotocol/sdk": "0.25.0",
     "@ai-sdk/gateway": "3.0.125",
     "@ai-sdk/openai-compatible": "2.0.48",
+    "@ai-sdk/provider": "^3.0.0",
     "@grida/ai-models": "workspace:*",
     "@grida/home": "workspace:*",
     "@hono/node-server": "^1.13.7",

--- a/packages/grida-ai-agent/src/__public-api__.test.ts
+++ b/packages/grida-ai-agent/src/__public-api__.test.ts
@@ -110,10 +110,13 @@ describe("@grida/agent public API", () => {
     });
 
     it("exposes BYOK provider identity, wire vocab, tiers, and session-row types", () => {
-      expect(BYOK_PROVIDER_IDS).toEqual(["openrouter", "vercel"]);
+      // fal is image-only BYOK (#908) — present for key storage + image
+      // routing, excluded from the text resolver via its `modalities` marker.
+      expect(BYOK_PROVIDER_IDS).toEqual(["openrouter", "vercel", "fal"]);
       expect(BYOK_PROVIDER_METADATA.map((provider) => provider.label)).toEqual([
         "OpenRouter",
         "Vercel",
+        "fal",
       ]);
       const byok: ByokProviderId = "vercel";
       const metadata: ByokProviderMetadata = BYOK_PROVIDER_METADATA[0];
@@ -233,6 +236,10 @@ describe("@grida/agent public API", () => {
         home: "/Users/example",
       });
       expect(policy.network.allowed_domains).toContain("openrouter.ai");
+      // BYOK image provider fal (#908): queue API + media CDN must be reachable.
+      expect(policy.network.allowed_domains).toEqual(
+        expect.arrayContaining(["*.fal.run", "fal.media", "*.fal.media"])
+      );
       // Agent-provider class (issue #813): the external agent's vendor backend
       // must be reachable through the srt allowlist. Pin the full host set so a
       // dropped domain fails here, not at runtime egress.

--- a/packages/grida-ai-agent/src/__public-api__.test.ts
+++ b/packages/grida-ai-agent/src/__public-api__.test.ts
@@ -118,6 +118,16 @@ describe("@grida/agent public API", () => {
         "Vercel",
         "fal",
       ]);
+      // The modality matrix drives image/video resolver routing (via
+      // byokProvidersFor) — pin it so a bad metadata edit can't silently
+      // re-route provider selection.
+      expect(
+        BYOK_PROVIDER_METADATA.map(({ id, modalities }) => ({ id, modalities }))
+      ).toEqual([
+        { id: "openrouter", modalities: ["text", "image", "video"] },
+        { id: "vercel", modalities: ["text", "image", "video"] },
+        { id: "fal", modalities: ["image", "video"] },
+      ]);
       const byok: ByokProviderId = "vercel";
       const metadata: ByokProviderMetadata = BYOK_PROVIDER_METADATA[0];
       expect(byok).toBe("vercel");

--- a/packages/grida-ai-agent/src/http/routes/handshake.ts
+++ b/packages/grida-ai-agent/src/http/routes/handshake.ts
@@ -31,6 +31,8 @@ const SUPPORTS_TAGS: Record<keyof AgentServerCapabilities, string> = {
   workspaces: "workspaces@1",
   sessions: "sessions@1",
   providers: "providers@1",
+  images: "images@1",
+  video: "video@1",
   shell: "shell@1",
 };
 

--- a/packages/grida-ai-agent/src/http/routes/images.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/images.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `/images/generate` route (#908) — bare Hono app, fake secrets, mocked
+ * `generateImage`. No model, no network.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { SecretsStore } from "../../secrets";
+import { registerImagesRoutes } from "./images";
+
+// Replace the `ai` SDK's generateImage so the route never drives a real model.
+vi.mock("ai", () => ({
+  generateImage: async () => ({
+    images: [{ base64: "AAAA", mediaType: "image/png" }],
+  }),
+}));
+
+function fakeSecrets(keys: Record<string, string>): SecretsStore {
+  return {
+    _getKey: async (id: string) => keys[id] ?? null,
+  } as unknown as SecretsStore;
+}
+
+function appWith(keys: Record<string, string>) {
+  const app = new Hono();
+  registerImagesRoutes(app, { secrets: fakeSecrets(keys) });
+  return app;
+}
+
+function post(app: Hono, payload: unknown) {
+  return app.request("/images/generate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+const LISTED = "openai/gpt-image-2";
+
+describe("POST /images/generate", () => {
+  it("200 + image bytes for a listed model with a connected key", async () => {
+    const res = await post(appWith({ fal: "sk-fal" }), {
+      model_id: LISTED,
+      prompt: "a red apple",
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.provider_id).toBe("fal");
+    expect(json.model_id).toBe(LISTED);
+    expect(json.images).toEqual([{ base64: "AAAA", media_type: "image/png" }]);
+  });
+
+  it("400 for an unknown model id", async () => {
+    const res = await post(appWith({ fal: "sk-fal" }), {
+      model_id: "nobody/nope",
+      prompt: "x",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when no provider key is connected", async () => {
+    const res = await post(appWith({}), { model_id: LISTED, prompt: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on a malformed body (missing prompt)", async () => {
+    const res = await post(appWith({ fal: "sk-fal" }), { model_id: LISTED });
+    expect(res.status).toBe(400);
+  });
+
+  it("honors an explicit provider pick", async () => {
+    const res = await post(appWith({ vercel: "sk-v", openrouter: "sk-or" }), {
+      model_id: LISTED,
+      prompt: "x",
+      provider: "vercel",
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).provider_id).toBe(
+      "vercel"
+    );
+  });
+
+  it("never returns the api key in the response", async () => {
+    const res = await post(appWith({ fal: "sk-secret-123" }), {
+      model_id: LISTED,
+      prompt: "x",
+    });
+    expect(await res.text()).not.toContain("sk-secret-123");
+  });
+});
+
+// Phase 4 (#908) — the BYOK path must never enter the web Grida-billed seam.
+describe("images route billing isolation", () => {
+  const src = readFileSync(new URL("./images.ts", import.meta.url), "utf8");
+
+  it("does not import the web billing server", () => {
+    // Match an actual import/require, not the prose mention in the docblock.
+    expect(src).not.toMatch(/(from|require\()\s*["'][^"']*editor\/lib\/ai/);
+  });
+
+  it("never sets the `grida` provider-option (the billing trigger)", () => {
+    // The route MAY set providerOptions keyed by the image provider (e.g. for
+    // quality), but never a literal `grida: { … }` — that's the field the web
+    // billing middleware keys on. Image providers are vercel/fal/openrouter.
+    // (Prose mentions of `providerOptions.grida` in the docblock are fine;
+    // assert only an actual object-literal key.)
+    expect(src).not.toMatch(/grida\s*:\s*\{/);
+  });
+});

--- a/packages/grida-ai-agent/src/http/routes/images.ts
+++ b/packages/grida-ai-agent/src/http/routes/images.ts
@@ -106,19 +106,22 @@ export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
         ...(providerOptions ? { providerOptions } : {}),
       });
     } catch (e) {
-      // Keep the raw upstream body (AI SDK APICallError.responseBody) in the
-      // sidecar log ONLY — never echo provider diagnostics / prompt content back
-      // across the bridge to the renderer.
+      // Detail (e.message can include upstream body text — the fal/OpenRouter
+      // adapters embed safeText(res)) + the raw responseBody stay in the sidecar
+      // log ONLY; the renderer gets a generic message.
       const detail = e instanceof Error ? e.message : String(e);
       const upstreamBody = (e as { responseBody?: unknown })?.responseBody;
-      const message = `image generation failed: ${detail}`;
       console.error(
-        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${message}${
+        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${detail}${
           upstreamBody ? ` — ${String(upstreamBody).slice(0, 300)}` : ""
         }`
       );
       return c.json(
-        { error: message, model_id, provider_id: resolved.provider_id },
+        {
+          error: "image generation failed",
+          model_id,
+          provider_id: resolved.provider_id,
+        },
         502
       );
     }

--- a/packages/grida-ai-agent/src/http/routes/images.ts
+++ b/packages/grida-ai-agent/src/http/routes/images.ts
@@ -1,0 +1,134 @@
+/**
+ * GRIDA-SEC-004 — `/images/generate` route (BYOK image generation, #908).
+ *
+ * Desktop-only, user-BYOK image generation. The route resolves the user's
+ * connected provider for a curated model id, builds the `ImageModelV3` with the
+ * key (read internally — never exposed), and returns the generated **bytes**.
+ *
+ * Security contract (reviewed):
+ *   - Reads `_getKey` internally (legal — sidecar only). The response carries
+ *     base64 image bytes + provider id only: never the key, never the raw
+ *     upstream JSON.
+ *   - `model_id` is a closed catalog lookup (curated `listed` cards only) and
+ *     `provider` is `oneOf` the fixed image providers — there is NO
+ *     user-supplied base URL, so this opens no new egress beyond the three
+ *     fixed provider hosts (unlike the endpoint routes, issue #806).
+ *
+ * Billing contract (#908, Phase 4): this path NEVER enters the web
+ * Grida-billed image seam (`editor/lib/ai/server.ts`). It calls `generateImage`
+ * WITHOUT `providerOptions.grida` — the field that triggers Grida's billing
+ * middleware — so the user's own key pays the provider directly and no Grida
+ * credit is metered. Do not add `providerOptions.grida` here.
+ */
+
+import type { Hono } from "hono";
+import { generateImage } from "ai";
+import type { SecretsStore } from "../../secrets";
+import {
+  ImageModelUnavailableError,
+  resolveImageModel,
+} from "../../providers/resolve-image";
+import { body, v } from "../validate";
+
+const IMAGE_PROVIDERS = ["vercel", "fal", "openrouter"] as const;
+
+export type ImagesRoutesDeps = {
+  secrets: SecretsStore;
+};
+
+export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
+  const { secrets } = deps;
+
+  app.post("/images/generate", async (c) => {
+    const r = await body(c, {
+      model_id: v.string,
+      prompt: v.string,
+      provider: v.optional(v.oneOf(IMAGE_PROVIDERS)),
+      width: v.optional(v.number),
+      height: v.optional(v.number),
+      aspect_ratio: v.optional(v.string),
+      n: v.optional(v.number),
+      seed: v.optional(v.number),
+      quality: v.optional(v.string),
+    });
+    if (!r.ok) return r.res;
+    const {
+      model_id,
+      prompt,
+      provider,
+      width,
+      height,
+      aspect_ratio,
+      n,
+      seed,
+      quality,
+    } = r.data;
+
+    let resolved;
+    try {
+      resolved = await resolveImageModel(
+        { secrets },
+        model_id,
+        provider ? { explicit: provider } : {}
+      );
+    } catch (e) {
+      if (e instanceof ImageModelUnavailableError) {
+        return c.json({ error: e.message, model_id: e.model_id }, 400);
+      }
+      throw e;
+    }
+
+    const size =
+      width && height
+        ? (`${Math.round(width)}x${Math.round(height)}` as `${number}x${number}`)
+        : undefined;
+
+    // Quality is forwarded as a provider-option keyed by the resolved provider.
+    // The OpenRouter/fal adapters spread their provider-option bag into the
+    // upstream request body, so `{ quality }` reaches the provider that supports
+    // it; others ignore it. NB: keyed by provider, never `grida` (no billing).
+    const providerOptions =
+      quality && quality !== "auto"
+        ? { [resolved.provider_id]: { quality } }
+        : undefined;
+
+    let generation;
+    try {
+      generation = await generateImage({
+        model: resolved.model,
+        prompt,
+        n: n ?? 1,
+        ...(size ? { size } : {}),
+        ...(aspect_ratio
+          ? { aspectRatio: aspect_ratio as `${number}:${number}` }
+          : {}),
+        ...(seed !== undefined ? { seed } : {}),
+        ...(providerOptions ? { providerOptions } : {}),
+      });
+    } catch (e) {
+      // Surface a useful message: the SDK's message plus any upstream response
+      // body (AI SDK APICallError carries `responseBody`/`statusCode`).
+      const detail = e instanceof Error ? e.message : String(e);
+      const body = (e as { responseBody?: unknown })?.responseBody;
+      const message = `image generation failed: ${detail}${
+        body ? ` — ${String(body).slice(0, 300)}` : ""
+      }`;
+      console.error(
+        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${message}`
+      );
+      return c.json(
+        { error: message, model_id, provider_id: resolved.provider_id },
+        502
+      );
+    }
+
+    return c.json({
+      model_id: resolved.model_id,
+      provider_id: resolved.provider_id,
+      images: generation.images.map((f) => ({
+        base64: f.base64,
+        media_type: f.mediaType,
+      })),
+    });
+  });
+}

--- a/packages/grida-ai-agent/src/http/routes/images.ts
+++ b/packages/grida-ai-agent/src/http/routes/images.ts
@@ -106,15 +106,16 @@ export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
         ...(providerOptions ? { providerOptions } : {}),
       });
     } catch (e) {
-      // Surface a useful message: the SDK's message plus any upstream response
-      // body (AI SDK APICallError carries `responseBody`/`statusCode`).
+      // Keep the raw upstream body (AI SDK APICallError.responseBody) in the
+      // sidecar log ONLY — never echo provider diagnostics / prompt content back
+      // across the bridge to the renderer.
       const detail = e instanceof Error ? e.message : String(e);
-      const body = (e as { responseBody?: unknown })?.responseBody;
-      const message = `image generation failed: ${detail}${
-        body ? ` — ${String(body).slice(0, 300)}` : ""
-      }`;
+      const upstreamBody = (e as { responseBody?: unknown })?.responseBody;
+      const message = `image generation failed: ${detail}`;
       console.error(
-        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${message}`
+        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${message}${
+          upstreamBody ? ` — ${String(upstreamBody).slice(0, 300)}` : ""
+        }`
       );
       return c.json(
         { error: message, model_id, provider_id: resolved.provider_id },

--- a/packages/grida-ai-agent/src/http/routes/video.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `/video/generate` route (#908) — bare Hono app, fake secrets. The happy path
+ * goes through fal (a plain-fetch adapter) with a mocked global fetch; the
+ * error paths exercise resolve + validation. No SDK, no network.
+ */
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { SecretsStore } from "../../secrets";
+import { registerVideoRoutes } from "./video";
+
+function fakeSecrets(keys: Record<string, string>): SecretsStore {
+  return {
+    _getKey: async (id: string) => keys[id] ?? null,
+  } as unknown as SecretsStore;
+}
+
+function appWith(keys: Record<string, string>) {
+  const app = new Hono();
+  registerVideoRoutes(app, { secrets: fakeSecrets(keys) });
+  return app;
+}
+
+function post(app: Hono, payload: unknown) {
+  return app.request("/video/generate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+// Veo binds vercel + fal; fal is a plain-fetch adapter we can drive end-to-end.
+const VEO = "google/veo-3.1";
+
+/** Shape of the `init` arg our `fetch` mock reads. */
+type MockInit = { method?: string; body?: string };
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("POST /video/generate", () => {
+  it("200 + base64 video for a listed model via fal (sidecar downloads the clip)", async () => {
+    const MP4 = new Uint8Array([0, 0, 0, 24]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        if (init.method === "POST")
+          return new Response(
+            JSON.stringify({
+              request_id: "r",
+              status_url: "https://queue.fal.run/r/status",
+              response_url: "https://queue.fal.run/r",
+            }),
+            { status: 200 }
+          );
+        if (url.endsWith("/status"))
+          return new Response(JSON.stringify({ status: "COMPLETED" }), {
+            status: 200,
+          });
+        if (url === "https://fal.media/v.mp4")
+          return new Response(MP4, {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          });
+        return new Response(
+          JSON.stringify({
+            video: {
+              url: "https://fal.media/v.mp4",
+              content_type: "video/mp4",
+            },
+          }),
+          { status: 200 }
+        );
+      })
+    );
+    const res = await post(appWith({ fal: "sk-fal" }), {
+      model_id: VEO,
+      prompt: "a cat surfing",
+      provider: "fal",
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.provider_id).toBe("fal");
+    expect(json.videos).toEqual([
+      { base64: Buffer.from(MP4).toString("base64"), media_type: "video/mp4" },
+    ]);
+  });
+
+  it("400 for an unknown model id", async () => {
+    const res = await post(appWith({ vercel: "sk-v" }), {
+      model_id: "no/pe",
+      prompt: "x",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when the connected provider does not serve the model", async () => {
+    // Seedance has no fal binding.
+    const res = await post(appWith({ fal: "sk-fal" }), {
+      model_id: "bytedance/seedance-2.0",
+      prompt: "x",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on a malformed body (missing prompt)", async () => {
+    const res = await post(appWith({ fal: "sk-fal" }), { model_id: VEO });
+    expect(res.status).toBe(400);
+  });
+
+  it("never leaks the api key in the response", async () => {
+    const res = await post(appWith({}), { model_id: VEO, prompt: "x" });
+    expect(await res.text()).not.toContain("sk-");
+  });
+});
+
+describe("video route billing isolation", () => {
+  const src = readFileSync(new URL("./video.ts", import.meta.url), "utf8");
+  it("does not import the web billing server", () => {
+    expect(src).not.toMatch(/(from|require\()\s*["'][^"']*editor\/lib\/ai/);
+  });
+  it("never sets the `grida` provider-option", () => {
+    expect(src).not.toMatch(/grida\s*:\s*\{/);
+    expect(src).not.toMatch(/providerOptions\s*\.\s*grida/);
+  });
+});

--- a/packages/grida-ai-agent/src/http/routes/video.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.test.ts
@@ -108,8 +108,13 @@ describe("POST /video/generate", () => {
   });
 
   it("never leaks the api key in the response", async () => {
-    const res = await post(appWith({}), { model_id: VEO, prompt: "x" });
-    expect(await res.text()).not.toContain("sk-");
+    // A real secret is present so a regression that echoes connected keys would
+    // actually fail this assertion (an empty store could never leak).
+    const res = await post(appWith({ fal: "sk-secret-123" }), {
+      model_id: "no/pe",
+      prompt: "x",
+    });
+    expect(await res.text()).not.toContain("sk-secret-123");
   });
 });
 

--- a/packages/grida-ai-agent/src/http/routes/video.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.ts
@@ -95,19 +95,19 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
     try {
       generation = await resolved.model.doGenerate(callOptions);
     } catch (e) {
-      // Upstream body stays in the sidecar log only — never echoed to the
-      // renderer (provider diagnostics / prompt content).
+      // Detail (which can include upstream body text — fal adapters embed
+      // safeText(res) in their thrown messages) stays in the sidecar log only;
+      // the renderer gets a generic message.
       const detail = e instanceof Error ? e.message : String(e);
       const upstream = (e as { responseBody?: unknown })?.responseBody;
-      const message = `video generation failed: ${detail}`;
       console.error(
-        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${message}${
+        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${detail}${
           upstream ? ` — ${String(upstream).slice(0, 300)}` : ""
         }`
       );
       return c.json(
         {
-          error: message,
+          error: "video generation failed",
           model_id: d.model_id,
           provider_id: resolved.provider_id,
         },

--- a/packages/grida-ai-agent/src/http/routes/video.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.ts
@@ -1,0 +1,153 @@
+/**
+ * GRIDA-SEC-004 — `/video/generate` route (BYOK video generation, #908).
+ *
+ * Desktop-only, user-BYOK video generation — the video sibling of
+ * {@link ./images.ts}. Resolves the user's connected provider for a curated
+ * model id, builds the `VideoModelV3` with the key (read internally — never
+ * exposed), and returns the generated video (a provider CDN URL, or base64 for
+ * inline data).
+ *
+ * Security contract (reviewed): reads `_getKey` internally (sidecar only); the
+ * response carries a URL / base64 + provider id only — never the key, never raw
+ * upstream JSON. `model_id` is a closed catalog lookup and `provider` is
+ * `oneOf` the fixed video providers — no user-supplied base URL, so no new
+ * egress beyond the fixed provider hosts.
+ *
+ * Billing contract (#908): this path NEVER enters the web Grida-billed seam. It
+ * calls the model directly without the grida provider-option (the field the web
+ * billing middleware keys on), so the user's own key pays the provider. Do not
+ * add a grida provider-option here.
+ *
+ * Note: `experimental_generateVideo` is text-to-video only (no image arg), so
+ * the route drives the model's `doGenerate` directly — that lets it pass an
+ * optional start frame for image-to-video (which fal's catalog bindings need).
+ */
+
+import type { Hono } from "hono";
+import type { Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions } from "@ai-sdk/provider";
+import type { SecretsStore } from "../../secrets";
+import {
+  VideoModelUnavailableError,
+  resolveVideoModel,
+} from "../../providers/resolve-video";
+import { body, v } from "../validate";
+
+const VIDEO_PROVIDERS = ["vercel", "fal", "openrouter"] as const;
+
+export type VideoRoutesDeps = {
+  secrets: SecretsStore;
+};
+
+export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
+  const { secrets } = deps;
+
+  app.post("/video/generate", async (c) => {
+    const r = await body(c, {
+      model_id: v.string,
+      prompt: v.string,
+      provider: v.optional(v.oneOf(VIDEO_PROVIDERS)),
+      aspect_ratio: v.optional(v.string),
+      resolution: v.optional(v.string),
+      duration: v.optional(v.number),
+      fps: v.optional(v.number),
+      seed: v.optional(v.number),
+      image_url: v.optional(v.string),
+    });
+    if (!r.ok) return r.res;
+    const d = r.data;
+
+    let resolved;
+    try {
+      resolved = await resolveVideoModel(
+        { secrets },
+        d.model_id,
+        d.provider ? { explicit: d.provider } : {}
+      );
+    } catch (e) {
+      if (e instanceof VideoModelUnavailableError) {
+        return c.json({ error: e.message, model_id: e.model_id }, 400);
+      }
+      throw e;
+    }
+
+    const callOptions: VideoModelV3CallOptions = {
+      prompt: d.prompt,
+      n: 1,
+      aspectRatio: d.aspect_ratio
+        ? (d.aspect_ratio as `${number}:${number}`)
+        : undefined,
+      resolution: d.resolution
+        ? (d.resolution as `${number}x${number}`)
+        : undefined,
+      duration: d.duration,
+      fps: d.fps,
+      seed: d.seed,
+      image: d.image_url ? { type: "url", url: d.image_url } : undefined,
+      providerOptions: {},
+    };
+
+    let generation;
+    try {
+      generation = await resolved.model.doGenerate(callOptions);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      const upstream = (e as { responseBody?: unknown })?.responseBody;
+      const message = `video generation failed: ${detail}${
+        upstream ? ` — ${String(upstream).slice(0, 300)}` : ""
+      }`;
+      console.error(
+        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${message}`
+      );
+      return c.json(
+        {
+          error: message,
+          model_id: d.model_id,
+          provider_id: resolved.provider_id,
+        },
+        502
+      );
+    }
+
+    // Normalize every result to base64 bytes. Providers return large clips as
+    // CDN URLs, but the desktop renderer can't load cross-origin media under
+    // the CSP — so the sidecar downloads them and hands back base64 the
+    // renderer plays as a `data:` URL. (The OpenRouter adapter already
+    // pre-downloads its authed content endpoint.)
+    let videos;
+    try {
+      videos = await Promise.all(
+        generation.videos.map(async (vid) => {
+          if (vid.type === "base64")
+            return { base64: vid.data, media_type: vid.mediaType };
+          if (vid.type === "binary")
+            return {
+              base64: Buffer.from(vid.data).toString("base64"),
+              media_type: vid.mediaType,
+            };
+          // type === "url": public CDN (fal/vercel) — download in the sidecar.
+          const dl = await fetch(vid.url);
+          if (!dl.ok) throw new Error(`download failed (${dl.status})`);
+          return {
+            base64: Buffer.from(await dl.arrayBuffer()).toString("base64"),
+            media_type: dl.headers.get("content-type") ?? vid.mediaType,
+          };
+        })
+      );
+    } catch (e) {
+      return c.json(
+        {
+          error: `video fetch failed: ${e instanceof Error ? e.message : String(e)}`,
+          model_id: d.model_id,
+          provider_id: resolved.provider_id,
+        },
+        502
+      );
+    }
+
+    return c.json({
+      model_id: resolved.model_id,
+      provider_id: resolved.provider_id,
+      videos,
+    });
+  });
+}

--- a/packages/grida-ai-agent/src/http/routes/video.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.ts
@@ -30,6 +30,7 @@ import {
   VideoModelUnavailableError,
   resolveVideoModel,
 } from "../../providers/resolve-video";
+import { assertHttpsUrl } from "../../providers/fetch-helpers";
 import { body, v } from "../validate";
 
 const VIDEO_PROVIDERS = ["vercel", "fal", "openrouter"] as const;
@@ -46,12 +47,16 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
       model_id: v.string,
       prompt: v.string,
       provider: v.optional(v.oneOf(VIDEO_PROVIDERS)),
-      aspect_ratio: v.optional(v.string),
-      resolution: v.optional(v.string),
+      // Reject malformed option strings at the boundary (400) instead of
+      // letting them reach the provider and bounce back as a 502.
+      aspect_ratio: v.optional(v.matching(/^\d+:\d+$/, 'must be "<w>:<h>"')),
+      resolution: v.optional(v.matching(/^\d+x\d+$/, 'must be "<w>x<h>"')),
       duration: v.optional(v.number),
       fps: v.optional(v.number),
       seed: v.optional(v.number),
-      image_url: v.optional(v.string),
+      image_url: v.optional(
+        v.matching(/^https:\/\/.+/i, "must be an https url")
+      ),
     });
     if (!r.ok) return r.res;
     const d = r.data;
@@ -90,13 +95,15 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
     try {
       generation = await resolved.model.doGenerate(callOptions);
     } catch (e) {
+      // Upstream body stays in the sidecar log only — never echoed to the
+      // renderer (provider diagnostics / prompt content).
       const detail = e instanceof Error ? e.message : String(e);
       const upstream = (e as { responseBody?: unknown })?.responseBody;
-      const message = `video generation failed: ${detail}${
-        upstream ? ` — ${String(upstream).slice(0, 300)}` : ""
-      }`;
+      const message = `video generation failed: ${detail}`;
       console.error(
-        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${message}`
+        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${message}${
+          upstream ? ` — ${String(upstream).slice(0, 300)}` : ""
+        }`
       );
       return c.json(
         {
@@ -125,6 +132,12 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
               media_type: vid.mediaType,
             };
           // type === "url": public CDN (fal/vercel) — download in the sidecar.
+          // Require HTTPS here; host-level egress control is enforced by the
+          // OS sandbox allowlist (sandbox/policy.ts), the primary SSRF defense.
+          assertHttpsUrl(
+            vid.url,
+            `[agent-host-video] ${resolved.provider_id} url`
+          );
           const dl = await fetch(vid.url);
           if (!dl.ok) throw new Error(`download failed (${dl.status})`);
           return {

--- a/packages/grida-ai-agent/src/http/server.ts
+++ b/packages/grida-ai-agent/src/http/server.ts
@@ -13,6 +13,8 @@ import { registerFilesRoutes } from "./routes/files";
 import { registerRecentRoutes } from "./routes/recent";
 import { registerSecretsRoutes } from "./routes/secrets";
 import { registerProvidersRoutes } from "./routes/providers";
+import { registerImagesRoutes } from "./routes/images";
+import { registerVideoRoutes } from "./routes/video";
 import { registerAgentRoutes } from "./routes/agent";
 import { registerWorkspacesRoutes } from "./routes/workspaces";
 import { registerSessionsRoutes } from "./routes/sessions";
@@ -156,6 +158,12 @@ export function buildServer(opts: ServerOptions): BuiltServer {
       endpoints: endpointsStore,
       secrets: secretsStore,
     });
+  }
+  if (opts.capabilities.images) {
+    registerImagesRoutes(app, { secrets: secretsStore });
+  }
+  if (opts.capabilities.video) {
+    registerVideoRoutes(app, { secrets: secretsStore });
   }
   // Agent runtime owns the run loop + the in-flight stream registry.
   // `opts.streamRegistry` is undefined for direct callers (the runtime

--- a/packages/grida-ai-agent/src/http/validate.ts
+++ b/packages/grida-ai-agent/src/http/validate.ts
@@ -59,6 +59,14 @@ export namespace v {
     };
   }
 
+  /** Non-empty string that matches `re`; `hint` is the user-facing error. */
+  export function matching(re: RegExp, hint: string): Validator<string> {
+    return (raw) =>
+      typeof raw === "string" && re.test(raw)
+        ? { ok: true, value: raw }
+        : { ok: false, error: hint };
+  }
+
   export function optional<T>(inner: Validator<T>): Validator<T | undefined> {
     return (raw) => {
       if (raw === undefined) return { ok: true, value: undefined };

--- a/packages/grida-ai-agent/src/index.ts
+++ b/packages/grida-ai-agent/src/index.ts
@@ -5,11 +5,25 @@
 export {
   BYOK_PROVIDER_METADATA,
   BYOK_PROVIDER_IDS,
+  byokProvidersFor,
   isByokProviderId,
+  type ByokModality,
   type ByokProviderMetadata,
   type ByokProviderId,
   type ProviderId,
 } from "./protocol/provider-ids";
+export type {
+  ImageGenProvider,
+  ImageGenerateRequest,
+  ImageGeneratedImage,
+  ImageGenerateResult,
+} from "./protocol/images";
+export type {
+  VideoGenProvider,
+  VideoGenerateRequest,
+  GeneratedVideo,
+  VideoGenerateResult,
+} from "./protocol/video";
 export {
   OLLAMA_ENDPOINT_PRESET,
   isValidEndpointProviderId,

--- a/packages/grida-ai-agent/src/protocol/handshake.ts
+++ b/packages/grida-ai-agent/src/protocol/handshake.ts
@@ -17,6 +17,18 @@ export type AgentServerCapabilities = {
    * clients treat a missing flag as "not served".
    */
   providers?: boolean;
+  /**
+   * `/images/generate` — BYOK image generation (#908). Optional so older
+   * host-supplied capability shapes stay valid; clients treat a missing flag
+   * as "not served" and hide the image-generation UI.
+   */
+  images?: boolean;
+  /**
+   * `/video/generate` — BYOK video generation (#908). Optional so older
+   * host-supplied capability shapes stay valid; clients treat a missing flag
+   * as "not served" and hide the video-generation UI.
+   */
+  video?: boolean;
   /** Reserved for future `/shell/*` route group; always `false` in V1. */
   shell: boolean;
 };
@@ -31,6 +43,8 @@ export const AGENT_SERVER_DEFAULT_CAPABILITIES: AgentServerCapabilities = {
   workspaces: true,
   sessions: true,
   providers: true,
+  images: true,
+  video: true,
   shell: false,
 };
 

--- a/packages/grida-ai-agent/src/protocol/images.ts
+++ b/packages/grida-ai-agent/src/protocol/images.ts
@@ -1,0 +1,43 @@
+/**
+ * Image-generation wire protocol (#908). Client-safe: request/result shapes
+ * for the `/images/generate` route, no provider SDK imports.
+ */
+
+import type { models } from "@grida/ai-models";
+
+/** A BYOK image provider (mirrors {@link models.image.ImageProvider}). */
+export type ImageGenProvider = models.image.ImageProvider;
+
+export type ImageGenerateRequest = {
+  /** Canonical catalog id (a curated `listed` image model). */
+  model_id: string;
+  prompt: string;
+  /** Optional explicit provider override; otherwise the resolver picks. */
+  provider?: ImageGenProvider;
+  width?: number;
+  height?: number;
+  aspect_ratio?: string;
+  n?: number;
+  seed?: number;
+  /**
+   * Quality tier (`high` | `medium` | `low`). Only meaningful for models that
+   * expose quality tiers (per-image-tiered pricing, e.g. GPT Image). Forwarded
+   * to the provider as a provider-option; ignored by models that don't support
+   * it. Omit (or `auto`) to use the provider default.
+   */
+  quality?: string;
+};
+
+export type ImageGeneratedImage = {
+  /** Base64-encoded image bytes (no data: prefix). */
+  base64: string;
+  /** MIME type, e.g. `image/png`. */
+  media_type: string;
+};
+
+export type ImageGenerateResult = {
+  model_id: string;
+  /** The provider that actually served the request. */
+  provider_id: ImageGenProvider;
+  images: ImageGeneratedImage[];
+};

--- a/packages/grida-ai-agent/src/protocol/provider-ids.ts
+++ b/packages/grida-ai-agent/src/protocol/provider-ids.ts
@@ -5,14 +5,31 @@
  * contract consumers can compile against and render from.
  */
 
+/**
+ * Which generation modalities a BYOK provider serves. A provider may serve
+ * several: OpenRouter does text + image; Vercel does text + image + video; fal
+ * does image + video (its catalog bindings are image-to-video). The marker
+ * keeps each resolver from ever picking a provider that can't serve its
+ * modality, while the secrets store + settings UI still list every provider so
+ * its key can be stored.
+ */
+export type ByokModality = "text" | "image" | "video";
+
 export const BYOK_PROVIDER_METADATA = [
   {
     id: "openrouter",
     label: "OpenRouter",
+    modalities: ["text", "image", "video"],
   },
   {
     id: "vercel",
     label: "Vercel",
+    modalities: ["text", "image", "video"],
+  },
+  {
+    id: "fal",
+    label: "fal",
+    modalities: ["image", "video"],
   },
 ] as const;
 
@@ -26,6 +43,15 @@ export const BYOK_PROVIDER_IDS = BYOK_PROVIDER_METADATA.map(
 
 export function isByokProviderId(id: string): id is ByokProviderId {
   return (BYOK_PROVIDER_IDS as readonly string[]).includes(id);
+}
+
+/** BYOK providers that serve `modality`, in precedence (metadata) order. */
+export function byokProvidersFor(
+  modality: ByokModality
+): readonly ByokProviderMetadata[] {
+  return BYOK_PROVIDER_METADATA.filter((p) =>
+    (p.modalities as readonly string[]).includes(modality)
+  );
 }
 
 /**

--- a/packages/grida-ai-agent/src/protocol/video.ts
+++ b/packages/grida-ai-agent/src/protocol/video.ts
@@ -1,0 +1,44 @@
+/**
+ * Video-generation wire protocol (#908). Client-safe: request/result shapes
+ * for the `/video/generate` route, no provider SDK imports.
+ */
+
+import type { models } from "@grida/ai-models";
+
+/** A BYOK video provider (mirrors {@link models.video.VideoProvider}). */
+export type VideoGenProvider = models.video.VideoProvider;
+
+export type VideoGenerateRequest = {
+  /** Canonical catalog id (a curated `listed` video model). */
+  model_id: string;
+  prompt: string;
+  /** Optional explicit provider override; otherwise the resolver picks. */
+  provider?: VideoGenProvider;
+  aspect_ratio?: string;
+  /** `"{width}x{height}"`. */
+  resolution?: string;
+  /** Output duration in seconds. */
+  duration?: number;
+  fps?: number;
+  seed?: number;
+  /** Optional start-frame URL for image-to-video. */
+  image_url?: string;
+};
+
+export type GeneratedVideo = {
+  /**
+   * Base64-encoded video bytes. The route always returns bytes (the sidecar
+   * downloads provider CDN/authed URLs) so the renderer can play a `data:` URL
+   * under the desktop CSP without reaching an external origin.
+   */
+  base64?: string;
+  /** Reserved: a directly-playable URL, if a future path returns one. */
+  url?: string;
+  media_type: string;
+};
+
+export type VideoGenerateResult = {
+  model_id: string;
+  provider_id: VideoGenProvider;
+  videos: GeneratedVideo[];
+};

--- a/packages/grida-ai-agent/src/protocol/video.ts
+++ b/packages/grida-ai-agent/src/protocol/video.ts
@@ -29,11 +29,10 @@ export type GeneratedVideo = {
   /**
    * Base64-encoded video bytes. The route always returns bytes (the sidecar
    * downloads provider CDN/authed URLs) so the renderer can play a `data:` URL
-   * under the desktop CSP without reaching an external origin.
+   * under the desktop CSP without reaching an external origin. Required — the
+   * v1 contract never returns a bare URL.
    */
-  base64?: string;
-  /** Reserved: a directly-playable URL, if a future path returns one. */
-  url?: string;
+  base64: string;
   media_type: string;
 };
 

--- a/packages/grida-ai-agent/src/providers/fetch-helpers.ts
+++ b/packages/grida-ai-agent/src/providers/fetch-helpers.ts
@@ -1,0 +1,91 @@
+/**
+ * Small fetch/async helpers shared by the queue-based BYOK media adapters
+ * (image + video). Extracted so the two adapters can't drift on error-message
+ * truncation or abort handling.
+ */
+
+/** Read a response body for an error message, bounded and never throwing. */
+export async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500);
+  } catch {
+    return "<unreadable>";
+  }
+}
+
+/** Sleep `ms`, rejecting early with an AbortError if `abortSignal` fires. */
+export function delay(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    abortSignal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(t);
+        reject(abortError());
+      },
+      { once: true }
+    );
+  });
+}
+
+/** An `AbortError` matching the DOM convention (`name === "AbortError"`). */
+export function abortError(): Error {
+  const e = new Error("The operation was aborted.");
+  e.name = "AbortError";
+  return e;
+}
+
+/** Per-poll verdict: still running, finished, or failed (with a reason). */
+export type PollOutcome = "pending" | "done" | { failed: string };
+
+/** fal queue status → {@link PollOutcome}. fal reports IN_QUEUE / IN_PROGRESS / COMPLETED. */
+export function falQueueOutcome(body: { status: string }): PollOutcome {
+  if (body.status === "COMPLETED") return "done";
+  if (body.status === "IN_QUEUE" || body.status === "IN_PROGRESS")
+    return "pending";
+  return { failed: `generation failed with status: ${body.status}` };
+}
+
+/**
+ * Poll a queue-style status endpoint until it's `done` or `failed`, bounded by
+ * `timeoutMs` and abortable. Returns the final (completed) response body so the
+ * caller can read result fields off it. Shared by the queue-based BYOK media
+ * adapters (fal image/video, OpenRouter video) — they differ only in the status
+ * vocabulary, which they supply via `classify`.
+ */
+export async function pollQueue<T>(
+  url: string,
+  opts: {
+    headers: Record<string, string>;
+    timeoutMs: number;
+    intervalMs: number;
+    /** Error-message prefix, e.g. `"[fal] video"`. */
+    label: string;
+    classify: (body: T) => PollOutcome;
+  },
+  abortSignal?: AbortSignal
+): Promise<T> {
+  const deadline = Date.now() + opts.timeoutMs;
+  for (;;) {
+    if (abortSignal?.aborted) throw abortError();
+    const res = await fetch(url, {
+      headers: opts.headers,
+      signal: abortSignal,
+    });
+    if (!res.ok) {
+      throw new Error(
+        `${opts.label} poll failed (${res.status}): ${await safeText(res)}`
+      );
+    }
+    const body = (await res.json()) as T;
+    const outcome = opts.classify(body);
+    if (outcome === "done") return body;
+    if (typeof outcome === "object") {
+      throw new Error(`${opts.label} ${outcome.failed}`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`${opts.label} timed out after ${opts.timeoutMs}ms`);
+    }
+    await delay(opts.intervalMs, abortSignal);
+  }
+}

--- a/packages/grida-ai-agent/src/providers/fetch-helpers.ts
+++ b/packages/grida-ai-agent/src/providers/fetch-helpers.ts
@@ -132,6 +132,11 @@ export async function pollQueue<T>(
     if (Date.now() >= deadline) {
       throw new Error(`${opts.label} timed out after ${opts.timeoutMs}ms`);
     }
-    await delay(opts.intervalMs, abortSignal);
+    // Clamp the inter-poll sleep to the remaining budget so the loop can't
+    // overshoot `timeoutMs` by up to one interval.
+    await delay(
+      Math.min(opts.intervalMs, Math.max(0, deadline - Date.now())),
+      abortSignal
+    );
   }
 }

--- a/packages/grida-ai-agent/src/providers/fetch-helpers.ts
+++ b/packages/grida-ai-agent/src/providers/fetch-helpers.ts
@@ -4,6 +4,45 @@
  * truncation or abort handling.
  */
 
+/**
+ * Throw unless `url` is HTTPS and its host is allow-listed. Defends BYOK
+ * key-bearing fetches (queue submit/poll, authed downloads) against SSRF and
+ * credential exfil via a malicious or misbehaving provider response — a host
+ * entry is either an exact host or a `*.suffix` wildcard.
+ */
+export function assertAllowedUrl(
+  url: string,
+  allowedHosts: readonly string[],
+  label: string
+): void {
+  const u = assertHttpsUrl(url, label);
+  const host = u.hostname;
+  const ok = allowedHosts.some((h) =>
+    h.startsWith("*.")
+      ? host === h.slice(2) || host.endsWith(h.slice(1))
+      : host === h
+  );
+  if (!ok) throw new Error(`${label} returned a disallowed host: ${host}`);
+}
+
+/**
+ * Throw unless `url` is a valid HTTPS url; return the parsed `URL`. For public,
+ * non-credential downloads (e.g. a provider's pre-signed CDN link) where the
+ * host legitimately varies but a plaintext/relative url must still be refused.
+ */
+export function assertHttpsUrl(url: string, label: string): URL {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    throw new Error(`${label} returned an invalid url`);
+  }
+  if (u.protocol !== "https:") {
+    throw new Error(`${label} returned a non-https url`);
+  }
+  return u;
+}
+
 /** Read a response body for an error message, bounded and never throwing. */
 export async function safeText(res: Response): Promise<string> {
   try {
@@ -68,10 +107,17 @@ export async function pollQueue<T>(
   const deadline = Date.now() + opts.timeoutMs;
   for (;;) {
     if (abortSignal?.aborted) throw abortError();
-    const res = await fetch(url, {
-      headers: opts.headers,
-      signal: abortSignal,
-    });
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`${opts.label} timed out after ${opts.timeoutMs}ms`);
+    }
+    // Bound each request to the remaining budget so a stalled status endpoint
+    // can't hang the poll past `timeoutMs` even if no external abort fires.
+    const signal = AbortSignal.any([
+      ...(abortSignal ? [abortSignal] : []),
+      AbortSignal.timeout(remaining),
+    ]);
+    const res = await fetch(url, { headers: opts.headers, signal });
     if (!res.ok) {
       throw new Error(
         `${opts.label} poll failed (${res.status}): ${await safeText(res)}`

--- a/packages/grida-ai-agent/src/providers/image-byok.live.test.ts
+++ b/packages/grida-ai-agent/src/providers/image-byok.live.test.ts
@@ -1,0 +1,63 @@
+/**
+ * LIVE BYOK image test — real OpenRouter key, real API call. Opt-in only, so
+ * the normal suite never hits the network or spends credits.
+ *
+ *   GRIDA_LIVE_BYOK=1                — required, opts in.
+ *   BYOK_OPENROUTER_API_KEY=<key>   — the key (falls back to editor/.env.local).
+ *   LIVE_IMAGE_MODEL=<id>           — model to use (default: seedream-4.5).
+ *
+ * Run: `GRIDA_LIVE_BYOK=1 pnpm exec vitest run src/providers/image-byok.live.test.ts`
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { generateImage } from "ai";
+import { resolveImageModel } from "./resolve-image";
+import type { SecretsStore } from "../secrets";
+
+function loadKey(): string | undefined {
+  if (process.env.BYOK_OPENROUTER_API_KEY)
+    return process.env.BYOK_OPENROUTER_API_KEY;
+  // Convenience fallback: editor/.env.local, relative to this package.
+  try {
+    const env = fs.readFileSync(
+      path.resolve(process.cwd(), "../../editor/.env.local"),
+      "utf8"
+    );
+    const m = env.match(/^\s*BYOK_OPENROUTER_API_KEY\s*=\s*(.+)\s*$/m);
+    return m?.[1]?.trim().replace(/^["']|["']$/g, "");
+  } catch {
+    return undefined;
+  }
+}
+
+const LIVE = process.env.GRIDA_LIVE_BYOK === "1";
+const KEY = LIVE ? loadKey() : undefined;
+const MODEL = process.env.LIVE_IMAGE_MODEL ?? "bytedance/seedream-4.5";
+
+describe.skipIf(!LIVE || !KEY)("LIVE OpenRouter image generation", () => {
+  it(`resolves + generates a real image (${MODEL})`, async () => {
+    const secrets = {
+      _getKey: async (id: string) => (id === "openrouter" ? KEY! : null),
+    } as unknown as SecretsStore;
+
+    const resolved = await resolveImageModel({ secrets }, MODEL, {
+      explicit: "openrouter",
+    });
+    expect(resolved.provider_id).toBe("openrouter");
+    console.log(`[live] binding_id=${resolved.binding_id}`);
+
+    const result = await generateImage({
+      model: resolved.model,
+      prompt: "a single red apple on a white table, soft studio light",
+      n: 1,
+    });
+    const img = result.images[0];
+    expect(img).toBeTruthy();
+    expect(img.uint8Array.length).toBeGreaterThan(1000);
+    fs.writeFileSync("/tmp/grida-live-or.png", img.uint8Array);
+    console.log(
+      `[live] ✅ mediaType=${img.mediaType} bytes=${img.uint8Array.length} → /tmp/grida-live-or.png`
+    );
+  }, 120_000);
+});

--- a/packages/grida-ai-agent/src/providers/image-byok.test.ts
+++ b/packages/grida-ai-agent/src/providers/image-byok.test.ts
@@ -74,13 +74,16 @@ describe("FalImageModel.doGenerate", () => {
           return new Response(
             JSON.stringify({
               images: [
-                { url: "https://cdn.fal/i.png", content_type: "image/png" },
+                {
+                  url: "https://v3.fal.media/i.png",
+                  content_type: "image/png",
+                },
               ],
             }),
             { status: 200 }
           );
         }
-        if (url === "https://cdn.fal/i.png") {
+        if (url === "https://v3.fal.media/i.png") {
           return new Response(PNG, { status: 200 });
         }
         return new Response("not found", { status: 404 });

--- a/packages/grida-ai-agent/src/providers/image-byok.test.ts
+++ b/packages/grida-ai-agent/src/providers/image-byok.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ImageModelV3CallOptions } from "@ai-sdk/provider";
+import {
+  FalImageModel,
+  OpenRouterImageModel,
+  makeImageModelFor,
+} from "./image-byok";
+
+/** Minimal full ImageModelV3CallOptions with overridable fields. */
+function callOptions(
+  over: Partial<ImageModelV3CallOptions> = {}
+): ImageModelV3CallOptions {
+  return {
+    prompt: "a red apple",
+    n: 1,
+    size: "1024x1024",
+    aspectRatio: undefined,
+    seed: undefined,
+    files: undefined,
+    mask: undefined,
+    providerOptions: {},
+    ...over,
+  };
+}
+
+/** Shape of the `init` arg our `fetch` mocks read. */
+type MockInit = {
+  method?: string;
+  body?: string;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+};
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("FalImageModel.doGenerate", () => {
+  it("submits, polls until COMPLETED, and returns image bytes", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    let statusPolls = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        calls.push({
+          url,
+          method: init.method ?? "GET",
+          body: init.body ? JSON.parse(init.body) : undefined,
+        });
+        if (init.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              request_id: "req_1",
+              status_url: "https://queue.fal.run/req_1/status",
+              response_url: "https://queue.fal.run/req_1",
+            }),
+            { status: 200 }
+          );
+        }
+        if (url.endsWith("/status")) {
+          statusPolls++;
+          // first poll in-progress, second completed → exercises the loop
+          return new Response(
+            JSON.stringify({
+              status: statusPolls < 2 ? "IN_PROGRESS" : "COMPLETED",
+            }),
+            { status: 200 }
+          );
+        }
+        if (url === "https://queue.fal.run/req_1") {
+          return new Response(
+            JSON.stringify({
+              images: [
+                { url: "https://cdn.fal/i.png", content_type: "image/png" },
+              ],
+            }),
+            { status: 200 }
+          );
+        }
+        if (url === "https://cdn.fal/i.png") {
+          return new Response(PNG, { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      })
+    );
+
+    const model = new FalImageModel("sk-test", "fal-ai/flux-2-pro");
+    const result = await model.doGenerate(
+      callOptions({ seed: 42, providerOptions: { fal: { guidance: 3 } } })
+    );
+
+    // submit body carries the mapped params
+    const submit = calls.find((c) => c.method === "POST")!;
+    expect(submit.url).toBe("https://queue.fal.run/fal-ai/flux-2-pro");
+    expect(submit.body).toMatchObject({
+      prompt: "a red apple",
+      num_images: 1,
+      image_size: { width: 1024, height: 1024 },
+      seed: 42,
+      guidance: 3, // providerOptions.fal passthrough
+    });
+    // polled more than once (loop ran)
+    expect(statusPolls).toBe(2);
+    // bytes returned, not the url
+    expect(result.images).toEqual([PNG]);
+    expect(result.response.modelId).toBe("fal-ai/flux-2-pro");
+  });
+
+  it("throws when fal reports a failed status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        if (init.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              request_id: "r",
+              status_url: "https://queue.fal.run/r/status",
+              response_url: "https://queue.fal.run/r",
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({ status: "FAILED" }), {
+          status: 200,
+        });
+      })
+    );
+    const model = new FalImageModel("sk", "fal-ai/x");
+    await expect(model.doGenerate(callOptions())).rejects.toThrow(/FAILED/);
+  });
+
+  it("propagates an aborted signal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: MockInit = {}) => {
+        if (init.signal?.aborted) {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        return new Response("{}", { status: 200 });
+      })
+    );
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const model = new FalImageModel("sk", "fal-ai/x");
+    await expect(
+      model.doGenerate(callOptions({ abortSignal: ctrl.signal }))
+    ).rejects.toThrow(/abort/i);
+  });
+});
+
+describe("OpenRouterImageModel.doGenerate", () => {
+  it("POSTs the unified /v1/images route and returns base64 images", async () => {
+    let called: { url: string; body: unknown } | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        called = { url, body: JSON.parse(init.body ?? "{}") };
+        return new Response(
+          JSON.stringify({
+            data: [{ b64_json: "AAAA" }],
+            usage: { cost: 0.04 },
+          }),
+          { status: 200 }
+        );
+      })
+    );
+    const model = new OpenRouterImageModel("sk", "bytedance-seed/seedream-4.5");
+    const result = await model.doGenerate(
+      callOptions({ seed: 7, aspectRatio: "16:9" })
+    );
+    expect(called?.url).toBe("https://openrouter.ai/api/v1/images");
+    expect(called?.body).toMatchObject({
+      model: "bytedance-seed/seedream-4.5",
+      prompt: "a red apple",
+      aspect_ratio: "16:9",
+      seed: 7,
+    });
+    // base64 strings passed straight through (the AI SDK detects media type)
+    expect(result.images).toEqual(["AAAA"]);
+  });
+
+  it("throws with the upstream status + body on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("404 Not Found", { status: 404 }))
+    );
+    const model = new OpenRouterImageModel("sk", "openai/does-not-exist");
+    await expect(model.doGenerate(callOptions())).rejects.toThrow(/404/);
+  });
+});
+
+describe("makeImageModelFor", () => {
+  it("returns a fal adapter for the fal provider", () => {
+    const m = makeImageModelFor("fal", "sk", "fal-ai/flux-2-pro");
+    expect(m).toBeInstanceOf(FalImageModel);
+    expect(m.provider).toBe("fal");
+    expect(m.modelId).toBe("fal-ai/flux-2-pro");
+  });
+
+  it("returns the OpenRouter unified-image adapter for openrouter", () => {
+    const m = makeImageModelFor(
+      "openrouter",
+      "sk",
+      "bytedance-seed/seedream-4.5"
+    );
+    expect(m).toBeInstanceOf(OpenRouterImageModel);
+    expect(m.provider).toBe("openrouter");
+  });
+
+  it("builds a vercel image model without throwing", () => {
+    expect(makeImageModelFor("vercel", "sk", "bfl/flux-2-pro")).toBeTruthy();
+  });
+});

--- a/packages/grida-ai-agent/src/providers/image-byok.ts
+++ b/packages/grida-ai-agent/src/providers/image-byok.ts
@@ -17,7 +17,12 @@
 import { createGateway } from "@ai-sdk/gateway";
 import type { ImageModelV3, ImageModelV3CallOptions } from "@ai-sdk/provider";
 import type { models } from "@grida/ai-models";
-import { falQueueOutcome, pollQueue, safeText } from "./fetch-helpers";
+import {
+  assertAllowedUrl,
+  falQueueOutcome,
+  pollQueue,
+  safeText,
+} from "./fetch-helpers";
 
 type ImageProvider = models.image.ImageProvider;
 
@@ -131,6 +136,9 @@ export class OpenRouterImageModel implements ImageModelV3 {
 // ── fal adapter ─────────────────────────────────────────────────────
 
 const FAL_QUEUE_BASE = "https://queue.fal.run";
+/** Hosts fal responses may point us at (queue + media CDN). A response that
+ *  redirects elsewhere must not receive the key or a sidecar fetch. */
+const FAL_HOSTS = ["*.fal.run", "fal.run", "fal.media", "*.fal.media"] as const;
 /** Total poll budget. fal image jobs are typically seconds; cap to stay bounded. */
 const FAL_POLL_TIMEOUT_MS = 120_000;
 const FAL_POLL_INTERVAL_MS = 1_000;
@@ -198,6 +206,12 @@ export class FalImageModel implements ImageModelV3 {
     }
     const submit = (await submitRes.json()) as FalSubmitResponse;
 
+    // GRIDA-SEC-004: the key-bearing poll/result fetches use URLs from the
+    // response body — pin them to fal hosts so a hostile response can't exfil
+    // the key or drive the sidecar to an arbitrary origin.
+    assertAllowedUrl(submit.status_url, FAL_HOSTS, "[fal] status_url");
+    assertAllowedUrl(submit.response_url, FAL_HOSTS, "[fal] response_url");
+
     // 2. poll until COMPLETED (bounded, abort-aware)
     await pollQueue<{ status: FalStatus }>(
       submit.status_url,
@@ -225,8 +239,14 @@ export class FalImageModel implements ImageModelV3 {
       images?: Array<{ url?: string; content_type?: string }>;
     };
     const entries = result.images ?? [];
+    if (entries.length === 0) {
+      throw new Error("[fal] response contained no image");
+    }
     const images = await Promise.all(
-      entries.map((img) => downloadToBytes(img.url, abortSignal))
+      entries.map((img) => {
+        assertAllowedUrl(img.url ?? "", FAL_HOSTS, "[fal] image url");
+        return downloadToBytes(img.url, abortSignal);
+      })
     );
 
     return {

--- a/packages/grida-ai-agent/src/providers/image-byok.ts
+++ b/packages/grida-ai-agent/src/providers/image-byok.ts
@@ -1,0 +1,267 @@
+/**
+ * BYOK image-model factories — the image counterpart of {@link ./byok.ts}.
+ *
+ * Like the language factories, these are isolated `@ai-sdk/*` provider
+ * consumers so client-safe entries never pull provider SDKs. Given the user's
+ * stored key and a provider-specific binding id (from a
+ * {@link models.image.ImageProviderBinding}), each returns an `ImageModelV3`
+ * that `ai`'s `generateImage()` can drive.
+ *
+ * Only the Vercel gateway speaks an SDK-native image protocol (`@ai-sdk/gateway`
+ * `.imageModel()`). The others need hand-written adapters: OpenRouter has its own
+ * dedicated Unified Image API (`POST /api/v1/images`; it 404s on OpenAI's
+ * `/images/generations`), and fal is queue-based REST (submit → poll → fetch).
+ * See {@link OpenRouterImageModel} and {@link FalImageModel}.
+ */
+
+import { createGateway } from "@ai-sdk/gateway";
+import type { ImageModelV3, ImageModelV3CallOptions } from "@ai-sdk/provider";
+import type { models } from "@grida/ai-models";
+import { falQueueOutcome, pollQueue, safeText } from "./fetch-helpers";
+
+type ImageProvider = models.image.ImageProvider;
+
+// Internal per-provider builders — the public entry is makeImageModelFor.
+function makeOpenRouterImageModel(apiKey: string, id: string): ImageModelV3 {
+  return new OpenRouterImageModel(apiKey, id);
+}
+
+function makeVercelImageModel(apiKey: string, id: string): ImageModelV3 {
+  return createGateway({ apiKey }).imageModel(id);
+}
+
+function makeFalImageModel(apiKey: string, id: string): ImageModelV3 {
+  return new FalImageModel(apiKey, id);
+}
+
+/**
+ * Build the `ImageModelV3` for a resolved (provider, binding-id) pair using the
+ * user's key. The single switch the image resolver calls.
+ */
+export function makeImageModelFor(
+  provider: ImageProvider,
+  apiKey: string,
+  id: string
+): ImageModelV3 {
+  switch (provider) {
+    case "openrouter":
+      return makeOpenRouterImageModel(apiKey, id);
+    case "vercel":
+      return makeVercelImageModel(apiKey, id);
+    case "fal":
+      return makeFalImageModel(apiKey, id);
+  }
+}
+
+// ── OpenRouter adapter ──────────────────────────────────────────────
+
+const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
+
+/**
+ * `ImageModelV3` over OpenRouter's dedicated Unified Image API
+ * (`POST /api/v1/images`). OpenRouter has NO OpenAI-style
+ * `/images/generations` endpoint — `@ai-sdk/openai-compatible`'s `.imageModel()`
+ * 404s there. The unified route normalizes `model`/`prompt`/`size`/
+ * `aspect_ratio`/`seed` across all OpenRouter image models and returns base64 in
+ * `data[].b64_json` (verified live 2026-06-29).
+ */
+export class OpenRouterImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "openrouter";
+  readonly maxImagesPerCall = 4;
+
+  constructor(
+    private readonly apiKey: string,
+    readonly modelId: string
+  ) {}
+
+  async doGenerate(
+    options: ImageModelV3CallOptions
+  ): Promise<Awaited<ReturnType<ImageModelV3["doGenerate"]>>> {
+    const { prompt, n, size, aspectRatio, seed, providerOptions, abortSignal } =
+      options;
+    const orExtra =
+      (providerOptions?.openrouter as Record<string, unknown> | undefined) ??
+      {};
+
+    const res = await fetch(OPENROUTER_IMAGE_URL, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        "content-type": "application/json",
+      },
+      signal: abortSignal,
+      body: JSON.stringify({
+        model: this.modelId,
+        prompt,
+        n,
+        ...(size ? { size } : {}),
+        ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
+        ...(seed !== undefined ? { seed } : {}),
+        ...orExtra,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `[openrouter] image request failed (${res.status}): ${await safeText(res)}`
+      );
+    }
+    const json = (await res.json()) as {
+      data?: Array<{ b64_json?: string }>;
+    };
+    const images = (json.data ?? [])
+      .map((d) => d.b64_json)
+      .filter((b): b is string => typeof b === "string" && b.length > 0);
+    if (images.length === 0) {
+      throw new Error("[openrouter] response contained no image data");
+    }
+    return {
+      images, // base64 strings — the AI SDK detects the media type
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+      providerMetadata: { openrouter: { images: images.map(() => ({})) } },
+    };
+  }
+}
+
+// ── fal adapter ─────────────────────────────────────────────────────
+
+const FAL_QUEUE_BASE = "https://queue.fal.run";
+/** Total poll budget. fal image jobs are typically seconds; cap to stay bounded. */
+const FAL_POLL_TIMEOUT_MS = 120_000;
+const FAL_POLL_INTERVAL_MS = 1_000;
+
+type FalSubmitResponse = {
+  request_id: string;
+  status_url: string;
+  response_url: string;
+};
+
+type FalStatus = "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED" | (string & {});
+
+/**
+ * Minimal `ImageModelV3` over fal's queue REST API.
+ *
+ * `modelId` is the fal endpoint id from the catalog binding, e.g.
+ * `fal-ai/flux-2-pro` or `fal-ai/bytedance/seedream/v4.5/text-to-image`.
+ */
+export class FalImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "fal";
+  readonly maxImagesPerCall = 4;
+
+  constructor(
+    private readonly apiKey: string,
+    readonly modelId: string
+  ) {}
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Key ${this.apiKey}`,
+      "content-type": "application/json",
+    };
+  }
+
+  async doGenerate(
+    options: ImageModelV3CallOptions
+  ): Promise<Awaited<ReturnType<ImageModelV3["doGenerate"]>>> {
+    const { prompt, n, size, aspectRatio, seed, providerOptions, abortSignal } =
+      options;
+
+    // fal accepts `image_size` either as an enum or `{ width, height }`.
+    const image_size = size ? whFromSize(size) : undefined;
+    const falExtra =
+      (providerOptions?.fal as Record<string, unknown> | undefined) ?? {};
+
+    // 1. submit
+    const submitRes = await fetch(`${FAL_QUEUE_BASE}/${this.modelId}`, {
+      method: "POST",
+      headers: this.headers(),
+      signal: abortSignal,
+      body: JSON.stringify({
+        prompt,
+        num_images: n,
+        ...(image_size ? { image_size } : {}),
+        ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
+        ...(seed !== undefined ? { seed } : {}),
+        ...falExtra,
+      }),
+    });
+    if (!submitRes.ok) {
+      throw new Error(
+        `[fal] submit failed (${submitRes.status}): ${await safeText(submitRes)}`
+      );
+    }
+    const submit = (await submitRes.json()) as FalSubmitResponse;
+
+    // 2. poll until COMPLETED (bounded, abort-aware)
+    await pollQueue<{ status: FalStatus }>(
+      submit.status_url,
+      {
+        headers: this.headers(),
+        timeoutMs: FAL_POLL_TIMEOUT_MS,
+        intervalMs: FAL_POLL_INTERVAL_MS,
+        label: "[fal]",
+        classify: falQueueOutcome,
+      },
+      abortSignal
+    );
+
+    // 3. fetch the result, download each image to bytes
+    const resultRes = await fetch(submit.response_url, {
+      headers: this.headers(),
+      signal: abortSignal,
+    });
+    if (!resultRes.ok) {
+      throw new Error(
+        `[fal] result fetch failed (${resultRes.status}): ${await safeText(resultRes)}`
+      );
+    }
+    const result = (await resultRes.json()) as {
+      images?: Array<{ url?: string; content_type?: string }>;
+    };
+    const entries = result.images ?? [];
+    const images = await Promise.all(
+      entries.map((img) => downloadToBytes(img.url, abortSignal))
+    );
+
+    return {
+      images,
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+      providerMetadata: {
+        fal: { images: entries.map((e) => ({ content_type: e.content_type })) },
+      },
+    };
+  }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+function whFromSize(size: `${number}x${number}`): {
+  width: number;
+  height: number;
+} {
+  const [w, h] = size.split("x").map(Number);
+  return { width: w, height: h };
+}
+
+async function downloadToBytes(
+  url: string | undefined,
+  abortSignal?: AbortSignal
+): Promise<Uint8Array> {
+  if (!url) throw new Error("[fal] result image has no url");
+  const res = await fetch(url, { signal: abortSignal });
+  if (!res.ok) {
+    throw new Error(`[fal] image download failed (${res.status})`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}

--- a/packages/grida-ai-agent/src/providers/index.ts
+++ b/packages/grida-ai-agent/src/providers/index.ts
@@ -26,7 +26,7 @@ import type { ModelFactory } from "../agent";
 import type { ModelTier } from "../tiers";
 import type { SecretsStore } from "../secrets";
 import {
-  BYOK_PROVIDER_METADATA,
+  byokProvidersFor,
   isByokProviderId,
   type ByokProviderId,
 } from "../protocol/provider-ids";
@@ -119,7 +119,10 @@ export async function resolveProvider(
     return await resolveExplicit(options.explicit, deps);
   }
 
-  for (const provider of BYOK_PROVIDER_METADATA) {
+  // Text path: only text-capable BYOK providers. An image-only provider
+  // (fal) may have a stored key, but it serves no chat models — skip it so a
+  // fal-only user falls through to endpoints rather than erroring.
+  for (const provider of byokProvidersFor("text")) {
     const key = await deps.secrets._getKey(provider.id);
     if (key) {
       return makeResolvedByok(provider.id, key);
@@ -168,6 +171,11 @@ function makeResolvedByok(
         kind: "byok",
         model_factory: makeVercelFactory(key.trim()),
       };
+    case "fal":
+      // fal is an image-only BYOK provider — it has no text/chat factory.
+      // The text precedence loop already skips it (see `byokProvidersFor`);
+      // this guards an explicit text pick of `fal`.
+      throw new ProviderUnavailableError(providerId);
   }
   const _exhaustive: never = providerId;
   throw new ProviderUnavailableError(_exhaustive);

--- a/packages/grida-ai-agent/src/providers/resolve-image.test.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-image.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { SecretsStore } from "../secrets";
+import { ImageModelUnavailableError, resolveImageModel } from "./resolve-image";
+
+/** Fake SecretsStore exposing only the `_getKey` the resolver uses. */
+function fakeSecrets(keys: Record<string, string>): SecretsStore {
+  return {
+    _getKey: async (id: string) => keys[id] ?? null,
+  } as unknown as SecretsStore;
+}
+
+// A universal listed card (binds vercel + fal + openrouter).
+const LISTED = "openai/gpt-image-2";
+// A kept-but-unlisted card (bfl/flux-kontext-max — not on OpenRouter).
+const UNLISTED = "bfl/flux-kontext-max";
+
+describe("resolveImageModel", () => {
+  it("resolves the only connected provider (one key serves the list)", async () => {
+    const r = await resolveImageModel(
+      { secrets: fakeSecrets({ fal: "sk-fal" }) },
+      LISTED
+    );
+    expect(r.provider_id).toBe("fal");
+    expect(r.model_id).toBe(LISTED);
+    expect(r.binding_id).toBe("fal-ai/gpt-image-2");
+    expect(r.model.provider).toBe("fal");
+  });
+
+  it("follows precedence when multiple keys exist (openrouter before fal)", async () => {
+    const r = await resolveImageModel(
+      { secrets: fakeSecrets({ fal: "sk-fal", openrouter: "sk-or" }) },
+      LISTED
+    );
+    expect(r.provider_id).toBe("openrouter");
+    expect(r.binding_id).toBe("openai/gpt-image-2");
+  });
+
+  it("honors an explicit provider pick", async () => {
+    const r = await resolveImageModel(
+      { secrets: fakeSecrets({ vercel: "sk-v", fal: "sk-fal" }) },
+      LISTED,
+      { explicit: "fal" }
+    );
+    expect(r.provider_id).toBe("fal");
+  });
+
+  it("throws when the explicit provider has no key", async () => {
+    await expect(
+      resolveImageModel({ secrets: fakeSecrets({ vercel: "sk-v" }) }, LISTED, {
+        explicit: "fal",
+      })
+    ).rejects.toBeInstanceOf(ImageModelUnavailableError);
+  });
+
+  it("throws when no provider key is present", async () => {
+    await expect(
+      resolveImageModel({ secrets: fakeSecrets({}) }, LISTED)
+    ).rejects.toBeInstanceOf(ImageModelUnavailableError);
+  });
+
+  it("rejects a non-listed card even with a matching key", async () => {
+    // flux-kontext-max binds fal, but it's not in the curated v1 BYOK surface.
+    await expect(
+      resolveImageModel({ secrets: fakeSecrets({ fal: "sk-fal" }) }, UNLISTED)
+    ).rejects.toBeInstanceOf(ImageModelUnavailableError);
+  });
+
+  it("rejects an unknown model id", async () => {
+    await expect(
+      resolveImageModel(
+        { secrets: fakeSecrets({ fal: "sk-fal" }) },
+        "nobody/nope"
+      )
+    ).rejects.toBeInstanceOf(ImageModelUnavailableError);
+  });
+});

--- a/packages/grida-ai-agent/src/providers/resolve-image.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-image.ts
@@ -99,7 +99,7 @@ export async function resolveImageModel(
       provider_id: provider,
       model_id: modelId,
       binding_id: binding.id,
-      model: makeImageModelFor(provider, key, binding.id),
+      model: makeImageModelFor(provider, key.trim(), binding.id),
     };
   }
 

--- a/packages/grida-ai-agent/src/providers/resolve-image.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-image.ts
@@ -1,0 +1,107 @@
+/**
+ * GRIDA-SEC-004 — image-model provider resolver (in-package providers layer).
+ *
+ * The image counterpart of {@link ./index.ts}'s `resolveProvider`. Given a
+ * canonical image-model id, it picks a provider the user has a key for and
+ * which serves that model, then builds the runnable `ImageModelV3`. Like the
+ * language resolver this is node-only and in-process: it reads the
+ * package-owned `SecretsStore` (credentials never cross IPC) and never calls
+ * the model — only constructs the factory.
+ *
+ * Precedence mirrors `resolveProvider`: `BYOK_PROVIDER_METADATA` order,
+ * intersected with (a) providers this card binds and (b) providers with a
+ * stored key. Because the curated list is **universal** (every `listed` card
+ * binds every provider — enforced by a catalog invariant test), one connected
+ * key serves the whole list. Non-`listed` cards are not part of the v1 BYOK
+ * surface and are rejected.
+ */
+
+import { models } from "@grida/ai-models";
+import type { ImageModelV3 } from "@ai-sdk/provider";
+import type { SecretsStore } from "../secrets";
+import { byokProvidersFor } from "../protocol/provider-ids";
+import { makeImageModelFor } from "./image-byok";
+
+type ImageProvider = models.image.ImageProvider;
+
+const IMAGE_PROVIDERS: readonly ImageProvider[] = [
+  "vercel",
+  "fal",
+  "openrouter",
+];
+
+function isImageProvider(id: string): id is ImageProvider {
+  return (IMAGE_PROVIDERS as readonly string[]).includes(id);
+}
+
+export type ResolvedImageModel = {
+  provider_id: ImageProvider;
+  /** Canonical catalog id (our key). */
+  model_id: string;
+  /** Provider-specific call id actually handed to the SDK. */
+  binding_id: string;
+  model: ImageModelV3;
+};
+
+/**
+ * One error class for both "unknown / not-listed model" and "you picked
+ * provider X but it isn't available". The route maps `provider_id` being
+ * present to a 4xx that surfaces the picked id.
+ */
+export class ImageModelUnavailableError extends Error {
+  readonly code = "image_model_unavailable" as const;
+  constructor(
+    public readonly model_id: string,
+    public readonly provider_id?: string
+  ) {
+    super(
+      provider_id
+        ? `[agent-host-images] explicit provider not available: ${provider_id} for ${model_id}`
+        : `[agent-host-images] no provider available for ${model_id}`
+    );
+    this.name = "ImageModelUnavailableError";
+  }
+}
+
+export type ResolveImageDeps = {
+  secrets: SecretsStore;
+};
+
+export type ResolveImageOptions = {
+  /** Caller override. If set, precedence is skipped and only this provider is checked. */
+  explicit?: ImageProvider;
+};
+
+export async function resolveImageModel(
+  deps: ResolveImageDeps,
+  modelId: string,
+  options: ResolveImageOptions = {}
+): Promise<ResolvedImageModel> {
+  const card = models.image.models[modelId];
+  // Unknown id, or a non-curated card (legacy / not universal) — not part of
+  // the v1 BYOK image surface.
+  if (!card || !card.listed) {
+    throw new ImageModelUnavailableError(modelId, options.explicit);
+  }
+
+  const order: ImageProvider[] = options.explicit
+    ? [options.explicit]
+    : byokProvidersFor("image")
+        .map((p) => p.id)
+        .filter(isImageProvider);
+
+  for (const provider of order) {
+    const binding = models.image.binding(card, provider);
+    if (!binding) continue;
+    const key = await deps.secrets._getKey(provider);
+    if (!key) continue;
+    return {
+      provider_id: provider,
+      model_id: modelId,
+      binding_id: binding.id,
+      model: makeImageModelFor(provider, key, binding.id),
+    };
+  }
+
+  throw new ImageModelUnavailableError(modelId, options.explicit);
+}

--- a/packages/grida-ai-agent/src/providers/resolve-video.test.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { SecretsStore } from "../secrets";
+import { VideoModelUnavailableError, resolveVideoModel } from "./resolve-video";
+
+function fakeSecrets(keys: Record<string, string>): SecretsStore {
+  return {
+    _getKey: async (id: string) => keys[id] ?? null,
+  } as unknown as SecretsStore;
+}
+
+// Veo 3.1 binds vercel + fal; Seedance 2.0 binds vercel only.
+const VEO = "google/veo-3.1";
+const SEEDANCE = "bytedance/seedance-2.0";
+
+describe("resolveVideoModel", () => {
+  it("resolves a connected provider that serves the model", async () => {
+    const r = await resolveVideoModel(
+      { secrets: fakeSecrets({ fal: "sk-fal" }) },
+      VEO
+    );
+    expect(r.provider_id).toBe("fal");
+    expect(r.binding_id).toBe("fal-ai/veo3.1/image-to-video");
+  });
+
+  it("prefers Vercel (video precedence) when both keys exist", async () => {
+    const r = await resolveVideoModel(
+      { secrets: fakeSecrets({ vercel: "sk-v", fal: "sk-fal" }) },
+      VEO
+    );
+    expect(r.provider_id).toBe("vercel");
+    expect(r.binding_id).toBe("google/veo-3.1-generate-001");
+  });
+
+  it("falls through when the only key's provider does not serve the model", async () => {
+    // Seedance has no fal binding — a fal-only user can't run it.
+    await expect(
+      resolveVideoModel({ secrets: fakeSecrets({ fal: "sk-fal" }) }, SEEDANCE)
+    ).rejects.toBeInstanceOf(VideoModelUnavailableError);
+  });
+
+  it("resolves Seedance with a Vercel key", async () => {
+    const r = await resolveVideoModel(
+      { secrets: fakeSecrets({ vercel: "sk-v" }) },
+      SEEDANCE
+    );
+    expect(r.provider_id).toBe("vercel");
+  });
+
+  it("resolves Veo and Seedance with an OpenRouter key", async () => {
+    const veo = await resolveVideoModel(
+      { secrets: fakeSecrets({ openrouter: "sk-or" }) },
+      VEO
+    );
+    expect(veo.provider_id).toBe("openrouter");
+    expect(veo.binding_id).toBe("google/veo-3.1");
+    const seedance = await resolveVideoModel(
+      { secrets: fakeSecrets({ openrouter: "sk-or" }) },
+      SEEDANCE
+    );
+    expect(seedance.provider_id).toBe("openrouter");
+  });
+
+  it("honors an explicit provider pick", async () => {
+    const r = await resolveVideoModel(
+      { secrets: fakeSecrets({ vercel: "sk-v", fal: "sk-fal" }) },
+      VEO,
+      { explicit: "fal" }
+    );
+    expect(r.provider_id).toBe("fal");
+  });
+
+  it("throws with no key", async () => {
+    await expect(
+      resolveVideoModel({ secrets: fakeSecrets({}) }, VEO)
+    ).rejects.toBeInstanceOf(VideoModelUnavailableError);
+  });
+
+  it("rejects an unknown model id", async () => {
+    await expect(
+      resolveVideoModel({ secrets: fakeSecrets({ vercel: "sk-v" }) }, "x/y")
+    ).rejects.toBeInstanceOf(VideoModelUnavailableError);
+  });
+});

--- a/packages/grida-ai-agent/src/providers/resolve-video.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.ts
@@ -1,0 +1,94 @@
+/**
+ * GRIDA-SEC-004 — video-model provider resolver. The video counterpart of
+ * {@link ./resolve-image.ts}.
+ *
+ * Given a canonical video-model id, picks a provider the user has a key for and
+ * which serves that model, then builds the runnable `VideoModelV3`. Reads the
+ * package-owned `SecretsStore` (credentials never cross IPC); never calls the
+ * model.
+ *
+ * Precedence: `byokProvidersFor("video")` order (Vercel → fal), intersected
+ * with providers this card binds and providers with a stored key. Unlike image,
+ * video is NOT universal — a connected provider may not serve every listed
+ * model, so resolution is genuinely per-model. Non-`listed` cards are rejected.
+ */
+
+import { models } from "@grida/ai-models";
+import type { Experimental_VideoModelV3 as VideoModelV3 } from "@ai-sdk/provider";
+import type { SecretsStore } from "../secrets";
+import { byokProvidersFor } from "../protocol/provider-ids";
+import { makeVideoModelFor } from "./video-byok";
+
+type VideoProvider = models.video.VideoProvider;
+
+const VIDEO_PROVIDERS: readonly VideoProvider[] = [
+  "vercel",
+  "fal",
+  "openrouter",
+];
+
+function isVideoProvider(id: string): id is VideoProvider {
+  return (VIDEO_PROVIDERS as readonly string[]).includes(id);
+}
+
+export type ResolvedVideoModel = {
+  provider_id: VideoProvider;
+  model_id: string;
+  binding_id: string;
+  model: VideoModelV3;
+};
+
+export class VideoModelUnavailableError extends Error {
+  readonly code = "video_model_unavailable" as const;
+  constructor(
+    public readonly model_id: string,
+    public readonly provider_id?: string
+  ) {
+    super(
+      provider_id
+        ? `[agent-host-video] explicit provider not available: ${provider_id} for ${model_id}`
+        : `[agent-host-video] no provider available for ${model_id}`
+    );
+    this.name = "VideoModelUnavailableError";
+  }
+}
+
+export type ResolveVideoDeps = {
+  secrets: SecretsStore;
+};
+
+export type ResolveVideoOptions = {
+  explicit?: VideoProvider;
+};
+
+export async function resolveVideoModel(
+  deps: ResolveVideoDeps,
+  modelId: string,
+  options: ResolveVideoOptions = {}
+): Promise<ResolvedVideoModel> {
+  const card = models.video.models[modelId];
+  if (!card || !card.listed) {
+    throw new VideoModelUnavailableError(modelId, options.explicit);
+  }
+
+  const order: VideoProvider[] = options.explicit
+    ? [options.explicit]
+    : byokProvidersFor("video")
+        .map((p) => p.id)
+        .filter(isVideoProvider);
+
+  for (const provider of order) {
+    const binding = models.video.binding(card, provider);
+    if (!binding) continue;
+    const key = await deps.secrets._getKey(provider);
+    if (!key) continue;
+    return {
+      provider_id: provider,
+      model_id: modelId,
+      binding_id: binding.id,
+      model: makeVideoModelFor(provider, key, binding.id),
+    };
+  }
+
+  throw new VideoModelUnavailableError(modelId, options.explicit);
+}

--- a/packages/grida-ai-agent/src/providers/resolve-video.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.ts
@@ -86,7 +86,7 @@ export async function resolveVideoModel(
       provider_id: provider,
       model_id: modelId,
       binding_id: binding.id,
-      model: makeVideoModelFor(provider, key, binding.id),
+      model: makeVideoModelFor(provider, key.trim(), binding.id),
     };
   }
 

--- a/packages/grida-ai-agent/src/providers/video-byok.test.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.test.ts
@@ -162,7 +162,7 @@ describe("FalVideoModel.doGenerate", () => {
 });
 
 describe("OpenRouterVideoModel.doGenerate", () => {
-  it("submits, polls, downloads the clip with auth, and returns base64", async () => {
+  it("submits, polls, downloads the unsigned clip WITHOUT the key, returns base64", async () => {
     const MP4 = new Uint8Array([0, 0, 0, 24]);
     let submit: Record<string, unknown> = {};
     let downloadAuth: string | undefined;
@@ -209,8 +209,8 @@ describe("OpenRouterVideoModel.doGenerate", () => {
       duration: 8,
     });
     expect(polls).toBe(2);
-    // downloaded with the key, returned as base64 bytes (not a remote url)
-    expect(downloadAuth).toBe("Bearer sk");
+    // GRIDA-SEC-004: unsigned (public) URL is fetched WITHOUT the key.
+    expect(downloadAuth).toBeUndefined();
     expect(result.videos).toEqual([
       {
         type: "base64",
@@ -218,6 +218,40 @@ describe("OpenRouterVideoModel.doGenerate", () => {
         mediaType: "video/mp4",
       },
     ]);
+  });
+
+  it("falls back to the authed /content endpoint WITH the key when no unsigned url", async () => {
+    let contentAuth: string | undefined;
+    let polls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        if (url === "https://openrouter.ai/api/v1/videos")
+          return new Response(
+            JSON.stringify({
+              id: "job_1",
+              polling_url: "https://openrouter.ai/api/v1/videos/job_1",
+            }),
+            { status: 200 }
+          );
+        if (url.includes("/content")) {
+          contentAuth = init.headers?.authorization;
+          return new Response(new Uint8Array([1, 2]), {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          });
+        }
+        polls++;
+        // completed, but NO unsigned_urls → must use the authed /content path
+        return new Response(JSON.stringify({ status: "completed" }), {
+          status: 200,
+        });
+      })
+    );
+    const model = new OpenRouterVideoModel("sk", "google/veo-3.1");
+    await model.doGenerate(callOptions());
+    expect(polls).toBe(1);
+    expect(contentAuth).toBe("Bearer sk");
   });
 
   it("throws when OpenRouter reports a failed job", async () => {

--- a/packages/grida-ai-agent/src/providers/video-byok.test.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions } from "@ai-sdk/provider";
+import {
+  FalVideoModel,
+  OpenRouterVideoModel,
+  makeVideoModelFor,
+} from "./video-byok";
+
+function callOptions(
+  over: Partial<VideoModelV3CallOptions> = {}
+): VideoModelV3CallOptions {
+  return {
+    prompt: "a cat surfing",
+    n: 1,
+    aspectRatio: "16:9",
+    resolution: undefined,
+    duration: 5,
+    fps: undefined,
+    seed: undefined,
+    image: undefined,
+    providerOptions: {},
+    ...over,
+  };
+}
+
+/** Shape of the `init` arg our `fetch` mocks read. */
+type MockInit = {
+  method?: string;
+  body?: string;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("FalVideoModel.doGenerate", () => {
+  it("submits, polls until COMPLETED, and returns the video url", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    let polls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        calls.push({
+          url,
+          method: init.method ?? "GET",
+          body: init.body ? JSON.parse(init.body ?? "{}") : undefined,
+        });
+        if (init.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              request_id: "r",
+              status_url: "https://queue.fal.run/r/status",
+              response_url: "https://queue.fal.run/r",
+            }),
+            { status: 200 }
+          );
+        }
+        if (url.endsWith("/status")) {
+          polls++;
+          return new Response(
+            JSON.stringify({ status: polls < 2 ? "IN_PROGRESS" : "COMPLETED" }),
+            { status: 200 }
+          );
+        }
+        if (url === "https://queue.fal.run/r") {
+          return new Response(
+            JSON.stringify({
+              video: {
+                url: "https://fal.media/v.mp4",
+                content_type: "video/mp4",
+              },
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response("not found", { status: 404 });
+      })
+    );
+
+    const model = new FalVideoModel("sk", "fal-ai/veo3.1/image-to-video");
+    const result = await model.doGenerate(
+      callOptions({ duration: 8, seed: 3 })
+    );
+
+    const submit = calls.find((c) => c.method === "POST")!;
+    expect(submit.url).toBe(
+      "https://queue.fal.run/fal-ai/veo3.1/image-to-video"
+    );
+    expect(submit.body).toMatchObject({
+      prompt: "a cat surfing",
+      aspect_ratio: "16:9",
+      duration: 8,
+      seed: 3,
+    });
+    expect(polls).toBe(2);
+    expect(result.videos).toEqual([
+      { type: "url", url: "https://fal.media/v.mp4", mediaType: "video/mp4" },
+    ]);
+    expect(result.response.modelId).toBe("fal-ai/veo3.1/image-to-video");
+  });
+
+  it("passes an input image as image_url for image-to-video", async () => {
+    let submitBody: Record<string, unknown> = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        if (init.method === "POST") {
+          submitBody = JSON.parse(init.body ?? "{}");
+          return new Response(
+            JSON.stringify({
+              request_id: "r",
+              status_url: "https://queue.fal.run/r/status",
+              response_url: "https://queue.fal.run/r",
+            }),
+            { status: 200 }
+          );
+        }
+        if (url.endsWith("/status")) {
+          return new Response(JSON.stringify({ status: "COMPLETED" }), {
+            status: 200,
+          });
+        }
+        return new Response(
+          JSON.stringify({ video: { url: "https://fal.media/v.mp4" } }),
+          { status: 200 }
+        );
+      })
+    );
+    const model = new FalVideoModel("sk", "fal-ai/veo3.1/image-to-video");
+    await model.doGenerate(
+      callOptions({
+        image: { type: "url", url: "https://x/frame.png" },
+      })
+    );
+    expect(submitBody.image_url).toBe("https://x/frame.png");
+  });
+
+  it("throws when fal reports a failed status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: MockInit = {}) => {
+        if (init.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              request_id: "r",
+              status_url: "https://queue.fal.run/r/status",
+              response_url: "https://queue.fal.run/r",
+            }),
+            { status: 200 }
+          );
+        }
+        return new Response(JSON.stringify({ status: "ERROR" }), {
+          status: 200,
+        });
+      })
+    );
+    const model = new FalVideoModel("sk", "fal-ai/x");
+    await expect(model.doGenerate(callOptions())).rejects.toThrow(/ERROR/);
+  });
+});
+
+describe("OpenRouterVideoModel.doGenerate", () => {
+  it("submits, polls, downloads the clip with auth, and returns base64", async () => {
+    const MP4 = new Uint8Array([0, 0, 0, 24]);
+    let submit: Record<string, unknown> = {};
+    let downloadAuth: string | undefined;
+    let polls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: MockInit = {}) => {
+        if (url === "https://openrouter.ai/api/v1/videos") {
+          submit = JSON.parse(init.body ?? "{}");
+          return new Response(
+            JSON.stringify({
+              id: "job_1",
+              polling_url: "https://openrouter.ai/api/v1/videos/job_1",
+            }),
+            { status: 200 }
+          );
+        }
+        if (url === "https://or.cdn/v.mp4") {
+          downloadAuth = init.headers?.authorization;
+          return new Response(MP4, {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          });
+        }
+        polls++;
+        return new Response(
+          JSON.stringify(
+            polls < 2
+              ? { status: "in_progress" }
+              : { status: "completed", unsigned_urls: ["https://or.cdn/v.mp4"] }
+          ),
+          { status: 200 }
+        );
+      })
+    );
+    const model = new OpenRouterVideoModel("sk", "google/veo-3.1");
+    const result = await model.doGenerate(
+      callOptions({ duration: 8, aspectRatio: "16:9" })
+    );
+    expect(submit).toMatchObject({
+      model: "google/veo-3.1",
+      prompt: "a cat surfing",
+      aspect_ratio: "16:9",
+      duration: 8,
+    });
+    expect(polls).toBe(2);
+    // downloaded with the key, returned as base64 bytes (not a remote url)
+    expect(downloadAuth).toBe("Bearer sk");
+    expect(result.videos).toEqual([
+      {
+        type: "base64",
+        data: Buffer.from(MP4).toString("base64"),
+        mediaType: "video/mp4",
+      },
+    ]);
+  });
+
+  it("throws when OpenRouter reports a failed job", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "https://openrouter.ai/api/v1/videos")
+          return new Response(JSON.stringify({ id: "j" }), { status: 200 });
+        return new Response(
+          JSON.stringify({ status: "failed", error: "nope" }),
+          {
+            status: 200,
+          }
+        );
+      })
+    );
+    const model = new OpenRouterVideoModel("sk", "google/veo-3.1");
+    await expect(model.doGenerate(callOptions())).rejects.toThrow(/failed/);
+  });
+});
+
+describe("makeVideoModelFor", () => {
+  it("returns a fal adapter for fal", () => {
+    const m = makeVideoModelFor("fal", "sk", "fal-ai/veo3.1/image-to-video");
+    expect(m).toBeInstanceOf(FalVideoModel);
+    expect(m.provider).toBe("fal");
+  });
+
+  it("returns the OpenRouter adapter for openrouter", () => {
+    const m = makeVideoModelFor("openrouter", "sk", "google/veo-3.1");
+    expect(m).toBeInstanceOf(OpenRouterVideoModel);
+    expect(m.provider).toBe("openrouter");
+  });
+
+  it("builds a vercel video model without throwing", () => {
+    expect(
+      makeVideoModelFor("vercel", "sk", "google/veo-3.1-generate-001")
+    ).toBeTruthy();
+  });
+});

--- a/packages/grida-ai-agent/src/providers/video-byok.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.ts
@@ -1,0 +1,346 @@
+/**
+ * BYOK video-model factories — the video counterpart of {@link ./image-byok.ts}.
+ *
+ * Given the user's stored key and a provider-specific binding id (from a
+ * {@link models.video.VideoProviderBinding}), each returns a `VideoModelV3`
+ * whose `doGenerate` the `/video/generate` route drives directly (so it can
+ * pass an optional input frame for image-to-video and return provider URLs).
+ *
+ * The Vercel gateway speaks SDK-native video (`@ai-sdk/gateway` `.videoModel()`).
+ * fal and OpenRouter are async REST (submit → poll → fetch) — see
+ * {@link FalVideoModel} (queue API) and {@link OpenRouterVideoModel}
+ * (`/api/v1/videos` job API). OpenRouter serves Veo + Seedance (not Grok 1.5).
+ */
+
+import { createGateway } from "@ai-sdk/gateway";
+import type {
+  // Video is still `Experimental_`-prefixed in @ai-sdk/provider's public
+  // exports (image is not). Alias to the stable internal names locally.
+  Experimental_VideoModelV3 as VideoModelV3,
+  Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions,
+} from "@ai-sdk/provider";
+import type { models } from "@grida/ai-models";
+import {
+  falQueueOutcome,
+  pollQueue,
+  safeText,
+  type PollOutcome,
+} from "./fetch-helpers";
+
+type VideoProvider = models.video.VideoProvider;
+
+// Internal per-provider builders — the public entry is makeVideoModelFor.
+function makeVercelVideoModel(apiKey: string, id: string): VideoModelV3 {
+  return createGateway({ apiKey }).videoModel(id);
+}
+
+function makeFalVideoModel(apiKey: string, id: string): VideoModelV3 {
+  return new FalVideoModel(apiKey, id);
+}
+
+function makeOpenRouterVideoModel(apiKey: string, id: string): VideoModelV3 {
+  return new OpenRouterVideoModel(apiKey, id);
+}
+
+/**
+ * Build the `VideoModelV3` for a resolved (provider, binding-id) pair. The
+ * single switch the video resolver calls.
+ */
+export function makeVideoModelFor(
+  provider: VideoProvider,
+  apiKey: string,
+  id: string
+): VideoModelV3 {
+  switch (provider) {
+    case "vercel":
+      return makeVercelVideoModel(apiKey, id);
+    case "fal":
+      return makeFalVideoModel(apiKey, id);
+    case "openrouter":
+      return makeOpenRouterVideoModel(apiKey, id);
+  }
+}
+
+// ── fal adapter ─────────────────────────────────────────────────────
+
+const FAL_QUEUE_BASE = "https://queue.fal.run";
+/** Video jobs are slower than image — allow a longer bounded poll budget. */
+const FAL_POLL_TIMEOUT_MS = 300_000;
+const FAL_POLL_INTERVAL_MS = 2_000;
+
+type FalSubmitResponse = {
+  request_id: string;
+  status_url: string;
+  response_url: string;
+};
+
+type FalStatus = "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED" | (string & {});
+
+/**
+ * Minimal `VideoModelV3` over fal's queue REST API. `modelId` is the fal
+ * endpoint id from the catalog binding (e.g. `fal-ai/veo3.1/image-to-video`).
+ * fal returns a video URL on its CDN, which we pass straight through.
+ */
+export class FalVideoModel implements VideoModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "fal";
+  readonly maxVideosPerCall = 1;
+
+  constructor(
+    private readonly apiKey: string,
+    readonly modelId: string
+  ) {}
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Key ${this.apiKey}`,
+      "content-type": "application/json",
+    };
+  }
+
+  async doGenerate(
+    options: VideoModelV3CallOptions
+  ): Promise<Awaited<ReturnType<VideoModelV3["doGenerate"]>>> {
+    const {
+      prompt,
+      aspectRatio,
+      resolution,
+      duration,
+      seed,
+      image,
+      providerOptions,
+      abortSignal,
+    } = options;
+    const falExtra =
+      (providerOptions?.fal as Record<string, unknown> | undefined) ?? {};
+
+    const submitRes = await fetch(`${FAL_QUEUE_BASE}/${this.modelId}`, {
+      method: "POST",
+      headers: this.headers(),
+      signal: abortSignal,
+      body: JSON.stringify({
+        prompt,
+        ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
+        ...(resolution ? { resolution } : {}),
+        ...(duration !== undefined ? { duration } : {}),
+        ...(seed !== undefined ? { seed } : {}),
+        // image-to-video: fal takes the start frame as `image_url`.
+        ...(image ? { image_url: fileToUrl(image) } : {}),
+        ...falExtra,
+      }),
+    });
+    if (!submitRes.ok) {
+      throw new Error(
+        `[fal] video submit failed (${submitRes.status}): ${await safeText(submitRes)}`
+      );
+    }
+    const submit = (await submitRes.json()) as FalSubmitResponse;
+
+    await pollQueue<{ status: FalStatus }>(
+      submit.status_url,
+      {
+        headers: this.headers(),
+        timeoutMs: FAL_POLL_TIMEOUT_MS,
+        intervalMs: FAL_POLL_INTERVAL_MS,
+        label: "[fal] video",
+        classify: falQueueOutcome,
+      },
+      abortSignal
+    );
+
+    const resultRes = await fetch(submit.response_url, {
+      headers: this.headers(),
+      signal: abortSignal,
+    });
+    if (!resultRes.ok) {
+      throw new Error(
+        `[fal] video result fetch failed (${resultRes.status}): ${await safeText(resultRes)}`
+      );
+    }
+    const result = (await resultRes.json()) as {
+      video?: { url?: string; content_type?: string };
+      videos?: Array<{ url?: string; content_type?: string }>;
+    };
+    const entries = result.videos ?? (result.video ? [result.video] : []);
+    const videos = entries
+      .filter((v) => typeof v.url === "string")
+      .map((v) => ({
+        type: "url" as const,
+        url: v.url as string,
+        mediaType: v.content_type ?? "video/mp4",
+      }));
+    if (videos.length === 0) {
+      throw new Error("[fal] response contained no video");
+    }
+
+    return {
+      videos,
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+      providerMetadata: {
+        fal: { videos: entries.map((e) => ({ content_type: e.content_type })) },
+      },
+    };
+  }
+}
+
+// ── OpenRouter adapter ──────────────────────────────────────────────
+
+const OPENROUTER_VIDEO_URL = "https://openrouter.ai/api/v1/videos";
+const OR_POLL_TIMEOUT_MS = 300_000;
+const OR_POLL_INTERVAL_MS = 2_000;
+
+type OrSubmitResponse = { id: string; polling_url?: string };
+type OrPollResponse = {
+  status?: string;
+  unsigned_urls?: string[];
+  error?: string;
+};
+
+/**
+ * `VideoModelV3` over OpenRouter's async Unified Video API (`POST
+ * /api/v1/videos` → job id → poll `polling_url` → `unsigned_urls[0]`). The
+ * `unsigned_urls` are public, so we hand the URL straight to the renderer (no
+ * auth needed to play it). Verified live 2026-06-29.
+ */
+export class OpenRouterVideoModel implements VideoModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "openrouter";
+  readonly maxVideosPerCall = 1;
+
+  constructor(
+    private readonly apiKey: string,
+    readonly modelId: string
+  ) {}
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.apiKey}`,
+      "content-type": "application/json",
+    };
+  }
+
+  async doGenerate(
+    options: VideoModelV3CallOptions
+  ): Promise<Awaited<ReturnType<VideoModelV3["doGenerate"]>>> {
+    const {
+      prompt,
+      aspectRatio,
+      resolution,
+      duration,
+      seed,
+      image,
+      providerOptions,
+      abortSignal,
+    } = options;
+    const orExtra =
+      (providerOptions?.openrouter as Record<string, unknown> | undefined) ??
+      {};
+
+    const submitRes = await fetch(OPENROUTER_VIDEO_URL, {
+      method: "POST",
+      headers: this.headers(),
+      signal: abortSignal,
+      body: JSON.stringify({
+        model: this.modelId,
+        prompt,
+        ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
+        // SDK `resolution` is `WxH`; OpenRouter's `size` takes that form
+        // (its `resolution` field is a label like "720p").
+        ...(resolution ? { size: resolution } : {}),
+        ...(duration !== undefined ? { duration } : {}),
+        ...(seed !== undefined ? { seed } : {}),
+        ...(image?.type === "url" ? { input_references: [image.url] } : {}),
+        ...orExtra,
+      }),
+    });
+    if (!submitRes.ok) {
+      throw new Error(
+        `[openrouter] video submit failed (${submitRes.status}): ${await safeText(submitRes)}`
+      );
+    }
+    const submit = (await submitRes.json()) as OrSubmitResponse;
+    const pollUrl =
+      submit.polling_url ?? `${OPENROUTER_VIDEO_URL}/${submit.id}`;
+
+    const poll = await pollQueue<OrPollResponse>(
+      pollUrl,
+      {
+        headers: this.headers(),
+        timeoutMs: OR_POLL_TIMEOUT_MS,
+        intervalMs: OR_POLL_INTERVAL_MS,
+        label: "[openrouter] video",
+        classify: orVideoOutcome,
+      },
+      abortSignal
+    );
+    const url =
+      poll.unsigned_urls?.[0] ??
+      `${OPENROUTER_VIDEO_URL}/${submit.id}/content?index=0`;
+
+    // Download in the sidecar (with the key) and return bytes — the URL is the
+    // authed OpenRouter content endpoint, which the renderer can neither auth
+    // nor reach under the desktop CSP. The route turns these bytes into a
+    // `data:` URL the <video> can play.
+    const dl = await fetch(url, {
+      headers: { authorization: `Bearer ${this.apiKey}` },
+      signal: abortSignal,
+    });
+    if (!dl.ok) {
+      throw new Error(
+        `[openrouter] video download failed (${dl.status}): ${await safeText(dl)}`
+      );
+    }
+    const data = Buffer.from(await dl.arrayBuffer()).toString("base64");
+
+    return {
+      videos: [
+        {
+          type: "base64",
+          data,
+          mediaType: dl.headers.get("content-type") ?? "video/mp4",
+        },
+      ],
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+      providerMetadata: { openrouter: { id: submit.id } },
+    };
+  }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/** OpenRouter video job status → {@link PollOutcome}. */
+function orVideoOutcome(body: OrPollResponse): PollOutcome {
+  if (body.status === "completed") return "done";
+  if (
+    body.status === "failed" ||
+    body.status === "cancelled" ||
+    body.status === "expired"
+  ) {
+    return {
+      failed: `generation ${body.status}${body.error ? `: ${body.error}` : ""}`,
+    };
+  }
+  return "pending";
+}
+
+/** A VideoModelV3File is a url or base64/binary file; fal wants a fetchable url. */
+function fileToUrl(
+  image: NonNullable<VideoModelV3CallOptions["image"]>
+): string {
+  if (image.type === "url") return image.url;
+  const data =
+    typeof image.data === "string"
+      ? image.data
+      : Buffer.from(image.data).toString("base64");
+  return `data:${image.mediaType};base64,${data}`;
+}

--- a/packages/grida-ai-agent/src/providers/video-byok.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.ts
@@ -21,6 +21,8 @@ import type {
 } from "@ai-sdk/provider";
 import type { models } from "@grida/ai-models";
 import {
+  assertAllowedUrl,
+  assertHttpsUrl,
   falQueueOutcome,
   pollQueue,
   safeText,
@@ -64,6 +66,10 @@ export function makeVideoModelFor(
 // ── fal adapter ─────────────────────────────────────────────────────
 
 const FAL_QUEUE_BASE = "https://queue.fal.run";
+/** Hosts fal/OpenRouter responses may point us at. Key-bearing fetches are
+ *  pinned to these so a hostile response can't exfil the key (GRIDA-SEC-004). */
+const FAL_HOSTS = ["*.fal.run", "fal.run", "fal.media", "*.fal.media"] as const;
+const OPENROUTER_HOSTS = ["openrouter.ai", "*.openrouter.ai"] as const;
 /** Video jobs are slower than image — allow a longer bounded poll budget. */
 const FAL_POLL_TIMEOUT_MS = 300_000;
 const FAL_POLL_INTERVAL_MS = 2_000;
@@ -135,6 +141,14 @@ export class FalVideoModel implements VideoModelV3 {
       );
     }
     const submit = (await submitRes.json()) as FalSubmitResponse;
+
+    // GRIDA-SEC-004: pin key-bearing fetches to fal hosts.
+    assertAllowedUrl(submit.status_url, FAL_HOSTS, "[fal] video status_url");
+    assertAllowedUrl(
+      submit.response_url,
+      FAL_HOSTS,
+      "[fal] video response_url"
+    );
 
     await pollQueue<{ status: FalStatus }>(
       submit.status_url,
@@ -266,6 +280,12 @@ export class OpenRouterVideoModel implements VideoModelV3 {
     const submit = (await submitRes.json()) as OrSubmitResponse;
     const pollUrl =
       submit.polling_url ?? `${OPENROUTER_VIDEO_URL}/${submit.id}`;
+    // GRIDA-SEC-004: the poll fetch carries the key — pin it to OpenRouter.
+    assertAllowedUrl(
+      pollUrl,
+      OPENROUTER_HOSTS,
+      "[openrouter] video polling_url"
+    );
 
     const poll = await pollQueue<OrPollResponse>(
       pollUrl,
@@ -287,8 +307,14 @@ export class OpenRouterVideoModel implements VideoModelV3 {
     // a `data:` URL the <video> plays.
     //
     // GRIDA-SEC-004: `unsigned_urls` are pre-signed public CDN links — fetch
-    // them WITHOUT the key, or the BYOK secret leaks to a third-party CDN host.
-    // Only the authed `/content` fallback gets the Authorization header.
+    // them WITHOUT the key (or the secret leaks to a third-party host), and
+    // require HTTPS. The authed `/content` fallback is pinned to OpenRouter and
+    // gets the Authorization header.
+    if (unsignedUrl) {
+      assertHttpsUrl(unsignedUrl, "[openrouter] video url");
+    } else {
+      assertAllowedUrl(url, OPENROUTER_HOSTS, "[openrouter] video content");
+    }
     const dl = await fetch(url, {
       headers: unsignedUrl ? {} : { authorization: `Bearer ${this.apiKey}` },
       signal: abortSignal,

--- a/packages/grida-ai-agent/src/providers/video-byok.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.ts
@@ -112,6 +112,7 @@ export class FalVideoModel implements VideoModelV3 {
       aspectRatio,
       resolution,
       duration,
+      fps,
       seed,
       image,
       providerOptions,
@@ -129,6 +130,7 @@ export class FalVideoModel implements VideoModelV3 {
         ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
         ...(resolution ? { resolution } : {}),
         ...(duration !== undefined ? { duration } : {}),
+        ...(fps !== undefined ? { fps } : {}),
         ...(seed !== undefined ? { seed } : {}),
         // image-to-video: fal takes the start frame as `image_url`.
         ...(image ? { image_url: fileToUrl(image) } : {}),
@@ -246,6 +248,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       aspectRatio,
       resolution,
       duration,
+      fps,
       seed,
       image,
       providerOptions,
@@ -267,6 +270,7 @@ export class OpenRouterVideoModel implements VideoModelV3 {
         // (its `resolution` field is a label like "720p").
         ...(resolution ? { size: resolution } : {}),
         ...(duration !== undefined ? { duration } : {}),
+        ...(fps !== undefined ? { fps } : {}),
         ...(seed !== undefined ? { seed } : {}),
         ...(image?.type === "url" ? { input_references: [image.url] } : {}),
         ...orExtra,

--- a/packages/grida-ai-agent/src/providers/video-byok.ts
+++ b/packages/grida-ai-agent/src/providers/video-byok.ts
@@ -278,16 +278,19 @@ export class OpenRouterVideoModel implements VideoModelV3 {
       },
       abortSignal
     );
+    const unsignedUrl = poll.unsigned_urls?.[0];
     const url =
-      poll.unsigned_urls?.[0] ??
-      `${OPENROUTER_VIDEO_URL}/${submit.id}/content?index=0`;
+      unsignedUrl ?? `${OPENROUTER_VIDEO_URL}/${submit.id}/content?index=0`;
 
-    // Download in the sidecar (with the key) and return bytes — the URL is the
-    // authed OpenRouter content endpoint, which the renderer can neither auth
-    // nor reach under the desktop CSP. The route turns these bytes into a
-    // `data:` URL the <video> can play.
+    // Download in the sidecar and return bytes — the renderer can't reach the
+    // content endpoint under the desktop CSP; the route turns these bytes into
+    // a `data:` URL the <video> plays.
+    //
+    // GRIDA-SEC-004: `unsigned_urls` are pre-signed public CDN links — fetch
+    // them WITHOUT the key, or the BYOK secret leaks to a third-party CDN host.
+    // Only the authed `/content` fallback gets the Authorization header.
     const dl = await fetch(url, {
-      headers: { authorization: `Bearer ${this.apiKey}` },
+      headers: unsignedUrl ? {} : { authorization: `Bearer ${this.apiKey}` },
       signal: abortSignal,
     });
     if (!dl.ok) {

--- a/packages/grida-ai-agent/src/sandbox/policy.ts
+++ b/packages/grida-ai-agent/src/sandbox/policy.ts
@@ -41,6 +41,12 @@ export type AgentHostSandboxPolicy = {
 const BYOK_PROVIDER_NETWORK_HOSTS = {
   openrouter: ["openrouter.ai"],
   vercel: ["ai-gateway.vercel.sh", "*.vercel-ai.com"],
+  // fal (#908) — BYOK image provider. Submit/poll/result ride the queue API
+  // (`queue.fal.run`); generated images download from the fal media CDN
+  // (`fal.media`, incl. `v3.fal.media`). srt `*.host` matches subdomains only,
+  // so the apexes are listed too. Same posture as the other BYOK hosts: the
+  // provider sees the prompt by design — not a new exfil class.
+  fal: ["fal.run", "*.fal.run", "fal.media", "*.fal.media"],
 } as const satisfies Record<ByokProviderId, readonly string[]>;
 
 /**

--- a/packages/grida-ai-agent/src/transport.ts
+++ b/packages/grida-ai-agent/src/transport.ts
@@ -17,6 +17,14 @@ import {
   type AgentLifecycleEvent,
 } from "./protocol/events";
 import type { AgentServerHandshakeResponse } from "./protocol/handshake";
+import type {
+  ImageGenerateRequest,
+  ImageGenerateResult,
+} from "./protocol/images";
+import type {
+  VideoGenerateRequest,
+  VideoGenerateResult,
+} from "./protocol/video";
 import type { AgentUIMessageChunk } from "./protocol/wire";
 import type {
   ChatMessageWithParts,
@@ -446,6 +454,24 @@ export namespace AgentTransport {
         installed: boolean;
         path?: string;
       }> => await this.postJson("/providers/claude/detect"),
+    } as const;
+
+    /** BYOK image generation (#908). Desktop-only; gated by the `images`
+     *  capability. Returns base64 bytes — never the user's key. */
+    readonly images = {
+      generate: async (
+        req: ImageGenerateRequest
+      ): Promise<ImageGenerateResult> =>
+        await this.postJson<ImageGenerateResult>("/images/generate", req),
+    } as const;
+
+    /** BYOK video generation (#908). Desktop-only; gated by the `video`
+     *  capability. Returns a provider URL (or base64) — never the user's key. */
+    readonly video = {
+      generate: async (
+        req: VideoGenerateRequest
+      ): Promise<VideoGenerateResult> =>
+        await this.postJson<VideoGenerateResult>("/video/generate", req),
     } as const;
 
     readonly sessions = {

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -112,6 +112,16 @@ Image pricing is a discriminated union:
 Audio models currently use flat per-run pricing. Image tools use flat
 per-invocation pricing.
 
+Image cards are multi-homed like video: each card holds a `providers` record of
+bindings — one per serving provider (`vercel` / `fal` / `openrouter`), each with
+that provider's own call `id` and pricing — alongside a top-level `provider` +
+`pricing` that name the **primary/default** binding (kept for the legacy
+single-provider readers). Resolve a route with
+`models.image.binding(card, provider)`. A `listed` boolean marks the curated,
+user-facing set (proprietary · SOTA · **universal**, so one BYOK key serves the
+whole list); non-universal/legacy cards stay in the catalog with `listed: false`
+and a `listed_reason`. `models.image.listed_models()` returns the curated set.
+
 Video is different: the provider ecosystem is fragmented, so a video card is
 **canonical** (provider-agnostic `vendor/model` id + intrinsic specs) and holds a
 `providers` record of bindings — one per serving provider (`vercel` / `fal` /

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -59,6 +59,58 @@ describe("models.image catalogue invariants", () => {
   });
 });
 
+describe("models.image provider-binding invariants", () => {
+  it("every card has at least one provider binding", () => {
+    for (const card of Object.values(models.image.models)) {
+      if (!card) continue;
+      expect(Object.keys(card.providers).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each binding's provider field matches its key", () => {
+    for (const card of Object.values(models.image.models)) {
+      if (!card) continue;
+      for (const [key, b] of Object.entries(card.providers)) {
+        if (!b) continue;
+        expect(b.provider).toBe(key);
+      }
+    }
+  });
+
+  it("the card's primary provider has a matching binding", () => {
+    for (const card of Object.values(models.image.models)) {
+      if (!card) continue;
+      expect(card.providers[card.provider]).toBeDefined();
+    }
+  });
+
+  it("listed cards are universal (served by every supported provider)", () => {
+    // The one-key promise: a single connected provider serves every listed
+    // card. If a listed card loses a binding, this fails loudly.
+    const ALL: models.image.ImageProvider[] = ["vercel", "fal", "openrouter"];
+    for (const card of models.image.listed_models()) {
+      for (const p of ALL) {
+        expect(models.image.binding(card, p)).not.toBeNull();
+      }
+    }
+  });
+
+  it("binding() resolves a present provider and nulls an absent one", () => {
+    const kontext = models.image.models["bfl/flux-kontext-max"]!;
+    expect(models.image.binding(kontext, "fal")?.id).toBe(
+      "fal-ai/flux-pro/kontext/max"
+    );
+    // Not on OpenRouter → no binding (why it is not listed).
+    expect(models.image.binding(kontext, "openrouter")).toBeNull();
+  });
+
+  it("listed_models returns only listed cards", () => {
+    for (const card of models.image.listed_models()) {
+      expect(card.listed).toBe(true);
+    }
+  });
+});
+
 describe("models.video catalogue invariants", () => {
   it("every dict key resolves to a defined card", () => {
     for (const id of Object.keys(models.video.models)) {
@@ -109,13 +161,26 @@ describe("models.video catalogue invariants", () => {
     expect(models.video.binding(veo, "vercel")?.id).toBe(
       "google/veo-3.1-generate-001"
     );
-    // OpenRouter has no verified per-second meter yet → no binding.
-    expect(models.video.binding(veo, "openrouter")).toBeNull();
+    // OpenRouter serves Veo + Seedance (verified rates).
+    expect(models.video.binding(veo, "openrouter")?.id).toBe("google/veo-3.1");
 
     const grok = models.video.models["xai/grok-imagine-video-1.5"]!;
     expect(models.video.binding(grok, "fal")?.id).toBe(
       "xai/grok-imagine-video/v1.5/image-to-video"
     );
+    // Grok 1.5 is NOT on OpenRouter (only 1.0) — correctly absent.
+    expect(models.video.binding(grok, "openrouter")).toBeNull();
+  });
+
+  it("listed video models are curated and each has at least one binding", () => {
+    const listed = models.video.listed_models();
+    expect(listed.length).toBeGreaterThan(0);
+    for (const card of listed) {
+      expect(card.listed).toBe(true);
+      // Video is fragmented (no universality guarantee) — only require that a
+      // listed model is servable by SOME provider.
+      expect(Object.keys(card.providers).length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -381,6 +381,10 @@ export namespace models {
       | "bfl/flux-kontext-max"
       | "bfl/flux-kontext-pro"
       | "bfl/flux-pro-1.1"
+      // ByteDance
+      | "bytedance/seedream-4.5"
+      // Recraft
+      | "recraft/recraft-v3"
       | (string & {});
 
     export type AspectRatioString = `${number}:${number}`;
@@ -478,6 +482,43 @@ export namespace models {
       | PerImageFlatPricing
       | PerTokenPricing;
 
+    // ── Providers ───────────────────────────────────────────────────
+
+    /**
+     * A provider that can serve an image model. Distinct from the top-level
+     * {@link models.Provider} because the same flagship proprietary model is
+     * now multi-homed: fal, OpenRouter, and the Vercel gateway each serve it
+     * under a different id (and sometimes a different meter). Mirrors
+     * {@link video.VideoProvider}.
+     */
+    export type ImageProvider = "vercel" | "fal" | "openrouter";
+
+    /**
+     * How one provider serves an image model: the id you actually call on that
+     * provider, plus that provider's own meter. The unit of provider-selection.
+     * Keyed by {@link ImageProvider} in {@link ImageModelCard.providers}, so
+     * `provider` here must equal that key. Mirrors {@link video.VideoProviderBinding}.
+     */
+    export type ImageProviderBinding = {
+      provider: ImageProvider;
+      /**
+       * Provider-specific call id. Format varies — `openai/gpt-image-2` (Vercel),
+       * `fal-ai/gpt-image-2` (fal), `openai/gpt-image-2` (OpenRouter).
+       */
+      id: string;
+      /** Real upstream pricing for **this** provider — meters differ across providers. */
+      pricing: ImageModelPricing;
+      /**
+       * Coarse provider cost per invocation in USD. For budget estimation;
+       * not for display.
+       */
+      avg_cost_usd: number;
+      /** Per-binding deprecation (a provider may retire a route independently). */
+      deprecated?: boolean;
+      /** Provider's page for this binding; UI falls back to the card. */
+      url?: string;
+    };
+
     // ── Size constraints ────────────────────────────────────────────
 
     /**
@@ -545,7 +586,28 @@ export namespace models {
       deprecated: boolean;
       short_description: string;
       vendor: Vendor;
+      /**
+       * Primary/default provider for legacy single-provider readers (the web
+       * Grida-billed path). Equals one of the keys in {@link providers}. Kept
+       * alongside {@link providers} so existing consumers compile unchanged.
+       */
       provider: Provider;
+      /**
+       * Whether this model is surfaced in the curated, user-facing list.
+       * Curation rule: proprietary · SOTA · **universal** (served by every
+       * supported provider, so one BYOK key serves the whole list). Models that
+       * fail the rule stay in the catalog (resolvable by id) but are hidden from
+       * the default picker. See {@link listed_reason}.
+       */
+      listed: boolean;
+      /** Why a card is `listed: false` (legacy, superseded, or not universal). */
+      listed_reason?: string;
+      /**
+       * Providers that serve this model, keyed by provider. **No implied
+       * preference** — default-provider selection is deferred to the runtime
+       * resolver. Mirrors {@link video.VideoModelCard.providers}.
+       */
+      providers: Partial<Record<ImageProvider, ImageProviderBinding>>;
       styles: string[] | null;
       speed_label: SpeedLabel;
       speed_max: string;
@@ -597,6 +659,37 @@ export namespace models {
           "State-of-the-art image generation and editing with flexible resolutions",
         vendor: "openai",
         provider: "vercel",
+        listed: true,
+        // ids/prices verified 2026-06-29, see github.com/gridaco/grida/issues/908
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "openai/gpt-image-2",
+            pricing: { type: "per_token", input: 5.0, output: 30.0 },
+            avg_cost_usd: 0.053,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "openai/gpt-image-2",
+            pricing: { type: "per_token", input: 8.0, output: 8.0 },
+            avg_cost_usd: 0.05,
+            url: "https://openrouter.ai/openai/gpt-image-2",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/gpt-image-2",
+            pricing: {
+              type: "per_image_tiered",
+              tiers: {
+                "low/1024x1024": 0.006,
+                "medium/1024x1024": 0.053,
+                "high/1024x1024": 0.211,
+              },
+            },
+            avg_cost_usd: 0.053,
+            url: "https://fal.ai/models/openai/gpt-image-2",
+          },
+        },
         speed_label: "medium",
         speed_max: "1m",
         styles: null,
@@ -650,6 +743,16 @@ export namespace models {
           "Previous-generation image model. Superseded by GPT Image 2.",
         vendor: "openai",
         provider: "vercel",
+        listed: false,
+        listed_reason: "Previous-generation model, superseded by GPT Image 2.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "openai/gpt-image-1.5",
+            pricing: { type: "per_token", input: 5.0, output: 32.0 },
+            avg_cost_usd: 0.034,
+          },
+        },
         speed_label: "medium",
         speed_max: "1m",
         styles: null,
@@ -697,6 +800,17 @@ export namespace models {
         short_description: "Cost-efficient image generation model",
         vendor: "openai",
         provider: "vercel",
+        listed: false,
+        listed_reason:
+          "Cost-tier model, not part of the curated flagship/SOTA list.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "openai/gpt-image-1-mini",
+            pricing: { type: "per_token", input: 2.0, output: 8.0 },
+            avg_cost_usd: 0.011,
+          },
+        },
         speed_label: "slow",
         speed_max: "1m",
         styles: null,
@@ -749,6 +863,30 @@ export namespace models {
           "Fast, efficient multimodal model with native image generation",
         vendor: "google",
         provider: "vercel",
+        listed: true,
+        // "Nano Banana 2"; ids/prices verified 2026-06-29, see issues/908
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "google/gemini-3.1-flash-image-preview",
+            pricing: { type: "per_token", input: 0.5, output: 3.0 },
+            avg_cost_usd: 0.004,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "google/gemini-3.1-flash-image",
+            pricing: { type: "per_token", input: 0.5, output: 3.0 },
+            avg_cost_usd: 0.004,
+            url: "https://openrouter.ai/google/gemini-3.1-flash-image",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/gemini-3.1-flash-image-preview",
+            pricing: { type: "per_image_flat", usd: 0.08 },
+            avg_cost_usd: 0.08,
+            url: "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview",
+          },
+        },
         speed_label: "fast",
         speed_max: "15s",
         styles: null,
@@ -772,6 +910,30 @@ export namespace models {
           "High-quality multimodal model with native image generation",
         vendor: "google",
         provider: "vercel",
+        listed: true,
+        // "Nano Banana Pro"; ids/prices verified 2026-06-29, see issues/908
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "google/gemini-3-pro-image",
+            pricing: { type: "per_token", input: 2.0, output: 12.0 },
+            avg_cost_usd: 0.015,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "google/gemini-3-pro-image-preview",
+            pricing: { type: "per_token", input: 2.0, output: 12.0 },
+            avg_cost_usd: 0.015,
+            url: "https://openrouter.ai/google/gemini-3-pro-image-preview",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/nano-banana-pro",
+            pricing: { type: "per_image_flat", usd: 0.15 },
+            avg_cost_usd: 0.15,
+            url: "https://fal.ai/models/fal-ai/nano-banana-pro",
+          },
+        },
         speed_label: "medium",
         speed_max: "30s",
         styles: null,
@@ -798,6 +960,31 @@ export namespace models {
           "Latest Flux model with best-in-class image quality and prompt adherence",
         vendor: "black-forest-labs",
         provider: "vercel",
+        listed: true,
+        // ids/prices verified 2026-06-29, see issues/908. OR/fal meter per-MP
+        // (~$0.03 first MP); represented as flat at the 1MP baseline.
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bfl/flux-2-pro",
+            pricing: { type: "per_image_flat", usd: 0.06 },
+            avg_cost_usd: 0.06,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "black-forest-labs/flux.2-pro",
+            pricing: { type: "per_image_flat", usd: 0.03 },
+            avg_cost_usd: 0.03,
+            url: "https://openrouter.ai/black-forest-labs/flux.2-pro",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/flux-2-pro",
+            pricing: { type: "per_image_flat", usd: 0.03 },
+            avg_cost_usd: 0.03,
+            url: "https://fal.ai/models/fal-ai/flux-2-pro",
+          },
+        },
         speed_label: "medium",
         speed_max: "30s",
         styles: null,
@@ -819,6 +1006,24 @@ export namespace models {
           "Highest quality Flux model for context-aware image generation and editing",
         vendor: "black-forest-labs",
         provider: "vercel",
+        listed: false,
+        listed_reason:
+          "Image-editing model; not on OpenRouter, so not universal (one-key) coverage.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bfl/flux-kontext-max",
+            pricing: { type: "per_image_flat", usd: 0.08 },
+            avg_cost_usd: 0.08,
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/flux-pro/kontext/max",
+            pricing: { type: "per_image_flat", usd: 0.08 },
+            avg_cost_usd: 0.08,
+            url: "https://fal.ai/models/fal-ai/flux-pro/kontext/max",
+          },
+        },
         speed_label: "slow",
         speed_max: "30s",
         styles: null,
@@ -839,6 +1044,17 @@ export namespace models {
         short_description: "Fast context-aware image generation and editing",
         vendor: "black-forest-labs",
         provider: "vercel",
+        listed: false,
+        listed_reason:
+          "Image-editing model; superseded by Flux 2 and not universal.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bfl/flux-kontext-pro",
+            pricing: { type: "per_image_flat", usd: 0.05 },
+            avg_cost_usd: 0.05,
+          },
+        },
         speed_label: "medium",
         speed_max: "20s",
         styles: null,
@@ -860,11 +1076,119 @@ export namespace models {
           "Faster, better FLUX Pro. Text-to-image model with excellent image quality and output diversity.",
         vendor: "black-forest-labs",
         provider: "vercel",
+        listed: false,
+        listed_reason: "Superseded by Flux 2 Pro; not universal.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bfl/flux-pro-1.1",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+          },
+        },
         speed_label: "slow",
         speed_max: "30s",
         styles: null,
         sizes: null,
         constraints: { min_edge: 256, max_edge: 1440 },
+        pricing: { type: "per_image_flat", usd: 0.04 },
+        avg_cost_usd: 0.04,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // ByteDance — Seedream 4.5
+      // -----------------------------------------------------------------
+      // Universal: $0.04/img identical on all three providers (verified
+      // 2026-06-29, see github.com/gridaco/grida/issues/908).
+      "bytedance/seedream-4.5": {
+        id: "bytedance/seedream-4.5",
+        label: "Seedream 4.5",
+        deprecated: false,
+        short_description:
+          "ByteDance's unified image generation and editing model.",
+        vendor: "bytedance",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bytedance/seedream-4.5",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "bytedance-seed/seedream-4.5",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+            url: "https://openrouter.ai/bytedance-seed/seedream-4.5",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/bytedance/seedream/v4.5/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+            url: "https://fal.ai/models/fal-ai/bytedance/seedream/v4.5/text-to-image",
+          },
+        },
+        speed_label: "fast",
+        speed_max: "15s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 4096 },
+        pricing: { type: "per_image_flat", usd: 0.04 },
+        avg_cost_usd: 0.04,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // Recraft — V3
+      // -----------------------------------------------------------------
+      // Universal: ~$0.04/img across providers (verified 2026-06-29, see
+      // issues/908). OpenRouter org slug is `recraft`, not `recraft-ai`.
+      "recraft/recraft-v3": {
+        id: "recraft/recraft-v3",
+        label: "Recraft V3",
+        deprecated: false,
+        short_description:
+          "Design-grade image model with strong text rendering and vector styles.",
+        vendor: "recraft-ai",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "recraft/recraft-v3",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "recraft/recraft-v3",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+            url: "https://openrouter.ai/recraft/recraft-v3",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/recraft/v3/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+            url: "https://fal.ai/models/fal-ai/recraft/v3/text-to-image",
+          },
+        },
+        speed_label: "medium",
+        speed_max: "30s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 2048 },
         pricing: { type: "per_image_flat", usd: 0.04 },
         avg_cost_usd: 0.04,
         default: {
@@ -904,6 +1228,25 @@ export namespace models {
       }
       return null;
     }
+
+    /**
+     * The binding for a specific provider, or `null` if that provider does
+     * not serve this model. Mirrors {@link video.binding}.
+     */
+    export function binding(
+      card: ImageModelCard,
+      provider: ImageProvider
+    ): ImageProviderBinding | null {
+      return card.providers[provider] ?? null;
+    }
+
+    let _listed: ImageModelCard[] | null = null;
+    /** Cards in the curated user-facing list (`listed: true`). Computed once —
+     *  the catalog is static, so callers (pickers, settings) can call freely. */
+    export const listed_models = (): ImageModelCard[] =>
+      (_listed ??= Object.values(models).filter(
+        (card): card is ImageModelCard => !!card && card.listed
+      ));
   }
 
   // ── models.audio ──────────────────────────────────────────────────
@@ -1121,6 +1464,16 @@ export namespace models {
       deprecated: boolean;
       short_description: string;
       vendor: Vendor;
+      /**
+       * Whether this model is surfaced in the curated, user-facing list.
+       * Unlike image (where `listed` also implies universal coverage), the
+       * video provider ecosystem is fragmented — no model is on every provider
+       * — so `listed` here means proprietary · SOTA only. The runtime resolver
+       * still gates per-model on which provider the user actually connected.
+       */
+      listed: boolean;
+      /** Why a card is `listed: false` (legacy or superseded). */
+      listed_reason?: string;
       /** Supported aspect ratios. */
       aspect_ratios: image.AspectRatioString[];
       /** Inclusive output-duration bounds, in seconds. */
@@ -1157,6 +1510,7 @@ export namespace models {
         short_description:
           "Google's flagship video model — strong prompt adherence with native, synchronized audio.",
         vendor: "google",
+        listed: true,
         aspect_ratios: ["16:9", "9:16"],
         min_duration: 4,
         max_duration: 8,
@@ -1205,9 +1559,22 @@ export namespace models {
             avg_cost_usd: 3.2, // 1080p audio × 8s default
             url: "https://fal.ai/models/fal-ai/veo3.1/image-to-video",
           },
-          // OpenRouter also serves it as `google/veo-3.1`, but its API surfaces
-          // only token pricing ($0/MTok) for video — no usable per-second
-          // meter confirmed. Add a binding once a real rate is verified.
+          // OpenRouter — async `/api/v1/videos` (job → poll → unsigned url).
+          // Text-to-video + image-to-video; native audio. "from $0.40/s"
+          // (verified 2026-06-29, https://openrouter.ai/google/veo-3.1).
+          openrouter: {
+            provider: "openrouter",
+            id: "google/veo-3.1",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.4 },
+                "1080p": { audio: 0.4 },
+              },
+            },
+            avg_cost_usd: 3.2, // 1080p audio × 8s default
+            url: "https://openrouter.ai/google/veo-3.1",
+          },
         },
       },
       // -----------------------------------------------------------------
@@ -1220,6 +1587,7 @@ export namespace models {
         short_description:
           "ByteDance's state-of-the-art video model — top-tier image-to-video with reference and editing modes.",
         vendor: "bytedance",
+        listed: true,
         aspect_ratios: ["16:9", "9:16", "1:1"],
         min_duration: 5,
         max_duration: 15,
@@ -1250,6 +1618,23 @@ export namespace models {
             },
             avg_cost_usd: 1.0, // 720p audio × 5s default (≈ $0.995)
           },
+          // OpenRouter — async `/api/v1/videos`. Flat $0.06726/s (verified
+          // 2026-06-29, https://openrouter.ai/bytedance/seedance-2.0) — far
+          // below Vercel's per-resolution rate (the proprietary-pricing-
+          // diverges finding, #908). No separate silent meter surfaced.
+          openrouter: {
+            provider: "openrouter",
+            id: "bytedance/seedance-2.0",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.06726 },
+                "720p": { audio: 0.06726 },
+              },
+            },
+            avg_cost_usd: 0.34, // 720p audio × 5s default
+            url: "https://openrouter.ai/bytedance/seedance-2.0",
+          },
           // Also served by fal.ai and Replicate — add those bindings once
           // their per-second rates are verified.
         },
@@ -1269,6 +1654,7 @@ export namespace models {
         short_description:
           "xAI's image-to-video model — animates a still into cinematic video with native, lip-synced audio.",
         vendor: "xai",
+        listed: true,
         aspect_ratios: ["16:9", "9:16"],
         min_duration: 5,
         max_duration: 15,
@@ -1328,6 +1714,14 @@ export namespace models {
     ): VideoProviderBinding | null {
       return card.providers[provider] ?? null;
     }
+
+    let _listed: VideoModelCard[] | null = null;
+    /** Cards in the curated user-facing list (`listed: true`). Computed once —
+     *  the catalog is static, so callers (pickers, settings) can call freely. */
+    export const listed_models = (): VideoModelCard[] =>
+      (_listed ??= Object.values(models).filter(
+        (card): card is VideoModelCard => !!card && card.listed
+      ));
   }
 
   // ── models.image_tools ────────────────────────────────────────────

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -1240,12 +1240,15 @@ export namespace models {
       return card.providers[provider] ?? null;
     }
 
-    let _listed: ImageModelCard[] | null = null;
-    /** Cards in the curated user-facing list (`listed: true`). Computed once —
-     *  the catalog is static, so callers (pickers, settings) can call freely. */
-    export const listed_models = (): ImageModelCard[] =>
-      (_listed ??= Object.values(models).filter(
-        (card): card is ImageModelCard => !!card && card.listed
+    let _listed: readonly ImageModelCard[] | null = null;
+    /** Cards in the curated user-facing list (`listed: true`). Computed once and
+     *  frozen — the catalog is static, so callers can call freely without
+     *  risking mutation of the shared view. */
+    export const listed_models = (): readonly ImageModelCard[] =>
+      (_listed ??= Object.freeze(
+        Object.values(models).filter(
+          (card): card is ImageModelCard => !!card && card.listed
+        )
       ));
   }
 
@@ -1715,12 +1718,15 @@ export namespace models {
       return card.providers[provider] ?? null;
     }
 
-    let _listed: VideoModelCard[] | null = null;
-    /** Cards in the curated user-facing list (`listed: true`). Computed once —
-     *  the catalog is static, so callers (pickers, settings) can call freely. */
-    export const listed_models = (): VideoModelCard[] =>
-      (_listed ??= Object.values(models).filter(
-        (card): card is VideoModelCard => !!card && card.listed
+    let _listed: readonly VideoModelCard[] | null = null;
+    /** Cards in the curated user-facing list (`listed: true`). Computed once and
+     *  frozen — the catalog is static, so callers can call freely without
+     *  risking mutation of the shared view. */
+    export const listed_models = (): readonly VideoModelCard[] =>
+      (_listed ??= Object.freeze(
+        Object.values(models).filter(
+          (card): card is VideoModelCard => !!card && card.listed
+        )
       ));
   }
 

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -14,6 +14,10 @@ import type {
   ProviderId,
   EndpointProviderConfig,
   ProbedEndpointModel,
+  ImageGenerateRequest,
+  ImageGenerateResult,
+  VideoGenerateRequest,
+  VideoGenerateResult,
   ChatMessageWithParts,
   ChatSessionRow,
   CreateSessionOptions,
@@ -304,6 +308,23 @@ export type DesktopBridge = {
      *  filesystem probe, NOT a login check (login surfaces on the first run).
      *  Optional — older binaries lack it; renderers feature-detect. */
     detect_claude?: () => Promise<{ installed: boolean; path?: string }>;
+  };
+  /**
+   * BYOK image generation (#908). Desktop-only: the request resolves the
+   * user's connected provider key inside the sidecar and returns base64 image
+   * bytes — never the key. Optional — older binaries lack it; renderers
+   * feature-detect and hide the surface when absent.
+   */
+  images?: {
+    generate: (req: ImageGenerateRequest) => Promise<ImageGenerateResult>;
+  };
+  /**
+   * BYOK video generation (#908). Desktop-only; resolves the user's key in the
+   * sidecar and returns a provider URL (or base64) — never the key. Optional —
+   * older binaries lack it; renderers feature-detect.
+   */
+  video?: {
+    generate: (req: VideoGenerateRequest) => Promise<VideoGenerateResult>;
   };
   agent: {
     run: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,7 +1077,7 @@ importers:
         specifier: 2.0.48
         version: 2.0.48(zod@4.3.6)
       '@ai-sdk/provider':
-        specifier: ^3.0.0
+        specifier: 3.0.10
         version: 3.0.10
       '@grida/ai-models':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@react-three/drei':
         specifier: ^10.0.7
         version: 10.7.7(@react-three/fiber@9.1.2(@types/react@19.1.3)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0))(@types/react@19.1.3)(@types/three@0.170.0)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0)
@@ -119,16 +119,16 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/plugin-sitemap':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.10.0
-        version: 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
       '@docusaurus/theme-mermaid':
         specifier: 3.10.0
-        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.1.0
         version: 3.1.1(@types/react@19.1.3)(react@19.2.5)
@@ -147,13 +147,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/tsconfig':
         specifier: 3.10.0
         version: 3.10.0
       '@docusaurus/types':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: 19.1.3
         version: 19.1.3
@@ -168,19 +168,19 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/plugin-client-redirects':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/plugin-google-gtag':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/plugin-sitemap':
         specifier: 3.10.0
-        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.10.0
-        version: 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.1.0
         version: 3.1.1(@types/react@19.1.3)(react@19.2.5)
@@ -208,13 +208,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/tsconfig':
         specifier: 3.10.0
         version: 3.10.0
       '@docusaurus/types':
         specifier: 3.10.0
-        version: 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -468,7 +468,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.5))
       '@mdx-js/loader':
         specifier: ^3.0.1
-        version: 3.1.1(acorn@8.16.0)(webpack@5.98.0)
+        version: 3.1.1(acorn@8.17.0)(webpack@5.98.0)
       '@mdx-js/react':
         specifier: ^3.1.0
         version: 3.1.1(@types/react@19.1.3)(react@19.2.5)
@@ -480,10 +480,10 @@ importers:
         version: 4.7.0(monaco-editor@0.47.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@next/mdx':
         specifier: 16.2.6
-        version: 16.2.6(@mdx-js/loader@3.1.1(acorn@8.16.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))
+        version: 16.2.6(@mdx-js/loader@3.1.1(acorn@8.17.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@number-flow/react':
         specifier: ^0.5.7
         version: 0.5.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -519,7 +519,7 @@ importers:
         version: 0.0.38(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^10.34.0
-        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)
+        version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)
       '@stepperize/react':
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.5)
@@ -612,10 +612,10 @@ importers:
         version: 10.3.1(react@19.2.5)
       '@vercel/analytics':
         specifier: ^1.3.1
-        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
+        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
       '@vercel/edge-config':
         specifier: ^1.2.1
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@vercel/functions':
         specifier: ^1.6.0
         version: 1.6.0
@@ -624,7 +624,7 @@ importers:
         version: 1.19.1
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
+        version: 1.3.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))
       '@visx/responsive':
         specifier: ^3.10.2
         version: 3.12.0(react@19.2.5)
@@ -798,7 +798,7 @@ importers:
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       openai:
         specifier: 6.18.0
-        version: 6.18.0(ws@8.19.0)(zod@4.3.6)
+        version: 6.18.0(ws@8.21.0)(zod@4.3.6)
       p-queue:
         specifier: ^7.2.0
         version: 7.4.1
@@ -1076,6 +1076,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: 2.0.48
         version: 2.0.48(zod@4.3.6)
+      '@ai-sdk/provider':
+        specifier: ^3.0.0
+        version: 3.0.10
       '@grida/ai-models':
         specifier: workspace:*
         version: link:../grida-ai-models
@@ -17153,7 +17156,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17165,7 +17168,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.3
       tslib: 2.8.1
@@ -17179,14 +17182,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.0(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/bundler@3.10.0(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/babel': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/cssnano-preset': 3.10.0
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.98.0)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.98.0)
@@ -17221,15 +17224,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/core@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.10.0(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/babel': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/bundler': 3.10.0(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.1.3)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -17297,12 +17300,12 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.3.2
@@ -17333,9 +17336,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.1.3
       '@types/react-router-config': 5.0.11
@@ -17352,13 +17355,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-client-redirects@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       eta: 2.2.0
       fs-extra: 11.3.3
       lodash: 4.17.21
@@ -17384,17 +17387,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-blog@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -17427,17 +17430,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
@@ -17468,13 +17471,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-pages@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17499,12 +17502,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -17527,11 +17530,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-debug@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17556,11 +17559,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-analytics@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -17583,11 +17586,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-gtag@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17611,11 +17614,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -17638,14 +17641,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-sitemap@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17670,12 +17673,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-svgr@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.5
@@ -17701,23 +17704,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/preset-classic@3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-classic': 3.10.0(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-debug': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-analytics': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-sitemap': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-svgr': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-classic': 3.10.0(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-search-algolia': 3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -17747,21 +17750,21 @@ snapshots:
       '@types/react': 19.1.3
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.0(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/theme-classic@3.10.0(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-blog': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.1.3)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -17796,13 +17799,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.1.3
       '@types/react-router-config': 5.0.11
@@ -17821,13 +17824,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/theme-mermaid@3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/module-type-aliases': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       mermaid: 11.12.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -17852,17 +17855,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/theme-search-algolia@3.10.0(@algolia/client-search@5.48.0)(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(@types/react@19.1.3)(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.48.0)(algoliasearch@5.48.0)(search-insights@2.17.3)
       '@docsearch/react': 4.5.4(@algolia/client-search@5.48.0)(@types/react@19.1.3)(algoliasearch@5.48.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.16.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))(acorn@8.17.0)(lightningcss@1.30.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       algoliasearch: 5.48.0
       algoliasearch-helper: 3.27.0(algoliasearch@5.48.0)
       clsx: 2.1.1
@@ -17902,9 +17905,9 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.0': {}
 
-  '@docusaurus/types@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
       '@types/react': 19.1.3
@@ -17924,9 +17927,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -17938,11 +17941,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/utils': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.3
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -17958,11 +17961,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.0
-      '@docusaurus/types': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.0(acorn@8.16.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.0(acorn@8.17.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.98.0)
@@ -18743,9 +18746,9 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mdx-js/loader@3.1.1(acorn@8.16.0)(webpack@5.98.0)':
+  '@mdx-js/loader@3.1.1(acorn@8.17.0)(webpack@5.98.0)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       source-map: 0.7.4
     optionalDependencies:
       webpack: 5.98.0
@@ -18753,7 +18756,7 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
+  '@mdx-js/mdx@3.1.0(acorn@8.17.0)':
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -18767,7 +18770,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.16.0)
+      recma-jsx: 1.0.0(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -18886,11 +18889,11 @@ snapshots:
 
   '@next/env@16.2.6': {}
 
-  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1(acorn@8.16.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))':
+  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1(acorn@8.17.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      '@mdx-js/loader': 3.1.1(acorn@8.16.0)(webpack@5.98.0)
+      '@mdx-js/loader': 3.1.1(acorn@8.17.0)(webpack@5.98.0)
       '@mdx-js/react': 3.1.1(@types/react@19.1.3)(react@19.2.5)
 
   '@next/swc-darwin-arm64@16.2.6':
@@ -18917,7 +18920,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -20811,7 +20814,7 @@ snapshots:
 
   '@sentry/core@10.38.0': {}
 
-  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)':
+  '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.98.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -22119,7 +22122,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.5
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
+  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -22128,7 +22131,7 @@ snapshots:
 
   '@vercel/edge-config-fs@0.1.0': {}
 
-  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
@@ -22149,7 +22152,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vercel/speed-insights@1.3.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
+  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@4.2.19)(vue@3.5.13(typescript@6.0.3))':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
@@ -22817,6 +22820,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.16.0
@@ -22830,8 +22837,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acorn@8.17.0:
-    optional: true
+  acorn@8.17.0: {}
 
   address@1.2.2: {}
 
@@ -22978,7 +22984,7 @@ snapshots:
 
   aria-query@4.2.2:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.26.9
 
   aria-query@5.3.2:
@@ -25441,7 +25447,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -27474,9 +27480,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.18.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.18.0(ws@8.21.0)(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.21.0
       zod: 4.3.6
 
   openapi-types@12.1.3: {}
@@ -28994,9 +29000,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.16.0):
+  recma-jsx@1.0.0(acorn@8.17.0):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -29040,7 +29046,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   regex-recursion@6.0.2:
     dependencies:


### PR DESCRIPTION
Closes part of #908 (engine + v1 desktop UI); delivers #876 (fal as an image/video provider). Remaining UX polish is tracked as follow-ups (below).

## What & why

The catalog bound each image model to a **single** provider and image generation was hardcoded to the Vercel gateway. But the same flagship models are now multi-homed (fal · OpenRouter · Vercel). This makes **the model the unit**, bound to one-or-many providers, so a user with **one BYOK key** gets a curated list working and every call routes to a provider that actually serves the picked model.

BYOK media generation runs **inside the desktop agent sidecar** (where keys legally live per GRIDA-SEC-004), separate from the untouched web Grida-billed path.

## What's landed

- **Catalog (`@grida/ai-models`)** — `ImageModelCard` gains a multi-binding `providers` map (mirroring video) + a `listed` curation flag + `image.binding()`/`listed_models()`; video cards gain `listed`. Curated universal image set with verified per-binding ids/prices; legacy ids kept `listed:false`. A universality invariant test gates the one-key promise.
- **Agent (`@grida/agent`)** — model→provider resolvers; BYOK adapters (Vercel gateway + custom OpenRouter unified-API and fal queue `ImageModelV3`/`VideoModelV3`); `POST /images/generate` + `/video/generate` (`images@1`/`video@1` capabilities); `images`/`video` loopback transport. `fal` joins BYOK metadata behind a `modalities` marker so the text resolver skips image-only providers; fal egress added to the SEC-004 sandbox allowlist.
- **Desktop** — `images`/`video` bridge namespaces; `/desktop/images` + `/desktop/video` playgrounds (gallery + floating composer, provider-hidden pickers, model-aware settings); Settings "Image/Video models" sections with readiness + "Try this model". CSP gains `media-src 'self' data: blob:` (+ a contract test) so sidecar-returned clips play as `data:`/`blob:`.

## Verified

- **Live image generation proven end-to-end** with a real OpenRouter key (resolver → adapter → real `/v1/images` → 2048² JPEG of the prompt).
- **650 agent tests pass** (adapters, resolvers, routes, billing-isolation, universality gate, public-API); typecheck clean; lint clean; format clean.

## Known limitations / follow-ups (not in this PR)

- **"One key unlocks all" holds for image, not video** — video providers are fragmented (e.g. Seedance is Vercel-only), so a connected user can be offered a video model their key can't serve (graceful error today, not a crash). Grey-out is the top follow-up.
- Settings still shows raw per-provider key slots (not the "connect one account / providers-invisible" UX from #908), no routing preference (cheapest/fastest), no plain-language error mapping, no "best for" model copy.
- **Video not yet live-verified** (no Vercel/fal key on hand; image path proven).
- Audio/TTS deferred per #908.

## Security (GRIDA-SEC-004)

BYOK keys are read only inside the sidecar; the `/images|/video/generate` responses carry bytes only (never the key, never raw upstream JSON). `model_id` is a closed catalog lookup and `provider` is a fixed enum — no user-supplied base URL, no new egress beyond the three provider hosts (added to the sandbox allowlist). The BYOK path never enters the Grida-billed seam (asserted by test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop image and video generation pages with model pickers, prompt templates, gallery-style playrooms, and fullscreen/media viewers.
  * Extended desktop integration with feature-detected image/video generation capabilities and deep-links to preselected models.
  * Surfaced image/video model options in desktop settings when supported.
* **Bug Fixes**
  * Tightened capability gating and ensured media generation routes validate inputs and return safe, consistent error responses.
* **Tests**
  * Added/expanded contract tests for desktop CSP and image/video generation endpoints, plus BYOK provider/resolution validation.
* **Documentation**
  * Updated media model docs for multi-provider bindings and listed-model semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->