### PR TITLE
feat(ai-models): add Claude Sonnet 5 + Gemini 3.1 Flash Lite Image

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -28,12 +28,12 @@ Models are organized into **tiers** based on capability and cost:
 
 ### Current Models
 
-| Tier   | Model                                             | Context | Max Output | Input (per 1M) | Output (per 1M) |
-| ------ | ------------------------------------------------- | ------- | ---------- | -------------- | --------------- |
-| `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | 400K    | 128K       | $0.20          | $1.25           |
-| `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | 400K    | 128K       | $0.75          | $4.50           |
-| `pro`  | Claude Sonnet 5 (`anthropic/claude-sonnet-5`)     | 1M      | 128K       | $3.00          | $15.00          |
-| `max`  | Claude Opus 4.8 (`anthropic/claude-opus-4.8`)     | 1M      | 128K       | $5.00          | $25.00          |
+| Tier   | Model                                         | Context | Max Output | Input (per 1M) | Output (per 1M) |
+| ------ | --------------------------------------------- | ------- | ---------- | -------------- | --------------- |
+| `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)          | 400K    | 128K       | $0.20          | $1.25           |
+| `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)          | 400K    | 128K       | $0.75          | $4.50           |
+| `pro`  | Claude Sonnet 5 (`anthropic/claude-sonnet-5`) | 1M      | 128K       | $3.00          | $15.00          |
+| `max`  | Claude Opus 4.8 (`anthropic/claude-opus-4.8`) | 1M      | 128K       | $5.00          | $25.00          |
 
 All tier models support **multimodal** inputs (text + images).
 
@@ -52,18 +52,18 @@ All tiers support prompt caching, which reduces cost for repeated context:
 
 Per 1M tokens.
 
-| Name                                                     | Input  | Cache Write | Cache Read | Output  |
-| -------------------------------------------------------- | ------ | ----------- | ---------- | ------- |
-| GPT-5.4 Nano (`openai/gpt-5.4-nano`)                     | $0.20  | —           | $0.02      | $1.25   |
-| GPT-5.4 Mini (`openai/gpt-5.4-mini`)                     | $0.75  | —           | $0.075     | $4.50   |
-| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)            | $3.00  | $3.75       | $0.30      | $15.00  |
+| Name                                                         | Input  | Cache Write | Cache Read | Output  |
+| ------------------------------------------------------------ | ------ | ----------- | ---------- | ------- |
+| GPT-5.4 Nano (`openai/gpt-5.4-nano`)                         | $0.20  | —           | $0.02      | $1.25   |
+| GPT-5.4 Mini (`openai/gpt-5.4-mini`)                         | $0.75  | —           | $0.075     | $4.50   |
+| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
-| Claude Opus 4.8 (`anthropic/claude-opus-4.8`)            | $5.00  | $6.25       | $0.50      | $25.00  |
-| Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_ | $5.00  | $6.25       | $0.50      | $25.00  |
-| GPT-5.5 (`openai/gpt-5.5`)                               | $5.00  | —           | $0.50      | $30.00  |
-| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                       | $30.00 | —           | —          | $180.00 |
-| Gemini 3.5 Flash (`google/gemini-3.5-flash`)             | $1.50  | —           | $0.15      | $9.00   |
-| Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`) | $2.00  | —           | $0.20      | $12.00  |
+| Claude Opus 4.8 (`anthropic/claude-opus-4.8`)                | $5.00  | $6.25       | $0.50      | $25.00  |
+| Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
+| GPT-5.5 (`openai/gpt-5.5`)                                   | $5.00  | —           | $0.50      | $30.00  |
+| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                           | $30.00 | —           | —          | $180.00 |
+| Gemini 3.5 Flash (`google/gemini-3.5-flash`)                 | $1.50  | —           | $0.15      | $9.00   |
+| Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`)     | $2.00  | —           | $0.20      | $12.00  |
 
 ## Image Generation Models
 
@@ -109,11 +109,11 @@ Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · im
 
 Per-token pricing (same model as text, with image output).
 
