### PR TITLE
feat(desktop): Grida sign-in — browser PKCE deep-link flow (GRIDA-SEC-005)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -587,10 +587,14 @@ PTYs per window, and (d) kills every PTY on window close and app quit.
 A contract test (`desktop/src/main/terminal-host.test.ts`) fails if a
 terminal channel is ever registered outside `guarded()`.
 
-**No hosted auth in V1.** Desktop V1 ships no `/auth/*` route group, no
-PKCE handoff, no cloud session refresh, and no entitlement polling. Future
-hosted-provider work must re-register its callback and hosted-model files in
-this record before code lands.
+**Hosted auth (sign-in only).** The desktop signs the webview into a
+first-class Supabase cookie session via the system browser + PKCE +
+`grida://auth/callback` deep link — that flow is its own boundary,
+`GRIDA-SEC-005` below. Within THIS boundary the invariant is unchanged:
+the Electron main process and the AgentHost sidecar hold no cloud
+credentials, and there is still no entitlement polling and no
+hosted-model routing. Future hosted-provider work (sidecar-held tokens,
+metered AI) must re-register its files in this record before code lands.
 
 **Update channel.** Release builds must be signed/notarized by platform
 policy. Security-sensitive runtime deps are reviewed as part of the
@@ -680,7 +684,7 @@ Today:
 - `desktop/src/window.ts` — blocks exposed desktop windows from navigating outside `/desktop/*`; injects non-secret preload arguments.
 - `desktop/src/agent-sidecar.ts` — sidecar entrypoint; constructs the composed agent daemon (`createAgentDaemon`).
 - `desktop/src/main/agent-sidecar-supervisor.ts` — generates per-spawn password; spawns/supervises the daemon sidecar; initializes the OS sandbox wrapper when supported (`srt` is not available on Windows yet).
-- `desktop/src/main/protocol-router.ts` — deep-link protocol guard; V1 has no cloud callback route.
+- `desktop/src/main/protocol-router.ts` — deep-link protocol guard; the auth callback arm is bound by GRIDA-SEC-005.
 - `desktop/src/main/ipc-handlers.ts` — validates every native IPC sender frame before executing OS capabilities.
 - `packages/grida-daemon/src/http/server.ts` — loopback HTTP app, daemon route registration, and the `DaemonTenant` seam behind shared guards; `packages/grida-ai-agent/src/server.ts` — the agent tenant that mounts the AI route groups through it.
 - `packages/grida-ai-agent/src/http/routes/secrets.ts` — BYOK key presence/set/delete route group; no key-read route.
@@ -709,13 +713,123 @@ daemon that binds `0.0.0.0`. An app that loads grida.co's
 non-`(desktop)` routes inside the desktop window without revoking the
 bridge first. Any IPC handler in Electron main that acts without
 checking `event.senderFrame.url`. A `grida://` deep-link handler that
