### PR TITLE
fix(library): align gemini search_path + cut over similar() to Gemini, drop Titan

### DIFF
--- a/database/database-generated.types.ts
+++ b/database/database-generated.types.ts
@@ -2552,21 +2552,18 @@ export type Database = {
       object_embedding: {
         Row: {
           created_at: string | null
-          embedding: string | null
           gemini_embedding_2__image: string | null
           gemini_embedding_2__text: string | null
           object_id: string
         }
         Insert: {
           created_at?: string | null
-          embedding?: string | null
           gemini_embedding_2__image?: string | null
           gemini_embedding_2__text?: string | null
           object_id: string
         }
         Update: {
           created_at?: string | null
-          embedding?: string | null
           gemini_embedding_2__image?: string | null
           gemini_embedding_2__text?: string | null
           object_id?: string

--- a/supabase/migrations/20260628204807_library_gemini_embeddings.sql
+++ b/supabase/migrations/20260628204807_library_gemini_embeddings.sql
@@ -14,8 +14,14 @@
 -- migration applied only after the new columns are backfilled & verified.
 ---------------------------------------------------------------------
 
--- `vector` type already installed in schema `extensions` (on search_path);
--- referenced bare, matching the existing library migrations.
+-- pgvector's `vector` type, `vector_cosine_ops` opclass, and `<=>` operator
+-- live in the `extensions` schema. That schema is NOT on the search_path that
+-- `supabase db push` uses on the hosted project, so bare references fail with
+-- `type "vector" does not exist`. Put `extensions` on the path for this
+-- migration so the bare references below resolve. (pg_catalog stays implicitly
+-- first; the qualified `grida_library.*` references are unaffected.)
+set search_path = extensions, public;
+
 ALTER TABLE grida_library.object_embedding
   ADD COLUMN gemini_embedding_2__image vector(1536),  -- NOT NULL deferred to post-backfill
   ADD COLUMN gemini_embedding_2__text  vector(1536);  -- NULLABLE: only described objects

--- a/supabase/migrations/20260629120000_library_gemini_similar_cutover_drop_titan.sql
+++ b/supabase/migrations/20260629120000_library_gemini_similar_cutover_drop_titan.sql
@@ -1,0 +1,66 @@
+---------------------------------------------------------------------
+-- [Gemini cutover + drop legacy Titan] --
+--
+-- Final step of the Titan -> Gemini Embedding 2 migration. The gemini
+-- columns are backfilled & verified on prod, so this migration:
+--
+--   1. repoints similar() from the legacy Titan `embedding` (vector_l2_ops
+--      ivfflat, queried with <#>) to `gemini_embedding_2__image` (cosine).
+--   2. drops the legacy `embedding` column and its ivfflat index.
+--
+-- After this, `object_embedding` holds only the two gemini vectors and the
+-- library has no remaining Titan references.
+--
+-- NOTE: the 28 image/svg+xml objects have a Titan vector but no gemini
+-- vector (Gemini rejects raw SVG; they were never re-rasterized). They drop
+-- out of similar() here by design — accepted.
+---------------------------------------------------------------------
+
+-- pgvector's `vector` type and `<=>` operator live in the `extensions`
+-- schema, which is NOT on the search_path `supabase db push` uses on the
+-- hosted project. Put it on the path so the bare references below resolve
+-- (same lesson as 20260628204807 — without this, db push fails with
+-- `type "vector" does not exist`).
+set search_path = extensions, public;
+
+---------------------------------------------------------------------
+-- [similar rpc — cutover to Gemini image embedding] --
+--
+-- Fixes the legacy opclass/operator MISMATCH along the way: the gemini
+-- index is vector_cosine_ops and this RPC queries with `<=>`, so the HNSW
+-- index actually serves the ORDER BY (the old <#> never matched the legacy
+-- vector_l2_ops ivfflat index).
+---------------------------------------------------------------------
+create or replace function grida_library.similar(
+  ref_id uuid
+)
+returns setof grida_library.object
+language sql
+stable
+as $$
+  with reference as (
+    select gemini_embedding_2__image as v
+    from grida_library.object_embedding
+    where object_id = ref_id
+  )
+  select o.*
+  from grida_library.object o
+  join grida_library.object_embedding e on e.object_id = o.id,
+       reference r
+  where o.id <> ref_id
+    and e.gemini_embedding_2__image is not null
+    and r.v is not null
+  order by e.gemini_embedding_2__image <=> r.v, o.id asc;  -- o.id = stable tiebreaker
+$$;
+
+---------------------------------------------------------------------
+-- [drop legacy Titan] --
+--
+-- Drop the ivfflat index first, then the column (dropping the column would
+-- cascade to the index anyway; explicit is clearer). Nothing references
+-- `embedding` after the similar() cutover above.
+---------------------------------------------------------------------
+drop index if exists grida_library.object_embedding_ivfflat_idx;
+
+alter table grida_library.object_embedding
+  drop column if exists embedding;

--- a/supabase/schemas/grida_library.sql
+++ b/supabase/schemas/grida_library.sql
@@ -169,18 +169,14 @@ CREATE INDEX object_search_idx ON grida_library.object USING GIN (search_tsv);
 --   single-modality, never fused. Image powers similar(); text powers
 --   search() (with a cross-modal image floor). __text is NULLABLE (only
 --   described objects).
--- embedding: LEGACY amazon.titan-embed-image-v1 (1024-d). Retained during
---   migration; dropped in a later cutover migration.
 ---------------------------------------------------------------------
 create table grida_library.object_embedding (
   object_id uuid primary key references grida_library.object(id) on delete cascade,
-  embedding vector(1024),                      -- legacy (Titan); to be dropped
   gemini_embedding_2__image vector(1536),
   gemini_embedding_2__text vector(1536),       -- nullable: described objects only
   created_at timestamptz default now()
 );
 
-CREATE INDEX object_embedding_ivfflat_idx ON grida_library.object_embedding USING ivfflat (embedding vector_l2_ops) WITH (lists = 100);  -- legacy
 CREATE INDEX object_embedding_gemini_image_hnsw_idx ON grida_library.object_embedding USING hnsw (gemini_embedding_2__image vector_cosine_ops);
 CREATE INDEX object_embedding_gemini_text_hnsw_idx ON grida_library.object_embedding USING hnsw (gemini_embedding_2__text vector_cosine_ops) WHERE gemini_embedding_2__text IS NOT NULL;
 ALTER TABLE grida_library.object_embedding ENABLE ROW LEVEL SECURITY;
@@ -239,30 +235,30 @@ $$ LANGUAGE plpgsql STABLE;
 
 ---------------------------------------------------------------------
 -- [similar rpc] --
--- Still on the legacy Titan `embedding`. Repointed to the gemini image
--- vector by a separate cutover migration applied AFTER the backfill (so
--- it never returns empty against an un-backfilled column).
+-- image<->image over gemini_embedding_2__image (cosine `<=>`, served by the
+-- HNSW vector_cosine_ops index). o.id is a stable paging tiebreaker.
 ---------------------------------------------------------------------
 create or replace function grida_library.similar(
   ref_id uuid
 )
 returns setof grida_library.object
+language sql
+stable
 as $$
-BEGIN
-  RETURN QUERY
-    with reference as (
-      select embedding
-      from grida_library.object_embedding
-      where object_id = ref_id
-    )
-    select o.*
-    from grida_library.object o
-    join grida_library.object_embedding e on e.object_id = o.id,
-         reference r
-    where o.id <> ref_id and e.embedding is not null
-    order by e.embedding <#> r.embedding;
-END;
-$$ language plpgsql stable;
+  with reference as (
+    select gemini_embedding_2__image as v
+    from grida_library.object_embedding
+    where object_id = ref_id
+  )
+  select o.*
+  from grida_library.object o
+  join grida_library.object_embedding e on e.object_id = o.id,
+       reference r
+  where o.id <> ref_id
+    and e.gemini_embedding_2__image is not null
+    and r.v is not null
+  order by e.gemini_embedding_2__image <=> r.v, o.id asc;
+$$;
 
 
 ---------------------------------------------------------------------

--- a/supabase/tests/grida_library_gemini_search_test.sql
+++ b/supabase/tests/grida_library_gemini_search_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(6);
+SELECT plan(7);
 
 -- ===================================================================
 -- grida_library Gemini embedding RPC: search()
@@ -9,8 +9,8 @@ SELECT plan(6);
 --   cross-modal image floor, even when the floor's distance is smaller.
 --   The two cosine distances are NEVER blended.
 --
--- (similar() is repointed to the gemini image vector by a separate cutover
--- migration applied after backfill; its test ships with that migration.)
+-- Also pins similar(): image<->image over the gemini image vector after the
+-- Titan cutover (the legacy `embedding` column is dropped).
 -- ===================================================================
 
 -- ── function existence ────────────────────────────────────────────
@@ -94,7 +94,18 @@ SELECT results_eq(
   'search(e1): tier-1 A then B; undescribed C last despite identical image'
 );
 
--- ── 2. category filter ─────────────────────────────────────────────
+-- ── 2. similar(): image<->image cosine over the gemini vector ──────
+-- Cutover pins similar() to gemini_embedding_2__image. similar(A) (image e1)
+-- ranks C (image e1, identical → distance 0) before B (image eclose),
+-- excluding A itself. Proves the legacy `embedding` path is gone.
+SELECT results_eq(
+  $$ SELECT id::text FROM grida_library.similar('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa') $$,
+  $$ VALUES ('cccccccc-cccc-cccc-cccc-cccccccccccc'::text),
+            ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::text) $$,
+  'similar(A): gemini image cosine ranks identical C before near B, excludes A'
+);
+
+-- ── 3. category filter ─────────────────────────────────────────────
 -- A non-matching category returns nothing (all fixtures are testgem).
 SELECT is_empty(
   format(


### PR DESCRIPTION
Final cleanup of the AWS Titan → Google Gemini Embedding 2 migration for the Grida Library. Gemini vectors are already backfilled & verified on prod (10,921 image / 9,571 text); this PR closes out the cutover and removes the legacy column.

### Two migrations

**`20260628204807` (search_path fix)** — the additive gemini migration as deployed on prod. pgvector's `vector` type lives in `extensions`, which is not on the hosted `db push` search_path, so the file now `set search_path = extensions, public;`. Aligns `main` with what was actually applied.

**`20260629120000` (cutover + drop Titan)**
- `similar()` repointed from the legacy Titan `embedding` (`vector_l2_ops` ivfflat, queried with `<#>`) → `gemini_embedding_2__image` cosine (`<=>`). The HNSW `vector_cosine_ops` index now actually serves the `ORDER BY` (fixes the old opclass/operator mismatch).
- `DROP COLUMN embedding` + `DROP INDEX object_embedding_ivfflat_idx`. `object_embedding` now holds only the two gemini vectors.
- Same `set search_path` guard.

### RPC / schema cleanup
- `supabase/schemas/grida_library.sql` purged of the legacy column, ivfflat index, `<#>`, and the plpgsql `similar()` form.
- `database-generated.types.ts` drops the `embedding` field from `object_embedding`.
- pgTAP → `plan(7)`, adding a `similar()` image-cosine ordering assertion. All 7 pass locally (`db reset` + `supabase test db`).

### Notes
- The 28 `image/svg+xml` objects (Titan-only, no gemini vector) drop out of `similar()` by design — accepted.
- Prod `db push` of `20260629120000` is a separate, gated, irreversible step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of vector-based search during deployments by ensuring required database search-path settings are applied.
  * Updated “similar objects” ranking to use Gemini Embedding 2 image vectors with cosine similarity, with consistent tie-breaking and null-vector filtering.

* **Database Changes**
  * Replaced legacy Titan embedding usage with Gemini Embedding 2 for similarity lookups, removing the old embedding column and associated index.

* **Tests**
  * Expanded SQL coverage to verify Gemini-based similarity ordering and to confirm the legacy embedding path is no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->