### PR TITLE
feat(desktop): reference-first home — auto-create projects under a managed root

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -610,6 +610,31 @@ deny (provider CDNs still excluded). The alternative — proxying library images
 through `grida-workspace:` like generated media — was rejected: the library is
 first-party public read-only storage, and the product keeps its pins as URLs.
 
+**Auto-created projects (managed root).** The reference-first home lets a
+newcomer start without choosing a folder: it posts to `POST /workspaces/create`,
+which mints a new project directory and seeds a `.canvas` bundle (a
+`<name>.canvas` dir + manifest inside it). This adds a new
+renderer-reachable **write** authority (previously the renderer could only
+register a folder the user had already picked through the OS dialog), so it is
+recorded here. The boundary holds by four rules, none of which trust the caller
+for a path: (a) the managed root is **host-injected** — the supervisor passes
+`--projects-root=<~/Documents/Grida>` (`desktop/src/main/agent-sidecar-supervisor.ts`),
+never derived from the request; a host that wired no root refuses with a 400.
+(b) The request's `name` is **slugified to a single filesystem segment**
+(`WorkspaceRegistry.createProject` / `slugifyProjectName`): path separators,
+`..`, NUL, and control chars cannot survive, so it can never be a path. (c) The
+minted directory's realpath is **asserted strictly under the managed root** via
+the shared `containsPath` (`path-contains.ts` — the same prefix+sep discipline
+as the shell runner's root gates); an escape is removed and rejected. (d)
+The `seed` is **field-constrained** (`seedValidator` in
+`http/routes/workspaces.ts`) to `{ src, layout? }` documents — a raw dotcanvas
+manifest never reaches disk, so the route is not a manifest-injection vector.
+The sidecar's own `fs` writes are not srt-confined (srt wraps only the
+`run_command` shell child), and a created project registers as a workspace root
+the shell fs-policy already unions — so this adds no new reachable root for the
+sandboxed shell. `workspaces.create.test.ts` pins traversal-name containment,
+seed field-constraining, and the no-managed-root refusal.
+
 **Files bound by this id.** Run `grep -rn GRIDA-SEC-004 .` to enumerate.
 Today:
 
@@ -623,7 +648,7 @@ Today:
 - [packages/grida-ai-agent/src/tools/run-command.ts](packages/grida-ai-agent/src/tools/run-command.ts) — the supervised-approval gate itself: the AI SDK `needsApproval` predicate that pauses a mutating command before `execute` in `accept-edits` (absent in `auto`). The decision lives on the tool, not the backend.
 - [packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts](packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts) — opened workspace to agent fs/todos/command bindings; wires the `accept-edits` supervised-approval predicate. The session scratch dir is wired as an additional sanctioned root for BOTH surfaces from one source (`deps.scratch_dir`): the shell's allowed cwd roots AND the fs backend's reachable roots (so `view_image`/`read_file`/`write_file` reach scratch, not just the shell). Containment is preserved per root — a path under no reachable root falls back contained to the workspace, and the secrets root is never a reachable root. Also builds the `generate_image` binding: it reads BYOK keys via `SecretsStore` to call the image provider in-process and returns the saved scratch path + metadata + base64 `data` (the bytes are for the CLIENT to render; `AgentGen.toModelOutput` is text-only, so they are NEVER lowered to the model — no context bloat, no perception claim). The complementary `view_image` perception path DOES deliver bytes to the model, but only ones already read under the agent's existing fs read capability: `agent/hoist-tool-result-images.ts` (wired at `agent/index.ts` `prepareStep`, #923) relocates an image tool-result into a synthetic user-message image part so the model can actually see it on the openai-compatible wire — a model-view lowering that moves bytes already inside the prompt, never persisted, with no new read, no new egress, and no boundary change. The key never leaves the host, and the call omits `providerOptions.grida` so it is BYOK-paid, never Grida-billed (mirrors the `/images/generate` route).
 - [packages/grida-ai-agent/src/session/scratch.ts](packages/grida-ai-agent/src/session/scratch.ts) — per-session ephemeral scratch dir (WG `scratch.md`): asserts the shell-writable scratch tree sits OUTSIDE `userData` (the secret root), creates it owner-only (`0700`), and reclaims it (per-session delete + synchronous host-start sweep). `writeScratchFile` lands produced bytes (e.g. `generate_image`) owner-only (`0600`) within the session tree, rejecting any filename that is not a single safe path segment AND opening `O_NOFOLLOW` so a symlink planted at the basename (e.g. by an auto-approved scratch-cwd `run_command`) fails the write instead of redirecting it outside the tree — closing the lexical-check TOCTOU.