-| Model                                                                | Input (per 1M) | Output (per 1M) |
-| -------------------------------------------------------------------- | -------------- | --------------- |
-| Gemini 3.1 Flash Image (`google/gemini-3.1-flash-image-preview`)     | $0.50          | $3.00           |
-| Gemini 3.1 Flash Lite Image (`google/gemini-3.1-flash-lite-image`)   | $0.25          | $1.50           |
-| Gemini 3 Pro Image (`google/gemini-3-pro-image`)                     | $2.00          | $12.00          |
+| Model                                                              | Input (per 1M) | Output (per 1M) |
+| ------------------------------------------------------------------ | -------------- | --------------- |
+| Gemini 3.1 Flash Image (`google/gemini-3.1-flash-image-preview`)   | $0.50          | $3.00           |
+| Gemini 3.1 Flash Lite Image (`google/gemini-3.1-flash-lite-image`) | $0.25          | $1.50           |
+| Gemini 3 Pro Image (`google/gemini-3-pro-image`)                   | $2.00          | $12.00          |
 
 ### Black Forest Labs
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -32,7 +32,7 @@ Models are organized into **tiers** based on capability and cost:
 | ------ | ------------------------------------------------- | ------- | ---------- | -------------- | --------------- |
 | `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)              | 400K    | 128K       | $0.20          | $1.25           |
 | `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)              | 400K    | 128K       | $0.75          | $4.50           |
-| `pro`  | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) | 1M      | 128K       | $3.00          | $15.00          |
+| `pro`  | Claude Sonnet 5 (`anthropic/claude-sonnet-5`)     | 1M      | 128K       | $3.00          | $15.00          |
 | `max`  | Claude Opus 4.8 (`anthropic/claude-opus-4.8`)     | 1M      | 128K       | $5.00          | $25.00          |
 
 All tier models support **multimodal** inputs (text + images).
@@ -56,7 +56,8 @@ Per 1M tokens.
 | -------------------------------------------------------- | ------ | ----------- | ---------- | ------- |
 | GPT-5.4 Nano (`openai/gpt-5.4-nano`)                     | $0.20  | —           | $0.02      | $1.25   |
 | GPT-5.4 Mini (`openai/gpt-5.4-mini`)                     | $0.75  | —           | $0.075     | $4.50   |
-| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`)        | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)            | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Opus 4.8 (`anthropic/claude-opus-4.8`)            | $5.00  | $6.25       | $0.50      | $25.00  |
 | Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_ | $5.00  | $6.25       | $0.50      | $25.00  |
 | GPT-5.5 (`openai/gpt-5.5`)                               | $5.00  | —           | $0.50      | $30.00  |
@@ -108,10 +109,11 @@ Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · im
 
 Per-token pricing (same model as text, with image output).
 
-| Model                                                            | Input (per 1M) | Output (per 1M) |
-| ---------------------------------------------------------------- | -------------- | --------------- |
-| Gemini 3.1 Flash Image (`google/gemini-3.1-flash-image-preview`) | $0.50          | $3.00           |
-| Gemini 3 Pro Image (`google/gemini-3-pro-image`)                 | $2.00          | $12.00          |
+| Model                                                                | Input (per 1M) | Output (per 1M) |
+| -------------------------------------------------------------------- | -------------- | --------------- |
+| Gemini 3.1 Flash Image (`google/gemini-3.1-flash-image-preview`)     | $0.50          | $3.00           |
+| Gemini 3.1 Flash Lite Image (`google/gemini-3.1-flash-lite-image`)   | $0.25          | $1.50           |
+| Gemini 3 Pro Image (`google/gemini-3-pro-image`)                     | $2.00          | $12.00          |
 
 ### Black Forest Labs
 
@@ -132,6 +134,7 @@ Flat per-image pricing.
 | GPT Image 1.5      | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
 | GPT Image Mini     | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
 | Gemini Flash Image | —         | 1536x1536                        | Flexible      |
+| Gemini Flash Lite  | —         | 1024x1024 (1K only)              | Flexible      |
 | Gemini Pro Image   | —         | 1536x1536                        | Flexible      |
 | Flux 2 Pro         | 256x256   | 1440x1440                        | Flexible      |
 | Flux Kontext Max   | —         | 1820x1820                        | Flexible      |

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -1010,13 +1010,13 @@ export namespace models {
             provider: "vercel",
             id: "google/gemini-3.1-flash-lite-image",
             pricing: { type: "per_token", input: 0.25, output: 1.5 },
-            avg_cost_usd: 0.002,
+            avg_cost_usd: 0.034,
           },
           openrouter: {
             provider: "openrouter",
             id: "google/gemini-3.1-flash-lite-image",
             pricing: { type: "per_token", input: 0.25, output: 1.5 },
-            avg_cost_usd: 0.002,
+            avg_cost_usd: 0.034,
             url: "https://openrouter.ai/google/gemini-3.1-flash-lite-image",
           },
         },
@@ -1026,7 +1026,10 @@ export namespace models {
         sizes: null,
         constraints: { max_edge: 1024 },
         pricing: { type: "per_token", input: 0.25, output: 1.5 },
-        avg_cost_usd: 0.002, // conservative per-image estimate for budget
+        // Published 1K per-image cost (the card default): $0.034 = 1120 tokens
+        // × $30/1M image-output (Google/Vercel changelog, 2026-07-01). The
+        // budget meter charges this per image, so it must be the real cost.
+        avg_cost_usd: 0.034,
         default: {
           width: 1024,
           height: 1024,

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -146,6 +146,20 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 30, output: 180 },
       },
+      // Standard rates stored as canonical (identical to Sonnet 4.6).
+      // Anthropic ran an introductory discount ($2 in / $10 out / $0.20
+      // cacheRead / $2.50 cacheWrite) through 2026-08-31; not modelled — the
+      // catalogue holds steady-state provider pricing.
+      "anthropic/claude-sonnet-5": {
+        id: "anthropic/claude-sonnet-5",
+        label: "Claude Sonnet 5",
+        short_label: "Sonnet 5",
+        multimodal: true,
+        tool_call: true,
+        contextWindow: 1_000_000,
+        outputLimit: 128_000,
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+      },
       "anthropic/claude-sonnet-4.6": {
         id: "anthropic/claude-sonnet-4.6",
         label: "Claude Sonnet 4.6",
@@ -155,6 +169,7 @@ export namespace models {
         contextWindow: 1_000_000,
         outputLimit: 128_000,
         cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        deprecated: true,
       },
       "anthropic/claude-opus-4.8": {
         id: "anthropic/claude-opus-4.8",
@@ -375,6 +390,7 @@ export namespace models {
       | "openai/gpt-image-1-mini"
       // Google (multimodal LLMs with image output)
       | "google/gemini-3.1-flash-image-preview"
+      | "google/gemini-3.1-flash-lite-image"
       | "google/gemini-3-pro-image"
       // Black Forest Labs
       | "bfl/flux-2-pro"
@@ -965,6 +981,43 @@ export namespace models {
         constraints: { max_edge: 1536 },
         pricing: { type: "per_token", input: 2.0, output: 12.0 },
         avg_cost_usd: 0.015, // conservative per-image estimate for budget
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // "Nano Banana 2 Lite" — GA on the Vercel gateway 2026-06-30. The
+      // cost/speed tier of the 3.1 Flash family: ~half of Nano Banana 2's
+      // meter, and 1K-only output (2K/4K unsupported — the differentiator).
+      // Vercel/OpenRouter/fal ids for the Lite aren't verified yet, so only
+      // the vercel binding is catalogued (TOOL-DESIGN: no unverified routes).
+      "google/gemini-3.1-flash-lite-image": {
+        id: "google/gemini-3.1-flash-lite-image",
+        label: "Gemini 3.1 Flash Lite Image",
+        deprecated: false,
+        short_description:
+          "Fastest, most cost-efficient Gemini image model; 1K output only.",
+        vendor: "google",
+        provider: "vercel",
+        listed: false,
+        listed_reason:
+          "Cost-tier model, not part of the curated flagship/SOTA list.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "google/gemini-3.1-flash-lite-image",
+            pricing: { type: "per_token", input: 0.25, output: 1.5 },
+            avg_cost_usd: 0.002,
+          },
+        },
+        speed_label: "fastest",
+        speed_max: "10s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 1024 },
+        pricing: { type: "per_token", input: 0.25, output: 1.5 },
+        avg_cost_usd: 0.002, // conservative per-image estimate for budget
         default: {
           width: 1024,
           height: 1024,

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -987,11 +987,13 @@ export namespace models {
           aspect_ratio: "1:1",
         },
       },
-      // "Nano Banana 2 Lite" — GA on the Vercel gateway 2026-06-30. The
-      // cost/speed tier of the 3.1 Flash family: ~half of Nano Banana 2's
-      // meter, and 1K-only output (2K/4K unsupported — the differentiator).
-      // Vercel/OpenRouter/fal ids for the Lite aren't verified yet, so only
-      // the vercel binding is catalogued (TOOL-DESIGN: no unverified routes).
+      // "Nano Banana 2 Lite" — GA 2026-06-30. The cost/speed tier of the 3.1
+      // Flash family: ~half of Nano Banana 2's meter, and 1K-only output
+      // (2K/4K unsupported — the differentiator). Vercel + OpenRouter both
+      // meter it at $0.25/$1.50 (verified 2026-07-01); fal id not verified,
+      // so left out. OpenRouter doesn't advertise input_references for the
+      // Lite (t2i only per its model page), so no `references` (TOOL-DESIGN:
+      // no unverified capability).
       "google/gemini-3.1-flash-lite-image": {
         id: "google/gemini-3.1-flash-lite-image",
         label: "Gemini 3.1 Flash Lite Image",
@@ -1009,6 +1011,13 @@ export namespace models {
             id: "google/gemini-3.1-flash-lite-image",
             pricing: { type: "per_token", input: 0.25, output: 1.5 },
             avg_cost_usd: 0.002,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "google/gemini-3.1-flash-lite-image",
+            pricing: { type: "per_token", input: 0.25, output: 1.5 },
+            avg_cost_usd: 0.002,
+            url: "https://openrouter.ai/google/gemini-3.1-flash-lite-image",
           },
         },
         speed_label: "fastest",

--- a/packages/grida-ai-models/src/tiers.ts
+++ b/packages/grida-ai-models/src/tiers.ts
@@ -38,7 +38,7 @@ export type ModelTier = "nano" | "mini" | "pro" | "max";
 export const TIER_MODEL_IDS = {
   nano: "openai/gpt-5.4-nano",
   mini: "openai/gpt-5.4-mini",
-  pro: "anthropic/claude-sonnet-4.6",
+  pro: "anthropic/claude-sonnet-5",
   max: "anthropic/claude-opus-4.8",
 } as const satisfies Record<ModelTier, models.text.CatalogId>;
 


### PR DESCRIPTION
## What changed

Two catalogue updates in `@grida/ai-models`, both web-verified against provider docs.

### 1. Claude Sonnet 5 (deprecate 4.6)
- Add `anthropic/claude-sonnet-5` — GA 2026-06-30, the direct successor to Sonnet 4.6.
- **Standard** pricing is identical to 4.6 (`$3` in / `$15` out / `$0.30` cacheRead / `$3.75` cacheWrite), so it's stored as canonical. Anthropic's introductory discount (`$2`/`$10`, expires 2026-08-31) is noted in a comment but not modelled — the catalogue holds steady-state provider pricing.
- Mark `anthropic/claude-sonnet-4.6` `deprecated: true`. It stays catalogued/callable (same pattern as `claude-opus-4.7`), so existing test and live-test references keep resolving.
- Repoint the `pro` tier to `anthropic/claude-sonnet-5`.

### 2. Gemini 3.1 Flash Lite Image ("Nano Banana 2 Lite")
- Add `google/gemini-3.1-flash-lite-image` — GA on the Vercel AI Gateway (no `-preview` suffix).
- `per_token` meter `input 0.25 / output 1.5` (half of Nano Banana 2), **1K-only** output (`max_edge: 1024` — the differentiator), `listed: false` cost-tier (like `gpt-image-1-mini`).
- Only the **vercel** binding is catalogued — OpenRouter/fal ids for the Lite aren't verified, and the catalogue doctrine forbids listing unverified routes.

### Docs
- Updated `docs/models/index.md` pricing/size tables (pro tier, all-models table with 4.6 as legacy, Google image table, image-sizes table).

## Why
Sonnet 5 is the current SOTA `pro`-tier model; 4.6 is superseded. The Gemini Lite variant fills the fast/cheap image tier.

## Notes for reviewers
- `apps/docs/docs/` is a gitignored generated mirror, so it's not in the diff.
- **Out of scope:** the separate Claude Code CLI provider mapping (`claude-code/sonnet-4.6` in `agent-provider/types.ts` + desktop `model-picker.tsx`) — that's the ACP-consumer path, not the gateway catalogue. Research confirmed the raw API id is `claude-sonnet-5` if we later want a Sonnet 5 option in the desktop picker (product decision).

## Verification
- `@grida/ai-models` build + tests (40/40) ✅
- `@grida/agent` typecheck ✅
- editor typecheck (40/40) ✅
- editor AI cost + agent-send tests (20/20) ✅
- oxfmt clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Claude Sonnet 5** to the model catalog and updated the **Pro** tier to use it.
  * Added **Gemini 3.1 Flash Lite Image** with updated token pricing/speed and a selectable **1024×1024 (1K only)** size.
* **Bug Fixes**
  * Marked **Claude Sonnet 4.6** as legacy/deprecated while keeping legacy pricing.
* **Documentation**
  * Updated pricing/availability tables to reflect the new model availability, per-1M rates, and legacy labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->