-exchanges OAuth codes without daemon-held PKCE state.
+exchanges OAuth codes itself — the exchange belongs to the same-origin
+`/desktop/auth/callback` route against the webview-held PKCE verifier
+cookie (GRIDA-SEC-005).
+
+---
+
+### `GRIDA-SEC-005` — Desktop sign-in deep-link boundary
+
+**What it protects.** Desktop sign-in gives the Electron webview a
+first-class Supabase **cookie session** — the same session shape as a
+browser tab, so every existing cookie-gated route and middleware works
+unchanged. The ceremony runs in the system browser (RFC 8252; embedded
+webviews are blocked by providers) and returns through the
+`grida://auth/callback` deep link. The boundary is the rule that **a
+`grida://` deep link is untrusted, world-invokable input: it must never
+be able to create, steal, or redirect a session. The only thing a deep
+link may cause is a navigation of a desktop window to the fixed
+same-origin `/desktop/auth/callback` route.**
+
+**Vulnerable scenario (prevented).** Custom-protocol URLs are invokable
+by any webpage and any local process (`open "grida://…"`). Without the
+boundary: (a) login-CSRF — an attacker mints their OWN authorization
+code and fires `grida://auth/callback?code=<attacker-code>` at the
+victim's app, silently signing the victim into the attacker's account so
+later work is saved where the attacker can read it; (b) a phished or
+replayed single-use code is redeemed by a party other than the app that
+started the flow; (c) the deep link is used as a navigation primitive to
+walk the privileged (bridge-attached) window to an attacker-chosen URL.
+
+**Why it's specifically risky here.** The desktop window carries the
+`window.grida` bridge (GRIDA-SEC-004), so a navigation primitive fed by
+an unauthenticated OS-level input lands directly on the app's most
+privileged surface. And the repo is open source — the exact flow shape,
+paths, and params are public, so the design must not rely on obscurity.
+
+**How the code prevents it.**
+
+1. **PKCE verifier confined to the Electron cookie jar** —
+   [editor/app/desktop/auth/start/route.ts](editor/app/desktop/auth/start/route.ts)
+   mints the `@supabase/ssr` code-verifier cookie on a route-handler
+   response (the supabase/ssr#55-safe shape) and returns the same-origin
+   `/sign-in/desktop` launch-page URL carrying only the PUBLIC
+   `code_challenge`. The sign-in method is chosen on that web page
+   ([editor/app/(site)/sign-in/desktop/](<editor/app/(site)/sign-in/desktop/page.tsx>)),
+   and every method binds its GoTrue flow to the forwarded challenge
+   (`host/auth/desktop-auth-flow.ts`, pinned by its test) — so the
+   desktop never names a provider, and whatever the method, the
+   resulting `code` is
+   exchangeable ONLY with the jar-held verifier: an attacker-minted code
+   was issued against a different verifier, so GoTrue rejects the
+   exchange (closes login-CSRF); a phished victim code is single-use,
+   expires in 5 minutes, and is useless off-machine without the jar. A
+   forged or attacker-chosen `challenge` on the launch page yields codes
+   nobody can exchange (the matching verifier exists in no jar the
+   attacker can reach).
+2. **Stateless, fixed-target router** —
+   [desktop/src/main/protocol-router.ts](desktop/src/main/protocol-router.ts)
+   performs no code exchange and holds no auth state. It navigates a
+   desktop window to the constant `/desktop/auth/callback` path on the
+   configured editor origin, forwarding only the known
+   `code`/`error*` params; nothing else from the deep link crosses the
+   boundary, and every branch consumes the URL (no re-queue loop).
+3. **Exchange only at the same-origin callback route** —
+   [editor/app/desktop/auth/callback/route.ts](editor/app/desktop/auth/callback/route.ts)
+   runs `exchangeCodeForSession` with the cookie client (identical
+   mechanism to the web `(auth)/auth/callback`); success and failure
+   both redirect inside `/desktop/*`.
+4. **Redirect containment** — the `will-redirect` guard in
+   [desktop/src/window.ts](desktop/src/window.ts) holds server 302s to
+   the same same-origin `/desktop/*` allowlist as user navigations
+   (`will-navigate` does not fire for server redirects, so without the
+   hook a redirect chain could walk the bridge-attached window
+   off-surface). Blocked redirects are NOT handed to the OS browser.
+   Sign-out is the same-origin
+   [editor/app/desktop/auth/sign-out/route.ts](editor/app/desktop/auth/sign-out/route.ts):
+   navigating the webview to the web `/sign-out` would be blocked and
+   `shell.openExternal`'d — logging the user out of their OS browser.
+5. **Ceremony in the system browser only** — the launch URL travels
+   renderer → `shell.open_external` (http/https-validated IPC); the
+   webview never loads a provider page, and the `grida://auth/callback`
+   redirect is allowlisted in Supabase
+   ([supabase/config.toml](supabase/config.toml) locally; the hosted
+   project's dashboard in production).
+
+The Electron main process and the sidecar remain credential-free: the
+session lives in the webview's cookie jar and is refreshed by the same
+`@supabase/ssr` middleware machinery as the web app. The `/desktop/*`
+CSP keeps `connect-src` closed, so session reads go through the
+same-origin `/desktop/auth/me` route rather than direct supabase-js
+calls.
+
+**Files bound by this id.** Run `grep -rn GRIDA-SEC-005 .` to enumerate.
+Today:
+
+- [supabase/config.toml](supabase/config.toml) — `grida://auth/callback` redirect allowlist entry.
+- [editor/app/desktop/auth/start/route.ts](editor/app/desktop/auth/start/route.ts) — PKCE start; verifier cookie + launch-page URL (method-neutral; the desktop never names a provider).
+- [editor/app/(site)/sign-in/desktop/page.tsx](<editor/app/(site)/sign-in/desktop/page.tsx>) — the web launch page (a `/sign-in` sibling sharing the sign-in shell and Google button, `authorize_url` mode): validates the challenge, binds the offered method's GoTrue flow to it, and mirrors the web sign-in's insiders routing (`NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` → redirect to the insiders page with the challenge forwarded).
+- [editor/host/auth/desktop-auth-flow.ts](editor/host/auth/desktop-auth-flow.ts) — the flow vocabulary shared by the launch page and the insiders route: challenge validation, challenge-bound authorize/OTP builders, verify-link extraction pinned to the Supabase origin (pinned by `desktop-auth-flow.test.ts`).
+- [editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts](<editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts>) (+ the hidden `challenge` passthrough in [basic/page.tsx](<editor/app/(insiders)/insiders/auth/basic/page.tsx>)) — the insiders **email+password** desktop branch: verifies the password exactly like the web insiders flow, then mints the challenge-bound code by firing the GoTrue OTP and consuming the emailed verify link straight from the local Mailpit capture, so the developer keeps email+password and still traverses the production verify → `grida://` → exchange path. A password grant alone can never produce a challenge-bound code (GoTrue returns sessions directly for passwords), which is why the mint rides the OTP-link machinery. Local-only by GRIDA-SEC-002 (`/insiders/*` 404s outside development), which is what makes the Mailpit coupling acceptable (pinned by its `route.test.ts`).
+- [editor/app/desktop/auth/callback/route.ts](editor/app/desktop/auth/callback/route.ts) — the only code-exchange point; `/desktop/*`-contained redirects (pinned by its `route.test.ts`).
+- [editor/app/desktop/auth/sign-out/route.ts](editor/app/desktop/auth/sign-out/route.ts) — same-origin sign-out (never the web `/sign-out`).
+- [desktop/src/main/protocol-router.ts](desktop/src/main/protocol-router.ts) — stateless fixed-target auth arm (pinned by `protocol-router.test.ts`).
+- [desktop/src/window.ts](desktop/src/window.ts) — `will-redirect` guard; `isAllowedNavigation` predicate (pinned by `window.test.ts`).
+
+**What does NOT belong here.** A code exchange in the Electron main
+process. A PKCE verifier carried on the deep link, the bridge, or argv.
+A router that navigates to a path taken from deep-link input, or that
+forwards params beyond `code`/`error*`. A desktop webview navigation to
+`(auth)` routes or the web `/sign-out`. Sidecar- or main-held session
+tokens — that is future hosted-provider work and must be registered
+here first.
 
 ---
 
 ## Adding a new GRIDA-SEC entry
 
-1. Allocate the next sequential id (`GRIDA-SEC-005` for the next one).
+1. Allocate the next sequential id (`GRIDA-SEC-006` for the next one).
 2. Add an "Active boundaries" subsection here with the same shape as
    GRIDA-SEC-001: what it protects, vulnerable scenario, why it's risky
    here, how the code prevents it, files bound.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -754,33 +754,46 @@ paths, and params are public, so the design must not rely on obscurity.
    [editor/app/desktop/auth/start/route.ts](editor/app/desktop/auth/start/route.ts)
    mints the `@supabase/ssr` code-verifier cookie on a route-handler
    response (the supabase/ssr#55-safe shape) and returns the same-origin
-   `/sign-in/desktop` launch-page URL carrying only the PUBLIC
-   `code_challenge`. The sign-in method is chosen on that web page
-   ([editor/app/(site)/sign-in/desktop/](<editor/app/(site)/sign-in/desktop/page.tsx>)),
+   `/desktop-auth` launch-page URL carrying the `code_challenge`. The
+   sign-in method is chosen on that web page
+   ([editor/app/(untracked)/desktop-auth/](<editor/app/(untracked)/desktop-auth/page.tsx>)),
    and every method binds its GoTrue flow to the forwarded challenge
    (`host/auth/desktop-auth-flow.ts`, pinned by its test) — so the
    desktop never names a provider, and whatever the method, the
-   resulting `code` is
-   exchangeable ONLY with the jar-held verifier: an attacker-minted code
-   was issued against a different verifier, so GoTrue rejects the
-   exchange (closes login-CSRF); a phished victim code is single-use,
-   expires in 5 minutes, and is useless off-machine without the jar. A
-   forged or attacker-chosen `challenge` on the launch page yields codes
-   nobody can exchange (the matching verifier exists in no jar the
-   attacker can reach).
-2. **Stateless, fixed-target router** —
+   resulting `code` is exchangeable ONLY with the jar-held verifier: a
+   code minted against a _different_ verifier is rejected by GoTrue
+   (closes the naive login-CSRF); a phished victim code is single-use,
+   expires in 5 minutes, and is useless off-machine without the jar.
+2. **The challenge is confidentiality-sensitive in transit** — in this
+   design the `code_challenge` doubles as the binding token between "the
+   desktop that started this flow" and an acceptable code: an attacker
+   who learns a victim's challenge can mint a code bound to it _for the
+   attacker's own account_ and fire the deep link at the victim, logging
+   the victim into the attacker's account (login-CSRF via challenge
+   replay — a _random_ attacker challenge is harmless, but the victim's
+   is not). It is unguessable (256-bit) and must not be disclosed, so the
+   launch page lives in the analytics-free `(untracked)` route group
+   ([editor/app/(untracked)/layout.tsx](<editor/app/(untracked)/layout.tsx>))
+   — no Google/Vercel pageview script ever sees its URL — with
+   `Referrer-Policy: no-referrer` so the challenge never leaks via a
+   `Referer` header either. The insiders redirect target is likewise
+   analytics-free (and dev-only). Address-bar / history exposure is
+   inherent to any browser OAuth handoff and bounded by the 5-min,
+   single-use code; the systematic third-party beacon is what is closed
+   here.
+3. **Stateless, fixed-target router** —
    [desktop/src/main/protocol-router.ts](desktop/src/main/protocol-router.ts)
    performs no code exchange and holds no auth state. It navigates a
    desktop window to the constant `/desktop/auth/callback` path on the
    configured editor origin, forwarding only the known
    `code`/`error*` params; nothing else from the deep link crosses the
    boundary, and every branch consumes the URL (no re-queue loop).
-3. **Exchange only at the same-origin callback route** —
+4. **Exchange only at the same-origin callback route** —
    [editor/app/desktop/auth/callback/route.ts](editor/app/desktop/auth/callback/route.ts)
    runs `exchangeCodeForSession` with the cookie client (identical
    mechanism to the web `(auth)/auth/callback`); success and failure
    both redirect inside `/desktop/*`.
-4. **Redirect containment** — the `will-redirect` guard in
+5. **Redirect containment** — the `will-redirect` guard in
    [desktop/src/window.ts](desktop/src/window.ts) holds server 302s to
    the same same-origin `/desktop/*` allowlist as user navigations
    (`will-navigate` does not fire for server redirects, so without the
@@ -790,7 +803,7 @@ paths, and params are public, so the design must not rely on obscurity.
    [editor/app/desktop/auth/sign-out/route.ts](editor/app/desktop/auth/sign-out/route.ts):
    navigating the webview to the web `/sign-out` would be blocked and
    `shell.openExternal`'d — logging the user out of their OS browser.
-5. **Ceremony in the system browser only** — the launch URL travels
+6. **Ceremony in the system browser only** — the launch URL travels
    renderer → `shell.open_external` (http/https-validated IPC); the
    webview never loads a provider page, and the `grida://auth/callback`
    redirect is allowlisted in Supabase
@@ -809,7 +822,7 @@ Today:
 
 - [supabase/config.toml](supabase/config.toml) — `grida://auth/callback` redirect allowlist entry.
 - [editor/app/desktop/auth/start/route.ts](editor/app/desktop/auth/start/route.ts) — PKCE start; verifier cookie + launch-page URL (method-neutral; the desktop never names a provider).
-- [editor/app/(site)/sign-in/desktop/page.tsx](<editor/app/(site)/sign-in/desktop/page.tsx>) — the web launch page (a `/sign-in` sibling sharing the sign-in shell and Google button, `authorize_url` mode): validates the challenge, binds the offered method's GoTrue flow to it, and mirrors the web sign-in's insiders routing (`NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` → redirect to the insiders page with the challenge forwarded).
+- [editor/app/(untracked)/desktop-auth/page.tsx](<editor/app/(untracked)/desktop-auth/page.tsx>) + [editor/app/(untracked)/layout.tsx](<editor/app/(untracked)/layout.tsx>) — the web launch page and its analytics-free root layout. Shares the sign-in shell ([editor/components/auth/sign-in-shell.tsx](editor/components/auth/sign-in-shell.tsx)) and Google button (`authorize_url` mode); validates the challenge, binds the offered method's GoTrue flow to it, mirrors the web sign-in's insiders routing (`NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` → redirect to the insiders page with the challenge forwarded). Deliberately NOT a `(site)` sibling: `(site)` loads Google/Vercel analytics that would beacon the challenge-bearing URL. The `(untracked)` group must never gain a URL-reporting script.
 - [editor/host/auth/desktop-auth-flow.ts](editor/host/auth/desktop-auth-flow.ts) — the flow vocabulary shared by the launch page and the insiders route: challenge validation, challenge-bound authorize/OTP builders, verify-link extraction pinned to the Supabase origin (pinned by `desktop-auth-flow.test.ts`).
 - [editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts](<editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts>) (+ the hidden `challenge` passthrough in [basic/page.tsx](<editor/app/(insiders)/insiders/auth/basic/page.tsx>)) — the insiders **email+password** desktop branch: verifies the password exactly like the web insiders flow, then mints the challenge-bound code by firing the GoTrue OTP and consuming the emailed verify link straight from the local Mailpit capture, so the developer keeps email+password and still traverses the production verify → `grida://` → exchange path. A password grant alone can never produce a challenge-bound code (GoTrue returns sessions directly for passwords), which is why the mint rides the OTP-link machinery. Local-only by GRIDA-SEC-002 (`/insiders/*` 404s outside development), which is what makes the Mailpit coupling acceptable (pinned by its `route.test.ts`).
 - [editor/app/desktop/auth/callback/route.ts](editor/app/desktop/auth/callback/route.ts) — the only code-exchange point; `/desktop/*`-contained redirects (pinned by its `route.test.ts`).
@@ -823,7 +836,9 @@ A router that navigates to a path taken from deep-link input, or that
 forwards params beyond `code`/`error*`. A desktop webview navigation to
 `(auth)` routes or the web `/sign-out`. Sidecar- or main-held session
 tokens — that is future hosted-provider work and must be registered
-here first.
+here first. The launch page in a route group that loads Google/Vercel
+analytics (or any URL-reporting script) — the challenge in its URL is
+confidentiality-sensitive, so it stays in `(untracked)`.
 
 ---
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/desktop/src/main/protocol-router.test.ts
+++ b/desktop/src/main/protocol-router.test.ts
@@ -80,6 +80,15 @@ describe("routeDeepLink — auth/callback", () => {
     expect(window.focus).toHaveBeenCalled();
   });
 
+  it("matches a case-varied auth host (custom schemes aren't lowercased)", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [window];
+    await routeDeepLink("grida://Auth/callback?code=abc-123");
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "https://grida.test/desktop/auth/callback?code=abc-123"
+    );
+  });
+
   it("forwards only known params — attacker extras are dropped", async () => {
     const window = makeWindow("https://grida.test/desktop/auth/sign-in");
     state.all = [window];

--- a/desktop/src/main/protocol-router.test.ts
+++ b/desktop/src/main/protocol-router.test.ts
@@ -1,0 +1,143 @@
+/**
+ * GRIDA-SEC-005 — deep-link auth callback routing.
+ *
+ * Pins the router's contract: every branch consumes (returns `true` — a
+ * `false` re-queues the URL forever in main.ts's drain loop), only the fixed
+ * same-origin `/desktop/auth/callback` path is ever navigated to, and only
+ * the known `code`/`error*` params cross the boundary.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const state: { all: MockWindow[]; focused: MockWindow | null } = {
+  all: [],
+  focused: null,
+};
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: () => state.all,
+    getFocusedWindow: () => state.focused,
+  },
+}));
+vi.mock("../env", () => ({ EDITOR_BASE_URL: "https://grida.test" }));
+
+import { routeDeepLink } from "./protocol-router";
+
+type MockWindow = ReturnType<typeof makeWindow>;
+
+function makeWindow(url: string, { minimized = false } = {}) {
+  return {
+    isDestroyed: () => false,
+    isMinimized: () => minimized,
+    restore: vi.fn<() => void>(),
+    focus: vi.fn<() => void>(),
+    loadURL: vi.fn<(url: string) => Promise<void>>(),
+    webContents: { getURL: () => url },
+  };
+}
+
+beforeEach(() => {
+  state.all = [];
+  state.focused = null;
+});
+
+describe("routeDeepLink — non-auth links", () => {
+  it("consumes malformed URLs", async () => {
+    await expect(routeDeepLink("not a url")).resolves.toBe(true);
+  });
+
+  it("consumes non-grida protocols", async () => {
+    await expect(routeDeepLink("https://example.com/x")).resolves.toBe(true);
+  });
+
+  it("consumes unknown hosts without navigating", async () => {
+    const window = makeWindow("https://grida.test/desktop/welcome");
+    state.all = [window];
+    await expect(routeDeepLink("grida://open/foo")).resolves.toBe(true);
+    expect(window.loadURL).not.toHaveBeenCalled();
+  });
+
+  it("consumes unknown auth paths without navigating", async () => {
+    const window = makeWindow("https://grida.test/desktop/welcome");
+    state.all = [window];
+    await expect(routeDeepLink("grida://auth/other?code=x")).resolves.toBe(
+      true
+    );
+    expect(window.loadURL).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeDeepLink — auth/callback", () => {
+  it("navigates to the fixed same-origin callback route with the code", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [window];
+    await expect(
+      routeDeepLink("grida://auth/callback?code=abc-123")
+    ).resolves.toBe(true);
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "https://grida.test/desktop/auth/callback?code=abc-123"
+    );
+    expect(window.focus).toHaveBeenCalled();
+  });
+
+  it("forwards only known params — attacker extras are dropped", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [window];
+    await routeDeepLink(
+      "grida://auth/callback?code=abc&evil=payload&error_code=otp_expired"
+    );
+    const target = new URL(window.loadURL.mock.calls[0][0]);
+    expect(target.origin).toBe("https://grida.test");
+    expect(target.pathname).toBe("/desktop/auth/callback");
+    expect(target.searchParams.get("code")).toBe("abc");
+    expect(target.searchParams.get("error_code")).toBe("otp_expired");
+    expect(target.searchParams.has("evil")).toBe(false);
+  });
+
+  it("forwards GoTrue error params when no code is present", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [window];
+    await routeDeepLink("grida://auth/callback?error=access_denied");
+    const target = new URL(window.loadURL.mock.calls[0][0]);
+    expect(target.pathname).toBe("/desktop/auth/callback");
+    expect(target.searchParams.get("error")).toBe("access_denied");
+  });
+
+  it("prefers the window waiting on the sign-in page over the focused one", async () => {
+    const other = makeWindow("https://grida.test/desktop/settings");
+    const signin = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [other, signin];
+    state.focused = other;
+    await routeDeepLink("grida://auth/callback?code=abc");
+    expect(signin.loadURL).toHaveBeenCalled();
+    expect(other.loadURL).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the focused window, then any window", async () => {
+    const a = makeWindow("https://grida.test/desktop/welcome");
+    const b = makeWindow("https://grida.test/desktop/settings");
+    state.all = [a, b];
+    state.focused = b;
+    await routeDeepLink("grida://auth/callback?code=abc");
+    expect(b.loadURL).toHaveBeenCalled();
+
+    state.focused = null;
+    await routeDeepLink("grida://auth/callback?code=def");
+    expect(a.loadURL).toHaveBeenCalled();
+  });
+
+  it("restores a minimized window before navigating", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in", {
+      minimized: true,
+    });
+    state.all = [window];
+    await routeDeepLink("grida://auth/callback?code=abc");
+    expect(window.restore).toHaveBeenCalled();
+  });
+
+  it("consumes safely when no window exists (cold macOS state)", async () => {
+    await expect(routeDeepLink("grida://auth/callback?code=abc")).resolves.toBe(
+      true
+    );
+  });
+});

--- a/desktop/src/main/protocol-router.ts
+++ b/desktop/src/main/protocol-router.ts
@@ -81,7 +81,10 @@ export async function routeDeepLink(url: string): Promise<boolean> {
     console.warn(`[grida] non-grida protocol, ignoring: ${parsed.protocol}`);
     return true;
   }
-  switch (parsed.hostname) {
+  // Custom-scheme hosts are NOT lowercased by the URL parser (unlike
+  // http(s)), so `grida://Auth/callback` from a case-varied invocation keeps
+  // its casing. Normalize so a valid callback is never silently dropped.
+  switch (parsed.hostname.toLowerCase()) {
     case "auth": {
       if (parsed.pathname !== "/callback") {
         console.warn(`[grida] unknown auth deep link: ${parsed.pathname}`);

--- a/desktop/src/main/protocol-router.ts
+++ b/desktop/src/main/protocol-router.ts
@@ -1,15 +1,73 @@
 /**
- * GRIDA-SEC-004 — `grida://` deep-link router.
+ * GRIDA-SEC-004 / GRIDA-SEC-005 — `grida://` deep-link router.
  *
- * V1 ships no OAuth callback flow, so the router only validates and
- * ignores known/unknown deep links. Future deep links
- * (`grida://open/...`, provider callbacks, etc.) land here as explicit
- * switch arms with their own trust-boundary review.
+ * Auth callback (GRIDA-SEC-005): `grida://auth/callback?code=…` carries the
+ * single-use PKCE `code` back from the system browser after the desktop
+ * sign-in ceremony. The router performs NO code exchange and holds no auth
+ * state — it only navigates a desktop window to the same-origin
+ * `/desktop/auth/callback` route, where the exchange succeeds solely against
+ * the PKCE verifier cookie already held by the Electron cookie jar (minted
+ * by `/desktop/auth/start`). An unsolicited, replayed, or attacker-crafted
+ * link therefore fails safe: at worst the app focuses and lands on its own
+ * sign-in error page.
+ *
+ * Future deep links (`grida://open/...`, provider callbacks, etc.) land here
+ * as explicit switch arms with their own trust-boundary review.
  */
+import { BrowserWindow } from "electron";
+import { EDITOR_BASE_URL } from "../env";
+import { findWindowByUrl } from "./window-focus";
+
+/**
+ * Query params forwarded from the deep link to the callback route. `code` is
+ * the PKCE code; the `error*` params are GoTrue's provider-failure report
+ * (user denied, expired flow). Nothing else crosses the boundary — the
+ * navigation target path is fixed.
+ */
+const AUTH_CALLBACK_FORWARDED_PARAMS = [
+  "code",
+  "error",
+  "error_code",
+  "error_description",
+] as const;
+
+/**
+ * Prefer the window that is waiting on the sign-in page, then the focused
+ * window, then any window. Returns `null` when the app has no windows (e.g.
+ * macOS with all windows closed) — the user re-initiates from a fresh
+ * window; an unconsumed deep link must not spawn UI.
+ */
+function pickAuthWindow(): BrowserWindow | null {
+  return (
+    findWindowByUrl("/desktop/auth/sign-in") ??
+    BrowserWindow.getFocusedWindow() ??
+    BrowserWindow.getAllWindows().find((window) => !window.isDestroyed()) ??
+    null
+  );
+}
+
+function routeAuthCallback(parsed: URL): void {
+  const target = new URL("/desktop/auth/callback", EDITOR_BASE_URL);
+  for (const key of AUTH_CALLBACK_FORWARDED_PARAMS) {
+    const value = parsed.searchParams.get(key);
+    if (value) target.searchParams.set(key, value);
+  }
+
+  const window = pickAuthWindow();
+  if (!window) {
+    console.warn("[grida] auth deep link arrived with no window; dropping");
+    return;
+  }
+  if (window.isMinimized()) window.restore();
+  window.focus();
+  void window.loadURL(target.toString());
+}
 
 /**
  * Route a `grida://` URL. Returns `true` when the URL was consumed and
- * should not be retried by the main-process queue.
+ * should not be retried by the main-process queue. Every branch returns
+ * `true` — returning `false` re-queues the URL indefinitely (see the drain
+ * loop in `main.ts`).
  */
 export async function routeDeepLink(url: string): Promise<boolean> {
   let parsed: URL;
@@ -23,6 +81,18 @@ export async function routeDeepLink(url: string): Promise<boolean> {
     console.warn(`[grida] non-grida protocol, ignoring: ${parsed.protocol}`);
     return true;
   }
-  console.log(`[grida] deep link host not handled: ${parsed.hostname}`);
-  return true;
+  switch (parsed.hostname) {
+    case "auth": {
+      if (parsed.pathname !== "/callback") {
+        console.warn(`[grida] unknown auth deep link: ${parsed.pathname}`);
+        return true;
+      }
+      routeAuthCallback(parsed);
+      return true;
+    }
+    default: {
+      console.log(`[grida] deep link host not handled: ${parsed.hostname}`);
+      return true;
+    }
+  }
 }

--- a/desktop/src/window.test.ts
+++ b/desktop/src/window.test.ts
@@ -1,0 +1,65 @@
+/**
+ * GRIDA-SEC-004 / GRIDA-SEC-005 — navigation allowlist predicate.
+ *
+ * `isAllowedNavigation` is the single predicate behind all three window
+ * guards (`will-navigate`, `did-navigate-in-page`, and the GRIDA-SEC-005
+ * `will-redirect` hook): same-origin AND `/desktop` or `/desktop/*` only.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  shell: { openExternal: vi.fn<(url: string) => Promise<void>>() },
+}));
+vi.mock("./main/ipc-handlers", () => ({
+  attachNavigationEvents: vi.fn<() => void>(),
+}));
+vi.mock("./branding", () => ({
+  RUNTIME_APP_ICON: { png: "icon.png", ico: "icon.ico" },
+}));
+vi.mock("./env", () => ({ IS_DEV: false }));
+
+import { isAllowedNavigation, isSafeExternalUrl } from "./window";
+
+const BASE = "https://grida.co";
+
+describe("isAllowedNavigation", () => {
+  it.each([
+    ["/desktop", true],
+    ["/desktop/", true],
+    ["/desktop/welcome", true],
+    ["/desktop/auth/sign-in?auth_error=x", true],
+    ["/desktop/auth/callback?code=abc", true],
+    ["/desktopX", false], // prefix must be a path segment
+    ["/", false],
+    ["/sign-out", false], // would sign the user out of the OS browser
+    ["/auth/callback?code=abc", false], // web callback — not the desktop one
+    ["/blog/foo", false],
+  ])("%s → %s", (path, allowed) => {
+    expect(isAllowedNavigation(BASE, `${BASE}${path}`)).toBe(allowed);
+  });
+
+  it("rejects cross-origin /desktop paths", () => {
+    expect(isAllowedNavigation(BASE, "https://evil.com/desktop/welcome")).toBe(
+      false
+    );
+  });
+
+  it("rejects malformed targets and base URLs", () => {
+    expect(isAllowedNavigation(BASE, "not a url")).toBe(false);
+    expect(isAllowedNavigation("not a url", `${BASE}/desktop`)).toBe(false);
+  });
+});
+
+describe("isSafeExternalUrl", () => {
+  it.each([
+    ["https://accounts.google.com/o/oauth2/auth", true],
+    ["http://localhost:3000/x", true],
+    ["javascript:alert(1)", false],
+    ["file:///etc/passwd", false],
+    ["grida://auth/callback", false],
+    ["//evil.com", false],
+  ])("%s → %s", (url, safe) => {
+    expect(isSafeExternalUrl(url)).toBe(safe);
+  });
+});

--- a/desktop/src/window.ts
+++ b/desktop/src/window.ts
@@ -109,8 +109,11 @@ function get_window_constructor_options(): BaseWindowConstructorOptions {
  * decided at page-load time, so client-side nav to e.g. `/blog/foo`
  * would *leave* the bridge attached — unsafe. Block such navs.
  *
- * Whitelisted: same-origin `/desktop` and `/desktop/*` paths only.
- * OAuth handoff leaves the desktop window via `shell.openExternal`.
+ * Whitelisted: same-origin `/desktop` and `/desktop/*` paths only —
+ * enforced for user navigations (`will-navigate`), SPA navigations
+ * (`did-navigate-in-page`), and server redirects (`will-redirect`,
+ * GRIDA-SEC-005). OAuth handoff leaves the desktop window via
+ * `shell.openExternal`.
  */
 function register_window_hooks(
   window: BrowserWindow,
@@ -148,6 +151,18 @@ function register_window_hooks(
     }
   });
 
+  // GRIDA-SEC-005 — server 302s don't fire `will-navigate`, so without this
+  // hook a redirect chain could walk the window off `/desktop/*` with the
+  // bridge attached. Unlike `will-navigate`, a blocked redirect is NOT
+  // handed to the OS browser: the target was chosen by a server response,
+  // not by the user.
+  window.webContents.on("will-redirect", (event, target) => {
+    if (!isAllowedNavigation(baseUrl, target)) {
+      event.preventDefault();
+      console.warn(`[grida] blocked redirect outside /desktop: ${target}`);
+    }
+  });
+
   window.webContents.on("did-navigate-in-page", (_event, target) => {
     if (isAllowedNavigation(baseUrl, target)) return;
     console.warn(
@@ -157,7 +172,7 @@ function register_window_hooks(
   });
 }
 
-function isAllowedNavigation(baseUrl: string, target: string): boolean {
+export function isAllowedNavigation(baseUrl: string, target: string): boolean {
   let url: URL;
   try {
     url = new URL(target);

--- a/desktop/src/window.ts
+++ b/desktop/src/window.ts
@@ -156,6 +156,12 @@ function register_window_hooks(
   // bridge attached. Unlike `will-navigate`, a blocked redirect is NOT
   // handed to the OS browser: the target was chosen by a server response,
   // not by the user.
+  //
+  // Intentionally frame-agnostic (no `isMainFrame` filter): the desktop CSP
+  // (GRIDA-SEC-004) already forbids cross-origin frames, so any redirect off
+  // `/desktop/*` in ANY frame is unexpected and blocked. This is the stricter
+  // choice — narrowing to the main frame would let a subframe redirect
+  // off-surface.
   window.webContents.on("will-redirect", (event, target) => {
     if (!isAllowedNavigation(baseUrl, target)) {
       event.preventDefault();

--- a/editor/app/(insiders)/insiders/auth/basic/page.tsx
+++ b/editor/app/(insiders)/insiders/auth/basic/page.tsx
@@ -26,7 +26,18 @@ type SerachParams = {
    * desktop deep-link mint instead of the web redirect.
    */
   challenge?: string;
+  /** Error code the sign-in route redirects back with (e.g. a failed mint). */
+  error?: string;
 };
+
+function describeError(code: string): string {
+  switch (code) {
+    case "desktop_link_failed":
+      return "Signed in, but the desktop hand-off failed (is Mailpit running?). Try again.";
+    default:
+      return "Sign-in failed. Please try again.";
+  }
+}
 
 export default async function InsidersBasicAuthPage(props: {
   searchParams: Promise<SerachParams>;
@@ -61,6 +72,11 @@ function Form({ searchParams }: { searchParams: SerachParams }) {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {searchParams.error && (
+            <p className="mb-4 text-sm text-destructive">
+              {describeError(searchParams.error)}
+            </p>
+          )}
           <form method="post" action="/insiders/auth/basic/sign-in">
             <input
               type="hidden"

--- a/editor/app/(insiders)/insiders/auth/basic/page.tsx
+++ b/editor/app/(insiders)/insiders/auth/basic/page.tsx
@@ -22,7 +22,7 @@ type SerachParams = {
   next?: string;
   /**
    * GRIDA-SEC-005 — desktop sign-in PKCE challenge, forwarded from
-   * `/sign-in/desktop`. When present, the sign-in route completes the
+   * `/desktop-auth`. When present, the sign-in route completes the
    * desktop deep-link mint instead of the web redirect.
    */
   challenge?: string;

--- a/editor/app/(insiders)/insiders/auth/basic/page.tsx
+++ b/editor/app/(insiders)/insiders/auth/basic/page.tsx
@@ -20,6 +20,12 @@ export const metadata: Metadata = {
 type SerachParams = {
   redirect_uri?: string;
   next?: string;
+  /**
+   * GRIDA-SEC-005 — desktop sign-in PKCE challenge, forwarded from
+   * `/sign-in/desktop`. When present, the sign-in route completes the
+   * desktop deep-link mint instead of the web redirect.
+   */
+  challenge?: string;
 };
 
 export default async function InsidersBasicAuthPage(props: {
@@ -62,6 +68,11 @@ function Form({ searchParams }: { searchParams: SerachParams }) {
               value={searchParams.redirect_uri}
             />
             <input type="hidden" name="next" value={searchParams.next} />
+            <input
+              type="hidden"
+              name="challenge"
+              value={searchParams.challenge}
+            />
             <div className="grid gap-6">
               <div className="grid gap-6">
                 <FieldGroup className="gap-6">

--- a/editor/app/(insiders)/insiders/auth/basic/sign-in/route.test.ts
+++ b/editor/app/(insiders)/insiders/auth/basic/sign-in/route.test.ts
@@ -1,0 +1,131 @@
+/**
+ * GRIDA-SEC-005 — insiders sign-in route, desktop branch.
+ *
+ * Pins the branch decision: password verification always runs first; the
+ * desktop mint happens only for a valid challenge; without one the classic
+ * web redirects are untouched; and the mint's redirect goes to the GoTrue
+ * verify URL extracted from Mailpit.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const signInWithPassword =
+  vi.fn<(creds: unknown) => Promise<{ error: { message: string } | null }>>();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { signInWithPassword } }),
+}));
+
+import { POST } from "./route";
+
+const ORIGIN = "http://grida.test";
+const CHALLENGE = "NF4wmu64KqpZmRNAuYJrxnETLbuzRbtPSbXpoHggKaA";
+const SUPABASE = "http://127.0.0.1:54321";
+const VERIFY = `${SUPABASE}/auth/v1/verify?token=pkce_tok&type=magiclink&redirect_to=grida://auth/callback`;
+
+function request(fields: Record<string, string>): NextRequest {
+  const body = new FormData();
+  for (const [key, value] of Object.entries(fields)) body.set(key, value);
+  return new Request(`${ORIGIN}/insiders/auth/basic/sign-in`, {
+    method: "POST",
+    body,
+  }) as unknown as NextRequest;
+}
+
+/**
+ * Fetch double for the desktop mint: 200 for the GoTrue /otp send, a
+ * fresh Mailpit message list, and the message body carrying the verify
+ * link.
+ */
+function stubMintFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url.includes("/auth/v1/otp")) {
+        return new Response("{}", { status: 200 });
+      }
+      if (url.includes("/api/v1/messages")) {
+        return Response.json({
+          messages: [
+            {
+              ID: "m1",
+              Created: new Date().toISOString(),
+              To: [{ Address: "insider@grida.co" }],
+            },
+          ],
+        });
+      }
+      if (url.includes("/api/v1/message/m1")) {
+        return Response.json({ Text: `link: ${VERIFY}`, HTML: "" });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    })
+  );
+}
+
+beforeEach(() => {
+  signInWithPassword.mockReset();
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", SUPABASE);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "publishable");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("POST /insiders/auth/basic/sign-in", () => {
+  it("keeps the classic web redirect when no challenge is present", async () => {
+    signInWithPassword.mockResolvedValue({ error: null });
+    const response = await POST(
+      request({ email: "insider@grida.co", password: "password" })
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(`${ORIGIN}/insiders/welcome`);
+  });
+
+  it("rejects a wrong password before any desktop mint", async () => {
+    signInWithPassword.mockResolvedValue({ error: { message: "invalid" } });
+    const fetchSpy = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchSpy);
+    const response = await POST(
+      request({
+        email: "insider@grida.co",
+        password: "wrong",
+        challenge: CHALLENGE,
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores an invalid challenge and falls back to the web redirect", async () => {
+    signInWithPassword.mockResolvedValue({ error: null });
+    const fetchSpy = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchSpy);
+    const response = await POST(
+      request({
+        email: "insider@grida.co",
+        password: "password",
+        challenge: "not-a-challenge!",
+      })
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(`${ORIGIN}/insiders/welcome`);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("mints the desktop verify redirect for a valid challenge", async () => {
+    signInWithPassword.mockResolvedValue({ error: null });
+    stubMintFetch();
+    const response = await POST(
+      request({
+        email: "insider@grida.co",
+        password: "password",
+        challenge: CHALLENGE,
+      })
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(VERIFY);
+  });
+});

--- a/editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts
+++ b/editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts
@@ -40,7 +40,10 @@ async function mintDesktopVerifyUrl(
     email,
     challenge,
   });
-  const sent = await fetch(otp.url, otp.init);
+  const sent = await fetch(otp.url, {
+    ...otp.init,
+    signal: AbortSignal.timeout(2000),
+  });
   if (!sent.ok) {
     console.error("[INSIDER] desktop OTP send failed:", sent.status);
     return null;
@@ -53,7 +56,11 @@ async function mintDesktopVerifyUrl(
       await new Promise((resolve) => setTimeout(resolve, 400));
     }
     try {
-      const list = await fetch(`${MAILPIT_URL}/api/v1/messages?limit=10`);
+      // Timeouts so a hung Mailpit fails fast into the retry loop instead of
+      // blocking the request handler indefinitely.
+      const list = await fetch(`${MAILPIT_URL}/api/v1/messages?limit=10`, {
+        signal: AbortSignal.timeout(2000),
+      });
       if (!list.ok) continue;
       const { messages } = (await list.json()) as {
         messages?: Array<{
@@ -69,7 +76,9 @@ async function mintDesktopVerifyUrl(
           ) && new Date(m.Created).getTime() >= since - 2000
       );
       if (!message) continue;
-      const full = await fetch(`${MAILPIT_URL}/api/v1/message/${message.ID}`);
+      const full = await fetch(`${MAILPIT_URL}/api/v1/message/${message.ID}`, {
+        signal: AbortSignal.timeout(2000),
+      });
       if (!full.ok) continue;
       const body = (await full.json()) as { Text?: string; HTML?: string };
       const verify = extractVerifyUrl(

--- a/editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts
+++ b/editor/app/(insiders)/insiders/auth/basic/sign-in/route.ts
@@ -1,8 +1,89 @@
 import { resolve_next } from "@/host/url";
+import {
+  buildOtpRequest,
+  extractVerifyUrl,
+  isValidChallenge,
+} from "@/host/auth/desktop-auth-flow";
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
 import type { NextRequest } from "next/server";
+
+/**
+ * GRIDA-SEC-005 — desktop branch of the insiders sign-in (see below).
+ * Local-only by GRIDA-SEC-002 (the proxy 404s `/insiders/*` outside
+ * development), so coupling to the local Supabase Mailpit capture is fine.
+ */
+const MAILPIT_URL = "http://127.0.0.1:54324";
+
+/**
+ * Completes the desktop sign-in mint for an ALREADY password-verified
+ * insider: fires the GoTrue email OTP bound to the desktop's PKCE
+ * challenge, then consumes the emailed verify link straight from Mailpit —
+ * the developer keeps the email+password flow and never opens an inbox.
+ * Following the returned verify URL makes GoTrue 302 to
+ * `grida://auth/callback?code=…`, i.e. the exact production callback path.
+ * A password grant alone can never produce that challenge-bound code
+ * (GoTrue returns sessions directly for passwords), which is why the mint
+ * rides the OTP-link machinery.
+ */
+async function mintDesktopVerifyUrl(
+  email: string,
+  challenge: string
+): Promise<string | null> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const since = Date.now();
+
+  const otp = buildOtpRequest({
+    supabaseUrl,
+    apikey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    email,
+    challenge,
+  });
+  const sent = await fetch(otp.url, otp.init);
+  if (!sent.ok) {
+    console.error("[INSIDER] desktop OTP send failed:", sent.status);
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    // GoTrue sends synchronously, so the mail is usually already captured —
+    // check immediately and only sleep between retries.
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+    try {
+      const list = await fetch(`${MAILPIT_URL}/api/v1/messages?limit=10`);
+      if (!list.ok) continue;
+      const { messages } = (await list.json()) as {
+        messages?: Array<{
+          ID: string;
+          Created: string;
+          To?: Array<{ Address?: string }>;
+        }>;
+      };
+      const message = (messages ?? []).find(
+        (m) =>
+          (m.To ?? []).some(
+            (t) => t.Address?.toLowerCase() === email.toLowerCase()
+          ) && new Date(m.Created).getTime() >= since - 2000
+      );
+      if (!message) continue;
+      const full = await fetch(`${MAILPIT_URL}/api/v1/message/${message.ID}`);
+      if (!full.ok) continue;
+      const body = (await full.json()) as { Text?: string; HTML?: string };
+      const verify = extractVerifyUrl(
+        `${body.Text ?? ""}\n${body.HTML ?? ""}`,
+        supabaseUrl
+      );
+      if (verify) return verify;
+    } catch {
+      // Mailpit transiently unavailable — keep polling.
+    }
+  }
+  console.error("[INSIDER] desktop OTP mail did not arrive in Mailpit");
+  return null;
+}
 
 export async function POST(req: NextRequest) {
   const requestUrl = new URL(req.url);
@@ -14,6 +95,7 @@ export async function POST(req: NextRequest) {
   const password = data.get("password") as string;
   const redirect_uri = data.get("redirect_uri") as string | null;
   const next = data.get("next") as string | null;
+  const challenge = data.get("challenge") as string | null;
 
   const { error } = await client.auth.signInWithPassword({
     email: email,
@@ -26,6 +108,26 @@ export async function POST(req: NextRequest) {
   }
 
   console.log("[INSIDER] Sign in successful");
+
+  // GRIDA-SEC-005 — desktop sign-in: the SAME email+password verification
+  // as the web flow above (a browser session is set as a side effect,
+  // exactly like signing into the web), then the challenge-bound
+  // deep-link mint.
+  if (challenge && isValidChallenge(challenge)) {
+    const verify = await mintDesktopVerifyUrl(email, challenge);
+    if (!verify) {
+      return NextResponse.redirect(
+        new URL(
+          `/insiders/auth/basic?challenge=${encodeURIComponent(challenge)}&error=desktop_link_failed`,
+          requestUrl.origin
+        ),
+        { status: 302 }
+      );
+    }
+    // The browser follows this to GoTrue, which 302s to
+    // grida://auth/callback?code=… — handing off to the desktop app.
+    return NextResponse.redirect(verify, { status: 302 });
+  }
 
   if (redirect_uri) {
     return NextResponse.redirect(new URL(redirect_uri, requestUrl.origin), {

--- a/editor/app/(site)/sign-in/_components/shell.tsx
+++ b/editor/app/(site)/sign-in/_components/shell.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { ChatBubbleIcon } from "@radix-ui/react-icons";
+import { GridaLogo } from "@/components/grida-logo";
+import Link from "next/link";
+import Image from "next/image";
+import abstract_photo from "../../../../public/images/abstract-placeholder.jpg";
+
+/**
+ * Shared page shell for the sign-in family (`/sign-in`, `/sign-in/desktop`).
+ * Owns the chrome — top nav, two-column layout with the photo aside, and the
+ * terms footer — parameterized only by the heading copy and the method list
+ * (children). Behavior (redirect params, method mechanics, gating) stays in
+ * each page.
+ */
+export function SignInShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: React.ReactNode;
+  subtitle: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="flex flex-col flex-1 bg-alternative">
+        <div className="absolute top-0 w-full px-8 mx-auto sm:px-6 lg:px-8 mt-14">
+          <nav className="relative flex items-center justify-between sm:h-10">
+            <div className="flex items-center grow shrink-0 lg:grow-0">
+              <div className="flex items-center justify-between w-full md:w-auto">
+                <Link className="flex gap-2 items-center" href="/">
+                  <GridaLogo />
+                  <span className="font-bold">Grida</span>
+                </Link>
+              </div>
+            </div>
+            <div className="items-center hidden space-x-3 md:ml-10 md:flex md:pr-4">
+              <Link
+                target="_blank"
+                rel="noreferrer"
+                type="button"
+                className="relative justify-center cursor-pointer inline-flex items-center space-x-2 text-center font-regular ease-out duration-200 rounded-md outline-none transition-all outline-0 focus-visible:outline-4 focus-visible:outline-offset-1 border text-foreground bg-button hover:bg-selection border-button hover:border-button-hover focus-visible:outline-brand-600 shadow-sm text-xs px-2.5 py-1"
+                href="/contact"
+              >
+                <ChatBubbleIcon />
+                <span className="truncate">Contact</span>
+              </Link>
+            </div>
+          </nav>
+        </div>
+        <div className="flex flex-1">
+          <main className="flex flex-col items-center flex-1 shrink-0 px-5 pt-16 pb-8 border-r shadow-lg bg-background border-default">
+            <div className="flex-1 flex flex-col justify-center w-[330px] sm:w-[384px]">
+              <div className="mb-10">
+                <h1 className="mt-8 mb-2 font-semibold text-2xl lg:text-3xl">
+                  {title}
+                </h1>
+                <h2 className="text-sm text-foreground-light">{subtitle}</h2>
+              </div>
+              <div className="flex flex-col gap-5">{children}</div>
+            </div>
+            <div className="sm:text-center">
+              <p className="text-xs text-foreground-lighter sm:mx-auto sm:max-w-sm">
+                By continuing, you agree to Grida&apos;s{" "}
+                <Link
+                  className="underline hover:text-foreground-light"
+                  href="/terms-and-conditions"
+                  target="_blank"
+                >
+                  Terms of Service
+                </Link>{" "}
+                and{" "}
+                <Link
+                  className="underline hover:text-foreground-light"
+                  href="/privacy-policy"
+                  target="_blank"
+                >
+                  Privacy Policy
+                </Link>
+                , and to receive periodic emails with updates.
+              </p>
+            </div>
+          </main>
+          <aside className="flex-col items-center justify-center flex-1 shrink hidden basis-1/4 xl:flex">
+            <div
+              className="relative flex flex-col gap-6 h-full"
+              style={{
+                height: "-webkit-fill-available",
+              }}
+            >
+              <div className="flex-1">
+                <Image
+                  className="object-cover w-full h-full"
+                  src={abstract_photo}
+                  alt={"Grida office"}
+                />
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/editor/app/(site)/sign-in/desktop/page.tsx
+++ b/editor/app/(site)/sign-in/desktop/page.tsx
@@ -1,0 +1,84 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-in launch page (the ceremony's web side).
+ *
+ * The `/sign-in` sibling for the desktop app: opened in the SYSTEM browser
+ * by the app's single "Sign in with browser" button, carrying only the
+ * public PKCE `code_challenge`. The sign-in method is chosen HERE — the
+ * desktop never names a provider — and every method binds its GoTrue flow
+ * to the forwarded challenge (`@/host/auth/desktop-auth-flow`), returning
+ * through the same `grida://auth/callback` deep link. Adding or changing
+ * methods is a web deploy; the desktop is untouched.
+ *
+ * Mirrors the web sign-in page's insiders routing exactly: when
+ * `NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` is on, redirect to the insiders
+ * email+password page with the challenge forwarded — its sign-in route
+ * completes the desktop mint (see the insiders sign-in route's desktop
+ * branch).
+ */
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { ContinueWithGoogleButton } from "@/host/auth/continue-with-google-button";
+import {
+  buildAuthorizeUrl,
+  isValidChallenge,
+} from "@/host/auth/desktop-auth-flow";
+import { SignInShell } from "../_components/shell";
+
+export const metadata: Metadata = {
+  title: "Sign in to Grida Desktop",
+  robots: { index: false, follow: false },
+};
+
+const USE_INSIDERS_AUTH =
+  process.env.NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH === "1";
+
+export default async function DesktopSignInLaunchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ challenge?: string }>;
+}) {
+  const { challenge } = await searchParams;
+  const valid = typeof challenge === "string" && isValidChallenge(challenge);
+
+  if (!valid) {
+    return (
+      <SignInShell
+        title={
+          <>
+            Sign in to
+            <br /> Grida Desktop
+          </>
+        }
+        subtitle="This link is incomplete. Start sign-in from the Grida app."
+      >
+        {null}
+      </SignInShell>
+    );
+  }
+
+  if (USE_INSIDERS_AUTH) {
+    return redirect(
+      "/insiders/auth/basic?challenge=" + encodeURIComponent(challenge)
+    );
+  }
+
+  return (
+    <SignInShell
+      title={
+        <>
+          Sign in to
+          <br /> Grida Desktop
+        </>
+      }
+      subtitle="Choose how to sign in. You'll be sent back to the app."
+    >
+      <ContinueWithGoogleButton
+        authorize_url={buildAuthorizeUrl({
+          supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          provider: "google",
+          challenge,
+        })}
+      />
+    </SignInShell>
+  );
+}

--- a/editor/app/(site)/sign-in/page.tsx
+++ b/editor/app/(site)/sign-in/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { SignInShell } from "./_components/shell";
+import { SignInShell } from "@/components/auth/sign-in-shell";
 
 type SearchParams = {
   redirect_uri?: string;

--- a/editor/app/(site)/sign-in/page.tsx
+++ b/editor/app/(site)/sign-in/page.tsx
@@ -1,14 +1,11 @@
 import React from "react";
-import { ChatBubbleIcon } from "@radix-ui/react-icons";
-import { GridaLogo } from "@/components/grida-logo";
 import { ContinueWithGoogleButton } from "@/host/auth/continue-with-google-button";
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import Image from "next/image";
-import abstract_photo from "../../../public/images/abstract-placeholder.jpg";
 import { createClient } from "@/lib/supabase/server";
+import { SignInShell } from "./_components/shell";
 
 type SearchParams = {
   redirect_uri?: string;
@@ -44,100 +41,25 @@ export default async function SigninPage({
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <div className="flex flex-col flex-1 bg-alternative">
-        <div className="absolute top-0 w-full px-8 mx-auto sm:px-6 lg:px-8 mt-14">
-          <nav className="relative flex items-center justify-between sm:h-10">
-            <div className="flex items-center grow shrink-0 lg:grow-0">
-              <div className="flex items-center justify-between w-full md:w-auto">
-                <Link className="flex gap-2 items-center" href="/">
-                  <GridaLogo />
-                  <span className="font-bold">Grida</span>
-                </Link>
-              </div>
-            </div>
-            <div className="items-center hidden space-x-3 md:ml-10 md:flex md:pr-4">
-              <Link
-                target="_blank"
-                rel="noreferrer"
-                type="button"
-                className="relative justify-center cursor-pointer inline-flex items-center space-x-2 text-center font-regular ease-out duration-200 rounded-md outline-none transition-all outline-0 focus-visible:outline-4 focus-visible:outline-offset-1 border text-foreground bg-button hover:bg-selection border-button hover:border-button-hover focus-visible:outline-brand-600 shadow-sm text-xs px-2.5 py-1"
-                href="/contact"
-              >
-                <ChatBubbleIcon />
-                <span className="truncate">Contact</span>
-              </Link>
-            </div>
-          </nav>
-        </div>
-        <div className="flex flex-1">
-          <main className="flex flex-col items-center flex-1 shrink-0 px-5 pt-16 pb-8 border-r shadow-lg bg-background border-default">
-            <div className="flex-1 flex flex-col justify-center w-[330px] sm:w-[384px]">
-              <div className="mb-10">
-                <h1 className="mt-8 mb-2 font-semibold text-2xl lg:text-3xl">
-                  Welcome to
-                  <br /> Grida
-                </h1>
-                <h2 className="text-sm text-foreground-light">
-                  Sign up or Sign in to your account
-                </h2>
-              </div>
-              <div className="flex flex-col gap-5">
-                <Suspense>
-                  <ContinueWithGoogleButton
-                    next={next}
-                    redirect_uri={redirect_uri}
-                  />
-                </Suspense>
-                <hr />
-                <Link
-                  href={`/sign-in/email?${q}`}
-                  className="flex items-center gap-1 hover:underline text-sm text-muted-foreground"
-                >
-                  Continue with Email →
-                </Link>
-              </div>
-            </div>
-            <div className="sm:text-center">
-              <p className="text-xs text-foreground-lighter sm:mx-auto sm:max-w-sm">
-                By continuing, you agree to Grida&apos;s{" "}
-                <Link
-                  className="underline hover:text-foreground-light"
-                  href="/terms-and-conditions"
-                  target="_blank"
-                >
-                  Terms of Service
-                </Link>{" "}
-                and{" "}
-                <Link
-                  className="underline hover:text-foreground-light"
-                  href="/privacy-policy"
-                  target="_blank"
-                >
-                  Privacy Policy
-                </Link>
-                , and to receive periodic emails with updates.
-              </p>
-            </div>
-          </main>
-          <aside className="flex-col items-center justify-center flex-1 shrink hidden basis-1/4 xl:flex">
-            <div
-              className="relative flex flex-col gap-6 h-full"
-              style={{
-                height: "-webkit-fill-available",
-              }}
-            >
-              <div className="flex-1">
-                <Image
-                  className="object-cover w-full h-full"
-                  src={abstract_photo}
-                  alt={"Grida office"}
-                />
-              </div>
-            </div>
-          </aside>
-        </div>
-      </div>
-    </div>
+    <SignInShell
+      title={
+        <>
+          Welcome to
+          <br /> Grida
+        </>
+      }
+      subtitle="Sign up or Sign in to your account"
+    >
+      <Suspense>
+        <ContinueWithGoogleButton next={next} redirect_uri={redirect_uri} />
+      </Suspense>
+      <hr />
+      <Link
+        href={`/sign-in/email?${q}`}
+        className="flex items-center gap-1 hover:underline text-sm text-muted-foreground"
+      >
+        Continue with Email →
+      </Link>
+    </SignInShell>
   );
 }

--- a/editor/app/(untracked)/desktop-auth/page.tsx
+++ b/editor/app/(untracked)/desktop-auth/page.tsx
@@ -43,9 +43,17 @@ export default async function DesktopSignInLaunchPage({
   searchParams: Promise<{ challenge?: string }>;
 }) {
   const { challenge } = await searchParams;
-  const valid = typeof challenge === "string" && isValidChallenge(challenge);
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 
-  if (!valid) {
+  // A missing challenge is a broken hand-off; a missing Supabase URL is a
+  // misconfigured deployment. Both degrade to the same inert shell rather
+  // than throwing (an unguarded `new URL(…, undefined)` would 500 this
+  // external-facing page).
+  if (
+    !supabaseUrl ||
+    typeof challenge !== "string" ||
+    !isValidChallenge(challenge)
+  ) {
     return (
       <SignInShell
         title={
@@ -79,7 +87,7 @@ export default async function DesktopSignInLaunchPage({
     >
       <ContinueWithGoogleButton
         authorize_url={buildAuthorizeUrl({
-          supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          supabaseUrl,
           provider: "google",
           challenge,
         })}

--- a/editor/app/(untracked)/desktop-auth/page.tsx
+++ b/editor/app/(untracked)/desktop-auth/page.tsx
@@ -1,19 +1,25 @@
 /**
  * GRIDA-SEC-005 — desktop sign-in launch page (the ceremony's web side).
  *
- * The `/sign-in` sibling for the desktop app: opened in the SYSTEM browser
- * by the app's single "Sign in with browser" button, carrying only the
- * public PKCE `code_challenge`. The sign-in method is chosen HERE — the
- * desktop never names a provider — and every method binds its GoTrue flow
- * to the forwarded challenge (`@/host/auth/desktop-auth-flow`), returning
- * through the same `grida://auth/callback` deep link. Adding or changing
- * methods is a web deploy; the desktop is untouched.
+ * `/desktop-auth`, opened in the SYSTEM browser by the app's single
+ * "Sign in with browser" button, carrying the PKCE `code_challenge`. The
+ * sign-in method is chosen HERE — the desktop never names a provider — and
+ * every method binds its GoTrue flow to the forwarded challenge
+ * (`@/host/auth/desktop-auth-flow`), returning through the same
+ * `grida://auth/callback` deep link. Adding or changing methods is a web
+ * deploy; the desktop is untouched.
  *
- * Mirrors the web sign-in page's insiders routing exactly: when
+ * Lives in the `(untracked)` route group (analytics-free root layout) ON
+ * PURPOSE: the challenge in this page's URL is confidentiality-sensitive
+ * (knowing it lets an attacker mint a code bound to it and defeat the
+ * login-CSRF protection), so no third-party pageview script may see it. The
+ * `(site)` sign-in pages run analytics, so this page cannot be their sibling.
+ *
+ * Mirrors the web sign-in page's insiders routing: when
  * `NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` is on, redirect to the insiders
  * email+password page with the challenge forwarded — its sign-in route
  * completes the desktop mint (see the insiders sign-in route's desktop
- * branch).
+ * branch). `(insiders)` also loads no analytics, and is dev-only.
  */
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
@@ -22,11 +28,10 @@ import {
   buildAuthorizeUrl,
   isValidChallenge,
 } from "@/host/auth/desktop-auth-flow";
-import { SignInShell } from "../_components/shell";
+import { SignInShell } from "@/components/auth/sign-in-shell";
 
 export const metadata: Metadata = {
   title: "Sign in to Grida Desktop",
-  robots: { index: false, follow: false },
 };
 
 const USE_INSIDERS_AUTH =

--- a/editor/app/(untracked)/layout.tsx
+++ b/editor/app/(untracked)/layout.tsx
@@ -1,0 +1,38 @@
+/**
+ * GRIDA-SEC-005 — analytics-free root layout.
+ *
+ * Root layout (this repo has no top-level `app/layout.tsx`; each route group
+ * owns its `<html>`). Deliberately loads NO third-party scripts — no Google
+ * Analytics, no Vercel Analytics/Speed Insights — unlike the `(site)` root
+ * layout. Pages here carry security-sensitive values in their URL (e.g. the
+ * desktop sign-in PKCE challenge) that must not be beaconed to third parties;
+ * a pageview capturing that URL would disclose the value. Do not add
+ * analytics or any URL-reporting script to this group.
+ */
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { ThemeProvider } from "@/components/theme-provider";
+import "../editor.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Grida",
+  robots: { index: false, follow: false },
+  // No third party ever receives the URL as a Referer either.
+  referrer: "no-referrer",
+};
+
+export default function UntrackedRootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={inter.className}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/editor/app/desktop/auth/callback/route.test.ts
+++ b/editor/app/desktop/auth/callback/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * GRIDA-SEC-005 — desktop PKCE exchange route.
+ *
+ * Pins: the exchange is the only session-creating step, failures always
+ * land back on the desktop sign-in page (never outside `/desktop/*`), and
+ * GoTrue error params forwarded by the protocol router survive as
+ * `auth_error`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const exchangeCodeForSession =
+  vi.fn<
+    (
+      code: string
+    ) => Promise<{ error: { code?: string; message?: string } | null }>
+  >();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { exchangeCodeForSession } }),
+}));
+
+import { GET } from "./route";
+
+const ORIGIN = "https://grida.test";
+
+function request(pathAndQuery: string): NextRequest {
+  return new Request(`${ORIGIN}${pathAndQuery}`) as unknown as NextRequest;
+}
+
+function redirectTarget(response: Response): URL {
+  expect(response.status).toBeGreaterThanOrEqual(300);
+  expect(response.status).toBeLessThan(400);
+  return new URL(response.headers.get("location")!);
+}
+
+beforeEach(() => {
+  exchangeCodeForSession.mockReset();
+});
+
+describe("GET /desktop/auth/callback", () => {
+  it("exchanges the code and redirects to the welcome surface", async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: null });
+    const target = redirectTarget(
+      await GET(request("/desktop/auth/callback?code=abc"))
+    );
+    expect(exchangeCodeForSession).toHaveBeenCalledWith("abc");
+    expect(target.origin).toBe(ORIGIN);
+    expect(target.pathname).toBe("/desktop/welcome");
+  });
+
+  it("redirects to sign-in with auth_error when the exchange fails", async () => {
+    exchangeCodeForSession.mockResolvedValue({
+      error: { code: "flow_state_expired", message: "expired" },
+    });
+    const target = redirectTarget(
+      await GET(request("/desktop/auth/callback?code=stale"))
+    );
+    expect(target.pathname).toBe("/desktop/auth/sign-in");
+    expect(target.searchParams.get("auth_error")).toBe("flow_state_expired");
+  });
+
+  it("rejects a missing code without touching the auth API", async () => {
+    const target = redirectTarget(await GET(request("/desktop/auth/callback")));
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(target.pathname).toBe("/desktop/auth/sign-in");
+    expect(target.searchParams.get("auth_error")).toBe("missing_code");
+  });
+
+  it("surfaces GoTrue error params forwarded by the protocol router", async () => {
+    const target = redirectTarget(
+      await GET(
+        request(
+          "/desktop/auth/callback?error=access_denied&error_code=otp_expired"
+        )
+      )
+    );
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(target.searchParams.get("auth_error")).toBe("otp_expired");
+  });
+
+  it("never redirects outside /desktop/*", async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: { code: "x" } });
+    for (const path of [
+      "/desktop/auth/callback",
+      "/desktop/auth/callback?code=a",
+      "/desktop/auth/callback?error=denied",
+    ]) {
+      const target = redirectTarget(await GET(request(path)));
+      expect(target.pathname.startsWith("/desktop/")).toBe(true);
+    }
+  });
+});

--- a/editor/app/desktop/auth/callback/route.ts
+++ b/editor/app/desktop/auth/callback/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-in, PKCE code exchange.
+ *
+ * The Electron main process navigates the desktop window here after the
+ * `grida://auth/callback?code=…` deep link returns from the system browser
+ * (`desktop/src/main/protocol-router.ts`). The exchange only succeeds when
+ * the PKCE verifier cookie minted by `../start/route.ts` is present in the
+ * Electron cookie jar — an attacker-supplied `code` (phished or replayed
+ * deep link) was issued against a different verifier and fails safe.
+ *
+ * On success the standard `@supabase/ssr` session cookies are set on this
+ * response (same mechanism as the web `(auth)/auth/callback` route) and the
+ * wrapped web app is signed in like any browser session. Every redirect out
+ * of this route MUST stay under `/desktop/*` (desktop navigation guard).
+ */
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+
+  const fail = (reason: string) =>
+    NextResponse.redirect(
+      new URL(
+        `/desktop/auth/sign-in?auth_error=${encodeURIComponent(reason)}`,
+        requestUrl.origin
+      )
+    );
+
+  if (!code) {
+    // GoTrue reports provider errors (user denied, expired flow) as
+    // `error`/`error_code` query params instead of a `code`; the desktop
+    // protocol router forwards them here verbatim.
+    return fail(
+      requestUrl.searchParams.get("error_code") ??
+        requestUrl.searchParams.get("error") ??
+        "missing_code"
+    );
+  }
+
+  const client = await createClient();
+  const { error } = await client.auth.exchangeCodeForSession(code);
+  if (error) {
+    console.error("[desktop-auth] exchangeCodeForSession failed:", error);
+    return fail(error.code ?? "exchange_failed");
+  }
+
+  return NextResponse.redirect(new URL("/desktop/welcome", requestUrl.origin));
+}

--- a/editor/app/desktop/auth/me/route.ts
+++ b/editor/app/desktop/auth/me/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Desktop session read, same-origin.
+ *
+ * The `/desktop/*` CSP keeps `connect-src` closed to `'self'` (+ loopback),
+ * so the desktop renderer cannot call Supabase directly (no supabase-js
+ * `getUser`/refresh from the page). All session reads go through this
+ * route; the proxy middleware refreshes the session cookies on every
+ * same-origin request, so no client-side refresh is needed either.
+ *
+ * Signed-out is an expected state, not an error: responds 200 with
+ * `{ user: null }`.
+ */
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export async function GET() {
+  const client = await createClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ user: null }, { headers: NO_STORE });
+  }
+
+  return NextResponse.json(
+    {
+      user: {
+        id: user.id,
+        email: user.email ?? null,
+        name: user.user_metadata?.full_name ?? user.user_metadata?.name ?? null,
+        avatar_url: user.user_metadata?.avatar_url ?? null,
+      },
+    },
+    { headers: NO_STORE }
+  );
+}

--- a/editor/app/desktop/auth/sign-in/_components/sign-in-card.tsx
+++ b/editor/app/desktop/auth/sign-in/_components/sign-in-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * Desktop sign-in card. Small and native-feeling: window chrome + a centered
+ * card with a single method-neutral button (the Figma/Linear "log in with
+ * browser" pattern).
+ *
+ * The button asks `/desktop/auth/start` for the web launch-page URL (which
+ * pins the PKCE verifier cookie into this window's cookie jar), then opens
+ * it in the SYSTEM browser via the bridge — never in the webview. The
+ * sign-in METHOD is chosen on the web launch page; whatever it is, success
+ * returns through the `grida://auth/callback` deep link and the main
+ * process navigates this window to `/desktop/auth/callback`, so on success
+ * this page simply goes away. Until then we show a passive waiting state
+ * with a retry.
+ */
+import { useState } from "react";
+import { GridaLogo } from "@/components/grida-logo";
+import { getDesktopBridge } from "@/lib/desktop/bridge";
+import { Button } from "@app/ui/components/button";
+import {
+  DesktopPageContent,
+  DesktopPageShell,
+} from "@/scaffolds/desktop/chrome/page-shell";
+
+type Phase = "idle" | "starting" | "waiting";
+
+/**
+ * One generic message for every `auth_error` code (missing_code, GoTrue
+ * flow/verifier failures, provider denials) — the codes are diagnostic,
+ * not user-actionable, and "try again" is the remedy for all of them.
+ */
+const SIGN_IN_FAILED_MESSAGE =
+  "Sign-in could not be completed. Please try again.";
+
+export function SignInCard({ authError }: { authError: string | null }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [error, setError] = useState<string | null>(
+    authError ? SIGN_IN_FAILED_MESSAGE : null
+  );
+
+  const signInWithBrowser = async () => {
+    setError(null);
+    setPhase("starting");
+    try {
+      const res = await fetch("/desktop/auth/start", { method: "POST" });
+      if (!res.ok) throw new Error("start_failed");
+      const { url } = (await res.json()) as { url: string };
+      const bridge = getDesktopBridge();
+      if (!bridge) throw new Error("bridge_missing");
+      await bridge.shell.open_external(url);
+      setPhase("waiting");
+    } catch {
+      setError("Couldn't open the browser to sign in. Please try again.");
+      setPhase("idle");
+    }
+  };
+
+  return (
+    <DesktopPageShell>
+      <DesktopPageContent className="flex items-center justify-center">
+        <div className="flex w-full max-w-xs flex-col items-center gap-6 px-6 py-12">
+          <GridaLogo size={32} />
+          <div className="text-center">
+            <h1 className="text-lg font-semibold">Sign in to Grida</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Your account connects this app to Grida.
+            </p>
+          </div>
+
+          {phase === "waiting" ? (
+            <div className="flex w-full flex-col items-center gap-3 text-center">
+              <p className="text-sm text-muted-foreground">
+                Finish signing in from your browser. This window will continue
+                automatically.
+              </p>
+              <Button variant="ghost" size="sm" onClick={signInWithBrowser}>
+                Try again
+              </Button>
+            </div>
+          ) : (
+            <Button
+              className="w-full"
+              onClick={signInWithBrowser}
+              disabled={phase === "starting"}
+            >
+              Sign in with browser
+            </Button>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      </DesktopPageContent>
+    </DesktopPageShell>
+  );
+}

--- a/editor/app/desktop/auth/sign-in/page.tsx
+++ b/editor/app/desktop/auth/sign-in/page.tsx
@@ -4,7 +4,7 @@
  * Server component: reads the session (already signed in → straight to the
  * welcome surface) and threads the `auth_error` code from a failed PKCE
  * exchange (`../callback/route.ts`) into the card. The ceremony itself runs
- * in the SYSTEM browser on the `/sign-in/desktop` launch page — this page
+ * in the SYSTEM browser on the `/desktop-auth` launch page — this page
  * only starts the flow and waits; it never names a sign-in method.
  */
 import { redirect } from "next/navigation";

--- a/editor/app/desktop/auth/sign-in/page.tsx
+++ b/editor/app/desktop/auth/sign-in/page.tsx
@@ -1,0 +1,28 @@
+/**
+ * Desktop sign-in page — the forced front door of the desktop app.
+ *
+ * Server component: reads the session (already signed in → straight to the
+ * welcome surface) and threads the `auth_error` code from a failed PKCE
+ * exchange (`../callback/route.ts`) into the card. The ceremony itself runs
+ * in the SYSTEM browser on the `/sign-in/desktop` launch page — this page
+ * only starts the flow and waits; it never names a sign-in method.
+ */
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { SignInCard } from "./_components/sign-in-card";
+
+export default async function DesktopSignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ auth_error?: string }>;
+}) {
+  const { auth_error } = await searchParams;
+
+  const client = await createClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+  if (user) redirect("/desktop/welcome");
+
+  return <SignInCard authError={auth_error ?? null} />;
+}

--- a/editor/app/desktop/auth/sign-out/route.ts
+++ b/editor/app/desktop/auth/sign-out/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-out, same-origin.
+ *
+ * The desktop renderer must NEVER navigate to the web `/sign-out` route:
+ * it is outside `/desktop/*`, so the desktop navigation guard would hand
+ * the URL to `shell.openExternal` — signing the user out of their OS
+ * browser session instead of the app. This route keeps sign-out (and its
+ * redirect) inside the `/desktop/*` surface; callers use a same-origin
+ * `fetch`.
+ */
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const client = await createClient();
+  await client.auth.signOut();
+  return NextResponse.redirect(
+    new URL("/desktop/auth/sign-in", requestUrl.origin),
+    { status: 303 }
+  );
+}

--- a/editor/app/desktop/auth/start/route.test.ts
+++ b/editor/app/desktop/auth/start/route.test.ts
@@ -1,7 +1,7 @@
 /**
  * GRIDA-SEC-005 — desktop PKCE start route.
  *
- * Pins: the route returns the same-origin `/sign-in/desktop` launch-page URL
+ * Pins: the route returns the same-origin `/desktop-auth` launch-page URL
  * carrying only the public challenge (never a provider URL, never a
  * redirect — the verifier cookie must land on a route-handler response and
  * the URL must open in the system browser), and the underlying PKCE flow is
@@ -47,7 +47,7 @@ describe("POST /desktop/auth/start", () => {
     const { url } = (await response.json()) as { url: string };
     const launch = new URL(url);
     expect(launch.origin).toBe("https://grida.test");
-    expect(launch.pathname).toBe("/sign-in/desktop");
+    expect(launch.pathname).toBe("/desktop-auth");
     expect(launch.searchParams.get("challenge")).toBe(CHALLENGE);
     // The verifier-minting flow is bound to the deep-link return.
     expect(signInWithOAuth).toHaveBeenCalledWith(

--- a/editor/app/desktop/auth/start/route.test.ts
+++ b/editor/app/desktop/auth/start/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * GRIDA-SEC-005 — desktop PKCE start route.
+ *
+ * Pins: the route returns the same-origin `/sign-in/desktop` launch-page URL
+ * carrying only the public challenge (never a provider URL, never a
+ * redirect — the verifier cookie must land on a route-handler response and
+ * the URL must open in the system browser), and the underlying PKCE flow is
+ * created against the fixed `grida://auth/callback` deep link.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const signInWithOAuth = vi.fn<
+  (options: unknown) => Promise<{
+    data: { url: string } | null;
+    error: { message: string } | null;
+  }>
+>();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { signInWithOAuth } }),
+}));
+
+import { POST } from "./route";
+
+const CHALLENGE = "NF4wmu64KqpZmRNAuYJrxnETLbuzRbtPSbXpoHggKaA";
+
+function request(): NextRequest {
+  return new Request("https://grida.test/desktop/auth/start", {
+    method: "POST",
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  signInWithOAuth.mockReset();
+});
+
+describe("POST /desktop/auth/start", () => {
+  it("returns the same-origin launch-page URL carrying the challenge", async () => {
+    signInWithOAuth.mockResolvedValue({
+      data: {
+        url: `https://supabase.test/auth/v1/authorize?provider=google&code_challenge=${CHALLENGE}&code_challenge_method=s256`,
+      },
+      error: null,
+    });
+    const response = await POST(request());
+    expect(response.status).toBe(200);
+    const { url } = (await response.json()) as { url: string };
+    const launch = new URL(url);
+    expect(launch.origin).toBe("https://grida.test");
+    expect(launch.pathname).toBe("/sign-in/desktop");
+    expect(launch.searchParams.get("challenge")).toBe(CHALLENGE);
+    // The verifier-minting flow is bound to the deep-link return.
+    expect(signInWithOAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          redirectTo: "grida://auth/callback",
+          skipBrowserRedirect: true,
+        }),
+      })
+    );
+  });
+
+  it("responds 500 when the auth API fails", async () => {
+    signInWithOAuth.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+    const response = await POST(request());
+    expect(response.status).toBe(500);
+  });
+
+  it("responds 500 when no challenge is present in the generated URL", async () => {
+    signInWithOAuth.mockResolvedValue({
+      data: { url: "https://supabase.test/auth/v1/authorize?provider=google" },
+      error: null,
+    });
+    const response = await POST(request());
+    expect(response.status).toBe(500);
+  });
+});

--- a/editor/app/desktop/auth/start/route.ts
+++ b/editor/app/desktop/auth/start/route.ts
@@ -1,0 +1,61 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-in, PKCE start.
+ *
+ * Mints the PKCE code verifier as an `@supabase/ssr` cookie on THIS
+ * response — i.e. into the Electron cookie jar — and returns the web
+ * **launch page** URL (`/sign-in/desktop?challenge=…`) for the system
+ * browser.
+ * The desktop shows a single "Sign in with browser" button; the sign-in
+ * METHOD is chosen on the web launch page, which builds its GoTrue flow
+ * against the forwarded challenge. The challenge is public by design
+ * (PKCE S256); the verifier never leaves this jar, so the `code` that any
+ * method produces is only exchangeable by this webview
+ * (see `../callback/route.ts`).
+ *
+ * Must stay a route handler returning `{ url }` (not a redirect): the
+ * verifier cookie is only reliably set on a route-handler response
+ * (supabase/ssr#55), and the URL must open in the SYSTEM browser
+ * (`shell.open_external`), never in the webview.
+ */
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Deep-link return target. Allowlisted in `supabase/config.toml` locally
+ * and in the hosted project's dashboard for production. Deliberately a
+ * local twin of `DESKTOP_AUTH_REDIRECT` in
+ * `editor/host/auth/desktop-auth-flow.ts` — `app/desktop/**` is lint-barred
+ * from importing `@/host/**` (GRIDA-SEC-004 renderer boundary), and one
+ * duplicated line beats a hole in that boundary. Its test pins the value
+ * against drift.
+ */
+const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";
+
+export async function POST(request: NextRequest) {
+  const client = await createClient();
+
+  // supabase-js has no standalone "create PKCE flow" API — generating an
+  // authorize URL is the supported way to mint the verifier cookie. The
+  // provider named here is irrelevant: the verifier is flow-agnostic, and
+  // the launch page builds the real authorize/OTP request (with whichever
+  // method the user picks) against the same challenge.
+  const { data, error } = await client.auth.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: DESKTOP_AUTH_REDIRECT,
+      skipBrowserRedirect: true,
+    },
+  });
+
+  const challenge = data?.url
+    ? new URL(data.url).searchParams.get("code_challenge")
+    : null;
+  if (error || !challenge) {
+    console.error("[desktop-auth] PKCE start failed:", error);
+    return NextResponse.json({ error: "start_failed" }, { status: 500 });
+  }
+
+  const launch = new URL("/sign-in/desktop", new URL(request.url).origin);
+  launch.searchParams.set("challenge", challenge);
+  return NextResponse.json({ url: launch.toString() });
+}

--- a/editor/app/desktop/auth/start/route.ts
+++ b/editor/app/desktop/auth/start/route.ts
@@ -3,14 +3,15 @@
  *
  * Mints the PKCE code verifier as an `@supabase/ssr` cookie on THIS
  * response — i.e. into the Electron cookie jar — and returns the web
- * **launch page** URL (`/sign-in/desktop?challenge=…`) for the system
- * browser.
+ * **launch page** URL (`/desktop-auth?challenge=…`) for the system browser.
  * The desktop shows a single "Sign in with browser" button; the sign-in
  * METHOD is chosen on the web launch page, which builds its GoTrue flow
- * against the forwarded challenge. The challenge is public by design
- * (PKCE S256); the verifier never leaves this jar, so the `code` that any
- * method produces is only exchangeable by this webview
- * (see `../callback/route.ts`).
+ * against the forwarded challenge. The verifier never leaves this jar, so
+ * the `code` that any method produces is only exchangeable by this webview
+ * (see `../callback/route.ts`). The challenge, though, is confidentiality-
+ * sensitive in THIS design (knowing it lets an attacker mint a code bound
+ * to it — login-CSRF), which is why the launch page lives in the
+ * analytics-free `(untracked)` route group.
  *
  * Must stay a route handler returning `{ url }` (not a redirect): the
  * verifier cookie is only reliably set on a route-handler response
@@ -55,7 +56,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "start_failed" }, { status: 500 });
   }
 
-  const launch = new URL("/sign-in/desktop", new URL(request.url).origin);
+  const launch = new URL("/desktop-auth", new URL(request.url).origin);
   launch.searchParams.set("challenge", challenge);
   return NextResponse.json({ url: launch.toString() });
 }

--- a/editor/app/desktop/auth/start/route.ts
+++ b/editor/app/desktop/auth/start/route.ts
@@ -18,19 +18,9 @@
  * (supabase/ssr#55), and the URL must open in the SYSTEM browser
  * (`shell.open_external`), never in the webview.
  */
+import { DESKTOP_AUTH_REDIRECT } from "@/lib/desktop/auth-deeplink";
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse, type NextRequest } from "next/server";
-
-/**
- * Deep-link return target. Allowlisted in `supabase/config.toml` locally
- * and in the hosted project's dashboard for production. Deliberately a
- * local twin of `DESKTOP_AUTH_REDIRECT` in
- * `editor/host/auth/desktop-auth-flow.ts` — `app/desktop/**` is lint-barred
- * from importing `@/host/**` (GRIDA-SEC-004 renderer boundary), and one
- * duplicated line beats a hole in that boundary. Its test pins the value
- * against drift.
- */
-const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";
 
 export async function POST(request: NextRequest) {
   const client = await createClient();

--- a/editor/app/desktop/settings/page.tsx
+++ b/editor/app/desktop/settings/page.tsx
@@ -58,10 +58,11 @@ export default function DesktopSettingsPage() {
         <header>
           <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            AI provider keys, local models, and app info.
+            Account, AI provider keys, local models, and app info.
           </p>
         </header>
 
+        <AccountSection />
         <ByokSection />
         <ImageModelsSection />
         <VideoModelsSection />
@@ -69,6 +70,100 @@ export default function DesktopSettingsPage() {
         <AboutSection />
       </DesktopPageContent>
     </DesktopPageShell>
+  );
+}
+
+/* ───────────────────────────── Account ───────────────────────────── */
+
+type AccountState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "signed-in"; email: string | null }
+  | { kind: "signing-out" };
+
+/**
+ * The Grida account this app is signed in with. Session reads and sign-out
+ * go through the same-origin `/desktop/auth/*` routes — the desktop CSP
+ * blocks direct supabase-js calls, and navigating to the web `/sign-out`
+ * would be handed to the OS browser by the navigation guard (see
+ * GRIDA-SEC-005 in /SECURITY.md).
+ *
+ * The cookie jar is shared across all desktop windows, so signing out here
+ * signs out the whole app; other open windows keep their rendered state
+ * until their next navigation hits the welcome gate.
+ */
+function AccountSection() {
+  const [state, setState] = useState<AccountState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/desktop/auth/me")
+      .then((res) => res.json())
+      .then(({ user }: { user: { email: string | null } | null }) => {
+        if (cancelled) return;
+        setState(
+          user
+            ? { kind: "signed-in", email: user.email }
+            : { kind: "signed-out" }
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "signed-out" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const signOut = async () => {
+    setState({ kind: "signing-out" });
+    try {
+      await fetch("/desktop/auth/sign-out", { method: "POST" });
+    } finally {
+      window.location.assign("/desktop/auth/sign-in");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Account</CardTitle>
+        <CardDescription>
+          The Grida account this app is signed in with.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {state.kind === "loading" ? (
+          <Skeleton className="h-9 w-full" />
+        ) : state.kind === "signed-out" ? (
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-sm text-muted-foreground">Not signed in</span>
+            <Button
+              size="sm"
+              onClick={() => window.location.assign("/desktop/auth/sign-in")}
+            >
+              Sign in
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-sm">
+              {state.kind === "signed-in" && state.email
+                ? state.email
+                : "Signed in"}
+            </span>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={signOut}
+              disabled={state.kind === "signing-out"}
+            >
+              Sign out
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/editor/app/desktop/welcome/layout.test.ts
+++ b/editor/app/desktop/welcome/layout.test.ts
@@ -1,0 +1,41 @@
+/**
+ * GRIDA-SEC-005 — the desktop welcome segment is the enforced sign-in gate.
+ * Pins the redirect-when-signed-out / render-when-signed-in decision so an
+ * inverted condition can't silently let anonymous users into the app.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getUser =
+  vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+const redirect = vi.fn<(url: string) => never>((url) => {
+  throw new Error(`REDIRECT:${url}`);
+});
+vi.mock("next/navigation", () => ({ redirect: (u: string) => redirect(u) }));
+
+import DesktopWelcomeLayout from "./layout";
+
+beforeEach(() => {
+  getUser.mockReset();
+  redirect.mockClear();
+});
+
+describe("DesktopWelcomeLayout", () => {
+  it("redirects to the sign-in gate when there is no session", async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    await expect(DesktopWelcomeLayout({ children: "content" })).rejects.toThrow(
+      "REDIRECT:/desktop/auth/sign-in"
+    );
+    expect(redirect).toHaveBeenCalledWith("/desktop/auth/sign-in");
+  });
+
+  it("renders children when signed in", async () => {
+    getUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    const element = await DesktopWelcomeLayout({ children: "content" });
+    expect(redirect).not.toHaveBeenCalled();
+    expect(element).toBeTruthy();
+  });
+});

--- a/editor/app/desktop/welcome/layout.tsx
+++ b/editor/app/desktop/welcome/layout.tsx
@@ -1,0 +1,28 @@
+/**
+ * Forced sign-in gate for the desktop front door.
+ *
+ * The desktop requires a Grida account: the welcome surface (the default
+ * window every launch lands on) redirects signed-out sessions to
+ * `/desktop/auth/sign-in`. The gate lives on this segment's layout — NOT on
+ * `app/desktop/layout.tsx`, which also wraps the sign-in page itself — and
+ * `welcome/page.tsx` stays a client component untouched.
+ *
+ * Scope note: only the welcome entry is gated. Windows opened directly on
+ * other `/desktop/*` surfaces (file associations, settings) are a separate
+ * product decision.
+ */
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function DesktopWelcomeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const client = await createClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+  if (!user) redirect("/desktop/auth/sign-in");
+  return <>{children}</>;
+}

--- a/editor/components/auth/sign-in-shell.tsx
+++ b/editor/components/auth/sign-in-shell.tsx
@@ -3,10 +3,10 @@ import { ChatBubbleIcon } from "@radix-ui/react-icons";
 import { GridaLogo } from "@/components/grida-logo";
 import Link from "next/link";
 import Image from "next/image";
-import abstract_photo from "../../../../public/images/abstract-placeholder.jpg";
+import abstract_photo from "../../public/images/abstract-placeholder.jpg";
 
 /**
- * Shared page shell for the sign-in family (`/sign-in`, `/sign-in/desktop`).
+ * Shared page shell for the sign-in family (`/sign-in`, `/desktop-auth`).
  * Owns the chrome — top nav, two-column layout with the photo aside, and the
  * terms footer — parameterized only by the heading copy and the method list
  * (children). Behavior (redirect params, method mechanics, gating) stays in

--- a/editor/host/auth/continue-with-google-button.tsx
+++ b/editor/host/auth/continue-with-google-button.tsx
@@ -11,7 +11,7 @@ type ContinueWithGoogleButtonProps = {
   /**
    * Pre-built GoTrue authorize URL. When set, the button is a plain anchor
    * to it and the supabase-js flow below is skipped entirely — used by the
-   * desktop launch page (`/sign-in/desktop`), whose PKCE challenge belongs
+   * desktop launch page (`/desktop-auth`), whose PKCE challenge belongs
    * to the desktop app's cookie jar, not this browser (GRIDA-SEC-005).
    */
   authorize_url?: string;

--- a/editor/host/auth/continue-with-google-button.tsx
+++ b/editor/host/auth/continue-with-google-button.tsx
@@ -8,14 +8,49 @@ type ContinueWithGoogleButtonProps = {
   next?: string;
   redirect_uri?: string;
   onSuccess?: () => void;
+  /**
+   * Pre-built GoTrue authorize URL. When set, the button is a plain anchor
+   * to it and the supabase-js flow below is skipped entirely — used by the
+   * desktop launch page (`/sign-in/desktop`), whose PKCE challenge belongs
+   * to the desktop app's cookie jar, not this browser (GRIDA-SEC-005).
+   */
+  authorize_url?: string;
 };
+
+const BUTTON_CLASS =
+  "flex px-4 py-2 rounded-sm items-center justify-center gap-4 border shadow-sm hover:shadow-md transition-shadow";
 
 export function ContinueWithGoogleButton({
   skipBrowserRedirect,
   next,
   redirect_uri,
   onSuccess,
+  authorize_url,
 }: ContinueWithGoogleButtonProps) {
+  if (authorize_url) {
+    return (
+      <a className={BUTTON_CLASS} href={authorize_url}>
+        <GoogleLogo />
+        Continue with Google
+      </a>
+    );
+  }
+  return (
+    <ContinueWithGoogleOAuthButton
+      skipBrowserRedirect={skipBrowserRedirect}
+      next={next}
+      redirect_uri={redirect_uri}
+      onSuccess={onSuccess}
+    />
+  );
+}
+
+function ContinueWithGoogleOAuthButton({
+  skipBrowserRedirect,
+  next,
+  redirect_uri,
+  onSuccess,
+}: Omit<ContinueWithGoogleButtonProps, "authorize_url">) {
   const client = createBrowserClient();
 
   const url = new URL(`${Env.web.HOST}/auth/callback`);
@@ -30,7 +65,7 @@ export function ContinueWithGoogleButton({
 
   return (
     <button
-      className="flex px-4 py-2 rounded-sm items-center justify-center gap-4 border shadow-sm hover:shadow-md transition-shadow"
+      className={BUTTON_CLASS}
       onClick={() => {
         client.auth
           .signInWithOAuth({

--- a/editor/host/auth/continue-with-google-button.tsx
+++ b/editor/host/auth/continue-with-google-button.tsx
@@ -3,46 +3,38 @@
 import { Env } from "@/env";
 import { createBrowserClient } from "@/lib/supabase/client";
 
-type ContinueWithGoogleButtonProps = {
+type OAuthButtonProps = {
   skipBrowserRedirect?: boolean;
   next?: string;
   redirect_uri?: string;
   onSuccess?: () => void;
-  /**
-   * Pre-built GoTrue authorize URL. When set, the button is a plain anchor
-   * to it and the supabase-js flow below is skipped entirely — used by the
-   * desktop launch page (`/desktop-auth`), whose PKCE challenge belongs
-   * to the desktop app's cookie jar, not this browser (GRIDA-SEC-005).
-   */
-  authorize_url?: string;
 };
+
+/**
+ * Discriminated union: either a pre-built GoTrue authorize URL (plain-anchor
+ * mode) OR the supabase-js OAuth flow props — never both. Anchor mode is used
+ * by the desktop launch page (`/desktop-auth`), whose PKCE challenge belongs
+ * to the desktop app's cookie jar, not this browser (GRIDA-SEC-005); passing
+ * OAuth props alongside `authorize_url` is a type error rather than a silent
+ * no-op.
+ */
+type ContinueWithGoogleButtonProps =
+  | ({ authorize_url: string } & { [K in keyof OAuthButtonProps]?: never })
+  | ({ authorize_url?: undefined } & OAuthButtonProps);
 
 const BUTTON_CLASS =
   "flex px-4 py-2 rounded-sm items-center justify-center gap-4 border shadow-sm hover:shadow-md transition-shadow";
 
-export function ContinueWithGoogleButton({
-  skipBrowserRedirect,
-  next,
-  redirect_uri,
-  onSuccess,
-  authorize_url,
-}: ContinueWithGoogleButtonProps) {
-  if (authorize_url) {
+export function ContinueWithGoogleButton(props: ContinueWithGoogleButtonProps) {
+  if (props.authorize_url) {
     return (
-      <a className={BUTTON_CLASS} href={authorize_url}>
+      <a className={BUTTON_CLASS} href={props.authorize_url}>
         <GoogleLogo />
         Continue with Google
       </a>
     );
   }
-  return (
-    <ContinueWithGoogleOAuthButton
-      skipBrowserRedirect={skipBrowserRedirect}
-      next={next}
-      redirect_uri={redirect_uri}
-      onSuccess={onSuccess}
-    />
-  );
+  return <ContinueWithGoogleOAuthButton {...props} />;
 }
 
 function ContinueWithGoogleOAuthButton({
@@ -50,7 +42,7 @@ function ContinueWithGoogleOAuthButton({
   next,
   redirect_uri,
   onSuccess,
-}: Omit<ContinueWithGoogleButtonProps, "authorize_url">) {
+}: OAuthButtonProps) {
   const client = createBrowserClient();
 
   const url = new URL(`${Env.web.HOST}/auth/callback`);

--- a/editor/host/auth/desktop-auth-flow.test.ts
+++ b/editor/host/auth/desktop-auth-flow.test.ts
@@ -1,0 +1,101 @@
+/**
+ * GRIDA-SEC-005 — desktop-auth flow builders.
+ *
+ * Pins: every method's GoTrue flow is bound to the forwarded challenge and
+ * the fixed `grida://auth/callback` redirect; challenge validation refuses
+ * anything that couldn't be a PKCE S256 challenge; verify-link extraction
+ * only ever returns URLs on the configured Supabase origin.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  DESKTOP_AUTH_REDIRECT,
+  buildAuthorizeUrl,
+  buildOtpRequest,
+  extractVerifyUrl,
+  isValidChallenge,
+} from "./desktop-auth-flow";
+
+const CHALLENGE = "NF4wmu64KqpZmRNAuYJrxnETLbuzRbtPSbXpoHggKaA";
+
+describe("isValidChallenge", () => {
+  it.each([
+    [CHALLENGE, true],
+    ["A".repeat(20), true],
+    ["A".repeat(128), true],
+    ["short", false],
+    ["A".repeat(129), false],
+    ["has spaces not allowed here padded to length", false],
+    ["semi;colon-injection-attempt-padded-to-len", false],
+    ["", false],
+  ])("%s → %s", (value, valid) => {
+    expect(isValidChallenge(value)).toBe(valid);
+  });
+});
+
+describe("buildAuthorizeUrl", () => {
+  it("binds the provider flow to the challenge and the deep-link redirect", () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        supabaseUrl: "https://supabase.test",
+        provider: "google",
+        challenge: CHALLENGE,
+      })
+    );
+    expect(url.origin).toBe("https://supabase.test");
+    expect(url.pathname).toBe("/auth/v1/authorize");
+    expect(url.searchParams.get("provider")).toBe("google");
+    expect(url.searchParams.get("redirect_to")).toBe(DESKTOP_AUTH_REDIRECT);
+    expect(url.searchParams.get("code_challenge")).toBe(CHALLENGE);
+    expect(url.searchParams.get("code_challenge_method")).toBe("s256");
+  });
+});
+
+describe("extractVerifyUrl", () => {
+  const SUPABASE = "http://127.0.0.1:54321";
+
+  it("extracts the verify URL from a plain-text email body", () => {
+    const body = `Follow this link:\n${SUPABASE}/auth/v1/verify?token=pkce_abc&type=magiclink&redirect_to=grida://auth/callback\n`;
+    expect(extractVerifyUrl(body, SUPABASE)).toBe(
+      `${SUPABASE}/auth/v1/verify?token=pkce_abc&type=magiclink&redirect_to=grida://auth/callback`
+    );
+  });
+
+  it("unescapes HTML-entity ampersands from HTML bodies", () => {
+    const body = `<a href="${SUPABASE}/auth/v1/verify?token=pkce_abc&amp;type=magiclink&amp;redirect_to=grida://auth/callback">Log In</a>`;
+    expect(extractVerifyUrl(body, SUPABASE)).toBe(
+      `${SUPABASE}/auth/v1/verify?token=pkce_abc&type=magiclink&redirect_to=grida://auth/callback`
+    );
+  });
+
+  it("returns null when no verify URL for the given origin exists", () => {
+    expect(extractVerifyUrl("no links here", SUPABASE)).toBeNull();
+    expect(
+      extractVerifyUrl(
+        "https://evil.test/auth/v1/verify?token=pkce_abc",
+        SUPABASE
+      )
+    ).toBeNull();
+  });
+});
+
+describe("buildOtpRequest", () => {
+  it("mirrors supabase-js wire shape with the forwarded challenge", () => {
+    const { url, init } = buildOtpRequest({
+      supabaseUrl: "https://supabase.test",
+      apikey: "publishable",
+      email: "insider@grida.co",
+      challenge: CHALLENGE,
+    });
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/auth/v1/otp");
+    expect(parsed.searchParams.get("redirect_to")).toBe(DESKTOP_AUTH_REDIRECT);
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).apikey).toBe("publishable");
+    expect(JSON.parse(init.body as string)).toEqual({
+      email: "insider@grida.co",
+      create_user: false,
+      code_challenge: CHALLENGE,
+      code_challenge_method: "s256",
+    });
+  });
+});

--- a/editor/host/auth/desktop-auth-flow.ts
+++ b/editor/host/auth/desktop-auth-flow.ts
@@ -8,11 +8,11 @@
  * whatever the method, the resulting single-use `code` deep-links back to
  * the app and is exchangeable only against the app's verifier.
  *
- * Pure URL/request builders, no IO — pinned by `flow.test.ts`.
+ * Pure URL/request builders, no IO — pinned by `desktop-auth-flow.test.ts`.
  */
+import { DESKTOP_AUTH_REDIRECT } from "@/lib/desktop/auth-deeplink";
 
-/** Deep-link return target — must match the desktop start route. */
-export const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";
+export { DESKTOP_AUTH_REDIRECT };
 
 /**
  * A PKCE S256 challenge is base64url. Bounds are generous (RFC 7636

--- a/editor/host/auth/desktop-auth-flow.ts
+++ b/editor/host/auth/desktop-auth-flow.ts
@@ -1,0 +1,101 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-in launch page, flow builders.
+ *
+ * The desktop app mints a PKCE verifier into its own cookie jar and opens
+ * this page in the system browser with only the public `code_challenge`.
+ * Every sign-in method offered here MUST create its GoTrue flow with that
+ * forwarded challenge and the fixed `grida://auth/callback` redirect — so
+ * whatever the method, the resulting single-use `code` deep-links back to
+ * the app and is exchangeable only against the app's verifier.
+ *
+ * Pure URL/request builders, no IO — pinned by `flow.test.ts`.
+ */
+
+/** Deep-link return target — must match the desktop start route. */
+export const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";
+
+/**
+ * A PKCE S256 challenge is base64url. Bounds are generous (RFC 7636
+ * verifiers are 43–128 chars; an S256 challenge is 43) — the point is to
+ * refuse anything that couldn't be a challenge before it reaches a URL.
+ */
+export function isValidChallenge(value: string): boolean {
+  return /^[A-Za-z0-9_-]{20,128}$/.test(value);
+}
+
+/**
+ * GoTrue OAuth authorize URL for a provider, bound to the desktop's
+ * challenge. Hitting this URL creates the flow state server-side and
+ * starts the provider ceremony in the browser.
+ */
+export function buildAuthorizeUrl({
+  supabaseUrl,
+  provider,
+  challenge,
+}: {
+  supabaseUrl: string;
+  provider: "google";
+  challenge: string;
+}): string {
+  const url = new URL("/auth/v1/authorize", supabaseUrl);
+  url.searchParams.set("provider", provider);
+  url.searchParams.set("redirect_to", DESKTOP_AUTH_REDIRECT);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "s256");
+  return url.toString();
+}
+
+/**
+ * GoTrue email OTP-link request bound to the desktop's challenge
+ * (development-only method; the link lands in Mailpit locally). Mirrors
+ * supabase-js's `signInWithOtp` wire shape: `redirect_to` as a query
+ * param, challenge in the body, `create_user: false`.
+ */
+export function buildOtpRequest({
+  supabaseUrl,
+  apikey,
+  email,
+  challenge,
+}: {
+  supabaseUrl: string;
+  apikey: string;
+  email: string;
+  challenge: string;
+}): { url: string; init: RequestInit } {
+  const url = new URL("/auth/v1/otp", supabaseUrl);
+  url.searchParams.set("redirect_to", DESKTOP_AUTH_REDIRECT);
+  return {
+    url: url.toString(),
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json", apikey },
+      body: JSON.stringify({
+        email,
+        create_user: false,
+        code_challenge: challenge,
+        code_challenge_method: "s256",
+      }),
+    },
+  };
+}
+
+/**
+ * Extracts the GoTrue verify URL from an email body (the OTP link that,
+ * when followed, 302s to `grida://auth/callback?code=…`). Used by the
+ * insiders desktop branch to consume the link straight from the local
+ * Mailpit capture — the developer never opens an inbox. Tolerates
+ * HTML-entity-escaped ampersands from HTML email bodies.
+ */
+export function extractVerifyUrl(
+  body: string,
+  supabaseUrl: string
+): string | null {
+  const unescaped = body.replace(/&amp;/g, "&");
+  const base = supabaseUrl
+    .replace(/\/+$/, "")
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = unescaped.match(
+    new RegExp(`${base}/auth/v1/verify[^\\s"'<>]*`)
+  );
+  return match?.[0] ?? null;
+}

--- a/editor/lib/desktop/auth-deeplink.ts
+++ b/editor/lib/desktop/auth-deeplink.ts
@@ -1,0 +1,14 @@
+/**
+ * GRIDA-SEC-005 — desktop sign-in deep-link contract.
+ *
+ * The single source for the `grida://auth/callback` return target, shared by
+ * the parts that must agree on it: the PKCE start route
+ * (`app/desktop/auth/start/route.ts`), the launch-page flow builders
+ * (`host/auth/desktop-auth-flow.ts`), the Electron protocol router, and the
+ * Supabase redirect allowlist (`supabase/config.toml`). It lives in
+ * `@/lib/desktop` precisely because `app/desktop/**` is lint-barred from
+ * `@/host/**` (GRIDA-SEC-004) but not from `@/lib/desktop` — so both the
+ * route and the flow module import ONE constant instead of duplicating the
+ * literal and risking drift across the contract.
+ */
+export const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -158,7 +158,10 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# GRIDA-SEC-005 — `grida://auth/callback` is the desktop deep-link return for the
+# PKCE sign-in flow (see /SECURITY.md). The hosted project's dashboard must
+# allowlist the same URL before a desktop release that enables sign-in.
+additional_redirect_urls = ["https://127.0.0.1:3000", "grida://auth/callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
## What

Desktop gets a first-party **Grida account session** — part 1 (agnostic auth) of the no-BYOK initiative. The desktop app shows a single, method-neutral **"Sign in with browser"** button (the Figma/Linear pattern); the sign-in method lives entirely on the web.

**Flow**: `POST /desktop/auth/start` mints the PKCE verifier as a standard `@supabase/ssr` cookie *into the Electron jar* and returns the launch-page URL → system browser opens `/sign-in/desktop?challenge=…` → whatever method the web offers creates its GoTrue flow bound to that (public) challenge → GoTrue redirects `grida://auth/callback?code=…` → the protocol router navigates the desktop window to `/desktop/auth/callback`, where `exchangeCodeForSession` succeeds only against the jar-held verifier. End state: a first-class cookie session — **every existing cookie-gated route, page, and middleware works unchanged** (zero modifications to `(auth)`, proxy, or CSP).

## Surfaces

- **editor (desktop routes)**: `/desktop/auth/{start,callback,me,sign-out}` (`me`/`sign-out` are same-origin because the desktop CSP blocks direct supabase-js calls, and navigating to the web `/sign-out` would get `shell.openExternal`'d — logging the user out of their OS browser). Forced sign-in gate on `welcome/layout.tsx`; native-feeling sign-in page; Account section in `/desktop/settings`.
- **web**: `/sign-in/desktop` launch page — a `/sign-in` sibling reusing the extracted `SignInShell` and `ContinueWithGoogleButton` (new single `authorize_url` prop renders the identical button as an anchor to a pre-built challenge-bound URL). Mirrors the web sign-in's insiders routing: flag on → redirect to `/insiders/auth/basic?challenge=…`.
- **insiders (dev-only, GRIDA-SEC-002-gated)**: email+**password** kept exactly as-is; on success the route's desktop branch fires the challenge-bound OTP and consumes the verify link straight from Mailpit's API server-side — dev keeps `insider@grida.co`/`password` muscle memory, never opens an inbox, and still traverses the exact production verify → deep-link → exchange path. (A password grant can never emit an authorization code in GoTrue; the OTP link is the code-minting carrier.)
- **desktop (Electron)**: protocol-router `auth/callback` arm — stateless, fixed-target, forwards only `code`/`error*`, always consumes (a `false` re-queues forever). New `will-redirect` guard in `window.ts` (server 302s previously bypassed the `/desktop/*` allowlist). Window pick reuses `window-focus.ts`. **No bridge/IPC/preload changes** — `@grida/desktop-bridge` untouched.

## Security

New boundary **`GRIDA-SEC-005`** registered in SECURITY.md (deep links are world-invokable input; the PKCE verifier confined to the Electron jar is what makes attacker-minted/phished codes fail safe — login-CSRF closed). Security review per the `security` skill completed; GRIDA-SEC-004 layers untouched or tightened; stale "no hosted auth in V1" text revised. Note: `app/desktop/**` is lint-barred from `@/host/**`, so `DESKTOP_AUTH_REDIRECT` is a deliberate documented twin, not an import.

## ⚠️ Deployment prerequisite

Add `grida://auth/callback` to the **hosted Supabase project's redirect allowlist** (dashboard) before a desktop release enables sign-in. Local `config.toml` is already updated. Google-visible (non-insiders) rendering of the launch page should get a glance on the preview deploy — local dev runs insiders mode.

## Verification

- 129 new/updated unit tests green (desktop 104 incl. first `protocol-router.test.ts` + `window.test.ts`; editor: start/callback routes, flow builders, insiders branch decisions). Typecheck + oxlint clean on the rebased tree (#937).
- Headless local E2E of the full flow, three ways: dev OTP link, insiders email+password (real Mailpit polling), and failure paths — including the cross-jar negative (a context without the verifier gets `pkce_code_verifier_not_found`; the desktop jar redeems the same code), single-use replay rejection, stale/unsolicited `grida://` links as safe no-ops, and session persistence across app restart.
- Not exercisable locally: the real Google leg (needs prod-shaped OAuth) and packaged-build protocol registration (per-OS release checklist item).

Part 2 (entitlement / metered "Grida as a provider" in the sidecar) is deliberately out of scope; the sidecar and main process hold no cloud credentials in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the full desktop sign-in flow, including a browser-based start, deep-link auth callback completion, and a welcome gate.
  * Added desktop sign-in UI shell, desktop auth session/status and sign-out endpoints, and account sign-in state to settings.
* **Bug Fixes**
  * Hardened deep-link handling with strict same-site navigation allowlisting, safe consumption of malformed inputs, and forwarding only expected query parameters.
* **Tests**
  * Added/extended test coverage for deep-link routing, navigation safety, and desktop auth endpoints.
* **Documentation**
  * Updated desktop security guidance with revised trust boundaries for deep links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->