-- [packages/grida-ai-agent/src/path-contains.ts](packages/grida-ai-agent/src/path-contains.ts) — shared `path.sep`-prefix containment used by the shell runner's workspace/secret-root gates and the scratch containment assert (one source so the discipline can't drift).
+- [packages/grida-ai-agent/src/path-contains.ts](packages/grida-ai-agent/src/path-contains.ts) — shared `path.sep`-prefix containment used by the shell runner's workspace/secret-root gates, the scratch containment assert, and `createProject`'s managed-root assert (one source so the discipline can't drift).
 - [packages/grida-ai-agent/src/runtime/run-input.ts](packages/grida-ai-agent/src/runtime/run-input.ts) — wire-message normalization + `coerceApprovalAnswer`/`applyApprovalAnswer` (shape-gates the explicit `approval_answer` body field and routes it to `store.answerApproval`).
 - [packages/grida-ai-agent/src/session/store.ts](packages/grida-ai-agent/src/session/store.ts) — sessions store; `answerApproval` is the server-authoritative supervised-approval gate (answers only a real pending approval, never forges a call).
 - [packages/grida-ai-agent/src/workspaces.ts](packages/grida-ai-agent/src/workspaces.ts) — opened workspace registry and root canonicalization.

--- a/desktop/src/agent-sidecar.ts
+++ b/desktop/src/agent-sidecar.ts
@@ -82,6 +82,10 @@ const runtimeEditorBaseUrl = getCliArg("editor-base-url") ?? EDITOR_BASE_URL;
 // disabled, so a future supervisor bug that drops the flag can't silently
 // expose an unsandboxed shell.
 const sandboxEnforced = getCliArg("sandbox-enforced") === "1";
+// GRIDA-SEC-004 — host-injected managed root for auto-created projects
+// (`~/Documents/Grida`). The supervisor owns the path fact and forwards it;
+// absent (e.g. a future supervisor bug) means auto-create simply refuses.
+const projectsRoot = getCliArg("projects-root");
 
 async function main() {
   const password = await readPasswordFromStdin();
@@ -94,6 +98,7 @@ async function main() {
   const host = new AgentHost({
     password,
     user_data_path: requiredUserDataPath,
+    projects_root: projectsRoot,
     http_access: {
       allowed_origins: [editorOrigin],
       allowed_referer_paths: ["/desktop"],

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,7 +1,10 @@
 import { app, shell, BrowserWindow, Menu, dialog } from "electron";
 import { updateElectronApp } from "update-electron-app";
 import started from "electron-squirrel-startup";
-import create_menu, { focus_or_open_canvas_window } from "./menu";
+import create_menu, {
+  focus_or_open_canvas_window,
+  rebuild_application_menu,
+} from "./menu";
 import { open_welcome_window, open_document_window } from "./window";
 import { EDITOR_BASE_URL } from "./env";
 import {
@@ -84,6 +87,16 @@ registerWorkspaceMediaScheme();
 // here even though it's defined further down.
 const menu = create_menu(app, shell, { onOpenFile: handleFilePath });
 Menu.setApplicationMenu(menu);
+
+// Keep File ▸ Open Recent in sync with the workspace list (the same recents the
+// renderer's ⌃R palette shows). Rebuilds are signature-guarded, so firing on
+// every window focus is cheap and only re-sets the menu when recents change —
+// which catches the auto-create flow (a project made via client-side nav never
+// spawns a new window the main process could hook).
+function refresh_recent_menu(): void {
+  void rebuild_application_menu(app, shell, { onOpenFile: handleFilePath });
+}
+app.on("browser-window-focus", refresh_recent_menu);
 
 // `grida://` deep-link router lives in `main/protocol-router.ts`.
 // Fire-and-forget from the event handlers below: the deep-link IO is
@@ -376,6 +389,10 @@ app.on("ready", async () => {
     app,
     base_url: EDITOR_BASE_URL,
   });
+
+  // Populate File ▸ Open Recent now that the sidecar can answer `workspaces.list`
+  // (the module-top menu was built before it was up).
+  refresh_recent_menu();
 
   // Drain anything that arrived before ready. `splice(0)` clears the
   // queue atomically so any `open-file` event firing during the drain

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -94,7 +94,13 @@ Menu.setApplicationMenu(menu);
 // which catches the auto-create flow (a project made via client-side nav never
 // spawns a new window the main process could hook).
 function refresh_recent_menu(): void {
-  void rebuild_application_menu(app, shell, { onOpenFile: handleFilePath });
+  // Swallow-and-log: a failed rebuild (e.g. menu construction throwing) must
+  // not become an unhandled rejection in main; the menu just stays stale until
+  // the next trigger. (A sidecar that isn't up yet already resolves to an
+  // empty recents list inside `rebuild_application_menu`.)
+  rebuild_application_menu(app, shell, { onOpenFile: handleFilePath }).catch(
+    (err) => console.error("[grida] open-recent menu rebuild failed:", err)
+  );
 }
 app.on("browser-window-focus", refresh_recent_menu);
 

--- a/desktop/src/main/agent-sidecar-supervisor.ts
+++ b/desktop/src/main/agent-sidecar-supervisor.ts
@@ -200,6 +200,11 @@ class AgentSidecarSupervisor {
     const args = [
       scriptPath,
       `--user-data=${this.user_data_path}`,
+      // GRIDA-SEC-004 — host-injected managed root for the auto-create flow.
+      // A visible, Finder-navigable location (files stay visible); the sidecar
+      // may only mint project folders INSIDE this root. `documents` needs a
+      // ready app, which holds at spawn time (post `app.whenReady`).
+      `--projects-root=${path.join(app.getPath("documents"), "Grida")}`,
       `--editor-base-url=${EDITOR_BASE_URL}`,
       // GRIDA-SEC-004 — tell the sidecar whether srt wraps this spawn. Only
       // then does it expose the `run_command` shell tool (fail-closed). On

--- a/desktop/src/menu.ts
+++ b/desktop/src/menu.ts
@@ -106,17 +106,9 @@ async function open_picker_and_register(
     return;
   }
 
-  let workspaceId: string;
-  // Auto-detect: a folder that contains the bundle marker (`.canvas.json`)
-  // opens the `.canvas` slides editor; anything else opens the file workbench.
-  // Sniff the RESOLVED root (the agent server may expand the picked path to a
-  // containing repo). This process has no `dotcanvas` import by design — keep the
-  // marker name in sync with `dotcanvas.MANIFEST_FILENAME`.
-  let isCanvas = false;
+  let workspace: { id: string; root: string };
   try {
-    const workspace = await agentSidecarClient.openWorkspace(picked);
-    workspaceId = workspace.id;
-    isCanvas = existsSync(join(workspace.root, ".canvas.json"));
+    workspace = await agentSidecarClient.openWorkspace(picked);
   } catch (err) {
     console.error("[grida] open workspace failed:", err);
     dialog.showErrorBox(
@@ -125,19 +117,7 @@ async function open_picker_and_register(
     );
     return;
   }
-  if (isCanvas) {
-    focus_or_open_canvas_window({
-      app,
-      agentSidecar,
-      workspace_id: workspaceId,
-    });
-  } else {
-    focus_or_open_workspace_window({
-      app,
-      agentSidecar,
-      workspace_id: workspaceId,
-    });
-  }
+  route_workspace_window(app, workspace);
   // Record the folder in Recents, matching the OS-open paths (`main.ts` adds
   // both files and directories). The file branch above already does this via
   // `onOpenFile`, so only the directory branch needs it here.
@@ -196,6 +176,104 @@ function focus_or_open_canvas_window({
 }
 
 export { focus_or_open_workspace_window, focus_or_open_canvas_window };
+
+/** How many recent projects to list under File ▸ Open Recent — enough to be
+ *  useful without turning the menu into the full ⌃R palette (which stays the
+ *  complete, searchable list). */
+const MAX_RECENT_MENU_ITEMS = 12;
+
+/**
+ * Route a registered workspace to its window: a root containing the bundle
+ * marker (`.canvas.json`) opens the `.canvas` board window, anything else the
+ * file workbench — with the shared focus-or-open dedup. The ONE main-process
+ * copy of this rule, used by the Open… flow and File ▸ Open Recent. Sniffs the
+ * RESOLVED root (the agent server may expand the picked path). This process has
+ * no `dotcanvas` import by design — keep the marker name in sync with
+ * `dotcanvas.MANIFEST_FILENAME`.
+ */
+function route_workspace_window(
+  app: App,
+  workspace: { id: string; root: string }
+) {
+  const agentSidecar = getAgentSidecarInfo();
+  if (!agentSidecar) return; // pre-ready / between restarts
+  const isCanvas = existsSync(join(workspace.root, ".canvas.json"));
+  if (isCanvas) {
+    focus_or_open_canvas_window({
+      app,
+      agentSidecar,
+      workspace_id: workspace.id,
+    });
+  } else {
+    focus_or_open_workspace_window({
+      app,
+      agentSidecar,
+      workspace_id: workspace.id,
+    });
+  }
+}
+
+/**
+ * The recent workspaces for File ▸ Open Recent — the SAME source the renderer's
+ * ⌃R "Recent projects" palette uses (`workspaces.list()`), so the two stay in
+ * lock-step. Empty when the sidecar isn't ready yet or nothing's been opened.
+ */
+async function list_recent_workspaces() {
+  try {
+    return (await agentSidecarClient.listWorkspaces()).slice(
+      0,
+      MAX_RECENT_MENU_ITEMS
+    );
+  } catch {
+    // Sidecar not ready / transient — an empty Open Recent (disabled placeholder).
+    return [];
+  }
+}
+
+// Last-built Open Recent signature (ordered workspace ids). `rebuild_application_menu`
+// skips re-setting the native menu when the recents are unchanged, so frequent
+// triggers (window focus) don't thrash it.
+let last_recent_signature: string | null = null;
+// Coalesce overlapping triggers (rapid focus flips): one fetch at a time, and
+// no out-of-order `Menu.setApplicationMenu` from a slow earlier fetch landing
+// after a fast later one.
+let rebuild_in_flight = false;
+
+/**
+ * Re-fetch recents and rebuild the whole application menu so File ▸ Open Recent
+ * reflects the current workspace list. Cheap and idempotent — it no-ops when the
+ * recents are unchanged (signature match), so it's safe to call on every window
+ * focus. Call once the sidecar is ready and whenever recents may have shifted.
+ */
+export async function rebuild_application_menu(
+  app: App,
+  shell: Shell,
+  opts?: { onOpenFile?: (filePath: string) => void }
+): Promise<void> {
+  if (rebuild_in_flight) return;
+  rebuild_in_flight = true;
+  try {
+    await rebuild_application_menu_locked(app, shell, opts);
+  } finally {
+    rebuild_in_flight = false;
+  }
+}
+
+async function rebuild_application_menu_locked(
+  app: App,
+  shell: Shell,
+  opts?: { onOpenFile?: (filePath: string) => void }
+): Promise<void> {
+  const recents = await list_recent_workspaces();
+  const signature = recents.map((w) => w.id).join(" ");
+  if (signature === last_recent_signature && Menu.getApplicationMenu()) return;
+  last_recent_signature = signature;
+  const recent: MenuItemConstructorOptions[] = recents.map((w) => ({
+    label: w.name || w.root,
+    click: () => route_workspace_window(app, w),
+  }));
+  Menu.setApplicationMenu(create_menu(app, shell, { ...opts, recent }));
+}
 
 function is_workspace_window(window: BrowserWindow): boolean {
   try {
@@ -385,7 +463,13 @@ export function create_default_menu(
 export default function create_menu(
   app: App,
   shell: Shell,
-  opts?: { onOpenFile?: (filePath: string) => void }
+  opts?: {
+    onOpenFile?: (filePath: string) => void;
+    /** Pre-fetched File ▸ Open Recent items (built by {@link rebuild_application_menu}).
+     *  Omitted on the initial synchronous build (sidecar not up yet) → the menu
+     *  shows a disabled "No Recent Projects" placeholder until the first rebuild. */
+    recent?: MenuItemConstructorOptions[];
+  }
 ) {
   const default_menu = create_default_menu(app, shell);
   // Minimal File menu. An extension-keyed registry (one entry per
@@ -442,6 +526,16 @@ export default function create_menu(
                 },
               },
             ]),
+        // Recent projects — the same list the renderer's ⌃R palette shows,
+        // kept fresh by `rebuild_application_menu`. Disabled placeholder until
+        // the sidecar is up and the first rebuild runs.
+        {
+          label: "Open Recent",
+          submenu:
+            opts?.recent && opts.recent.length > 0
+              ? opts.recent
+              : [{ label: "No Recent Projects", enabled: false }],
+        },
         // Cross-platform shortcut to Settings. macOS gets the same
         // entry under the app menu (above) per platform convention,
         // but Cmd/Ctrl+, is the universal expectation — keep it here

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -387,6 +387,7 @@ const bridge: DesktopBridge = {
   workspaces: {
     list: () => agentClient.workspaces.list(),
     open: (rootPath) => agentClient.workspaces.open(rootPath),
+    create: (input) => agentClient.workspaces.create(input),
     pin: async (id, pinned) => {
       await agentClient.workspaces.pin(id, pinned);
     },

--- a/editor/app/(library)/library/actions.ts
+++ b/editor/app/(library)/library/actions.ts
@@ -204,6 +204,42 @@ export const listCategories = cache(_listCategories);
 
 const PAGE = 60;
 
+/**
+ * Cold browse — the curated corpus ordered by score, optionally filtered to a
+ * category. Powers the desktop home's reference gallery
+ * (scroll-and-pick-to-start): unlike {@link search}, which returns empty for an
+ * empty query, this lists the library best-first so the gallery has something
+ * to show before any keyword. Also the listing behind `search`'s category-only
+ * branch, so the curation-order query is defined once. Paginated by `range`
+ * with an estimated `count` for infinite scroll.
+ */
+export async function browse({
+  category,
+  range = [0, PAGE - 1],
+}: { category?: string; range?: [number, number] } = {}): Promise<{
+  data: Library.ObjectDetail[];
+  count: number | undefined;
+}> {
+  const client = await createLibraryClient();
+  const q = client
+    .from("object")
+    .select(__select_object_with_author, { count: "estimated" });
+  if (category) {
+    q.eq("category", category);
+  }
+  const { data, error, count } = await q
+    .order("score", { ascending: false, nullsFirst: false })
+    .order("id", { ascending: true })
+    .range(range[0], range[1]);
+  if (error) {
+    throw error;
+  }
+  return {
+    data: __with_object_urls(client, data as unknown as ObjectWithAuthor[]),
+    count: count ?? undefined,
+  };
+}
+
 export async function search({
   text,
   category,
@@ -216,30 +252,13 @@ export async function search({
   if (!text && !category) {
     return { data: [], count: 0 };
   }
-  const client = await createLibraryClient();
 
-  // Category-only (no query text): a filtered listing, not a search. Keep
-  // the table browse ordered by curation score.
+  // Category-only (no query text): a filtered listing, not a search — the
+  // same curation-score browse the reference gallery uses.
   if (!text?.trim()) {
-    const q = client
-      .from("object")
-      .select(__select_object_with_author, { count: "estimated" });
-    if (category) {
-      q.eq("category", category);
-    }
-    q.order("score", { ascending: false, nullsFirst: false });
-    q.order("id", { ascending: true });
-    q.range(range[0], range[1]);
-
-    const { data, error, count } = await q;
-    if (error) {
-      throw error;
-    }
-    return {
-      data: __with_object_urls(client, data as unknown as ObjectWithAuthor[]),
-      count,
-    };
+    return browse({ category, range });
   }
+  const client = await createLibraryClient();
 
   // Semantic search: embed the query (text↔text, with a cross-modal image
   // floor handled inside the `search` RPC). Pagination is done inside the

--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -1,26 +1,35 @@
 "use client";
 
 /**
- * Desktop welcome window.
+ * Desktop welcome window — the reference-first artwork studio front door.
  *
- * A composer-first home: pick a workspace, describe what you want, and
- * submitting hands the prompt off to that workspace's agent chat (a
- * fresh session) via {@link welcome_handoff}. Opening a folder or
- * clicking a recent both navigate into the workspace IDE
- * (`/desktop/workspace?id=…`), same-window by design — this window
- * becomes the workspace window (the nav guard in `window.ts` allows
- * any `/desktop/*` route).
+ * Composer-first and outcome-first: describe what you want, or gather references
+ * from the gallery — then Grida AUTO-CREATES a fresh project
+ * for you — a `.canvas` board under `~/Documents/Grida` — then hands your
+ * prompt to that project's agent as a fresh first turn via {@link welcome_handoff}.
+ * No workspace picker, no folder dialog to get started: the newcomer never has
+ * to choose a folder. "Open folder…" and the recents list stay for opening
+ * work that already exists (files stay visible — a named tree, not hidden).
  *
- * Workspaces are backed by `bridge.workspaces.*` and re-fetched on
- * window focus, so opening a folder via the File menu surfaces here
- * immediately. Window/tab UX is intentionally not the SDK's concern
- * (see `docs/wg/desktop/process-model.md`).
+ * Clicking a gallery reference doesn't start a board on its own — it drops the
+ * pin into the composer's picked-references tray (multi-select). The user can
+ * collect several, optionally add a prompt, then start ONE project seeded with
+ * all of them. Every start opens the MAIN workbench (`/desktop/workspace`) — the
+ * full surface with the file tree, tool-approval, and auto-accept — whose agent
+ * pane consumes the handoff and auto-sends when there's a prompt. The seeded
+ * `.canvas` board is the document the agent works on.
+ *
+ * Landing surface: `/desktop/workspace?id=…` (the workbench), whose agent pane
+ * already consumes the handoff and auto-sends turn one. The handoff carries the
+ * `dotcanvas` skill so the artwork agent knows the board format from the start,
+ * even before any editor tab is open.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
+  ArrowRightIcon,
   CheckIcon,
   ChevronDownIcon,
   FolderIcon,
@@ -29,6 +38,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { Button } from "@app/ui/components/button";
+import { cn } from "@app/ui/lib/utils";
 import {
   Command,
   CommandEmpty,
@@ -61,16 +71,59 @@ import {
   useModelPickerState,
 } from "@/scaffolds/desktop/shared/model-picker";
 import { useEndpointProviders } from "@/scaffolds/desktop/shared/registered-models";
-import { useWorkspaceComposerCatalog } from "@/scaffolds/desktop/shared/use-workspace-composer-catalog";
+import type { ComposerCatalog } from "@/kits/composer";
 import { workspaceWorkbenchHref } from "@/scaffolds/desktop/workbench/workspace-workbench-url";
+import { ReferenceGallery } from "@/scaffolds/desktop/home/reference-gallery";
+import { RecentProjectsCommand } from "@/scaffolds/desktop/home/recent-projects-command";
+import type { AgentDesignSearch } from "@grida/agent/tools/design-search";
 
 const NOOP = () => {};
 
+/** The home composer targets no existing workspace (a fresh project is created
+ *  on submit), so there are no `@` file refs or `/` skills to offer. A constant
+ *  — not `useWorkspaceComposerCatalog("")`, which would fire doomed bridge
+ *  readdirs per mount just to yield this same empty shape. */
+const EMPTY_CATALOG: ComposerCatalog = { commands: [], mentions: [] };
+
+/** A short, friendly folder name derived from the prompt (the sidecar slugifies
+ *  it further). First few words keep the project recognizable in the tree. */
+function deriveProjectName(prompt: string): string {
+  const words = prompt.trim().split(/\s+/).slice(0, 6).join(" ");
+  return words.slice(0, 48) || "Untitled";
+}
+
 export default function DesktopWelcomePage() {
   const router = useRouter();
+  // The home's single page-scroll container — everything (composer, gallery)
+  // scrolls together inside it; the gallery virtualizes against it.
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Recent-projects quick switcher (⌃R, VS Code's "Open Recent"). Keeps the
+  // home minimal — no persistent recents list.
+  const [commandOpen, setCommandOpen] = useState(false);
+  // The composer's target: null = create a NEW project (the default), or an
+  // existing workspace to send the prompt into instead.
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [target, setTarget] = useState<Workspace | null>(null);
+  // References the user has gathered from the gallery (multi-select). They seed
+  // ONE fresh board on submit; a click in the gallery toggles membership here.
+  const [pickedRefs, setPickedRefs] = useState<
+    AgentDesignSearch.DesignSearchResult[]
+  >([]);
+  const selectedRefIds = useMemo(
+    () => new Set(pickedRefs.map((p) => p.id)),
+    [pickedRefs]
+  );
+  // Composer docking: the composer starts as the in-flow hero, then floats as a
+  // fixed bottom bar once it scrolls out of view — so you can keep writing while
+  // browsing the gallery. It's the SAME element (its position toggles), so the
+  // Tiptap draft, focus, and caret survive the transition; `heroHeight` is a
+  // spacer that holds its old spot so the gallery doesn't jump when it detaches.
+  const composerRef = useRef<HTMLDivElement>(null);
+  const composerSlotRef = useRef<HTMLDivElement>(null);
+  const [docked, setDocked] = useState(false);
+  const [heroHeight, setHeroHeight] = useState<number>();
   // First-run onboarding (issue #813): zero-config Claude detection. Start
   // hidden so the server render and first client render agree — `localStorage`
   // is client-only, so seeding in the initializer would render the modal during
@@ -81,10 +134,6 @@ export default function DesktopWelcomePage() {
   }, []);
 
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  // The composer's target. Defaults to the most-recent workspace once
-  // the list loads (see effect below) so the composer is usable without
-  // an explicit pick, while still letting the user retarget.
-  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const refreshWorkspaces = useCallback(async () => {
     const bridge = getDesktopBridge();
@@ -92,7 +141,7 @@ export default function DesktopWelcomePage() {
     try {
       setWorkspaces(await workspacesNs.list());
     } catch (err) {
-      // Non-fatal — the welcome page can still open a folder.
+      // Non-fatal — the welcome page can still create or open a folder.
       console.warn("[welcome] workspaces.list failed:", err);
     }
   }, []);
@@ -106,21 +155,56 @@ export default function DesktopWelcomePage() {
     return () => window.removeEventListener("focus", onFocus);
   }, [refreshWorkspaces]);
 
-  // Keep the selection pointed at a valid, most-recent workspace: seed
-  // it when the list first arrives, and re-seed if the selected one is
-  // forgotten.
+  // ⌃R toggles the recent-projects palette (Ctrl, NOT Cmd — Cmd+R reloads the
+  // window in Electron). preventDefault so no reload accelerator fires.
   useEffect(() => {
-    setSelectedId((cur) =>
-      cur && workspaces.some((w) => w.id === cur)
-        ? cur
-        : (workspaces[0]?.id ?? null)
-    );
-  }, [workspaces]);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.ctrlKey && !e.metaKey && (e.key === "r" || e.key === "R")) {
+        e.preventDefault();
+        setCommandOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
-  // Auto-detect `.canvas` decks among the recents: a folder containing
-  // `.canvas.json` opens the file window in deck mode (`/desktop/file?id=`)
-  // instead of the file workbench. Probed via the bridge once per list (the main
-  // process does the same fs sniff for the File-menu "Open…" path).
+  // Track the composer's natural (in-flow) height so the spacer can reserve it
+  // when the composer detaches to float — otherwise the flow collapses and the
+  // gallery jumps up by the composer's height at the dock moment.
+  useEffect(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => setHeroHeight(el.offsetHeight));
+    ro.observe(el);
+    setHeroHeight(el.offsetHeight);
+    return () => ro.disconnect();
+  }, []);
+
+  // Dock the composer once its hero slot scrolls past the top of the page, and
+  // restore it in place when scrolled back up. We watch the SLOT (which stays in
+  // flow as a spacer even while the composer floats) rather than the composer
+  // itself — the floated bar re-enters the viewport at the bottom, so watching it
+  // would immediately undock and thrash. Gone above the top edge → float.
+  useEffect(() => {
+    const root = scrollRef.current;
+    const slot = composerSlotRef.current;
+    if (!root || !slot) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        const rootTop = entry.rootBounds?.top ?? 0;
+        setDocked(
+          !entry.isIntersecting && entry.boundingClientRect.top <= rootTop
+        );
+      },
+      { root, threshold: 0 }
+    );
+    io.observe(slot);
+    return () => io.disconnect();
+  }, []);
+
+  // Auto-detect `.canvas` decks/boards among the recents: a folder containing
+  // `.canvas.json` opens the board file window (`/desktop/file?id=`) instead of
+  // the file workbench. Probed via the bridge once per list.
   const [canvasIds, setCanvasIds] = useState<Set<string>>(new Set());
   useEffect(() => {
     let cancelled = false;
@@ -148,24 +232,110 @@ export default function DesktopWelcomePage() {
     };
   }, [workspaces]);
 
-  // Composer catalog (`@` file refs + `/` skills) for the selected
-  // workspace. Empty until one is selected — the hook tolerates the
-  // empty id and yields an empty catalog.
-  const catalog = useWorkspaceComposerCatalog(selectedId ?? "");
-
   // Configured endpoint providers (issue #806): registered local models
   // join the welcome composer's picker too.
   const endpoints = useEndpointProviders();
 
-  // Model selection for the composer. No sessions here (the welcome page
-  // never loads a chat), so this just holds the user's pick at the
-  // default; it rides the handoff so the workspace chat's first turn runs
-  // on the chosen model rather than the fallback tier.
+  // Model selection for the composer. No sessions here (the welcome page never
+  // loads a chat), so this just holds the user's pick; it rides the handoff so
+  // the created project's first turn runs on the chosen model.
   const { model_id: modelId, setModelId } = useModelPickerState({
     current_id: null,
     sessions: [],
     endpoints,
   });
+
+  // Stash the (possibly empty) prompt + model + skill for a workspace's agent and
+  // become the workspace window. Shared by the new-project and existing-target
+  // paths; an empty prompt lands primed but doesn't auto-send a turn.
+  const handoffAndGo = useCallback(
+    (workspace: Workspace, prompt: string) => {
+      welcome_handoff.set(workspace.id, {
+        prompt,
+        model_id: modelId,
+        skills: ["dotcanvas"],
+      });
+      router.push(workspaceWorkbenchHref(workspace));
+    },
+    [modelId, router]
+  );
+
+  const createAndGo = useCallback(
+    async (opts: {
+      name?: string;
+      prompt: string;
+      seed?: { documents: { src: string }[] };
+    }) => {
+      const bridge = getDesktopBridge();
+      if (!bridge) {
+        setError("Desktop bridge not available.");
+        return;
+      }
+      try {
+        setBusy(true);
+        setError(null);
+        const ws = await workspacesNs.createProject({
+          name: opts.name,
+          seed: opts.seed,
+        });
+        // Every start opens the MAIN workbench (`/desktop/workspace`) — the full
+        // surface with the file tree, tool-approval bar, and auto-accept mode
+        // picker. The seeded `.canvas` board is the document the agent works on;
+        // the workbench's agent pane consumes the handoff and auto-sends when
+        // there's a prompt. (The lean board window at `/desktop/file` stays for
+        // directly opening an existing `.canvas`/file — Finder, ⌃R, File ▸ Open.)
+        handoffAndGo(ws, opts.prompt);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Couldn't create a project."
+        );
+        setBusy(false); // navigation unmounts on success; only reset on failure
+      }
+    },
+    [handoffAndGo]
+  );
+
+  // The one "start" path, shared by the composer's send and the reference
+  // tray's Start button. References (if any) always seed a fresh board and take
+  // precedence over the target picker — they're only meaningful for a new board.
+  const start = useCallback(
+    (text: string) => {
+      const t = text.trim();
+      if (busy) return;
+      if (pickedRefs.length > 0) {
+        void createAndGo({
+          name: t ? deriveProjectName(t) : pickedRefs[0]?.title || "Artwork",
+          prompt: t,
+          seed: { documents: pickedRefs.map((p) => ({ src: p.url })) },
+        });
+        return;
+      }
+      if (!t) return;
+      // No references: send into an existing project, or auto-create from words.
+      if (target) handoffAndGo(target, t);
+      else void createAndGo({ name: deriveProjectName(t), prompt: t });
+    },
+    [busy, pickedRefs, target, handoffAndGo, createAndGo]
+  );
+
+  const onStartBlank = useCallback(() => {
+    if (busy) return;
+    void createAndGo({ prompt: "" });
+  }, [busy, createAndGo]);
+
+  // Clicking a gallery reference toggles it in the composer's tray (multi-select)
+  // instead of starting a board on its own — the user gathers several, then
+  // starts one board from all of them via the composer / the tray's Start button.
+  const togglePick = useCallback(
+    (pin: AgentDesignSearch.DesignSearchResult) => {
+      setPickedRefs((cur) =>
+        cur.some((p) => p.id === pin.id)
+          ? cur.filter((p) => p.id !== pin.id)
+          : [...cur, pin]
+      );
+    },
+    []
+  );
 
   const onOpen = useCallback(async () => {
     const bridge = getDesktopBridge();
@@ -184,7 +354,7 @@ export default function DesktopWelcomePage() {
       if (!paths || paths.length === 0) return;
       const ws = await workspacesNs.openFolder(paths[0]);
       await refreshWorkspaces();
-      setSelectedId(ws.id);
+      setTarget(ws); // aim the composer at the just-opened project
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't open folder.");
     } finally {
@@ -192,37 +362,14 @@ export default function DesktopWelcomePage() {
     }
   }, [refreshWorkspaces]);
 
-  const onForget = useCallback(
-    async (id: string) => {
-      try {
-        await workspacesNs.forget(id);
-        await refreshWorkspaces();
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Couldn't forget.");
-      }
-    },
-    [refreshWorkspaces]
-  );
-
-  const onSubmit = useCallback(
-    (text: string) => {
-      const t = text.trim();
-      if (!t || !selectedId) return;
-      // Stash for the workspace chat to pick up + auto-send as a fresh
-      // session, then become the workspace window. The model rides along
-      // so the picker's choice survives the navigation.
-      welcome_handoff.set(selectedId, { prompt: t, model_id: modelId });
-      router.push(`/desktop/workspace?id=${encodeURIComponent(selectedId)}`);
-    },
-    [selectedId, modelId, router]
-  );
-
-  const selected = workspaces.find((w) => w.id === selectedId) ?? null;
-  const hasWorkspaces = workspaces.length > 0;
-
   return (
     <div
       data-testid="desktop-welcome"
+      // The desktop shell locks <body> to h-svh/overflow-hidden, so the home
+      // owns its layout: one scroll pane with the composer hero on top and the
+      // reference gallery below. Once the hero scrolls out of view the composer
+      // detaches into a floating bottom bar (see `docked`) so you can keep
+      // writing while browsing.
       className="flex h-svh w-full flex-col bg-background"
     >
       {onboarding && (
@@ -230,18 +377,16 @@ export default function DesktopWelcomePage() {
           onDone={(openedWorkspaceId) => {
             setOnboarding(false);
             // A folder opened during onboarding lives only in the wizard until
-            // now — pull it into this page's list and select it so the composer
-            // and recents reflect it immediately (not just on the next focus).
-            if (openedWorkspaceId) {
-              void refreshWorkspaces().then(() =>
-                setSelectedId(openedWorkspaceId)
-              );
-            }
+            // now — pull it into this page's list so recents reflect it.
+            if (openedWorkspaceId) void refreshWorkspaces();
           }}
         />
       )}
       <TitleBar>
-        <div className="ml-auto" style={TITLEBAR_NO_DRAG_STYLE}>
+        <div
+          className="ml-auto flex items-center gap-0.5"
+          style={TITLEBAR_NO_DRAG_STYLE}
+        >
           <Button
             asChild
             variant="ghost"
@@ -256,161 +401,231 @@ export default function DesktopWelcomePage() {
         </div>
       </TitleBar>
 
-      <main className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto flex min-h-full w-full max-w-xl flex-col justify-center gap-10 px-6 py-12">
-          {/* Composer hero — target workspace + prompt. */}
-          <div className="flex flex-col gap-2.5">
-            <div className="flex">
-              <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    role="combobox"
-                    aria-expanded={pickerOpen}
-                    className="max-w-[16rem] gap-1.5"
-                  >
-                    <FolderIcon className="size-3.5 shrink-0" />
-                    <span className="min-w-0 truncate">
-                      {selected?.name ?? "Select a workspace"}
-                    </span>
-                    <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="start" className="w-72 p-0">
-                  <Command>
-                    <CommandInput placeholder="Search workspaces…" />
-                    <CommandList>
-                      <CommandEmpty>No workspace found.</CommandEmpty>
-                      {hasWorkspaces && (
-                        <CommandGroup heading="Recent">
-                          {workspaces.map((w) => (
-                            <CommandItem
-                              key={w.id}
-                              value={w.id}
-                              keywords={[w.name, w.root]}
-                              onSelect={() => {
-                                setSelectedId(w.id);
-                                setPickerOpen(false);
-                              }}
-                            >
-                              <span className="truncate">{w.name}</span>
-                              {w.id === selectedId && (
-                                <CheckIcon className="ml-auto size-4" />
-                              )}
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
+      {/* One page-scroll container — composer hero then gallery scroll together
+          (no nested scroll); the gallery virtualizes against this element. */}
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 pb-10 pt-[14vh]">
+          {/* Composer slot — narrow and centered; the gallery below spans the
+              wider container. This slot stays in flow and is what the dock
+              observer watches; once the composer floats it reserves `heroHeight`
+              so detaching doesn't jump the gallery up. */}
+          <div
+            ref={composerSlotRef}
+            className="mx-auto w-full max-w-2xl"
+            style={docked ? { height: heroHeight } : undefined}
+          >
+            {/* The composer itself. In the hero it's a plain in-flow block; once
+                docked it becomes a floating card fixed to the bottom, sliding up
+                on entry. It's the SAME element in both states, so the Tiptap
+                draft, focus, and caret carry across the transition. */}
+            <div
+              ref={composerRef}
+              className={cn(
+                "flex flex-col gap-2",
+                docked &&
+                  "fixed inset-x-4 bottom-4 z-30 mx-auto max-w-2xl rounded-xl border bg-background/95 p-2 shadow-lg backdrop-blur-sm duration-200 animate-in fade-in slide-in-from-bottom-4"
+              )}
+            >
+              {/* Target picker + blank, above the input. */}
+              <div className="flex items-center gap-3 px-1">
+                <Popover open={pickerOpen} onOpenChange={setPickerOpen} modal>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      role="combobox"
+                      aria-expanded={pickerOpen}
+                      className="max-w-[16rem] gap-1.5"
+                    >
+                      {target ? (
+                        <FolderIcon className="size-3.5 shrink-0" />
+                      ) : (
+                        <PlusIcon className="size-3.5 shrink-0" />
                       )}
-                      <CommandGroup>
-                        <CommandItem
-                          value="open folder new workspace"
-                          onSelect={() => {
-                            setPickerOpen(false);
-                            void onOpen();
-                          }}
-                        >
-                          Open folder…
-                        </CommandItem>
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-            </div>
-
-            <AgentComposerInput
-              catalog={catalog}
-              onSubmit={onSubmit}
-              isStreaming={false}
-              onStop={NOOP}
-              autofocus
-              placeholder={
-                selected
-                  ? `Ask Grida to design something in ${selected.name}…`
-                  : "Open a folder to start designing…"
-              }
-              toolbar={
-                <DesktopModelPicker
-                  value={modelId}
-                  onValueChange={setModelId}
-                  endpoints={endpoints}
-                />
-              }
-            />
-          </div>
-
-          {/* Divider — extra breathing room between the composer and the
-              recents list. */}
-          <div className="border-t" />
-
-          {/* Recent — click a row to open that workspace; the last row
-              opens a new folder so adding one is always discoverable. */}
-          <section className="flex flex-col gap-1.5">
-            {hasWorkspaces && (
-              <h2 className="px-1 text-xs font-medium text-muted-foreground">
-                Recent
-              </h2>
-            )}
-            <ul className="flex flex-col gap-0.5">
-              {workspaces.map((w) => (
-                <li
-                  key={w.id}
-                  className="group flex items-center gap-2 rounded-md transition-colors hover:bg-accent"
-                >
-                  <Link
-                    href={
-                      canvasIds.has(w.id)
-                        ? `/desktop/file?id=${encodeURIComponent(w.id)}`
-                        : workspaceWorkbenchHref(w)
-                    }
-                    prefetch={false}
-                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5"
-                  >
-                    <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="shrink-0 truncate text-sm font-medium">
-                      {w.name}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
-                      {w.root}
-                    </span>
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => onForget(w.id)}
-                    aria-label={`Forget ${w.name}`}
-                    className="mr-1 opacity-0 group-hover:opacity-100"
-                  >
-                    <XIcon className="size-3.5" />
-                  </Button>
-                </li>
-              ))}
-              <li>
+                      <span className="min-w-0 truncate">
+                        {target?.name ?? "New project"}
+                      </span>
+                      <ChevronDownIcon className="size-3.5 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  {/* Radix flips on collision, so this opens down in the hero and
+                      up when the composer is docked at the bottom. */}
+                  <PopoverContent align="start" className="w-72 p-0">
+                    <Command>
+                      <CommandInput placeholder="Search projects…" />
+                      <CommandList>
+                        <CommandEmpty>No project found.</CommandEmpty>
+                        <CommandGroup>
+                          <CommandItem
+                            value="new project"
+                            onSelect={() => {
+                              setTarget(null);
+                              setPickerOpen(false);
+                            }}
+                          >
+                            <PlusIcon className="text-muted-foreground" />
+                            New project
+                            {target === null && (
+                              <CheckIcon className="ml-auto size-4" />
+                            )}
+                          </CommandItem>
+                        </CommandGroup>
+                        {workspaces.length > 0 && (
+                          <CommandGroup heading="Recent">
+                            {workspaces.map((w) => (
+                              <CommandItem
+                                key={w.id}
+                                value={`${w.name} ${w.root}`}
+                                onSelect={() => {
+                                  setTarget(w);
+                                  setPickerOpen(false);
+                                }}
+                              >
+                                <FolderIcon className="text-muted-foreground" />
+                                <span className="min-w-0 flex-1 truncate">
+                                  {w.name}
+                                </span>
+                                {target?.id === w.id && (
+                                  <CheckIcon className="ml-auto size-4" />
+                                )}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        )}
+                        <CommandGroup>
+                          <CommandItem
+                            value="open folder existing project"
+                            onSelect={() => {
+                              setPickerOpen(false);
+                              void onOpen();
+                            }}
+                          >
+                            Open folder…
+                          </CommandItem>
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
                 <button
                   type="button"
-                  onClick={onOpen}
+                  onClick={onStartBlank}
                   disabled={busy}
-                  className="flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                  className="text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline disabled:opacity-50"
                 >
-                  <PlusIcon className="size-4 shrink-0" />
-                  Open folder…
+                  or start with a blank
                 </button>
-              </li>
-            </ul>
-          </section>
+              </div>
+              {/* Picked-references tray — the gallery drops pins here so several
+                  can be gathered before starting one board from all of them. A
+                  single horizontal scroll row keeps the composer compact — which
+                  matters most once it's floating. */}
+              {pickedRefs.length > 0 && (
+                <div className="flex flex-col gap-2 rounded-lg border bg-muted/30 p-2">
+                  <div className="flex items-center justify-between px-1">
+                    <span className="text-xs text-muted-foreground">
+                      {pickedRefs.length} reference
+                      {pickedRefs.length > 1 ? "s" : ""} selected — add a
+                      prompt, or just start
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setPickedRefs([])}
+                        className="text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+                      >
+                        Clear
+                      </button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => start("")}
+                        disabled={busy}
+                        className="h-6 gap-1 px-2 text-xs"
+                      >
+                        Start
+                        <ArrowRightIcon className="size-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="flex gap-2 overflow-x-auto">
+                    {pickedRefs.map((p) => (
+                      <div
+                        key={p.id}
+                        className="group relative size-16 shrink-0 overflow-hidden rounded-md border"
+                      >
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={p.url}
+                          alt={p.title}
+                          className="size-full object-cover"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => togglePick(p)}
+                          aria-label={`Remove ${p.title}`}
+                          className="absolute right-0.5 top-0.5 flex size-4 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow transition group-hover:opacity-100"
+                        >
+                          <XIcon className="size-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <AgentComposerInput
+                catalog={EMPTY_CATALOG}
+                onSubmit={start}
+                isStreaming={false}
+                onStop={NOOP}
+                autofocus
+                placeholder={
+                  pickedRefs.length > 0
+                    ? "Describe what to make from these references…"
+                    : target
+                      ? `Ask Grida to design something in ${target.name}…`
+                      : "Describe an image to create, or start from a reference…"
+                }
+                toolbar={
+                  <DesktopModelPicker
+                    value={modelId}
+                    onValueChange={setModelId}
+                    endpoints={endpoints}
+                  />
+                }
+              />
+              {/* Kept inside the composer so a submit error is visible even when
+                  the composer is floating (docked). */}
+              {error && (
+                <p
+                  role="alert"
+                  className="px-1 text-center text-xs text-destructive"
+                  onClick={() => setError(null)}
+                >
+                  {error}
+                </p>
+              )}
+            </div>
+          </div>
 
-          {error && (
-            <p
-              role="alert"
-              className="text-center text-xs text-destructive"
-              onClick={() => setError(null)}
-            >
-              {error}
-            </p>
-          )}
+          {/* Reference gallery — part of the single page scroll (virtualizes
+              against the scroll container above). */}
+          <ReferenceGallery
+            onPick={togglePick}
+            selectedIds={selectedRefIds}
+            disabled={busy}
+            scrollContainerRef={scrollRef}
+          />
         </div>
-      </main>
+      </div>
+
+      <RecentProjectsCommand
+        open={commandOpen}
+        onOpenChange={setCommandOpen}
+        workspaces={workspaces}
+        canvasIds={canvasIds}
+        onOpenFolder={onOpen}
+      />
     </div>
   );
 }

--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -161,6 +161,7 @@ export default function DesktopWelcomePage() {
     const onKey = (e: KeyboardEvent) => {
       if (e.ctrlKey && !e.metaKey && (e.key === "r" || e.key === "R")) {
         e.preventDefault();
+        if (e.repeat) return; // holding the key must not flicker the palette
         setCommandOpen((v) => !v);
       }
     };
@@ -170,13 +171,21 @@ export default function DesktopWelcomePage() {
 
   // Track the composer's natural (in-flow) height so the spacer can reserve it
   // when the composer detaches to float — otherwise the flow collapses and the
-  // gallery jumps up by the composer's height at the dock moment.
+  // gallery jumps up by the composer's height at the dock moment. Measurements
+  // are frozen WHILE docked: the floating card has its own padding/border, and
+  // adopting its height would skew the spacer. When the composer re-enters the
+  // flow its size changes, so the observer fires again and re-measures.
+  const dockedRef = useRef(docked);
+  dockedRef.current = docked;
   useEffect(() => {
     const el = composerRef.current;
     if (!el) return;
-    const ro = new ResizeObserver(() => setHeroHeight(el.offsetHeight));
+    const measure = () => {
+      if (!dockedRef.current) setHeroHeight(el.offsetHeight);
+    };
+    const ro = new ResizeObserver(measure);
     ro.observe(el);
-    setHeroHeight(el.offsetHeight);
+    measure();
     return () => ro.disconnect();
   }, []);
 
@@ -507,14 +516,19 @@ export default function DesktopWelcomePage() {
                     </Command>
                   </PopoverContent>
                 </Popover>
-                <button
-                  type="button"
-                  onClick={onStartBlank}
-                  disabled={busy}
-                  className="text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline disabled:opacity-50"
-                >
-                  or start with a blank
-                </button>
+                {/* Hidden while references are picked: "blank" means blank, and
+                    rendering it would either silently drop the gathered picks or
+                    duplicate the tray's Start — the tray owns starting then. */}
+                {pickedRefs.length === 0 && (
+                  <button
+                    type="button"
+                    onClick={onStartBlank}
+                    disabled={busy}
+                    className="text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline disabled:opacity-50"
+                  >
+                    or start with a blank
+                  </button>
+                )}
               </div>
               {/* Picked-references tray — the gallery drops pins here so several
                   can be gathered before starting one board from all of them. A

--- a/editor/lib/agent-chat/web-daemon-bridge.ts
+++ b/editor/lib/agent-chat/web-daemon-bridge.ts
@@ -193,6 +193,9 @@ export function createWebDaemonBridge(
     workspaces: {
       list: () => client.workspaces.list(),
       open: (rootPath) => client.workspaces.open(rootPath),
+      // Auto-create needs a host-injected managed root, which the plain-browser
+      // daemon doesn't wire — the desktop app owns this capability.
+      create: () => unavailable("workspaces.create"),
       pin: (id, pinned) => client.workspaces.pin(id, pinned),
       forget: (id) => client.workspaces.forget(id),
       readdir: (workspaceId, relPath) =>

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -55,6 +55,7 @@ import type {
   NavigationState,
   Workspace,
   WorkspaceChangeEvent,
+  WorkspaceCreateInput,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -801,12 +802,23 @@ export namespace workspaces {
   export async function openFolder(rootPath: string): Promise<Workspace> {
     return await bridgeOrThrow().workspaces.open(rootPath);
   }
+  /**
+   * Auto-create a fresh project — mint a managed-root folder, seed a `.canvas`
+   * board (optionally with placed reference documents), and register it. Powers
+   * the home's "auto-create, ask nothing" flow: no OS folder dialog. Rejects
+   * when the host wired no managed root (e.g. the web-daemon dev bridge).
+   */
+  export async function createProject(
+    input: WorkspaceCreateInput
+  ): Promise<Workspace> {
+    return await bridgeOrThrow().workspaces.create(input);
+  }
   export async function pin(id: string, pinned: boolean): Promise<void> {
     await bridgeOrThrow().workspaces.pin(id, pinned);
   }
-  export async function forget(id: string): Promise<void> {
-    await bridgeOrThrow().workspaces.forget(id);
-  }
+  // NOTE: `DesktopBridge.workspaces.forget` intentionally has no wrapper here —
+  // the home redesign dropped the per-row forget affordance, so nothing in the
+  // renderer calls it today. Re-add the wrapper with the next forget UI.
   /**
    * List immediate children of `relPath` (workspace root if omitted).
    * Empty array on an empty directory; throws on workspace-not-found,

--- a/editor/lib/desktop/welcome-handoff.ts
+++ b/editor/lib/desktop/welcome-handoff.ts
@@ -25,6 +25,8 @@
  * module rather than re-deriving the key.
  */
 
+import type { SkillId } from "@grida/agent";
+
 const KEY_PREFIX = "grida.welcome.pendingPrompt";
 
 function storageKey(workspaceId: string): string {
@@ -33,12 +35,20 @@ function storageKey(workspaceId: string): string {
 
 /** The prompt + composer settings stashed for the workspace chat. */
 export type WelcomeHandoff = {
-  /** The composer prompt, sent verbatim as the first turn. */
+  /** The composer prompt, sent verbatim as the first turn. Empty string when
+   * the home only wants to open the workspace primed (e.g. a picked reference)
+   * without auto-sending a turn. */
   prompt: string;
   /** The model the home composer was set to. Applied to that first
    * turn so the picker's choice survives the navigation; omitted when
    * the workspace chat should fall back to its own default. */
   model_id?: string;
+  /** Skills to prime the FIRST turn with when no editor tab is open yet — an
+   * auto-created project lands with no active tab, so the workbench can't infer
+   * the skill from a file extension. The home passes `["dotcanvas"]` so the
+   * artwork agent knows the `.canvas` board format from turn one. Once the user
+   * opens a tab, the active tab's skill takes over. */
+  skills?: SkillId[];
 };
 
 export namespace welcome_handoff {

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -20,6 +20,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Chat, useChat } from "@ai-sdk/react";
 import { AgentFs } from "@grida/agent/fs";
 import { AgentTodos } from "@grida/agent/todos";
+import type { SkillId } from "@grida/agent";
 import { resolveDesignSearch } from "@/scaffolds/desktop/shared/design-search";
 import {
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -91,7 +92,17 @@ const EMPTY_CATALOG: ComposerCatalog = { commands: [], mentions: [] };
  * and are MUTUALLY EXCLUSIVE — the type forbids passing both — so the component
  * is always bound to exactly one (or neither: the empty placeholder state).
  */
-type AISidebarChatProps = { className?: string } & (
+type AISidebarChatProps = {
+  className?: string;
+  /**
+   * Skills to prime every turn with (the file window has no editor-tab model to
+   * infer them from). The shell passes `["dotcanvas"]` for a `.canvas` bundle
+   * and `["svg"]` for a single SVG, so the agent carries the right format block
+   * — e.g. a board seeded from a picked reference gets the dotcanvas working
+   * pattern from turn one.
+   */
+  skills?: SkillId[];
+} & (
   | {
       /**
        * Renderer-resolved fs for SINGLE-FILE (in-memory) mode: the agent's fs
@@ -118,6 +129,7 @@ export function AISidebarChat({
   fs,
   workspaceId,
   className,
+  skills,
 }: AISidebarChatProps) {
   const isWorkspace = !!workspaceId;
   // Chat-session lifecycle: list, pick, hydrate. Scoped to `workspaceId` when
@@ -304,6 +316,7 @@ export function AISidebarChat({
     runContextRef.current = {
       model_id: modelId,
       ...(providerId ? { provider_id: providerId } : {}),
+      ...(skills?.length ? { skills } : {}),
     };
   }
 
@@ -347,6 +360,7 @@ export function AISidebarChat({
       sessionId: chatSession.current_id,
       modelId,
       providerId: registered_models.providerIdForModel(modelId, endpoints),
+      skills,
     }),
   });
 

--- a/editor/scaffolds/desktop/file/file-shell.tsx
+++ b/editor/scaffolds/desktop/file/file-shell.tsx
@@ -108,9 +108,12 @@ export function DesktopFileShell({
                 the `.canvas` dir (sees the manifest + every slide). Single-file
                 mode resolves fs tools client-side against the in-memory editor. */}
             {mode === "deck" ? (
-              <AISidebarChat workspaceId={workspaceId} />
+              // A `.canvas` bundle (board or slides) — prime the dotcanvas
+              // format skill so a board seeded from a picked reference is
+              // understood from turn one.
+              <AISidebarChat workspaceId={workspaceId} skills={["dotcanvas"]} />
             ) : (
-              <AISidebarChat fs={fs} />
+              <AISidebarChat fs={fs} skills={["svg"]} />
             )}
           </aside>
         </ResizablePanel>

--- a/editor/scaffolds/desktop/home/recent-projects-command.tsx
+++ b/editor/scaffolds/desktop/home/recent-projects-command.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Recent-projects quick switcher — a cmdk command palette (VS Code's ⌃R "Open
+ * Recent"). Keeps the home itself minimal: instead of a persistent recents
+ * list, projects live one keystroke away. Search matches name OR path; opening
+ * a `.canvas` bundle routes to the board window, everything else to the
+ * workbench (same rule the old inline list used).
+ */
+
+import { useRouter } from "next/navigation";
+import { FolderIcon, FolderOpenIcon } from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@app/ui/components/command";
+import type { Workspace } from "@/lib/desktop/bridge";
+import { workspaceWorkbenchHref } from "@/scaffolds/desktop/workbench/workspace-workbench-url";
+
+export function RecentProjectsCommand({
+  open,
+  onOpenChange,
+  workspaces,
+  canvasIds,
+  onOpenFolder,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaces: Workspace[];
+  canvasIds: Set<string>;
+  onOpenFolder: () => void;
+}) {
+  const router = useRouter();
+
+  const openProject = (w: Workspace) => {
+    onOpenChange(false);
+    router.push(
+      canvasIds.has(w.id)
+        ? `/desktop/file?id=${encodeURIComponent(w.id)}`
+        : workspaceWorkbenchHref(w)
+    );
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Recent projects"
+      description="Search and open a recent project"
+    >
+      <CommandInput placeholder="Search projects…" />
+      <CommandList>
+        <CommandEmpty>No projects found.</CommandEmpty>
+        {workspaces.length > 0 && (
+          <CommandGroup heading="Recent">
+            {workspaces.map((w) => (
+              <CommandItem
+                key={w.id}
+                value={`${w.name} ${w.root}`}
+                onSelect={() => openProject(w)}
+              >
+                <FolderIcon className="text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">{w.name}</span>
+                <span className="ml-auto min-w-0 max-w-[50%] truncate font-mono text-xs text-muted-foreground">
+                  {w.root}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        <CommandGroup>
+          <CommandItem
+            value="open folder existing project"
+            onSelect={() => {
+              onOpenChange(false);
+              onOpenFolder();
+            }}
+          >
+            <FolderOpenIcon className="text-muted-foreground" />
+            Open folder…
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/editor/scaffolds/desktop/home/reference-gallery.tsx
+++ b/editor/scaffolds/desktop/home/reference-gallery.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * The home's infinite reference gallery — the second way in (alongside typing).
+ * Scrolls the curated Grida Library best-first (by score); each card's Add button
+ * drops the pin into the composer's picked-references tray (multi-select).
+ *
+ * Same engine as the agent's `design_search` picker: **`masonic`**'s lower-level
+ * `useMasonry`. But here the gallery is NOT its own scroll box — it shares the
+ * home's single page scroll (the whole page scrolls as one; no nested scroll).
+ * The desktop shell locks `<body>` to `h-svh overflow-hidden`, so the home owns
+ * one `overflow-y-auto` container and passes it in as `scrollContainerRef`; the
+ * gallery feeds masonic that container's `scrollTop` MINUS the gallery's own
+ * offset within it (the composer sits above), so virtualization lines up with the
+ * page scroll. Page 0 is seeded client-side (an empty grid renders
+ * nothing, so the loader can't pull it); the loader pages from there. Library
+ * pins stay URLs — nothing is downloaded; the picked url rides straight into the
+ * seeded board.
+ *
+ * Picking is a **toggle into the composer** (multi-select) via each card's Add
+ * button, revealed on hover: it adds the pin to the home's picked-references tray
+ * (Added → click to remove), so the user can gather several references before
+ * starting one board from all of them. The card body itself is intentionally
+ * NOT the add target — clicking it will later open a details / similar-images
+ * view (planned), so only the Add button mutates the tray today. The pick handler
+ * + selected-set ride a context so masonic's memoized cells stay stable.
+ */
+
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import {
+  useInfiniteLoader,
+  useMasonry,
+  usePositioner,
+  useResizeObserver,
+  type LoadMoreItemsCallback,
+} from "masonic";
+import { CheckIcon, Loader2Icon, PlusIcon } from "lucide-react";
+import { cn } from "@app/ui/lib/utils";
+import type { AgentDesignSearch } from "@grida/agent/tools/design-search";
+import {
+  DESIGN_SEARCH_PAGE,
+  resolveDesignBrowsePage,
+} from "@/scaffolds/desktop/shared/design-search";
+
+type Pin = AgentDesignSearch.DesignSearchResult;
+
+/** Stop paging past this many thumbnails — the home gallery is a starting point,
+ *  not the full library browser, and unbounded DOM would bloat the page. */
+const MAX_ITEMS = 300;
+
+/** Pick handler + selected-set passed to masonic-rendered cells via context
+ *  (masonic memoizes cells, so a per-render closure would defeat it). */
+const PickContext = createContext<{
+  onPick: (pin: Pin) => void;
+  selectedIds: Set<string>;
+  disabled: boolean;
+}>({ onPick: () => {}, selectedIds: new Set(), disabled: false });
+
+/** One masonry cell — masonic passes `{ data, width }`; we size to the pin's
+ *  aspect ratio (no per-item measurement). The card body is a plain container
+ *  (its click is reserved for a future details view); only the hover-revealed
+ *  Add button toggles the pick. A selected cell gets a primary ring, and its Add
+ *  button stays visible as "Added" so multi-select is legible. */
+function ReferenceCard({ data: pin, width }: { data: Pin; width: number }) {
+  const { onPick, selectedIds, disabled } = useContext(PickContext);
+  const selected = selectedIds.has(pin.id);
+  const aspect = pin.width && pin.height ? pin.width / pin.height : 1;
+  const height = width / aspect;
+  return (
+    <div
+      title={pin.title}
+      style={{ width, height }}
+      className={cn(
+        "group relative block overflow-hidden rounded-lg border-2 transition",
+        selected
+          ? "border-primary ring-2 ring-primary/40"
+          : "border-transparent"
+      )}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={pin.url}
+        alt={pin.title}
+        loading="lazy"
+        className={cn(
+          "size-full object-cover transition",
+          selected && "brightness-90"
+        )}
+      />
+      {/* Add / Added toggle — revealed on hover; stays put once added so a second
+          click removes it. The ONLY add target (card click is reserved for a
+          planned details / similar-images view). */}
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={selected}
+        onClick={() => onPick(pin)}
+        title={selected ? "Remove from composer" : "Add to composer"}
+        className={cn(
+          "absolute right-1.5 top-1.5 flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium shadow transition disabled:opacity-50",
+          selected
+            ? "bg-primary text-primary-foreground"
+            : "bg-background/90 text-foreground opacity-0 hover:bg-background group-hover:opacity-100 focus-visible:opacity-100"
+        )}
+      >
+        {selected ? (
+          <>
+            <CheckIcon className="size-3.5" />
+            Added
+          </>
+        ) : (
+          <>
+            <PlusIcon className="size-3.5" />
+            Add
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+/** `memo`-wrapped: the home page re-renders on every composer keystroke/resize
+ *  (`heroHeight`, `docked`, picker state…), and all props here are already
+ *  referentially stable — so the up-to-300-cell masonry only re-renders on a
+ *  real pick/selection change. */
+export const ReferenceGallery = memo(function ReferenceGallery({
+  onPick,
+  selectedIds,
+  disabled = false,
+  scrollContainerRef,
+}: {
+  onPick: (pin: Pin) => void;
+  /** Ids currently in the composer's picked-references tray — selected cells
+   *  render a check badge so multi-select reads at a glance. */
+  selectedIds: Set<string>;
+  disabled?: boolean;
+  /** The home's single page-scroll container — the gallery virtualizes against
+   *  it (offset by the content above) instead of owning its own scroll. */
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+}) {
+  const [items, setItems] = useState<Pin[]>([]);
+  const [count, setCount] = useState<number | undefined>(undefined);
+  const [seeded, setSeeded] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(false);
+  const loadingRef = useRef(false);
+
+  // Append a page, de-duped by id (score order is stable, but guard anyway).
+  const appendPage = useCallback((page: Pin[]) => {
+    setItems((cur) => {
+      const seen = new Set(cur.map((p) => p.id));
+      return [...cur, ...page.filter((p) => !seen.has(p.id))];
+    });
+  }, []);
+
+  // Seed page 0 (masonic's loader can't pull it from an empty grid).
+  useEffect(() => {
+    let live = true;
+    loadingRef.current = true;
+    void resolveDesignBrowsePage([0, DESIGN_SEARCH_PAGE - 1])
+      .then(({ items: page, count: total }) => {
+        if (!live) return;
+        setCount(total);
+        appendPage(page);
+      })
+      .catch(() => {
+        if (live) setError(true);
+      })
+      .finally(() => {
+        if (live) {
+          setSeeded(true);
+          loadingRef.current = false;
+        }
+      });
+    return () => {
+      live = false;
+    };
+  }, [appendPage]);
+
+  const maybeLoadMore = useInfiniteLoader<Pin, LoadMoreItemsCallback<Pin>>(
+    async (startIndex, stopIndex) => {
+      if (loadingRef.current || items.length >= MAX_ITEMS) return;
+      loadingRef.current = true;
+      setLoadingMore(true);
+      try {
+        const { items: page, count: total } = await resolveDesignBrowsePage([
+          startIndex,
+          stopIndex - 1,
+        ]);
+        setCount(total);
+        appendPage(page);
+      } catch {
+        /* a transient page error just stops paging; the grid stays */
+      } finally {
+        loadingRef.current = false;
+        setLoadingMore(false);
+      }
+    },
+    {
+      minimumBatchSize: DESIGN_SEARCH_PAGE,
+      isItemLoaded: (index, loaded) => index < loaded.length,
+      totalItems: count,
+    }
+  );
+
+  // ── share the page's scroll: feed masonic the container's scrollTop minus
+  //    this grid's offset within it (the composer sits above) ──
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(0);
+  const [viewportH, setViewportH] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [offsetTop, setOffsetTop] = useState(0);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollStop = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Distance from the top of the container's scrollable content to this grid —
+  // scroll-invariant, so it also self-corrects if the content above reflows.
+  const measureOffset = useCallback(() => {
+    const container = scrollContainerRef.current;
+    const wrap = wrapRef.current;
+    if (!container || !wrap) return;
+    const cRect = container.getBoundingClientRect();
+    const wRect = wrap.getBoundingClientRect();
+    setOffsetTop(wRect.top - cRect.top + container.scrollTop);
+    setWidth(wrap.clientWidth);
+    setViewportH(container.clientHeight);
+  }, [scrollContainerRef]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    const wrap = wrapRef.current;
+    if (!container || !wrap) return;
+    measureOffset();
+    // Scroll only moves the viewport: update scrollTop + the isScrolling flag.
+    // offset/width/viewportH are scroll-invariant, so they're re-measured ONLY on
+    // reflow (the ResizeObserver below) — not per scroll frame, which would force
+    // two extra getBoundingClientRect reflows on every tick.
+    const onScroll = () => {
+      setScrollTop(container.scrollTop);
+      setIsScrolling(true);
+      if (scrollStop.current) clearTimeout(scrollStop.current);
+      scrollStop.current = setTimeout(() => setIsScrolling(false), 120);
+    };
+    const ro = new ResizeObserver(measureOffset);
+    ro.observe(container);
+    ro.observe(wrap);
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      ro.disconnect();
+      container.removeEventListener("scroll", onScroll);
+    };
+  }, [scrollContainerRef, measureOffset]);
+
+  const positioner = usePositioner({
+    width: Math.max(0, width),
+    columnWidth: 180,
+    columnGutter: 12,
+    rowGutter: 12,
+    maxColumnCount: 6,
+  });
+  const resizeObserver = useResizeObserver(positioner);
+
+  // Stable context identity so a scroll tick doesn't push a new value to every
+  // masonry cell and defeat memoization — only a real pick/selection/disabled
+  // change should.
+  const pickContext = useMemo(
+    () => ({ onPick, selectedIds, disabled }),
+    [onPick, selectedIds, disabled]
+  );
+
+  const grid = useMasonry<Pin>({
+    positioner,
+    resizeObserver,
+    items,
+    height: viewportH,
+    scrollTop: Math.max(0, scrollTop - offsetTop),
+    isScrolling,
+    overscanBy: 2,
+    itemKey: (data) => data.id,
+    render: ReferenceCard,
+    onRender: maybeLoadMore,
+  });
+
+  return (
+    <div ref={wrapRef}>
+      {error && items.length === 0 && (
+        <p className="py-10 text-center text-xs text-muted-foreground">
+          Couldn’t load references.
+        </p>
+      )}
+
+      {!seeded && items.length === 0 && !error && (
+        <div className="flex items-center justify-center py-10 text-xs text-muted-foreground">
+          <Loader2Icon className="mr-2 size-4 animate-spin" />
+          Loading references…
+        </div>
+      )}
+
+      <PickContext.Provider value={pickContext}>{grid}</PickContext.Provider>
+
+      {loadingMore && (
+        <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
+          <Loader2Icon className="mr-2 size-4 animate-spin" />
+          Loading more…
+        </div>
+      )}
+    </div>
+  );
+});

--- a/editor/scaffolds/desktop/shared/design-search.ts
+++ b/editor/scaffolds/desktop/shared/design-search.ts
@@ -9,7 +9,7 @@
  * downloaded; a picked pin's url is fed straight into image-to-image.
  */
 
-import { search } from "@/app/(library)/library/actions";
+import { browse, search } from "@/app/(library)/library/actions";
 import type { AgentDesignSearch } from "@grida/agent/tools/design-search";
 
 /** Host-fixed result count — not an agent knob (TOOL-DESIGN doctrine). */
@@ -60,5 +60,15 @@ export async function resolveDesignSearchPage(
   range: [number, number]
 ): Promise<DesignSearchPage> {
   const { data, count } = await search({ text: query, range });
+  return { items: data.map(toPin), count: count ?? undefined };
+}
+
+/** Cold-browse a page of the curated corpus (no query) — the home reference
+ *  gallery's fetch. Same {@link DesignSearchPage} shape as the query path so a
+ *  gallery can page through either identically. */
+export async function resolveDesignBrowsePage(
+  range: [number, number]
+): Promise<DesignSearchPage> {
+  const { data, count } = await browse({ range });
   return { items: data.map(toPin), count: count ?? undefined };
 }

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -522,13 +522,18 @@ function AgentPaneContent({
   // turn. Wait for the session list to settle (loading=false) so the
   // forced-new null session is in place, then consume + send. Ref-guarded
   // so re-renders — and the onSubmit identity change after the fresh
-  // session adopts its id — can't re-fire it.
+  // session adopts its id — can't re-fire it. An EMPTY prompt (the home's
+  // blank / references-only start) is still consumed — cleared without
+  // sending — otherwise the stale handoff would force a fresh session on
+  // every later mount of this workspace.
   const autoSentRef = useRef(false);
   useEffect(() => {
-    if (!handoffPrompt || autoSentRef.current || chatSession.loading) return;
+    if (handoffPrompt == null || autoSentRef.current || chatSession.loading) {
+      return;
+    }
     autoSentRef.current = true;
     welcome_handoff.clear(workspace.id);
-    void onSubmit(handoffPrompt);
+    if (handoffPrompt) void onSubmit(handoffPrompt);
   }, [handoffPrompt, chatSession.loading, onSubmit, workspace.id]);
 
   // Rewind: soft-truncate to the chosen user message, then re-hydrate.

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -472,7 +472,10 @@ function AgentPaneContent({
   // Endpoint provider pin for the active model (issue #806) — rides every
   // run-entering body: normal sends AND approval resumes below.
   const providerId = registered_models.providerIdForModel(modelId, endpoints);
-  const activeSkills = skillsForActiveTab(activeRelPath);
+  // The active tab dictates skills; when none is open yet (a freshly
+  // auto-created project lands with no tab), fall back to the skills the home
+  // primed on the handoff so the first turn still gets its format block.
+  const activeSkills = skillsForActiveTab(activeRelPath) ?? handoff?.skills;
   // Keep the transport's body-less backfill (above) in step with the pickers.
   runContextRef.current = {
     model_id: modelId,

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -472,10 +472,15 @@ function AgentPaneContent({
   // Endpoint provider pin for the active model (issue #806) — rides every
   // run-entering body: normal sends AND approval resumes below.
   const providerId = registered_models.providerIdForModel(modelId, endpoints);
-  // The active tab dictates skills; when none is open yet (a freshly
-  // auto-created project lands with no tab), fall back to the skills the home
-  // primed on the handoff so the first turn still gets its format block.
-  const activeSkills = skillsForActiveTab(activeRelPath) ?? handoff?.skills;
+  // The active tab dictates skills; ONLY when no tab is open at all (a freshly
+  // auto-created project lands with no tab) fall back to the skills the home
+  // primed on the handoff so the first turn still gets its format block. An
+  // open-but-unmapped tab means no skills — the tab took over, per the
+  // contract above.
+  const activeSkills =
+    activeRelPath === null
+      ? handoff?.skills
+      : skillsForActiveTab(activeRelPath);
   // Keep the transport's body-less backfill (above) in step with the pickers.
   runContextRef.current = {
     model_id: modelId,

--- a/packages/grida-ai-agent/src/__public-api__.test.ts
+++ b/packages/grida-ai-agent/src/__public-api__.test.ts
@@ -52,6 +52,7 @@ import {
   type SessionStatus,
   type SkillId,
   type Workspace,
+  type WorkspaceCreateInput,
   type WorkspaceFsEntry,
 } from ".";
 import {
@@ -167,6 +168,7 @@ describe("@grida/agent public API", () => {
       type _FR = FileReadResult;
       type _RE = RecentEntry;
       type _W = Workspace;
+      type _WCI = WorkspaceCreateInput;
       type _WE = WorkspaceFsEntry;
       const row: ChatSessionRow = {
         id: "s",

--- a/packages/grida-ai-agent/src/agent-host.ts
+++ b/packages/grida-ai-agent/src/agent-host.ts
@@ -53,6 +53,13 @@ export type AgentHostOptions = {
    */
   scratch_base?: string;
   /**
+   * GRIDA-SEC-004 — host-injected managed root for the auto-create flow
+   * (`POST /workspaces/create`). The desktop supervisor passes `~/Documents/Grida`;
+   * CLI/dev leave it unset (auto-create then refuses). Forwarded to
+   * {@link ServerOptions} by the `...opts` spread below.
+   */
+  projects_root?: string;
+  /**
    * Catalog model id the agent's `generate_image` tool produces with — the
    * user's selected image model. The tool is prompt-only (model is host config,
    * not an agent argument). Forwarded to {@link ServerOptions} by the `...opts`

--- a/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
@@ -93,16 +93,21 @@ describe("POST /workspaces/create (auto-create)", () => {
     expect(manifest.documents[0].thumbnail).toBeUndefined();
   });
 
-  it("rejects a seed with more documents than the cap", async () => {
-    const res = await post(app, {
-      name: "Flood",
-      seed: {
-        documents: Array.from({ length: 501 }, (_, i) => ({
-          src: `https://library.grida.co/${i}.png`,
-        })),
-      },
+  it("caps seed documents at 500: exactly 500 passes, 501 rejects", async () => {
+    const docs = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        src: `https://library.grida.co/${i}.png`,
+      }));
+    const atCap = await post(app, {
+      name: "AtCap",
+      seed: { documents: docs(500) },
     });
-    expect(res.status).toBe(400);
+    expect(atCap.status).toBe(200);
+    const overCap = await post(app, {
+      name: "Flood",
+      seed: { documents: docs(501) },
+    });
+    expect(overCap.status).toBe(400);
   });
 
   it("slugifies a traversal name so it stays inside the managed root", async () => {

--- a/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
@@ -93,6 +93,18 @@ describe("POST /workspaces/create (auto-create)", () => {
     expect(manifest.documents[0].thumbnail).toBeUndefined();
   });
 
+  it("rejects a seed with more documents than the cap", async () => {
+    const res = await post(app, {
+      name: "Flood",
+      seed: {
+        documents: Array.from({ length: 501 }, (_, i) => ({
+          src: `https://library.grida.co/${i}.png`,
+        })),
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("slugifies a traversal name so it stays inside the managed root", async () => {
     const res = await post(app, { name: "../../pwned" });
     expect(res.status).toBe(200);

--- a/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.create.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable jest/no-standalone-expect */
+/**
+ * Contract pins — auto-create route `POST /workspaces/create` (GRIDA-SEC-004).
+ *
+ * The desktop home's "auto-create, ask nothing" flow posts here to mint a fresh
+ * project (a folder under the host's managed root) seeded with a `.canvas`
+ * board. What must hold: it creates + registers a project, the seed is
+ * field-constrained (only `src` + a numeric layout box reach the manifest — no
+ * raw-manifest injection), a hostile `name` can't escape the managed root, and
+ * a host without a managed root refuses with a 400.
+ *
+ * Routes are registered onto a bare Hono app and driven via `app.request()`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Hono } from "hono";
+import { WorkspaceRegistry } from "../../workspaces";
+import { registerWorkspacesRoutes } from "./workspaces";
+
+describe("POST /workspaces/create (auto-create)", () => {
+  let baseDir: string;
+  let userDataDir: string;
+  let projectsRoot: string;
+  let app: Hono;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "grida-create-route-"));
+    userDataDir = path.join(baseDir, "userdata");
+    projectsRoot = path.join(baseDir, "Grida");
+    await fs.mkdir(userDataDir);
+    app = new Hono();
+    registerWorkspacesRoutes(
+      app,
+      new WorkspaceRegistry(userDataDir, projectsRoot)
+    );
+  });
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  const post = (appToUse: Hono, jsonBody: unknown) =>
+    appToUse.request("/workspaces/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(jsonBody),
+    });
+
+  // The manifest lives inside the `<name>.canvas` bundle dir, not at the root.
+  const readManifest = async (root: string) =>
+    JSON.parse(
+      await fs.readFile(
+        path.join(root, `${path.basename(root)}.canvas`, ".canvas.json"),
+        "utf8"
+      )
+    );
+
+  it("creates + registers a project seeded with a board manifest", async () => {
+    const res = await post(app, { name: "Poster" });
+    expect(res.status).toBe(200);
+    const ws = await res.json();
+    expect(ws.name).toBe("Poster");
+    const manifest = await readManifest(ws.root);
+    expect(manifest.editor).toBe("board");
+    expect(manifest.documents).toEqual([]);
+  });
+
+  it("field-constrains the seed: only src + numeric layout survive", async () => {
+    const res = await post(app, {
+      name: "Ref",
+      seed: {
+        documents: [
+          {
+            src: "https://library.grida.co/ref.png",
+            layout: { x: 1, y: 2, evil: "rm -rf" },
+            skip: true,
+            thumbnail: "../../etc/passwd",
+          },
+          { notsrc: "dropme" }, // no src → dropped
+          "junk", // not an object → dropped
+        ],
+      },
+    });
+    expect(res.status).toBe(200);
+    const ws = await res.json();
+    const manifest = await readManifest(ws.root);
+    expect(manifest.documents).toEqual([
+      { src: "https://library.grida.co/ref.png", layout: { x: 1, y: 2 } },
+    ]);
+    // The smuggled top-level fields never reached the manifest.
+    expect(manifest.documents[0].skip).toBeUndefined();
+    expect(manifest.documents[0].thumbnail).toBeUndefined();
+  });
+
+  it("slugifies a traversal name so it stays inside the managed root", async () => {
+    const res = await post(app, { name: "../../pwned" });
+    expect(res.status).toBe(200);
+    const ws = await res.json();
+    const rootReal = await fs.realpath(projectsRoot);
+    expect(path.dirname(await fs.realpath(ws.root))).toBe(rootReal);
+  });
+
+  it("400s when the host wired no managed root", async () => {
+    const noRootApp = new Hono();
+    registerWorkspacesRoutes(noRootApp, new WorkspaceRegistry(userDataDir));
+    const res = await post(noRootApp, { name: "x" });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("projects-root-not-configured");
+  });
+});

--- a/packages/grida-ai-agent/src/http/routes/workspaces.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.ts
@@ -21,9 +21,56 @@
  */
 import { Readable } from "node:stream";
 import type { Context, Hono } from "hono";
-import type { Workspace, WorkspaceRegistry } from "../../workspaces";
+import type {
+  ProjectSeed,
+  ProjectSeedDocument,
+  Workspace,
+  WorkspaceRegistry,
+} from "../../workspaces";
 import { workspaceFs } from "../../workspaces/fs";
-import { body, v } from "../validate";
+import { body, v, type Validator } from "../validate";
+
+/**
+ * Keep only numeric x/y/w/h/z from a raw layout — drops anything else so a
+ * hostile body can't smuggle extra manifest fields through the seed.
+ */
+function sanitizeLayout(
+  raw: unknown
+): ProjectSeedDocument["layout"] | undefined {
+  if (raw === null || typeof raw !== "object") return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, number> = {};
+  for (const k of ["x", "y", "w", "h", "z"] as const) {
+    const val = src[k];
+    if (typeof val === "number" && Number.isFinite(val)) out[k] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Field-constrained `seed` validator (GRIDA-SEC-004): reduces an arbitrary body
+ * to a {@link ProjectSeed} of `{ src, layout? }` documents, silently dropping
+ * malformed entries. This is the injection-vector gate — a raw dotcanvas
+ * manifest never reaches disk, only `src` (string) + a numeric layout box.
+ */
+const seedValidator: Validator<ProjectSeed> = (raw) => {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, error: "must be an object" };
+  }
+  const docs = (raw as { documents?: unknown }).documents;
+  if (!Array.isArray(docs)) {
+    return { ok: false, error: "must have a documents array" };
+  }
+  const documents: ProjectSeedDocument[] = [];
+  for (const d of docs) {
+    if (d === null || typeof d !== "object") continue;
+    const src = (d as { src?: unknown }).src;
+    if (typeof src !== "string" || src.length === 0) continue;
+    const layout = sanitizeLayout((d as { layout?: unknown }).layout);
+    documents.push(layout ? { src, layout } : { src });
+  }
+  return { ok: true, value: { documents } };
+};
 
 /**
  * Resolve a workspace by id, or return a 404 JSON response. Caller
@@ -57,6 +104,30 @@ export function registerWorkspacesRoutes(
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "couldn't open workspace";
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  // POST /workspaces/create { name?, seed? } → Workspace | 400
+  // GRIDA-SEC-004 — auto-create a fresh project under the host's managed root.
+  // `name` is slugified and `seed` is field-constrained (see seedValidator);
+  // the registry mints + realpath-contains + registers. 400 on a host without
+  // a managed root wired (`projects-root-not-configured`).
+  app.post("/workspaces/create", async (c) => {
+    const r = await body(c, {
+      name: v.optional(v.string),
+      seed: v.optional(seedValidator),
+    });
+    if (!r.ok) return r.res;
+    try {
+      const workspace = await registry.createProject({
+        name: r.data.name,
+        seed: r.data.seed,
+      });
+      return c.json(workspace);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "couldn't create project";
       return c.json({ error: message }, 400);
     }
   });

--- a/packages/grida-ai-agent/src/http/routes/workspaces.ts
+++ b/packages/grida-ai-agent/src/http/routes/workspaces.ts
@@ -47,6 +47,11 @@ function sanitizeLayout(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/** Upper bound on seeded documents — far above any real pick tray (the home
+ *  gallery tops out at a few hundred cards) while keeping a buggy or hostile
+ *  caller from inflating the manifest write (GRIDA-SEC-004 posture). */
+const MAX_SEED_DOCUMENTS = 500;
+
 /**
  * Field-constrained `seed` validator (GRIDA-SEC-004): reduces an arbitrary body
  * to a {@link ProjectSeed} of `{ src, layout? }` documents, silently dropping
@@ -60,6 +65,12 @@ const seedValidator: Validator<ProjectSeed> = (raw) => {
   const docs = (raw as { documents?: unknown }).documents;
   if (!Array.isArray(docs)) {
     return { ok: false, error: "must have a documents array" };
+  }
+  if (docs.length > MAX_SEED_DOCUMENTS) {
+    return {
+      ok: false,
+      error: `documents exceeds the ${MAX_SEED_DOCUMENTS}-entry cap`,
+    };
   }
   const documents: ProjectSeedDocument[] = [];
   for (const d of docs) {

--- a/packages/grida-ai-agent/src/http/server.ts
+++ b/packages/grida-ai-agent/src/http/server.ts
@@ -50,6 +50,13 @@ export type ServerOptions = {
    */
   scratch_base?: string;
   /**
+   * GRIDA-SEC-004 — host-injected managed root under which the auto-create flow
+   * (`POST /workspaces/create`) mints new project folders (desktop:
+   * `~/Documents/Grida`). Host-owned, never client-derived. Omitted on hosts
+   * that don't wire it (CLI/dev), where `createProject` throws.
+   */
+  projects_root?: string;
+  /**
    * Catalog model id the agent's `generate_image` tool produces with — the
    * user's selected image model (host config). The tool is prompt-only, so the
    * model is not an agent argument. Omit to use the catalog default.
@@ -149,7 +156,10 @@ export function buildServer(opts: ServerOptions): BuiltServer {
   // and resets on restart; recent.json / auth.json are on disk and persist).
   const registry = new FileRegistry();
   const recentStore = new RecentStore(opts.user_data_path);
-  const workspaceRegistry = new WorkspaceRegistry(opts.user_data_path);
+  const workspaceRegistry = new WorkspaceRegistry(
+    opts.user_data_path,
+    opts.projects_root
+  );
   const authStore = new AuthStore(opts.user_data_path);
   const secretsStore = new SecretsStore(authStore);
   // Endpoint provider configs (issue #806): plain config beside the

--- a/packages/grida-ai-agent/src/index.ts
+++ b/packages/grida-ai-agent/src/index.ts
@@ -78,6 +78,7 @@ export type {
   FileWriteResult,
   RecentEntry,
   Workspace,
+  WorkspaceCreateInput,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,

--- a/packages/grida-ai-agent/src/path-contains.ts
+++ b/packages/grida-ai-agent/src/path-contains.ts
@@ -7,9 +7,9 @@ import path from "node:path";
  *
  * Both arguments must already be absolute (and ideally `realpath`'d by the
  * caller when symlink stability matters) — this is a pure string check, not a
- * filesystem op. Shared by the shell runner's workspace/secret-root gates and
- * the session scratch containment assert so the discipline can't drift between
- * copies.
+ * filesystem op. Shared by the shell runner's workspace/secret-root gates, the
+ * session scratch containment assert, and `WorkspaceRegistry.createProject`'s
+ * managed-root assert so the discipline can't drift between copies.
  */
 export function containsPath(root: string, candidate: string): boolean {
   const prefix = root.endsWith(path.sep) ? root : root + path.sep;

--- a/packages/grida-ai-agent/src/protocol/resources.ts
+++ b/packages/grida-ai-agent/src/protocol/resources.ts
@@ -37,6 +37,23 @@ export type WorkspaceFsEntry = {
   kind: "file" | "directory" | "symlink" | "other";
 };
 
+/**
+ * Wire input for `POST /workspaces/create` (auto-create). A field-constrained
+ * board seed — only a document's `src` (a bundle-relative path or an `https://`
+ * reference) and an optional layout box, never a raw manifest (GRIDA-SEC-004).
+ * The host re-validates this shape server-side before it touches disk.
+ */
+export type WorkspaceCreateSeedDocument = {
+  src: string;
+  layout?: { x?: number; y?: number; w?: number; h?: number; z?: number };
+};
+export type WorkspaceCreateInput = {
+  /** Friendly name → slugified into the folder segment. Defaults to "Untitled". */
+  name?: string;
+  /** Documents to place on the fresh board (e.g. a picked reference). */
+  seed?: { documents: WorkspaceCreateSeedDocument[] };
+};
+
 export type WorkspaceReadFileResult = {
   content: string;
   mtime: number;

--- a/packages/grida-ai-agent/src/transport.ts
+++ b/packages/grida-ai-agent/src/transport.ts
@@ -41,6 +41,7 @@ import type {
   FileWriteResult,
   RecentEntry,
   Workspace,
+  WorkspaceCreateInput,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -355,6 +356,10 @@ export namespace AgentTransport {
         await this.postJson<Workspace[]>("/workspaces/list"),
       open: async (rootPath: string): Promise<Workspace> =>
         await this.postJson<Workspace>("/workspaces/open", { path: rootPath }),
+      // Auto-create a fresh project (managed root, seeded `.canvas` board) and
+      // register it. Powers the desktop home's "auto-create, ask nothing" flow.
+      create: async (input: WorkspaceCreateInput): Promise<Workspace> =>
+        await this.postJson<Workspace>("/workspaces/create", input),
       pin: async (id: string, pinned: boolean): Promise<void> => {
         await this.postJson<unknown>("/workspaces/pin", { id, pinned });
       },

--- a/packages/grida-ai-agent/src/workspaces.test.ts
+++ b/packages/grida-ai-agent/src/workspaces.test.ts
@@ -15,7 +15,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { WorkspaceRegistry } from "./workspaces";
+import { WorkspaceRegistry, type Workspace } from "./workspaces";
 
 function expectedId(realRoot: string): string {
   return crypto
@@ -193,6 +193,27 @@ describe("Workspaces", () => {
       const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
       const ws = await registry.createProject({ name: "Poster v2..." });
       expect(path.basename(ws.root)).toBe("Poster v2");
+    });
+
+    it("rolls back the minted directory when a downstream step fails", async () => {
+      // Force the last step (registration via `open`) to fail — the mint must
+      // be removed so no orphaned half-project squats the slug.
+      class FailingRegistry extends WorkspaceRegistry {
+        override async open(): Promise<Workspace> {
+          throw new Error("boom");
+        }
+      }
+      const registry = new FailingRegistry(userDataDir, projectsRoot);
+      await expect(registry.createProject({ name: "Poster" })).rejects.toThrow(
+        "boom"
+      );
+      await expect(
+        fs.stat(path.join(projectsRoot, "Poster"))
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      // The slug is free again: a healthy registry mints "Poster", not "-2".
+      const healthy = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const ws = await healthy.createProject({ name: "Poster" });
+      expect(path.basename(ws.root)).toBe("Poster");
     });
 
     it("throws projects-root-not-configured when no managed root is wired", async () => {

--- a/packages/grida-ai-agent/src/workspaces.test.ts
+++ b/packages/grida-ai-agent/src/workspaces.test.ts
@@ -107,4 +107,83 @@ describe("Workspaces", () => {
 
   // Phase B+ coverage target once host sandbox policy compilation lands:
   // srt fs-policy unions workspace roots, ad-hoc docIds, and userData.
+
+  describe("createProject (auto-create)", () => {
+    let projectsRoot: string;
+    beforeEach(() => {
+      projectsRoot = path.join(baseDir, "Grida");
+    });
+
+    it("mints a folder holding a `<name>.canvas` bundle, seeds an empty board, and registers it", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const ws = await registry.createProject({ name: "Poster" });
+
+      // Folder lives under the managed root and is registered (recents).
+      const rootReal = await fs.realpath(projectsRoot);
+      expect(path.dirname(ws.root)).toBe(rootReal);
+      expect(ws.name).toBe("Poster");
+      expect(await registry.findById(ws.id)).not.toBeNull();
+
+      // The manifest lives INSIDE a `<name>.canvas` bundle dir (so the tree
+      // recognizes it as an openable board), NOT loose at the workspace root.
+      const bundleName = `${path.basename(ws.root)}.canvas`;
+      const rootEntries = await fs.readdir(ws.root);
+      expect(rootEntries).toContain(bundleName);
+      expect(rootEntries).not.toContain(".canvas.json"); // nothing loose at root
+      const manifest = JSON.parse(
+        await fs.readFile(
+          path.join(ws.root, bundleName, ".canvas.json"),
+          "utf8"
+        )
+      );
+      expect(manifest.editor).toBe("board");
+      expect(manifest.documents).toEqual([]);
+    });
+
+    it("seeds a picked reference as a first-class URI document", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const url = "https://library.grida.co/ref.png";
+      const ws = await registry.createProject({
+        name: "Sunset",
+        seed: { documents: [{ src: url }] },
+      });
+      const bundleName = `${path.basename(ws.root)}.canvas`;
+      const manifest = JSON.parse(
+        await fs.readFile(
+          path.join(ws.root, bundleName, ".canvas.json"),
+          "utf8"
+        )
+      );
+      expect(manifest.documents).toEqual([{ src: url }]);
+    });
+
+    it("suffixes -2, -3… on name collision (distinct folders + ids)", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const a = await registry.createProject({ name: "Poster" });
+      const b = await registry.createProject({ name: "Poster" });
+      expect(path.basename(a.root)).toBe("Poster");
+      expect(path.basename(b.root)).toBe("Poster-2");
+      expect(a.id).not.toBe(b.id);
+    });
+
+    it("slugifies a traversal name so it can never escape the managed root", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const ws = await registry.createProject({ name: "../../pwned" });
+      const rootReal = await fs.realpath(projectsRoot);
+      // The created folder is a single segment directly under the root — no
+      // separator survived, so nothing landed outside.
+      expect(path.dirname(await fs.realpath(ws.root))).toBe(rootReal);
+      // And no sibling of the managed root was created.
+      await expect(
+        fs.stat(path.join(path.dirname(rootReal), "pwned"))
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("throws projects-root-not-configured when no managed root is wired", async () => {
+      const registry = new WorkspaceRegistry(userDataDir);
+      await expect(registry.createProject({ name: "x" })).rejects.toThrow(
+        "projects-root-not-configured"
+      );
+    });
+  });
 });

--- a/packages/grida-ai-agent/src/workspaces.test.ts
+++ b/packages/grida-ai-agent/src/workspaces.test.ts
@@ -179,6 +179,22 @@ describe("Workspaces", () => {
       ).rejects.toMatchObject({ code: "ENOENT" });
     });
 
+    it("degrades Windows-invalid punctuation to spaces instead of failing the create", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      // `:` `?` `"` `<` `>` `|` `*` are invalid in a Windows path segment —
+      // an ordinary prompt-derived name must still mint a folder.
+      const ws = await registry.createProject({
+        name: 'Logo: "coffee shop"? <v2> *|final*',
+      });
+      expect(path.basename(ws.root)).toBe("Logo coffee shop v2 final");
+    });
+
+    it("strips trailing dots (Windows-invalid) from the folder name", async () => {
+      const registry = new WorkspaceRegistry(userDataDir, projectsRoot);
+      const ws = await registry.createProject({ name: "Poster v2..." });
+      expect(path.basename(ws.root)).toBe("Poster v2");
+    });
+
     it("throws projects-root-not-configured when no managed root is wired", async () => {
       const registry = new WorkspaceRegistry(userDataDir);
       await expect(registry.createProject({ name: "x" })).rejects.toThrow(

--- a/packages/grida-ai-agent/src/workspaces.ts
+++ b/packages/grida-ai-agent/src/workspaces.ts
@@ -227,16 +227,25 @@ export class WorkspaceRegistry {
       realDir,
       `${path.basename(realDir)}${BUNDLE_EXTENSION}`
     );
-    await fs.mkdir(bundleDir, { recursive: false });
-    await atomicWrite(
-      path.join(bundleDir, MANIFEST_FILENAME),
-      buildSeedManifest(opts.seed),
-      { mode: 0o644 }
-    );
-
-    // Register through `open` so the id (sha256(realpath)[:16]) and recents
-    // bookkeeping stay identical to a user-opened folder.
-    return this.open(realDir);
+    try {
+      await fs.mkdir(bundleDir, { recursive: false });
+      await atomicWrite(
+        path.join(bundleDir, MANIFEST_FILENAME),
+        buildSeedManifest(opts.seed),
+        { mode: 0o644 }
+      );
+      // Register through `open` so the id (sha256(realpath)[:16]) and recents
+      // bookkeeping stay identical to a user-opened folder.
+      return await this.open(realDir);
+    } catch (err) {
+      // Roll back the mint on any downstream failure (EACCES, disk full,
+      // persist error) — otherwise an orphaned half-project lingers on disk,
+      // unregistered, squatting the slug for the next create. Recursive rm is
+      // safe here: `realDir` is containment-asserted above and we created it
+      // fresh this call, so it holds nothing but our own partial seed.
+      await fs.rm(realDir, { recursive: true, force: true }).catch(() => {});
+      throw err;
+    }
   }
 
   /**

--- a/packages/grida-ai-agent/src/workspaces.ts
+++ b/packages/grida-ai-agent/src/workspaces.ts
@@ -349,10 +349,30 @@ export class WorkspaceRegistry {
 }
 
 /**
+ * Characters that cannot appear in a folder segment on EVERY platform we mint
+ * projects on. `/` and `\` are the traversal-relevant ones; the rest
+ * (`< > : " | ? *`) are Windows-invalid — the name comes from a free-form
+ * prompt ("Logo: coffee shop"), so ordinary punctuation must degrade to a
+ * space instead of failing the primary create flow with an `fs.mkdir` error.
+ */
+const SEGMENT_UNSAFE_CHARS = new Set([
+  "/",
+  "\\",
+  "<",
+  ">",
+  ":",
+  '"',
+  "|",
+  "?",
+  "*",
+]);
+
+/**
  * Reduce a user/prompt-supplied project name to a single, safe filesystem
- * segment. Strips control chars + NUL, turns path separators into spaces,
- * collapses whitespace, drops leading dots (so `.`/`..`/hidden names can't
- * form), and caps length. Empty result → "Untitled". The realpath-containment
+ * segment. Strips control chars + NUL, turns path separators and
+ * Windows-reserved punctuation into spaces, collapses whitespace, drops
+ * leading and trailing dots (`.`/`..`/hidden names; Windows rejects trailing
+ * dots), and caps length. Empty result → "Untitled". The realpath-containment
  * assert in {@link WorkspaceRegistry.createProject} is the backstop; this keeps
  * the common case readable AND the folder name never a traversal.
  */
@@ -363,15 +383,17 @@ function slugifyProjectName(name?: string): string {
   for (const ch of name ?? "") {
     const code = ch.codePointAt(0) ?? 0;
     if (code < 0x20 || code === 0x7f) continue; // control chars incl NUL
-    out += ch === "/" || ch === "\\" ? " " : ch;
+    out += SEGMENT_UNSAFE_CHARS.has(ch) ? " " : ch;
   }
   const cleaned = out
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^\.+/, "") // no leading dots (., .., hidden names)
+    .replace(/\.+$/, "") // no trailing dots (Windows-invalid)
     .trim()
     .slice(0, 60)
-    .trim();
+    .trim()
+    .replace(/\.+$/, ""); // the length cap can re-expose a trailing dot
   return cleaned || "Untitled";
 }
 

--- a/packages/grida-ai-agent/src/workspaces.ts
+++ b/packages/grida-ai-agent/src/workspaces.ts
@@ -30,6 +30,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { atomicWrite } from "./storage/atomic-write";
+import { containsPath } from "./path-contains";
 
 export type Workspace = {
   /** sha256(realRoot).slice(0,16) — stable across launches. */
@@ -42,16 +43,57 @@ export type Workspace = {
   pinned: boolean;
 };
 
+/**
+ * A field-constrained board seed for {@link WorkspaceRegistry.createProject}.
+ * Deliberately NOT a raw dotcanvas manifest — only a document's `src` (a
+ * bundle-relative path or an `https://` reference) and an optional layout box.
+ * Keeping the shape this narrow is what stops the `/workspaces/create` route
+ * from being a manifest-injection vector (GRIDA-SEC-004).
+ */
+export type ProjectSeedDocument = {
+  src: string;
+  layout?: { x?: number; y?: number; w?: number; h?: number; z?: number };
+};
+export type ProjectSeed = { documents: ProjectSeedDocument[] };
+
 const FILE_NAME = "workspaces.json";
 const MAX_ENTRIES = 100;
+
+/**
+ * The dotcanvas manifest filename (mirrors `dotcanvas.MANIFEST_FILENAME`).
+ * Inlined rather than imported so the sidecar doesn't pull in the whole
+ * `dotcanvas` package just to write a two-key seed — the shape below is the
+ * stable v1 contract the reader heals against.
+ */
+const MANIFEST_FILENAME = ".canvas.json";
+
+/**
+ * The dotcanvas bundle directory extension (mirrors `dotcanvas.BUNDLE_EXTENSION`).
+ * A bundle is a *directory* whose name ends with this — the macOS-package
+ * convention. Naming the seeded dir `<name>.canvas` is what makes the board
+ * RECOGNIZABLE: the file tree renders it as an openable bundle
+ * (`dotcanvas.isBundlePath`) and the workbench opens it as a board tab. A bare
+ * `.canvas.json` at the workspace root would just be a JSON file to the tree.
+ * Inlined (not imported) for the same reason as {@link MANIFEST_FILENAME}.
+ */
+const BUNDLE_EXTENSION = ".canvas";
 
 export class WorkspaceRegistry {
   private entries: Workspace[] = [];
   private loaded = false;
   private readonly file_path: string;
+  /**
+   * GRIDA-SEC-004 — the host-injected managed root under which
+   * {@link createProject} mints new project folders (desktop:
+   * `~/Documents/Grida`). Host-owned, NEVER derived from client input — the
+   * one writable root the auto-create path may touch. Undefined for hosts that
+   * don't wire it (the CLI/dev daemon), where `createProject` throws.
+   */
+  private readonly projects_root?: string;
 
-  constructor(userDataPath: string) {
+  constructor(userDataPath: string, projectsRoot?: string) {
     this.file_path = path.join(userDataPath, FILE_NAME);
+    this.projects_root = projectsRoot;
   }
 
   /**
@@ -129,6 +171,100 @@ export class WorkspaceRegistry {
     this.trim();
     await this.persist();
     return entry;
+  }
+
+  /**
+   * GRIDA-SEC-004 — auto-create a fresh project: mint a new directory under the
+   * host-injected {@link projects_root}, seed it with a real `.canvas` bundle
+   * (a `<name>.canvas` dir + manifest), and register it (via {@link open}, so id/name/persistence rules
+   * stay single-sourced). Powers the desktop home's "auto-create, ask nothing"
+   * flow — clicking a template or picking a reference lands the user in a board
+   * without ever choosing a folder.
+   *
+   * Safety (never trust the caller for a path):
+   *   - `name` is SLUGIFIED to a single filesystem segment — path separators,
+   *     `..`, NUL, and control chars can't survive, so it can never be a path.
+   *   - the created dir is `realpath`'d and asserted to sit under the (also
+   *     `realpath`'d) managed root; anything else is removed and rejected.
+   *   - the `seed` is field-constrained ({@link ProjectSeed}) — only `src` +
+   *     an optional layout box reach the manifest, never a raw manifest.
+   *
+   * Throws `projects-root-not-configured` on a host that didn't wire a root.
+   */
+  async createProject(opts: {
+    name?: string;
+    seed?: ProjectSeed;
+  }): Promise<Workspace> {
+    if (!this.projects_root) {
+      throw new Error("projects-root-not-configured");
+    }
+    await fs.mkdir(this.projects_root, { recursive: true });
+    const realRoot = await fs.realpath(this.projects_root);
+
+    const slug = slugifyProjectName(opts.name);
+    const dir = await this.mintProjectDir(realRoot, slug);
+
+    // Containment assert (the one new trust check): the minted dir's realpath
+    // MUST be STRICTLY under the managed root (`containsPath` also accepts
+    // root-equals-root, which here would mean the mint escaped). Same shared
+    // discipline as the shell runner's root gates and the scratch assert;
+    // catches a symlinked root or any residual escape.
+    const realDir = await fs.realpath(dir);
+    if (!containsPath(realRoot, realDir) || realDir === realRoot) {
+      await fs.rmdir(dir).catch(() => {});
+      throw new Error("project-path-escapes-root");
+    }
+
+    // The project is a plain workspace CONTAINER that holds a real dotcanvas
+    // BUNDLE — a `<name>.canvas` directory with the manifest inside it — NOT a
+    // loose `.canvas.json` at the root. That distinction is what makes the board
+    // recognizable: the file tree shows the `.canvas` dir as an openable bundle
+    // (`dotcanvas.isBundlePath`) and the workbench opens it as a board tab; a
+    // root-level manifest is just JSON to the tree. Keeping the manifest OUT of
+    // the workspace root also means the reopen path (menu/⌃R, which sniff root
+    // `.canvas.json`) lands on the workbench too, matching the create flow.
+    const bundleDir = path.join(
+      realDir,
+      `${path.basename(realDir)}${BUNDLE_EXTENSION}`
+    );
+    await fs.mkdir(bundleDir, { recursive: false });
+    await atomicWrite(
+      path.join(bundleDir, MANIFEST_FILENAME),
+      buildSeedManifest(opts.seed),
+      { mode: 0o644 }
+    );
+
+    // Register through `open` so the id (sha256(realpath)[:16]) and recents
+    // bookkeeping stay identical to a user-opened folder.
+    return this.open(realDir);
+  }
+
+  /**
+   * Create a uniquely-named directory under `realRoot`, suffixing `-2`, `-3`…
+   * on collision. `fs.mkdir({recursive:false})` is atomic create-or-fail, so
+   * two concurrent creates never hand back the same dir (no TOCTOU). Caps the
+   * probe and falls back to a random suffix so a pathological name can't spin.
+   */
+  private async mintProjectDir(
+    realRoot: string,
+    slug: string
+  ): Promise<string> {
+    for (let i = 1; i <= 50; i++) {
+      const name = i === 1 ? slug : `${slug}-${i}`;
+      const dir = path.join(realRoot, name);
+      try {
+        await fs.mkdir(dir, { recursive: false });
+        return dir;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
+    }
+    const dir = path.join(
+      realRoot,
+      `${slug}-${crypto.randomBytes(4).toString("hex")}`
+    );
+    await fs.mkdir(dir, { recursive: false });
+    return dir;
   }
 
   /** Most-recent-first. Defensive copy — callers may mutate. */
@@ -210,6 +346,54 @@ export class WorkspaceRegistry {
       (a, b) => b.opened_at - a.opened_at
     );
   }
+}
+
+/**
+ * Reduce a user/prompt-supplied project name to a single, safe filesystem
+ * segment. Strips control chars + NUL, turns path separators into spaces,
+ * collapses whitespace, drops leading dots (so `.`/`..`/hidden names can't
+ * form), and caps length. Empty result → "Untitled". The realpath-containment
+ * assert in {@link WorkspaceRegistry.createProject} is the backstop; this keeps
+ * the common case readable AND the folder name never a traversal.
+ */
+function slugifyProjectName(name?: string): string {
+  // Filter char-by-char (no control-char regex) so path separators, NUL, and
+  // other control chars can never survive into a folder segment.
+  let out = "";
+  for (const ch of name ?? "") {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue; // control chars incl NUL
+    out += ch === "/" || ch === "\\" ? " " : ch;
+  }
+  const cleaned = out
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^\.+/, "") // no leading dots (., .., hidden names)
+    .trim()
+    .slice(0, 60)
+    .trim();
+  return cleaned || "Untitled";
+}
+
+/**
+ * Serialize a `.canvas` board manifest for a freshly-created project. Mirrors
+ * the dotcanvas v1 board shape (see `fixtures/test-canvas/board.canvas`): an
+ * `https://` `src` is a first-class placed reference (used as-is), a relative
+ * `src` is a bundle file. Only `src` + an optional layout box are emitted — the
+ * seed is field-constrained upstream, so nothing else can reach disk.
+ */
+function buildSeedManifest(seed?: ProjectSeed): string {
+  const documents = (seed?.documents ?? []).map((d) => ({
+    src: d.src,
+    ...(d.layout ? { layout: d.layout } : {}),
+  }));
+  const manifest = {
+    $schema: "https://grida.co/schema/dotcanvas/v1.json",
+    version: "1",
+    editor: "board",
+    documents,
+  };
+  return JSON.stringify(manifest, null, 2) + "\n";
 }
 
 // `workspaceFs` is NOT re-exported here (de-barreled): import it directly

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -30,6 +30,7 @@ import type {
   SessionListPage,
   SessionStatus,
   Workspace,
+  WorkspaceCreateInput,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -68,6 +69,7 @@ export type {
   FileWriteResult,
   RecentEntry,
   Workspace,
+  WorkspaceCreateInput,
   WorkspaceFsEntry,
   WorkspaceReadFileBytesResult,
   WorkspaceReadFileResult,
@@ -191,6 +193,12 @@ export type DesktopBridge = {
   workspaces: {
     list: () => Promise<Workspace[]>;
     open: (rootPath: string) => Promise<Workspace>;
+    /**
+     * Auto-create a fresh project (managed root, seeded `.canvas` board) and
+     * register it — the desktop home's "auto-create, ask nothing" flow. No OS
+     * folder dialog. Rejects when the host wired no managed root.
+     */
+    create: (input: WorkspaceCreateInput) => Promise<Workspace>;
     pin: (id: string, pinned: boolean) => Promise<void>;
     forget: (id: string) => Promise<void>;
     readdir: (


### PR DESCRIPTION
## Summary

The desktop welcome window becomes an artwork-studio front door: describe what you want and/or gather references from the curated gallery, and Grida auto-creates a fresh project — a seeded `.canvas` board under `~/Documents/Grida` — and hands your prompt to that project's agent. No folder dialog to get started; "Open folder…" and recents remain for opening existing work.

## What's in it

- **`@grida/agent`**: `WorkspaceRegistry.createProject` + `POST /workspaces/create` (GRIDA-SEC-004: host-injected projects root, slugified single-segment name, shared-`containsPath` realpath assert, field-constrained seed — never a raw manifest), pinned by registry- and route-level tests. `SECURITY.md` documents the new renderer-reachable write authority. The created project is a plain workspace folder holding a real `<name>.canvas` **bundle** dir (so the file tree recognizes it as an openable board), not a loose root manifest.
- **desktop**: the supervisor injects `--projects-root=~/Documents/Grida`; new native **File ▸ Open Recent** backed by the same `workspaces.list()` the renderer palette uses, rebuilt (coalesced + signature-guarded) on window focus, sharing one main-process copy of the `.canvas` routing rule with the Open… flow.
- **editor**: rebuilt home — docking composer (the same DOM node floats to a fixed bottom bar once the hero scrolls away, so the draft/caret survive), multi-select reference gallery (memoized masonry virtualized against the single page scroll, backed by a new library `browse()` action that also serves `search`'s category-only branch), ⌃R recent-projects palette. The welcome handoff now carries `skills` so the first turn knows the board format before any editor tab is open; the file shell passes `dotcanvas`/`svg` skills likewise.

## Notes

- Known follow-up: the recents "forget" affordance was dropped with the old inline list; the bridge capability remains, but the UI needs a new home (likely the ⌃R palette).
- Verified: 733 `@grida/agent` tests green (incl. new `createProject` + route pins), `tsc` clean on editor/desktop/agent, oxlint/oxfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop “auto-create project” support (including reference-seeded creation) and optional skill priming for the first turn.
  * Introduced a “Recent projects” command palette and a virtualized reference gallery on the welcome screen.
  * Added library “cold browse” for category-only browsing, plus a design browse page resolver.
* **Bug Fixes**
  * Kept **Open Recent** synchronized with the latest workspaces after startup.
  * Prevented empty handoff prompts from being submitted.
* **Security**
  * Hardened managed auto-creation with strict seed validation and workspace-path containment.
  * Disabled web-daemon access to `workspaces.create`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->