### PR TITLE
fix(library): global semantic search + reliable gallery card rendering

### DIFF
--- a/editor/app/(library)/library/_components/gallery.tsx
+++ b/editor/app/(library)/library/_components/gallery.tsx
@@ -19,7 +19,6 @@ import {
   TooltipTrigger,
 } from "@app/ui/components/tooltip";
 import dynamic from "next/dynamic";
-import { motion } from "motion/react";
 import { Spinner } from "@app/ui/components/spinner";
 
 const Masonry: ComponentType<MasonryProps<ObjectDetail>> = dynamic(
@@ -138,12 +137,11 @@ function ImageCard({
     object.description || object.alt || object.title || object.prompt;
 
   return (
-    <motion.figure
-      initial={{ opacity: 0 }}
-      whileInView={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.3 }}
-      viewport={{ once: true }}
+    // No entrance animation: Masonic virtualizes (unmounts/remounts cards as
+    // they scroll through the viewport), so a viewport-gated `whileInView`
+    // fade left remounted-but-already-visible cards stuck at opacity 0. A
+    // plain figure renders reliably regardless of scroll position.
+    <figure
       className="group relative overflow-hidden rounded-lg"
       itemScope
       itemType="http://schema.org/ImageObject"
@@ -247,6 +245,6 @@ function ImageCard({
           </div>
         </div>
       </div>
-    </motion.figure>
+    </figure>
   );
 }

--- a/editor/app/(library)/library/page.tsx
+++ b/editor/app/(library)/library/page.tsx
@@ -15,7 +15,10 @@ export default async function LibraryHomePage(props: {
   // almost everything (the API route /library/search already searches
   // globally). So only apply the category when NOT searching.
   const category = "textures";
-  const search_category = q_search ? undefined : category;
+  // Trim-aware: search() treats a whitespace-only query as browse mode, so a
+  // blank query must keep the default category (not fall through to unscoped).
+  const has_search_query = !!q_search?.trim();
+  const search_category = has_search_query ? undefined : category;
   const objects = await search({
     category: search_category,
     text: q_search,

--- a/editor/app/(library)/library/page.tsx
+++ b/editor/app/(library)/library/page.tsx
@@ -10,16 +10,21 @@ export default async function LibraryHomePage(props: {
 }) {
   const searchParams = await props.searchParams;
   const q_search = searchParams?.search;
+  // "textures" is the default browse showcase for the library home. A search
+  // query, however, is global — scoping it to the browse category would hide
+  // almost everything (the API route /library/search already searches
+  // globally). So only apply the category when NOT searching.
   const category = "textures";
+  const search_category = q_search ? undefined : category;
   const objects = await search({
-    category: category,
+    category: search_category,
     text: q_search,
   });
 
   const next = async (range: [number, number]) => {
     "use server";
     const objects = await search({
-      category: category,
+      category: search_category,
       text: q_search,
       range,
     });


### PR DESCRIPTION
Two bugs in the public Grida Library web UI (`/library`), found while verifying that semantic search works against prod.

### 1. Search was locked to a hardcoded category
`page.tsx` pinned `const category = "textures"` (15 objects) and passed it into **every** `search()` call, so a query like "vector" returned almost nothing. A search query is now **global**; the `textures` browse default only applies when *not* searching — matching what the `/library/search` API route already does.

### 2. Cards randomly went invisible while scrolling
`ImageCard` was a `motion.figure` with `initial={{opacity:0}}` + `whileInView={{opacity:1}}`. Masonic **virtualizes** — it unmounts/remounts cards as they scroll through the viewport. `whileInView`'s IntersectionObserver doesn't fire an "enter" event for a card that mounts *already in view*, so remounted cards stuck at `opacity: 0`, leaving the blank gaps. Replaced with a plain `<figure>` (a viewport-gated entrance animation is incompatible with windowed virtualization by design; `masonic@4.1.0` / `motion@12.33.0` are both current — not a library bug).

### Verification
Both verified live against prod data (dev server pointed at the prod project):
- `search=vector` / `astronomy` / `mountain landscape` → full, relevant, multi-category results.
- Browse home (no query) → still `textures`-only.
- Gallery renders dense with no gaps; cards stay visible after scrolling (and infinite scroll continues to load).

Deferred (separate, noted in code review): the semantic-search result `count` is the candidate-universe size, which makes infinite scroll page through the whole library ranked by distance; and the per-IP rate-limit currently gates cached pagination too. Tracked for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results on the library page now remain unscoped by the default category when a search term is entered.
  * Pagination now uses the same search behavior, keeping subsequent results consistent during searches.
  * Library gallery image cards no longer use scroll-based entrance/exit animations, improving compatibility with virtualized scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->