### PR TITLE
feat(gg): Grida Gateway — desktop no-BYOK hosted AI (GRIDA-SEC-006)

### DIFF
--- a/.agents/skills/gg/SKILL.md
+++ b/.agents/skills/gg/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: gg
+description: >
+  Working pattern for Grida Gateway (GG) — Grida's first-party, metered,
+  no-BYOK AI surface: the scoped-token mint, the OpenAI-compatible +
+  native gateway endpoints, the `gg` client provider, and the desktop
+  wiring that spends org credit without a user key. Anchor for the
+  `GRIDA-GG: <surface>` grep marker; its security half is
+  `GRIDA-SEC-006`. Use when adding or touching any GG file, the `gg`
+  provider kind, the `gg:ai` token audience, or deciding whether code
+  belongs to the gateway surface. Companions: `security` (the
+  GRIDA-SEC-006 half), `ee-billing` (the ledger it spends), `agent-system`
+  and `desktop` (the two hosts).
+---
+
+# gg — Grida Gateway
+
+**Grida Gateway (GG)** is Grida's first-party AI gateway: the path by
+which a signed-in client runs AI — text, image, video — **without a
+user-supplied model key** (no BYOK), billed to the organization's prepaid
+credit. It is one coherent, extractable surface, marked so a single grep
+finds all of it, and it is **designed to spin out** of this repo into a
+standalone service at `grida.gg`. Treat every touch as work on a product
+that will one day live on its own.
+
+Canonical spec: [Hosted AI (metered, no-BYOK)](https://grida.co/docs/wg/platform/hosted-ai).
+Security boundary: `GRIDA-SEC-006` in [SECURITY.md](https://github.com/gridaco/grida/blob/main/SECURITY.md).
+
+## What counts as GG
+
+The test: _does this code exist to let a keyless client spend org credit on
+a Grida-hosted model?_ If yes, it is GG. Four surfaces:
+
+- **`token`** — the scoped-token mint + verify. A purpose-scoped,
+  short-lived, org-bound JWT (audience `gg:ai`) is the _only_ credential
+  the gateway accepts. This surface is also `GRIDA-SEC-006`.
+- **`gateway`** — the server endpoints: the OpenAI-compatible text surface
+  (chat completions, models) and the native image/video generation
+  surfaces. They verify the `gg:ai` token and meter through the billing
+  seam; they carry no billing logic of their own.
+- **`provider`** — the client-side `gg` provider kind (in the agent
+  package) that resolves to the gateway, plus its in-memory session store,
+  factories, and media adapters. It is the _consumer_ of GG.
+- **`desktop`** — the renderer lifecycle that mints/re-mints the token and
+  pushes it to the sidecar (memory-only custody), and the daemon `gg`
+  capability/namespace that receives it.
+
+Not GG: the billing ledger itself (that is `ee-billing` / `grida_billing`);
+the billing seam's `providerOptions.grida` namespace (Grida-billing's key,
+shared with GRIDA-SEC-003); BYOK providers (the carve-out GG sits beside).
+
+## The `GRIDA-GG` marker
+
+Like `GRIDA-EE`, the surface is grep-able. Tag every file that exists
+_only_ for GG, with the surface as the sub-label:
+
+```ts
+// GRIDA-GG: token — scoped-token mint/verify (also GRIDA-SEC-006)
+// GRIDA-GG: gateway — OpenAI-compatible chat completions
+// GRIDA-GG: provider — the `gg` client provider kind
+// GRIDA-GG: desktop — renderer token lifecycle
+```
+
+Sub-labels are surface names (`token` / `gateway` / `provider` /
+`desktop`), not ids. The grep is the index:
+
+```sh
+grep -rn 'GRIDA-GG' editor packages desktop
+```
+
+Tag the file header when the whole file is GG; tag inline when only a
+branch is (e.g. the `gg` arm inside a shared provider resolver). The
+canonical name is **Grida Gateway (GG)**; write it that way in prose.
+
+## The naming map (canonical identifiers)
+
+One brand, several forms — consistent with how the repo already names
+(`GRIDA-EE` marker + `grida_billing` schema + descriptive symbols):
+
+| concept                       | identifier                                                 |
+| ----------------------------- | ---------------------------------------------------------- |
+| grep marker                   | `GRIDA-GG: <surface>`                                      |
+| token audience (wire)         | `gg:ai`                                                    |
+| signing secret (env)          | `GG_TOKEN_SECRET` (+ `GG_TOKEN_SECRET_PREVIOUS`)           |
+| client provider kind (wire)   | `gg`                                                       |
+| provider id / metadata (code) | `GG_PROVIDER_ID`, `GG_PROVIDER_METADATA`, `isGgProviderId` |
+| daemon capability / namespace | `gg` (tag `gg@1`)                                          |
+| TS symbols                    | `GridaGateway*` (e.g. `GridaGatewaySessionStore`)          |
+| files                         | `gg-*.ts`                                                  |
+| future public host            | `grida.gg` (endpoint paths stay `/api/v1/ai/*` for now)    |
+
+Deliberate carve-outs (not renamed, on purpose): the public endpoint
+_paths_ (`/api/v1/ai/*`) — a versioned REST contract whose brand is the
+host, not the path; and `providerOptions.grida` — the billing seam's key.
+
+## Working on GG
+
+1. Tag every file you create or touch with `GRIDA-GG: <surface>`.
+2. Place new code in a `gg`-named location; don't dilute a BYOK or OSS one.
+3. **Direction of dependency: consumers → GG contract, not GG → consumers.**
+   The gateway must not import desktop/renderer code; the client provider
+   depends on the wire contract, not the server internals. This is what
+   makes the spin-out cheap.
+4. The gateway meters through the existing billing seam — it never grows
+   its own billing logic. Pre-flight entitlement gate, post-flight usage
+   ingest, sold at cost. See [`ee-billing`](../ee-billing/SKILL.md).
+
+## When GG crosses security
+
+The `token` surface (mint + verify + custody) **is** `GRIDA-SEC-006`. Any
+file on that surface carries **both** markers:
+
+```ts
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: token — scoped-token mint/verify
+```
+
+Touching it runs the [`security`](../security/SKILL.md) review **first**
+(the boundary contract, fail-closed secret handling, audience pinning),
+then this skill (the surface-organization pass). The invariant to protect:
+_the credential a native process holds for AI is worth at most 15 minutes
+of AI calls on one org's credit — and nothing more._
+
+> Precedence is stated here and cross-referenced from `GRIDA-SEC-006` in
+> SECURITY.md, so a reader entering from either side lands in the other.
+
+See also: [`security`](../security/SKILL.md) (the GRIDA-SEC-006 half),
+[`ee-billing`](../ee-billing/SKILL.md) (the credit ledger GG spends),
+[`ee`](../ee/SKILL.md) (the EE marker pattern this mirrors),
+[`agent-system`](../agent-system/SKILL.md) and
+[`desktop`](../desktop/SKILL.md) (the two hosts), [`naming`](../naming/SKILL.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -587,14 +587,24 @@ PTYs per window, and (d) kills every PTY on window close and app quit.
 A contract test (`desktop/src/main/terminal-host.test.ts`) fails if a
 terminal channel is ever registered outside `guarded()`.
 
-**Hosted auth (sign-in only).** The desktop signs the webview into a
+**Hosted auth + hosted AI.** The desktop signs the webview into a
 first-class Supabase cookie session via the system browser + PKCE +
 `grida://auth/callback` deep link — that flow is its own boundary,
-`GRIDA-SEC-005` below. Within THIS boundary the invariant is unchanged:
-the Electron main process and the AgentHost sidecar hold no cloud
-credentials, and there is still no entitlement polling and no
-hosted-model routing. Future hosted-provider work (sidecar-held tokens,
-metered AI) must re-register its files in this record before code lands.
+`GRIDA-SEC-005` below. The hosted "included" AI provider — **Grida
+Gateway (GG)**, the `gg` provider, GRIDA-SEC-006 — amends the old
+"sidecar holds no cloud credentials" invariant to its precise form:
+**the sidecar may hold ONLY the purpose-scoped, short-lived AI token**
+(memory-only, pushed by the renderer over `/auth/gg/set`, never
+`auth.json`, never a refresh token) — the durable session stays in the
+webview cookie jar. Files registered under this record for that work
+(all marked `GRIDA-GG`):
+`packages/grida-ai-agent/src/providers/{gg-session,gg,gg-media}.ts`,
+`src/http/routes/gg-auth.ts`, the `gg` arms in
+`src/providers/{index,resolve-image,resolve-video}.ts`, and the
+`gg_host` egress option in `src/sandbox/policy.ts` (the daemon
+may reach the configured editor origin — and nothing else new). The
+main process still holds no cloud credentials, and entitlement
+enforcement stays server-side (the hosted endpoints gate + meter).
 
 **Update channel.** Release builds must be signed/notarized by platform
 policy. Security-sensitive runtime deps are reviewed as part of the
@@ -810,9 +820,11 @@ paths, and params are public, so the design must not rely on obscurity.
    ([supabase/config.toml](supabase/config.toml) locally; the hosted
    project's dashboard in production).
 
-The Electron main process and the sidecar remain credential-free: the
-session lives in the webview's cookie jar and is refreshed by the same
-`@supabase/ssr` middleware machinery as the web app. The `/desktop/*`
+The Electron main process remains credential-free, and the sidecar
+holds at most the purpose-scoped, short-lived hosted-AI token
+(GRIDA-SEC-006 — memory-only, renderer-pushed, never a refresh token):
+the durable session lives in the webview's cookie jar and is refreshed
+by the same `@supabase/ssr` middleware machinery as the web app. The `/desktop/*`
 CSP keeps `connect-src` closed, so session reads go through the
 same-origin `/desktop/auth/me` route rather than direct supabase-js
 calls.
@@ -834,17 +846,124 @@ Today:
 process. A PKCE verifier carried on the deep link, the bridge, or argv.
 A router that navigates to a path taken from deep-link input, or that
 forwards params beyond `code`/`error*`. A desktop webview navigation to
-`(auth)` routes or the web `/sign-out`. Sidecar- or main-held session
-tokens — that is future hosted-provider work and must be registered
-here first. The launch page in a route group that loads Google/Vercel
+`(auth)` routes or the web `/sign-out`. Sidecar- or main-held SESSION
+tokens (the scoped hosted-AI token is the one sanctioned exception,
+registered under GRIDA-SEC-006 and the GRIDA-SEC-004 hosted-AI
+paragraph). The launch page in a route group that loads Google/Vercel
 analytics (or any URL-reporting script) — the challenge in its URL is
 confidentiality-sensitive, so it stays in `(untracked)`.
 
 ---
 
+### `GRIDA-SEC-006` — Hosted-AI scoped-token boundary
+
+> **Surface.** This is the **security half of Grida Gateway (GG)** — the
+> `token` surface. Every file here carries **both** `GRIDA-SEC-006` and
+> `GRIDA-GG: token`; touching it runs the [`security`](.agents/skills/security/SKILL.md)
+> review first, then the [`gg`](.agents/skills/gg/SKILL.md) surface skill.
+> The gateway endpoints, the `gg` client provider, and the desktop token
+> wiring are the other GG surfaces (`GRIDA-GG: gateway|provider|desktop`),
+> governed by the same skill. Domain spec:
+> [Hosted AI](https://grida.co/docs/wg/platform/hosted-ai).
+
+**What it protects.** The desktop app's hosted ("no-BYOK") AI calls are
+authenticated by a **purpose-scoped, short-lived, org-bound JWT** — and
+by nothing else. The `/api/v1/ai/*` endpoints never accept a Supabase
+access token, a cookie session, or an API key; the mint route
+(`/desktop/auth/token`) is the only place the token is created, and it
+requires a live cookie session with verified org membership. The
+boundary is the rule that **the credential a native process holds for
+AI must be worth at most 15 minutes of AI calls billed to an org the
+user was a member of — and nothing more.**
+
+**Vulnerable scenario (prevented).** A desktop process credential leaks
+— a log line, a crash dump, a local proxy, an exfiltrated memory
+snapshot. If that credential were the user's Supabase access token, the
+attacker gets the user's whole API surface: RLS-scoped database reads,
+storage, profile — the account, for up to an hour, renewable if the
+refresh token ever traveled with it. With the scoped token the blast
+radius is: AI calls, on one org's credit, for ≤15 minutes, and the
+token is structurally useless everywhere else (audience check) —
+Supabase never even sees it.
+
+**Why it's specifically risky here.** The sidecar is a long-lived local
+daemon that makes third-party network calls with credentials in memory;
+it is exactly the process class where credentials leak. And the desktop
+webview session (GRIDA-SEC-005) is a full first-class login — handing
+_that_ to the daemon would collapse two carefully separated trust
+levels into one.
+
+**How the code prevents it.**
+
+1. **Mint only from a live cookie session, same-origin** —
+   [editor/app/desktop/auth/token/route.ts](editor/app/desktop/auth/token/route.ts)
+   requires `auth.getUser()` and resolves the org through the
+   GRIDA-SEC-003 verified resolver (session fallback, or explicit
+   `org_id` through `requireOrganizationId` → `assertOrgMember`). The
+   route accepts no org header — no new org-id trust input. CSRF is
+   bounded by SameSite=Lax auth cookies + same-origin-only readability
+   (no CORS on `/desktop/*`).
+2. **Scope is cryptographic, not conventional** —
+   [editor/lib/auth/gg-token.ts](editor/lib/auth/gg-token.ts) signs
+   HS256 with a dedicated server-only secret (`GG_TOKEN_SECRET`),
+   pins `algorithms: ["HS256"]` (no alg-swap) and `aud: "gg:ai"`.
+   A Supabase token fails verification structurally (different keys),
+   and this token fails everywhere Supabase tokens are accepted.
+3. **15-minute expiry, 60s clock tolerance** — the token is the unit of
+   revocation; abandoning a leaked token requires no server state.
+4. **Fail-closed secret handling** — unset or <32-byte secret →
+   `not_configured` → 503. There is no fallback path to a weaker
+   credential. Rotation via `GG_TOKEN_SECRET_PREVIOUS`
+   (verify-only; signing always uses current; drop previous after
+   > 15 min).
+5. **Verification is local and exclusive** — every `/api/v1/ai/*`
+   handler authenticates via `verifyGgToken` only; none construct a
+   Supabase client from the bearer value (`createClientFromBearer` is
+   the _other_ pattern, for first-party Supabase tokens on
+   `/private/*` routes — grep-able invariant).
+6. **Custody doctrine (client half)** — the daemon holds the token in
+   memory only: never `auth.json`, never disk, never a refresh token.
+   The webview session remains the only durable credential
+   (GRIDA-SEC-005); the renderer re-mints and re-pushes. The sidecar
+   files implementing this register here when they land.
+7. **Mint rate limit** — `rl:v1-ai:mint` per-user sliding window
+   (fail-open when Upstash is unconfigured; the billing gate on the AI
+   endpoints is the actual spend control).
+
+**Residual risks (accepted, documented).** Org-membership revocation is
+not re-checked within a token's ≤15-minute lifetime. The mint rate
+limit fails open without Upstash. In-flight AI requests at sign-out
+complete on their token rather than being aborted — expiry is the
+revocation mechanism.
+
+**Files bound by this id.** Run `grep -rn GRIDA-SEC-006 .` to enumerate.
+Today:
+
+Every file below also carries the `GRIDA-GG` surface marker (`token` /
+`gateway` / `provider`); the [`gg`](.agents/skills/gg/SKILL.md) skill
+governs the surface, this record governs its security half.
+
+- [editor/lib/auth/gg-token.ts](editor/lib/auth/gg-token.ts) — sign/verify + secret handling (`GG_TOKEN_SECRET`; pinned by `gg-token.test.ts`).
+- [editor/app/desktop/auth/token/route.ts](editor/app/desktop/auth/token/route.ts) — the mint route (pinned by its `route.test.ts`).
+- `editor/app/(api)/(public)/api/v1/ai/**` — the hosted GG endpoints: OpenAI-compat chat/completions + models, Grida-native images/videos generations. Verify with `verifyGgToken` EXCLUSIVELY; billed through the seam (pinned by contract tests driving the real `@ai-sdk/openai-compatible` client).
+- [editor/lib/ai/openai-compat/](editor/lib/ai/openai-compat/codec.ts) — the wire codec + error envelope + allowlist + rate limits.
+- [packages/grida-ai-agent/src/providers/gg-session.ts](packages/grida-ai-agent/src/providers/gg-session.ts) — the daemon's in-memory custody (30s expiry slack; `status()` never returns the token; pinned by its test).
+- [packages/grida-ai-agent/src/http/routes/gg-auth.ts](packages/grida-ai-agent/src/http/routes/gg-auth.ts) — `/auth/gg/set|clear|status` behind the daemon perimeter; token never logged (pinned by its test).
+- [packages/grida-ai-agent/src/providers/gg.ts](packages/grida-ai-agent/src/providers/gg.ts) + [gg-media.ts](packages/grida-ai-agent/src/providers/gg-media.ts) — hosted text/image/video adapters: per-request token reads, editor-origin-only egress, code-led typed errors (401→`gg_token_expired`, 402→`insufficient_credits`), no upstream body text in thrown messages.
+- The `gg` resolver arms ([providers/index.ts](packages/grida-ai-agent/src/providers/index.ts), resolve-image, resolve-video) — precedence: explicit wins; implicit BYOK → `gg` → endpoints. The `/secrets/*` allowlist keeps REJECTING the `gg` id (no key may be stored under it; pinned by `gg-auth.test.ts`).
+- [packages/grida-ai-agent/src/sandbox/policy.ts](packages/grida-ai-agent/src/sandbox/policy.ts) — `gg_host` egress option (the ONLY new host a hosted-AI daemon may reach).
+
+**What does NOT belong here.** An AI endpoint that accepts Supabase
+access tokens or cookies. A mint path without a live session or without
+membership verification. The token (or a refresh token) persisted by
+the daemon, main process, or `auth.json`. A signing fallback when the
+secret is unset. A second minting location.
+
+---
+
 ## Adding a new GRIDA-SEC entry
 
-1. Allocate the next sequential id (`GRIDA-SEC-006` for the next one).
+1. Allocate the next sequential id (`GRIDA-SEC-007` for the next one).
 2. Add an "Active boundaries" subsection here with the same shape as
    GRIDA-SEC-001: what it protects, vulnerable scenario, why it's risky
    here, how the code prevents it, files bound.

--- a/desktop/src/agent-sidecar.ts
+++ b/desktop/src/agent-sidecar.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — pass the GG base URL to the daemon (docs/wg/platform/hosted-ai.md)
 /**
  * Agent sidecar entry point.
  *
@@ -114,6 +115,10 @@ async function main() {
     // The desktop renderer holds the editor's library session, so it can resolve
     // `design_search` (the artwork-station gather step) client-side.
     library: true,
+    // GRIDA-SEC-006 — hosted "included" AI: the grida provider calls this
+    // origin (same editor base the perimeter already trusts); the renderer
+    // pushes the short-lived session token over /auth/gg/set.
+    gg_base_url: runtimeEditorBaseUrl,
   });
 
   try {

--- a/desktop/src/main/agent-sidecar-supervisor.ts
+++ b/desktop/src/main/agent-sidecar-supervisor.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — pass the GG host into the sandbox policy (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — AgentSidecar supervisor.
  *
@@ -159,6 +160,9 @@ class AgentSidecarSupervisor {
     const policy = buildAgentDaemonSandboxPolicy({
       user_data: this.user_data_path,
       home: app.getPath("home"),
+      // GRIDA-SEC-006 — without this, the srt egress allowlist 403s the
+      // grida hosted provider's calls to the editor origin.
+      gg_host: new URL(EDITOR_BASE_URL).hostname,
     });
     await ensureInitialized({
       network: {

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — install the `gg` bridge namespace (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — Desktop agent-sidecar trust boundary (renderer side).
  *
@@ -520,6 +521,17 @@ const bridge: DesktopBridge = {
     info: () => agentClient.providers.info(),
     probe_endpoint: (baseUrl) => agentClient.providers.probe_endpoint(baseUrl),
     detect_claude: () => agentClient.providers.detect_claude(),
+  },
+
+  // GRIDA-SEC-006 — hosted-session custody push (renderer → sidecar).
+  gg: {
+    set_session: async (session) => {
+      await agentClient.gg.set_session(session);
+    },
+    clear_session: async () => {
+      await agentClient.gg.clear_session();
+    },
+    status: () => agentClient.gg.status(),
   },
 
   images: {

--- a/docs/wg/ai/agent/turn-authority.md
+++ b/docs/wg/ai/agent/turn-authority.md
@@ -107,8 +107,8 @@ and "reconstruct server state from local guesses" is a contract that
 
 Today the renderer is the only consumer. Tomorrow the same run-state
 lives behind a [cloud agent
-runtime](../../platform/grida-cloud-agent-runtime.md) and a
-`grida-agent` CLI. Each is a different process, with a different local
+runtime](../../platform/hosted-ai.md#scope-boundary-capacity-not-remote-execution)
+and a `grida-agent` CLI. Each is a different process, with a different local
 model of the queue, a different reconciliation cadence, a different
 notion of "the head of my mirror":
 
@@ -356,5 +356,6 @@ A conforming implementation MUST hold all of these:
   a wrong promotion corrupts.
 - [UX / queued sends](./ux.md#queued-sends) — the user-facing framing
   of the queue whose drain this governs.
-- [Deferred Grida Cloud Agent Provider](../../platform/grida-cloud-agent-runtime.md)
-  — one of the additional consumers this contract is written ahead of.
+- [Grida Gateway (GG)](../../platform/hosted-ai.md)
+  — hosted model capacity ships; a remote agent runtime remains a future
+  consumer this contract is written ahead of.

--- a/docs/wg/ai/grida/architecture.md
+++ b/docs/wg/ai/grida/architecture.md
@@ -17,9 +17,10 @@ This is the exposed contract for Grida's local agent system. The protocol
 itself is [the agent RFC](../agent/index.md); this page records how Grida
 binds it into `@grida/daemon`, `@grida/agent`, Desktop, and the editor bridge.
 
-V1 scope is deliberately narrow: the local daemon plus BYOK model providers.
-`grida-cloud` is deferred and documented separately as a future hosted provider
-that must fit this contract instead of shaping it.
+The local daemon runs BYOK model providers and — for signed-in users —
+[Grida Gateway (GG)](../../platform/hosted-ai.md), the first-party hosted
+provider. GG fit this contract instead of shaping it: it supplies model
+capacity only (the `gg` provider kind), while the agent loop stays local.
 
 **Host/tenant split (#927).** The local privileged process is a general
 **daemon** (`@grida/daemon`): the loopback HTTP server, the GRIDA-SEC-004
@@ -46,8 +47,8 @@ Sibling docs:
 - [Agent RFC](../agent/index.md) — the contract this realizes.
 - [Grida bindings](./index.md) — naming map, backends, built-in subagents.
 - [Desktop](../../desktop/index.md) — the desktop host landing.
-- [Deferred Grida Cloud Agent Provider](../../platform/grida-cloud-agent-runtime.md)
-  — preserved design notes for the removed hosted-provider prototype.
+- [Grida Gateway (GG)](../../platform/hosted-ai.md)
+  — the shipped hosted model-capacity provider; the agent loop stays local.
 - [Phase 3 agent contract cleanup](./agent-contract-cleanup.md) — seam
   decisions and refused alternatives after the BYOK-only cleanup.
 
@@ -301,5 +302,5 @@ describe("daemon/tenant seam (#927)", () => {
 - [Agent RFC](../agent/index.md)
 - [Grida bindings](./index.md)
 - [Desktop](../../desktop/index.md)
-- [Deferred Grida Cloud Agent Provider](../../platform/grida-cloud-agent-runtime.md)
+- [Grida Gateway (GG)](../../platform/hosted-ai.md)
 - [Built-in subagents](./agents-builtin.md)

--- a/docs/wg/desktop/index.md
+++ b/docs/wg/desktop/index.md
@@ -22,8 +22,9 @@ For the abstract contract:
   sessions, capability surface, sandbox placement.
 - [Grida bindings](../ai/grida/index.md) — how the locked tools, the
   filesystem backends, and the built-in subagents land in Grida.
-- [Grida Cloud Agent Runtime](../platform/grida-cloud-agent-runtime.md)
-  — deferred hosted-provider design; Desktop V1 ships BYOK only.
+- [Grida Gateway (GG)](../platform/hosted-ai.md)
+  — the shipped no-key AI path: scoped-token federation → metered
+  first-party gateway → org-credit spend. BYOK still bypasses it.
 
 For the user-facing app and the security boundary:
 

--- a/docs/wg/desktop/process-model.md
+++ b/docs/wg/desktop/process-model.md
@@ -71,15 +71,15 @@ breakdown.
 
 ## What the daemon owns
 
-| Concern              | Why                                                                                                                                                                                        |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `auth.json`          | One secrets file, chmod 0o600, lifetime is the user. See [storage-layout](./agent-storage-layout.md).                                                                                      |
-| Provider registry    | Resolves the V1 BYOK providers: OpenRouter, then AI Gateway, then unavailable. See [grida-cloud-agent-runtime](../platform/grida-cloud-agent-runtime.md) for the deferred hosted provider. |
-| Agent loop           | Outlives the renderer; resumable by `sessionId`. RFC contract: [session lifecycle](../ai/agent/session.md).                                                                                |
-| Document registry    | `docId → {path, mtime}`; dedups windows on the same file.                                                                                                                                  |
-| Workspace registry   | Persisted to `workspaces.json`. RFC variable expansion: [tools / capability requirements](../ai/agent/tools.md#capability-requirements).                                                   |
-| Atomic file I/O      | Write-to-temp + rename; centralized so dirty tracking works.                                                                                                                               |
-| Recent files (canon) | Persisted; `addRecentDocument` is a mirror, not truth.                                                                                                                                     |
+| Concern              | Why                                                                                                                                                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth.json`          | One secrets file, chmod 0o600, lifetime is the user. See [storage-layout](./agent-storage-layout.md).                                                                                                                   |
+| Provider registry    | Resolves providers by precedence — explicit choice, then BYOK (OpenRouter, then AI Gateway), then the hosted Grida provider, then unavailable. See [Grida Gateway (GG)](../platform/hosted-ai.md) for the no-BYOK path. |
+| Agent loop           | Outlives the renderer; resumable by `sessionId`. RFC contract: [session lifecycle](../ai/agent/session.md).                                                                                                             |
+| Document registry    | `docId → {path, mtime}`; dedups windows on the same file.                                                                                                                                                               |
+| Workspace registry   | Persisted to `workspaces.json`. RFC variable expansion: [tools / capability requirements](../ai/agent/tools.md#capability-requirements).                                                                                |
+| Atomic file I/O      | Write-to-temp + rename; centralized so dirty tracking works.                                                                                                                                                            |
+| Recent files (canon) | Persisted; `addRecentDocument` is a mirror, not truth.                                                                                                                                                                  |
 
 ## What the daemon does _not_ own
 
@@ -165,7 +165,7 @@ come from the daemon. See [renderer-bridge](./renderer-bridge.md).
 - [Storage layout](./agent-storage-layout.md) — `${userData}` file map.
 - [Agent system RFC / environments / computer](../ai/agent/environments.md#computer)
   — the abstract model this implements.
-- [Grida Cloud Agent Runtime](../platform/grida-cloud-agent-runtime.md)
-  — deferred hosted-provider design; not shipped in V1.
+- [Grida Gateway (GG)](../platform/hosted-ai.md)
+  — the shipped hosted model-capacity provider; the agent loop stays local.
 - [opencode](https://github.com/sst/opencode) — reference architecture
   for daemon split, provider registry, `auth.json` shape, agent-as-data.

--- a/docs/wg/platform/_history/hosted-ai-deferred-provider-2026-06.md
+++ b/docs/wg/platform/_history/hosted-ai-deferred-provider-2026-06.md
@@ -1,18 +1,31 @@
 ---
-title: Deferred Grida Cloud Agent Provider
-description: Deferred architecture note for fitting grida-cloud into the local Desktop AgentHost provider contract.
+title: Deferred Grida Cloud Agent Provider (historical, 2026-06)
+description: Historical snapshot of the deferred hosted-provider design, superseded by the shipped Hosted AI architecture.
 keywords:
   - desktop
   - grida-cloud
   - agent host
   - ai
   - billing
-draft: true
+  - historical
+status: historical
+unlisted: true
 format: md
 tags:
   - internal
   - wg
+  - platform
+  - historical
 ---
+
+> **Historical.** This is the _deferred_ design that predates the shipped
+> hosted-AI provider. It describes a removed prototype (agent-server PKCE,
+> `auth.json` session storage, a `/private/ai/model` proxy) that is **not**
+> what shipped. The re-entry criteria below were met, but the realized
+> architecture differs materially (renderer-minted scoped token,
+> memory-only custody, an OpenAI-compatible gateway). For current truth
+> see [Hosted AI](../hosted-ai.md). Kept for the design lineage and the
+> "agent loop stays local" doctrine.
 
 # Deferred Grida Cloud Agent Provider
 

--- a/docs/wg/platform/hosted-ai.md
+++ b/docs/wg/platform/hosted-ai.md
@@ -1,0 +1,320 @@
+---
+title: Grida Gateway (GG)
+description: Grida Gateway (GG) — how an untrusted native client runs Grida-hosted AI without its own API key via scoped-token federation, a first-party metered gateway, and server-side entitlement.
+keywords:
+  - grida gateway
+  - gg
+  - hosted ai
+  - no-byok
+  - ai gateway
+  - metered inference
+  - scoped token
+  - token federation
+  - entitlement
+  - openai-compatible
+  - credential custody
+format: md
+tags:
+  - internal
+  - wg
+  - platform
+  - ai
+---
+
+| feature id | status                 | description                                                                                               |
+| ---------- | ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| `gg`       | implemented (text/i/v) | No-BYOK AI for the desktop app: scoped-token federation → first-party metered gateway → org-credit spend. |
+
+# Grida Gateway (GG)
+
+**Grida Gateway** — **GG** — is the path by which a signed-in user runs AI
+— chat, image, and video — **without supplying their own model key** (no
+"bring your own key"), billed to their organization's prepaid credit. This
+doc is the canonical spec for _how an untrusted native client is allowed to
+spend credits_ and _why the design is shaped the way it is_. It sits on top
+of, and defers all money mechanics to,
+[Billing / AI Credits](./billing/ai-credits.md).
+
+**Name and lineage.** "Grida Gateway (GG)" is the branded name for this
+one service, chosen so the term carries this exact context. It is designed
+to **spin out** of the editor into a standalone gateway at a future host
+`grida.gg`; that portability is a design constraint, not an aspiration (see
+[Scope boundary](#scope-boundary-capacity-not-remote-execution) and the
+dependency direction below). Throughout: **GG** / **Grida Gateway** names
+the _service_; "hosted AI" is the generic capability it delivers.
+
+> **Boundary & surface.** The scoped-token trust boundary is
+> **`GRIDA-SEC-006`** in
+> [SECURITY.md](https://github.com/gridaco/grida/blob/main/SECURITY.md);
+> the code surface is marked `GRIDA-GG` and governed by the `gg` engineering
+> skill. This doc explains the domain; SECURITY.md is the enforced
+> invariant.
+
+## The problem
+
+Three forces have to be satisfied at once, and they pull against each
+other:
+
+1. **An untrusted client must be able to spend money.** The desktop app is
+   a native process on a machine we don't control. It must be able to
+   invoke paid models, yet it can never hold a credential that is worth
+   more than the narrow thing it is allowed to do.
+2. **Metering must be trustworthy.** Usage billed to a customer has to be
+   counted by a party the customer trusts — us, on the server — not
+   reported after the fact by the client or reconciled from a third party's
+   ledger days later.
+3. **BYOK must keep working, unchanged.** Users who bring their own key
+   must still pay $0 to us and route around all of this. Hosted AI is an
+   _additional_ path, never a replacement.
+
+The durable login (the browser/webview session) is a full first-class
+account credential. Handing _that_ to the native process would collapse
+"can use AI" into "is the whole account." So the durable credential must
+stay where it already lives, and the native process must receive something
+strictly weaker.
+
+## The design space (mental models)
+
+Four industry-named paradigms can deliver no-BYOK AI. Naming them makes the
+choice legible:
+
+| Model | Industry name                                     | Who calls the model provider                                   | Where metering happens                        |
+| ----- | ------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------- |
+| **A** | **Token Vending Machine** (STS-style federation)  | The client, directly, with a minted _upstream_ credential      | After the fact, from provider usage exports   |
+| **B** | **First-party AI Gateway** (LLM proxy / BFF)      | Our server, on the client's behalf                             | Inline, synchronous, server-side              |
+| **C** | **Managed gateway with provisioned virtual keys** | A third-party gateway (per-customer virtual key with a budget) | The vendor's ledger, reconciled into ours     |
+| **D** | **BYOK / client-direct**                          | The client, with the user's own key                            | Not metered by us (the carve-out we preserve) |
+
+**A (Token Vending Machine)** — the pattern AWS STS coined: the server
+mints a temporary _upstream_ credential and the client talks to the model
+provider directly. The server is only in the control plane. Simple and
+cheap, but a leaked minted key is spendable upstream until revoked, and
+metering degrades to asynchronous reconciliation.
+
+**B (First-party AI Gateway)** — every AI call flows through our own
+endpoint; we terminate auth, gate entitlement, stream the response through,
+and meter inline. This is what the shipping peers (Zed, Cursor, Copilot,
+Cody Gateway) converged on. We become a streaming hop and own a wire
+contract forever, but metering and credential blast-radius are both under
+our control.
+
+**C (Managed virtual keys)** — outsource B to a third party
+(provisioning-API sub-keys, per-customer virtual keys with budgets). Least
+infra, but double margin, hard catalog lock-in, and someone else's numbers
+in our ledger.
+
+### What we chose, and why
+
+**B for the data plane, with a thin slice of A for auth only.**
+
+The deciding fact is that the billing rail — entitlement gate and metered
+usage ingest against a prepaid credit ledger — **already lives on the
+server**, inside the AI seam that every first-party AI call passes through.
+Only model B lets that rail run **synchronously and authoritatively**:
+entitlement is checked _before_ the upstream stream opens (a hard,
+pre-flight "insufficient credit," never a surprise post-paid bill), usage
+is ingested from tokens _we_ counted, and the upstream provider key never
+leaves the server. A and C both push metering into asynchronous
+reconciliation and give up the pre-flight gate; C additionally adds margin
+and catalog lock-in.
+
+The "slice of A" is narrow and deliberate: the credential the native
+client holds is **not** an upstream key — it is a purpose-scoped token that
+is only good against _our own gateway_. So it is really the standard
+**OAuth2 resource-server / short-lived access token** pattern, not a true
+Token Vending Machine.
+
+The trade we accepted, stated plainly: we bought the **worst operational
+axis** (we are now in the hot path — if the gateway is down, hosted AI is
+down; we pay streaming egress and live under serverless duration ceilings)
+to buy the **best trust axes** (authoritative metering, minimal credential
+blast radius, upstream keys never exposed). For a product that bills per
+use, that is the correct trade, and it is the one every shipping peer made.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant W as Webview session<br/>(durable login)
+    participant M as Mint endpoint<br/>(first-party, same-origin)
+    participant D as Native daemon<br/>(sidecar — memory only)
+    participant G as Grida Gateway (GG)<br/>(first-party)
+    participant B as Entitlement + ledger<br/>(prepaid credit)
+    participant P as Upstream model provider
+
+    Note over W: signed in — the only durable credential (GRIDA-SEC-005)
+    D->>M: request scoped token (cookie session)
+    M->>M: verify session + org membership
+    M-->>D: scoped token — aud "gg:ai", ~15 min, org-bound
+    Note over D: held in memory only<br/>never on disk, never a refresh token
+    D->>G: AI request + Bearer scoped token
+    G->>G: verify token (audience, signature, expiry)
+    G->>B: entitlement gate (pre-flight)
+    alt insufficient credit
+        B-->>G: blocked
+        G-->>D: 402 insufficient_credits (before any upstream call)
+    else allowed
+        G->>P: model call (first-party upstream key)
+        P-->>G: streamed tokens / media
+        G-->>D: streamed response
+        G->>B: ingest usage (post-flight, at cost)
+    end
+```
+
+The flow reads top to bottom: the durable session mints a weak token; the
+native process holds that token in memory only; every AI call carries it to
+the first-party gateway; the gateway proves the token, gates the org's
+credit _before_ opening upstream, streams the model back, and meters what
+was actually used. **BYOK bypasses this entire diagram** — a user-supplied
+key resolves to a client-direct provider that never touches the gateway or
+the ledger.
+
+## The contract
+
+### 1. The scoped token (federation)
+
+The credential handed to the native process is a **purpose-scoped,
+short-lived, organization-bound token**:
+
+- **Purpose-scoped** — an audience claim (`gg:ai`) binds it to Grida
+  Gateway and nothing else. It is structurally useless at every other
+  endpoint; the account's real session endpoints never even accept it.
+- **Short-lived** — on the order of fifteen minutes. **Expiry is the unit
+  of revocation**: abandoning a leaked token requires no server-side state.
+- **Organization-bound** — it carries the org whose credit will be spent,
+  resolved from a verified membership at mint time. The gateway never
+  trusts a client-supplied organization id.
+- **Minted only from the durable session, same-origin** — the sole place a
+  token is created requires a live login and verified org membership. No
+  other input can produce one.
+- **Custody: memory only** — the native daemon holds the token in memory
+  and nowhere else: never on disk, never persisted, never a refresh token.
+  The webview session remains the _only_ durable credential; the client
+  re-mints proactively before expiry and again on an expiry error.
+
+This is the "thin slice of A": a minted credential, but scoped to our own
+resource server, so its blast radius is "≤15 minutes of AI on one org's
+credit" and nothing more.
+
+### 2. The gateway (a first-party metered surface)
+
+A first-party endpoint family authenticated by the scoped token **and
+nothing else** — it never accepts a durable session token, a cookie, or an
+API key. It presents two contract styles:
+
+- **Text: an OpenAI-compatible surface** — chat completions (streaming and
+  non-streaming, with tool-call passthrough and a usage report) plus a
+  model list. OpenAI's chat-completions shape is the de-facto industry ABI;
+  adopting it verbatim means any conformant client speaks it with no custom
+  code, and it is a contract we can honor for years. It is pinned by
+  contract tests so it cannot silently drift.
+- **Image and video: Grida-native generation surfaces** — request/response
+  shapes owned by our own protocol, returning inline results.
+
+### 3. Metering (deferred to the billing rail)
+
+Every hosted call runs the existing server-side AI seam, so the gateway
+carries **no billing logic of its own**:
+
+- **Pre-flight gate** — the org's entitlement is read before the upstream
+  call opens. No credit ⇒ a hard, pre-stream refusal. There is never a
+  post-paid surprise.
+- **Post-flight ingest** — usage is metered from what the server counted,
+  **sold at cost** (zero markup; see [AI Credits](./billing/ai-credits.md)),
+  and written to the ledger idempotently.
+- **Granularity** — one hosted request per model step, so per-request
+  gating _is_ step-level gating for the agent.
+
+### 4. Provider precedence
+
+When more than one way to reach a model is available, resolution is:
+
+1. **An explicit user choice always wins** — if the user selected a
+   specific provider, honor it.
+2. Otherwise **BYOK**, if a user key is present (the $0-to-us path).
+3. Otherwise **hosted (Grida)**, if signed in with a live token.
+4. Otherwise the remaining fallbacks.
+
+Hosted AI is thus _just another provider_ in an existing precedence order —
+adding it distorted neither BYOK nor the resolution model, and removing or
+reordering it is trivial.
+
+## Security boundary
+
+The trust boundary is registered as **`GRIDA-SEC-006` — Hosted-AI
+scoped-token boundary**. Its one-sentence invariant:
+
+> The credential a native process holds for AI must be worth **at most
+> fifteen minutes of AI calls billed to an org the user was a member of —
+> and nothing more.**
+
+It composes with the neighboring boundaries: the durable webview login is
+`GRIDA-SEC-005`; the native daemon's trust perimeter is `GRIDA-SEC-004`;
+the server-side org-id trust resolution that the mint reuses is
+`GRIDA-SEC-003`. The doctrine amendment those records carry is: _the
+sidecar may hold the short-lived scoped AI token (memory-only), and nothing
+more durable._ The enforced details — signing, audience pinning,
+fail-closed secret handling, rotation, rate limiting — live in
+[SECURITY.md](https://github.com/gridaco/grida/blob/main/SECURITY.md).
+
+## Scope boundary: capacity, not remote execution
+
+Hosted AI provides **model capacity only**. The agent loop — prompt
+composition, tool authority, session recording, workspace and filesystem
+access, abort propagation — **stays local** to the native host. File
+contents reach a hosted model only as ordinary model-call content produced
+by the local loop.
+
+Remote-running the agent itself (a true "cloud agent runtime," or a hosted
+agent behind a CLI) is a **separate, still-deferred concern** and must not
+be conflated with hosted model provision. Hosted AI moves the _model call_
+off-device; it does not move the _agent_ off-device.
+
+## Current state (honest)
+
+**Implemented (local, end-to-end verified):** text, image, and video all
+run keyless for a signed-in desktop user; the scoped token mints from the
+session, lives only in the daemon's memory, and is re-minted on expiry; the
+gateway gates and meters through the live billing rail; BYOK continues to
+bypass everything; precedence resolves explicit → BYOK → hosted →
+fallbacks.
+
+**Deferred / accepted limitations** — the parts deliberately left for
+later, and the honest risks:
+
+- **Synchronous video is the weakest long-term contract.** Video
+  generation is served request/response under a serverless duration
+  ceiling. Long-form generation will likely force an asynchronous
+  job-and-poll contract (v2) — and unlike a hosting change, that is a
+  _wire_ change every client must mirror. The v1 model allowlist is scoped
+  accordingly.
+- **Text-to-image and text-to-video only.** Image-to-image / image-to-video
+  need a hosted reference-upload story (blob custody, SSRF-safe intake)
+  that v1 does not provide.
+- **Mid-stream spend is not interrupted.** Gating is per-request; once a
+  stream is open it runs to completion even if the balance crosses zero.
+  Bounded by per-step request granularity; standard industry behavior.
+- **Org-membership revocation lags by up to a token lifetime** (~15 min) —
+  an accepted consequence of stateless, expiry-based revocation.
+- **Plan-included credit grants are not wired** (billing Phase 5) — today
+  only explicit top-ups create balance, so the revenue path for bundled
+  AI is a prerequisite tracked in [AI Credits](./billing/ai-credits.md), not
+  here.
+- **Default-model UX** — a signed-in keyless user still defaults to a
+  BYOK-oriented default model; steering the default to a hosted tier when a
+  hosted session is active is a separate product decision.
+- **Packaged egress smoke** — the native sandbox must be proven to reach
+  the hosted host from a _packaged_ build; the dev loop cannot prove the
+  packaged allowlist.
+- **Hosted-deploy prerequisite** — the gateway fails closed without its
+  dedicated signing secret configured in the hosted environment.
+
+## Related
+
+- [Billing / AI Credits](./billing/ai-credits.md) — the ledger, gate
+  primitive, at-cost pricing, and top-up flows this spends against.
+- [Metronome integration](./billing/metronome.md) — the metering substrate.
+- [SECURITY.md](https://github.com/gridaco/grida/blob/main/SECURITY.md) —
+  `GRIDA-SEC-003`/`004`/`005`/`006`, the enforced boundaries.
+- [Deferred Grida Cloud Agent Provider](./_history/hosted-ai-deferred-provider-2026-06.md)
+  — the superseded pre-build design, kept for lineage.

--- a/docs/wg/platform/index.md
+++ b/docs/wg/platform/index.md
@@ -13,6 +13,7 @@ Working group documents for Grida platform and infrastructure topics.
 ## Documents
 
 - [Billing](./billing) — subscriptions, AI credit, Stripe ↔ Metronome sync.
+- [Grida Gateway (GG)](./hosted-ai) — the first-party metered, no-BYOK AI gateway: scoped-token federation → org-credit spend; the desktop's no-key AI path.
 - [Grida Library](./library) — curated open visual-asset corpus and its retrieval model (similarity & semantic search).
 - [Multi-tenant Custom Domains on Vercel](./multi-tenant-custom-domain-vercel)
 - [Universal Docs Routing](./universal-docs-routing)

--- a/editor/.env.example
+++ b/editor/.env.example
@@ -42,6 +42,16 @@ OPENAI_API_KEY='sk-xxx'
 # BYOK_OPENROUTER_API_KEY=sk-or-v1-xxx   # https://openrouter.ai/keys
 # BYOK_AI_GATEWAY_API_KEY=...            # dedicated Vercel AI Gateway key
 
+# hosted-AI scoped tokens (GRIDA-SEC-006)
+# HS256 secret for the desktop hosted-AI tokens minted by
+# /desktop/auth/token and verified by /api/v1/ai/*. Server-only, >= 32
+# bytes; generate with `openssl rand -base64 48`. When unset, hosted AI
+# responds 503 (fail-closed) — BYOK and web AI flows are unaffected.
+# Rotation: move the current value to _PREVIOUS, set a new current,
+# drop _PREVIOUS after 15+ minutes.
+# GG_TOKEN_SECRET=""
+# GG_TOKEN_SECRET_PREVIOUS=""
+
 # resend
 RESEND_API_KEY='re_123'
 

--- a/editor/.oxlintrc.jsonc
+++ b/editor/.oxlintrc.jsonc
@@ -120,6 +120,13 @@
         // Metadata endpoint — lists OpenAI's available models for the
         // model selector UI. Not a billed inference call.
         "app/(api)/private/ai/models/openai/route.ts",
+        // Contract tests for the hosted OpenAI-compat endpoint
+        // (GRIDA-SEC-006): they value-import `@ai-sdk/openai-compatible`
+        // as the WIRE-CONTRACT DRIVER (the desktop sidecar's actual
+        // client), not to make billed calls. Mirrored in
+        // editor/scripts/audit-ai-seam.ts ALLOWLIST.
+        "app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts",
+        "app/(api)/(public)/api/v1/ai/chat/completions/route.byok.test.ts",
       ],
       "rules": {
         "no-restricted-imports": "off",

--- a/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.byok.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.byok.test.ts
@@ -1,0 +1,131 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * BYOK-env variant (GRIDA-SEC-003 carve-out) of the hosted chat route:
+ * with a `BYOK_*` provider active the text path is UNBILLED (no gate,
+ * no ingest) but authentication is NEVER bypassed — the scoped token
+ * is still required. Separate file because `byok` is resolved at
+ * module load of the seam.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Rate limits are pinned by their own module; route tests must NEVER
+// reach the real Upstash instance (vitest loads .env.local).
+vi.mock("@/lib/ai/openai-compat/limits", () => ({
+  allowAiRequest: async () => ({ success: true }),
+}));
+
+import type { LanguageModelV3, LanguageModelV3Usage } from "@ai-sdk/provider";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+const h = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock("@/lib/billing/metronome", () => ({
+  getEntitlement: vi.fn<(...args: never[]) => unknown>(),
+  ingestUsageEvent: vi.fn<(...args: never[]) => unknown>(),
+  refreshBalance: vi.fn<(...args: never[]) => unknown>(),
+  BillingMetronomeError: class BillingMetronomeError extends Error {
+    code = "internal";
+  },
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createLibraryClient: vi.fn<(...args: never[]) => unknown>(),
+}));
+vi.mock("@/lib/auth/organization", () => ({
+  requireOrganizationId: vi.fn<(...args: never[]) => unknown>(),
+}));
+
+const USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: undefined },
+  outputTokens: { total: 5, text: 5, reasoning: 0 },
+};
+
+vi.mock("@/lib/ai/models", async (orig) => {
+  const real = await orig<typeof import("@/lib/ai/models")>();
+  const bareModel = (modelId: string) => ({
+    specificationVersion: "v3" as const,
+    provider: "byok-bare",
+    modelId,
+    supportedUrls: {},
+    doGenerate: async () => {
+      h.calls += 1;
+      return {
+        content: [{ type: "text", text: "byok reply" }],
+        finishReason: { unified: "stop", raw: "stop" },
+        usage: USAGE,
+        warnings: [],
+      };
+    },
+    doStream: async () => {
+      throw new Error("unused");
+    },
+  });
+  return {
+    ...real,
+    // BYOK active: the seam's language provider is the BARE provider.
+    byok: { languageModel: bareModel },
+    isByokActive: () => true,
+    gateway: {
+      languageModel: () => {
+        throw new Error("gateway must not be used under BYOK text path");
+      },
+      imageModel: () => {
+        throw new Error("unused");
+      },
+      textEmbeddingModel: () => {
+        throw new Error("unused");
+      },
+    },
+  };
+});
+
+import { POST } from "./route";
+import { getEntitlement, ingestUsageEvent } from "@/lib/billing/metronome";
+import { signGgToken } from "@/lib/auth/gg-token";
+
+const SECRET = "byok-secret-0123456789abcdef0123456789abcdef00";
+const MODEL = "anthropic/claude-sonnet-5";
+
+function clientModel(token: string): LanguageModelV3 {
+  const provider = createOpenAICompatible({
+    name: "gg",
+    baseURL: "http://grida.test/api/v1/ai",
+    apiKey: token,
+    fetch: (async (input: string | URL | Request, init?: RequestInit) =>
+      POST(new Request(input, init))) as typeof fetch,
+  });
+  return provider(MODEL) as unknown as LanguageModelV3;
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+  h.calls = 0;
+  vi.mocked(getEntitlement).mockReset();
+  vi.mocked(ingestUsageEvent).mockReset();
+});
+
+describe("BYOK carve-out on /api/v1/ai/chat/completions", () => {
+  it("serves unbilled text (no gate, no ingest) but auth still runs", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const result = await clientModel(token).doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    });
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "text", text: "byok reply" }),
+    ]);
+    expect(h.calls).toBe(1);
+    expect(getEntitlement).not.toHaveBeenCalled();
+    expect(ingestUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("still rejects a missing token with 401", async () => {
+    await expect(
+      clientModel("not-a-token").doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      })
+    ).rejects.toSatisfy(
+      (err: unknown) => (err as { statusCode?: number }).statusCode === 401
+    );
+    expect(h.calls).toBe(0);
+  });
+});

--- a/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
@@ -1,0 +1,371 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * CONTRACT tests: the ACTUAL `@ai-sdk/openai-compatible` client (what
+ * the desktop sidecar's `grida` provider is built on) drives the ACTUAL
+ * route handler through its custom-fetch hook — no HTTP server.
+ *
+ * Pins: the V3 prompt survives the wire roundtrip verbatim; streamed
+ * tool-call argument text reassembles byte-for-byte; usage numbers
+ * arrive intact (streamed + non-streamed); the REAL billing middleware
+ * runs (gate before upstream, ingest with catalog-consistent mills);
+ * 401 for invalid/expired/foreign tokens (a Supabase-style token MUST
+ * fail); 402 is a clean pre-stream response; 404 before any provider
+ * call.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Rate limits are pinned by their own module; route tests must NEVER
+// reach the real Upstash instance (vitest loads .env.local).
+vi.mock("@/lib/ai/openai-compat/limits", () => ({
+  allowAiRequest: async () => ({ success: true }),
+}));
+
+import { SignJWT } from "jose";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+
+const h = vi.hoisted(() => ({
+  generate: null as unknown,
+  parts: [] as unknown[],
+  lastCallOptions: null as unknown,
+}));
+
+vi.mock("@/lib/billing/metronome", () => ({
+  getEntitlement: vi.fn<(...args: never[]) => unknown>(),
+  ingestUsageEvent: vi.fn<(...args: never[]) => unknown>(),
+  refreshBalance: vi.fn<(...args: never[]) => unknown>(),
+  BillingMetronomeError: class BillingMetronomeError extends Error {
+    code: string;
+    status: number;
+    constructor(message: string, code: string, status = 500) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createLibraryClient: vi.fn<(...args: never[]) => unknown>(),
+}));
+vi.mock("@/lib/auth/organization", () => ({
+  requireOrganizationId: vi.fn<(...args: never[]) => unknown>(),
+}));
+
+// Fake gateway: scripted V3 model behind the REAL billing middleware
+// (server.ts wraps whatever `gateway` this module exports).
+vi.mock("@/lib/ai/models", async (orig) => {
+  const real = await orig<typeof import("@/lib/ai/models")>();
+  const fakeLanguageModel = (modelId: string) => ({
+    specificationVersion: "v3" as const,
+    provider: "fake-gateway",
+    modelId,
+    supportedUrls: {},
+    doGenerate: async (options: unknown) => {
+      h.lastCallOptions = options;
+      return h.generate;
+    },
+    doStream: async (options: unknown) => {
+      h.lastCallOptions = options;
+      const parts = h.parts as never[];
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            for (const part of parts) controller.enqueue(part);
+            controller.close();
+          },
+        }),
+      };
+    },
+  });
+  return {
+    ...real,
+    byok: null,
+    isByokActive: () => false,
+    gateway: {
+      languageModel: fakeLanguageModel,
+      imageModel: () => {
+        throw new Error("unused in this suite");
+      },
+      textEmbeddingModel: () => {
+        throw new Error("unused in this suite");
+      },
+    },
+  };
+});
+
+import { POST } from "./route";
+import { getEntitlement, ingestUsageEvent } from "@/lib/billing/metronome";
+import { costMillsFromTokenUsage } from "@/lib/ai/server";
+import { signGgToken, GG_TOKEN_AUDIENCE } from "@/lib/auth/gg-token";
+
+const mockedGetEntitlement = vi.mocked(getEntitlement);
+const mockedIngest = vi.mocked(ingestUsageEvent);
+
+const SECRET = "contract-secret-0123456789abcdef0123456789abcdef";
+const MODEL = "anthropic/claude-sonnet-5";
+const ORG = 7;
+
+const USAGE: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 100,
+    noCache: 90,
+    cacheRead: 10,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 20, text: 15, reasoning: 5 },
+};
+
+function clientModel(token: string, modelId = MODEL): LanguageModelV3 {
+  const provider = createOpenAICompatible({
+    name: "gg",
+    baseURL: "http://grida.test/api/v1/ai",
+    apiKey: token,
+    includeUsage: true,
+    fetch: (async (input: string | URL | Request, init?: RequestInit) =>
+      POST(new Request(input, init))) as typeof fetch,
+  });
+  return provider(modelId) as unknown as LanguageModelV3;
+}
+
+async function mintedToken(): Promise<string> {
+  return (await signGgToken("user-1", ORG)).token;
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+  h.generate = null;
+  h.parts = [];
+  h.lastCallOptions = null;
+  mockedGetEntitlement.mockReset();
+  mockedIngest.mockReset();
+  mockedGetEntitlement.mockResolvedValue({
+    allowed: true,
+    cachedBalanceCents: 500,
+    cachedAt: "2026-07-03T00:00:00Z",
+  } as never);
+  mockedIngest.mockResolvedValue({ transactionId: "tx" } as never);
+});
+
+const PROMPT: LanguageModelV3CallOptions["prompt"] = [
+  { role: "system", content: "be helpful" },
+  { role: "user", content: [{ type: "text", text: "weather in Seoul?" }] },
+];
+
+const TOOLS: LanguageModelV3CallOptions["tools"] = [
+  {
+    type: "function",
+    name: "get_weather",
+    description: "Get weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+];
+
+describe("POST /api/v1/ai/chat/completions (contract)", () => {
+  it("non-stream: roundtrips the prompt, returns content + usage, bills real mills", async () => {
+    h.generate = {
+      content: [{ type: "text", text: "It is sunny." }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: USAGE,
+      warnings: [],
+    };
+    const model = clientModel(await mintedToken());
+    const result = await model.doGenerate({ prompt: PROMPT, tools: TOOLS });
+
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "text", text: "It is sunny." }),
+    ]);
+    expect(result.finishReason.unified).toBe("stop");
+    expect(result.usage.inputTokens.total).toBe(100);
+    expect(result.usage.inputTokens.cacheRead).toBe(10);
+    expect(result.usage.outputTokens.reasoning).toBe(5);
+
+    // The server-side model saw the SAME V3 prompt the client sent.
+    const serverOptions = h.lastCallOptions as LanguageModelV3CallOptions;
+    expect(serverOptions.prompt).toEqual(PROMPT);
+    expect(serverOptions.tools).toEqual([
+      expect.objectContaining({
+        type: "function",
+        name: "get_weather",
+        inputSchema:
+          TOOLS![0]!.type === "function" ? TOOLS![0]!.inputSchema : {},
+      }),
+    ]);
+    // Org context came from the token claim, never the request.
+    expect(
+      (serverOptions.providerOptions as { grida: { organizationId: number } })
+        .grida.organizationId
+    ).toBe(ORG);
+
+    // REAL billing middleware ran: gate + catalog-consistent ingest.
+    expect(mockedGetEntitlement).toHaveBeenCalledWith(ORG);
+    expect(mockedIngest).toHaveBeenCalledTimes(1);
+    const [orgArg, millsArg] = mockedIngest.mock.calls[0]!;
+    expect(orgArg).toBe(ORG);
+    expect(millsArg).toBeCloseTo(costMillsFromTokenUsage(MODEL, USAGE), 10);
+  });
+
+  it("stream: tool-call arguments reassemble byte-for-byte; usage arrives; ingest fires", async () => {
+    const args = '{"city":"Seoul","units":"metric"}';
+    h.parts = [
+      { type: "stream-start", warnings: [] },
+      { type: "text-start", id: "t0" },
+      { type: "text-delta", id: "t0", delta: "Let me check." },
+      { type: "text-end", id: "t0" },
+      { type: "tool-input-start", id: "call_1", toolName: "get_weather" },
+      { type: "tool-input-delta", id: "call_1", delta: args.slice(0, 12) },
+      { type: "tool-input-delta", id: "call_1", delta: args.slice(12) },
+      { type: "tool-input-end", id: "call_1" },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "get_weather",
+        input: args,
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_calls" },
+        usage: USAGE,
+      },
+    ] satisfies LanguageModelV3StreamPart[];
+
+    const model = clientModel(await mintedToken());
+    const { stream } = await model.doStream({ prompt: PROMPT, tools: TOOLS });
+
+    const received: LanguageModelV3StreamPart[] = [];
+    const reader = stream.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received.push(value);
+    }
+
+    const text = received
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("Let me check.");
+
+    const toolCall = received.find((p) => p.type === "tool-call") as {
+      toolCallId: string;
+      toolName: string;
+      input: string;
+    };
+    expect(toolCall).toBeDefined();
+    expect(toolCall.toolCallId).toBe("call_1");
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(toolCall.input).toBe(args); // byte-for-byte
+
+    const finish = received.find((p) => p.type === "finish") as {
+      finishReason: { unified: string };
+      usage: LanguageModelV3Usage;
+    };
+    expect(finish.finishReason.unified).toBe("tool-calls");
+    expect(finish.usage.inputTokens.total).toBe(100);
+    expect(finish.usage.outputTokens.total).toBe(20);
+
+    // Streaming ingest fires on flush (fire-and-forget) — allow a tick.
+    await vi.waitFor(() => expect(mockedIngest).toHaveBeenCalledTimes(1));
+    expect(mockedIngest.mock.calls[0]![1]).toBeCloseTo(
+      costMillsFromTokenUsage(MODEL, USAGE),
+      10
+    );
+  });
+
+  it("402: a blocked org fails clean, pre-stream, with insufficient_credits", async () => {
+    mockedGetEntitlement.mockResolvedValue({
+      allowed: false,
+      reason: "below_floor",
+      cachedBalanceCents: 10,
+      cachedAt: null,
+    } as never);
+    const model = clientModel(await mintedToken());
+    await expect(model.doStream({ prompt: PROMPT })).rejects.toSatisfy(
+      (err: unknown) => {
+        const e = err as { statusCode?: number; responseBody?: string };
+        return (
+          e.statusCode === 402 &&
+          String(e.responseBody).includes("insufficient_credits")
+        );
+      }
+    );
+    expect(h.lastCallOptions).toBeNull(); // upstream never opened
+    expect(mockedIngest).not.toHaveBeenCalled();
+  });
+
+  it("401: garbage, expired, and Supabase-style tokens all fail", async () => {
+    const expectStatus = async (token: string, bodyIncludes: string) => {
+      await expect(
+        clientModel(token).doGenerate({ prompt: PROMPT })
+      ).rejects.toSatisfy((err: unknown) => {
+        const e = err as { statusCode?: number; responseBody?: string };
+        return (
+          e.statusCode === 401 && String(e.responseBody).includes(bodyIncludes)
+        );
+      });
+    };
+    await expectStatus("garbage", "invalid_token");
+
+    const key = new TextEncoder().encode(SECRET);
+    const expired = await new SignJWT({ org: ORG })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-1")
+      .setAudience(GG_TOKEN_AUDIENCE)
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 1800)
+      .sign(key);
+    await expectStatus(expired, "token_expired");
+
+    // Supabase-style token: right signature shape, wrong audience —
+    // MUST be rejected (GRIDA-SEC-006: only the scoped token works).
+    const supabaseLike = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-1")
+      .setAudience("authenticated")
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(key);
+    await expectStatus(supabaseLike, "invalid_token");
+    expect(mockedGetEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("404: unlisted model fails before any provider or billing call", async () => {
+    const model = clientModel(await mintedToken(), "nope/unlisted-model");
+    await expect(model.doGenerate({ prompt: PROMPT })).rejects.toSatisfy(
+      (err: unknown) => {
+        const e = err as { statusCode?: number; responseBody?: string };
+        return (
+          e.statusCode === 404 &&
+          String(e.responseBody).includes("model_not_found")
+        );
+      }
+    );
+    expect(h.lastCallOptions).toBeNull();
+    expect(mockedGetEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("400: malformed body (raw request, empty messages)", async () => {
+    const token = await mintedToken();
+    const res = await POST(
+      new Request("http://grida.test/api/v1/ai/chat/completions", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: MODEL, messages: [] }),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(await res.json())).toContain("invalid_request_error");
+  });
+});

--- a/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.ts
@@ -1,0 +1,101 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+// GRIDA-EE: billing — see ee-billing
+/**
+ * `POST /api/v1/ai/chat/completions` — OpenAI chat-completions wire over
+ * the billed Grida model seam. The desktop sidecar's `grida` provider
+ * (`@ai-sdk/openai-compatible`, `baseURL = <origin>/api/v1/ai`) is the
+ * primary consumer.
+ *
+ * Auth: the scoped AI token ONLY (`verifyGgToken` — never Supabase
+ * tokens, never cookies; GRIDA-SEC-006). Org context comes from the
+ * token claim (membership was verified at mint).
+ *
+ * Billing: entirely the seam's — `grida.languageModel()` carries the
+ * billing middleware (`lib/ai/server.ts`), so the entitlement gate runs
+ * BEFORE the upstream opens (a 402 is always a clean pre-stream JSON
+ * response, never a mid-stream corpse) and usage is ingested on the
+ * finish part. One request per agent step ⇒ per-request gating IS
+ * step-level gating (Q-AI-2 resolved for desktop by construction).
+ *
+ * BYOK interplay (GRIDA-SEC-003): with a `BYOK_*` env set (contributor
+ * dev), the language provider is the bare BYOK provider — calls here
+ * are authenticated but unbilled, exactly like every other text
+ * surface under that carve-out.
+ */
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { verifyGgToken } from "@/lib/auth/gg-token";
+import { grida } from "@/lib/ai/server";
+import {
+  decodeRequest,
+  encodeCompletion,
+  streamEncoder,
+} from "@/lib/ai/openai-compat/codec";
+import {
+  fromUnknownError,
+  modelNotFound,
+  parseJsonRequest,
+  rateLimited,
+} from "@/lib/ai/openai-compat/errors";
+import { isHostedTextModel } from "@/lib/ai/openai-compat/hosted-models";
+import { allowAiRequest } from "@/lib/ai/openai-compat/limits";
+import { chatCompletionRequestSchema } from "@/lib/ai/openai-compat/wire";
+
+export const maxDuration = 300;
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export async function POST(request: Request) {
+  try {
+    const claims = await verifyGgToken(request);
+
+    const rl = await allowAiRequest("chat", claims.sub);
+    if (!rl.success) return rateLimited(rl.retryAfterSeconds);
+
+    const p = await parseJsonRequest(request, chatCompletionRequestSchema);
+    if (!p.ok) return p.res;
+    const req = p.data;
+
+    // Allowlist BEFORE any provider call — the gateway accepts arbitrary
+    // ids; an unlisted one must 404 here, not 500 at cost-card lookup.
+    if (!isHostedTextModel(req.model)) return modelNotFound(req.model);
+
+    const decoded = decodeRequest(req);
+    const model = grida.languageModel(req.model) as LanguageModelV3;
+    const callOptions = {
+      ...decoded.callOptions,
+      providerOptions: {
+        grida: {
+          organizationId: claims.org,
+          feature: "v1/ai/chat",
+          awaitIngest: false,
+        },
+      },
+    };
+
+    if (!decoded.stream) {
+      const result = await model.doGenerate(callOptions);
+      return Response.json(encodeCompletion(req.model, result), {
+        headers: NO_STORE,
+      });
+    }
+
+    // The gate awaits inside doStream (middleware) — a blocked org
+    // throws here, before any SSE bytes are written.
+    const { stream } = await model.doStream(callOptions);
+    return new Response(
+      stream.pipeThrough(
+        streamEncoder(req.model, { includeUsage: decoded.includeUsage })
+      ),
+      {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-store",
+          "x-accel-buffering": "no",
+        },
+      }
+    );
+  } catch (err) {
+    return fromUnknownError(err, "v1/ai/chat");
+  }
+}

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.test.ts
@@ -1,0 +1,178 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * POST /api/v1/ai/images/generations — token-gated hosted image
+ * generation through the REAL image billing middleware (fake gateway
+ * model): pre-priced mills reach ingest, blocked orgs 402 before the
+ * provider, unknown/unbound models 404, base64 results in the shared
+ * protocol shape, and NO library upload (the daemon owns persistence).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Rate limits are pinned by their own module; route tests must NEVER
+// reach the real Upstash instance (vitest loads .env.local).
+vi.mock("@/lib/ai/openai-compat/limits", () => ({
+  allowAiRequest: async () => ({ success: true }),
+}));
+
+const h = vi.hoisted(() => ({
+  imageCalls: 0,
+  lastOptions: null as unknown,
+}));
+
+vi.mock("@/lib/billing/metronome", () => ({
+  getEntitlement: vi.fn<(...args: never[]) => unknown>(),
+  ingestUsageEvent: vi.fn<(...args: never[]) => unknown>(),
+  refreshBalance: vi.fn<(...args: never[]) => unknown>(),
+  BillingMetronomeError: class BillingMetronomeError extends Error {
+    code: string;
+    status: number;
+    constructor(message: string, code: string, status = 500) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createLibraryClient: vi.fn<(...args: never[]) => unknown>(),
+  service_role: {},
+}));
+vi.mock("@/lib/auth/organization", () => ({
+  requireOrganizationId: vi.fn<(...args: never[]) => unknown>(),
+}));
+
+// Tiny valid PNG header so `generateImage` sniffs image/png.
+const PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAA7";
+
+vi.mock("@/lib/ai/models", async (orig) => {
+  const real = await orig<typeof import("@/lib/ai/models")>();
+  return {
+    ...real,
+    byok: null,
+    isByokActive: () => false,
+    gateway: {
+      languageModel: () => {
+        throw new Error("unused");
+      },
+      imageModel: (modelId: string) => ({
+        specificationVersion: "v3" as const,
+        provider: "fake-gateway",
+        modelId,
+        maxImagesPerCall: 4,
+        doGenerate: async (options: unknown) => {
+          h.imageCalls += 1;
+          h.lastOptions = options;
+          return {
+            images: [PNG_B64],
+            warnings: [],
+            response: {
+              timestamp: new Date(),
+              modelId,
+              headers: {},
+            },
+          };
+        },
+      }),
+      textEmbeddingModel: () => {
+        throw new Error("unused");
+      },
+    },
+  };
+});
+
+import { POST } from "./route";
+import { getEntitlement, ingestUsageEvent } from "@/lib/billing/metronome";
+import { signGgToken } from "@/lib/auth/gg-token";
+import { computeImageCostMills } from "@/lib/ai/image-cost";
+import ai from "@/lib/ai";
+
+const mockedGetEntitlement = vi.mocked(getEntitlement);
+const mockedIngest = vi.mocked(ingestUsageEvent);
+
+const SECRET = "images-secret-0123456789abcdef0123456789abcdef";
+
+// A real listed card with a vercel binding — resolved dynamically so
+// catalog churn doesn't rot the test.
+const CARD = ai.image
+  .listed_models()
+  .find((card) => ai.image.binding(card, "vercel"))!;
+
+function request(body: unknown, token?: string): Request {
+  return new Request("http://grida.test/api/v1/ai/images/generations", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+  h.imageCalls = 0;
+  h.lastOptions = null;
+  mockedGetEntitlement.mockReset();
+  mockedIngest.mockReset();
+  mockedGetEntitlement.mockResolvedValue({
+    allowed: true,
+    cachedBalanceCents: 500,
+    cachedAt: null,
+  } as never);
+  mockedIngest.mockResolvedValue({ transactionId: "tx" } as never);
+});
+
+describe("POST /api/v1/ai/images/generations", () => {
+  it("generates through the billed middleware with pre-priced mills", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(
+      request({ model_id: CARD.id, prompt: "a red square", n: 2 }, token)
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      model_id: string;
+      provider_id: string;
+      images: Array<{ base64: string; media_type: string }>;
+    };
+    expect(body.model_id).toBe(CARD.id);
+    expect(body.provider_id).toBe("vercel");
+    expect(body.images.length).toBeGreaterThan(0);
+    expect(body.images[0]!.base64).toBe(PNG_B64);
+    expect(body.images[0]!.media_type).toContain("image/");
+
+    expect(mockedGetEntitlement).toHaveBeenCalledWith(7);
+    const expected = computeImageCostMills(CARD, { n: 2 });
+    // n=2 with maxImagesPerCall=4 → one SDK call, one middleware pass.
+    expect(mockedIngest).toHaveBeenCalledTimes(1);
+    expect(mockedIngest.mock.calls[0]![0]).toBe(7);
+    expect(mockedIngest.mock.calls[0]![1]).toBe(expected);
+  });
+
+  it("401 without token; 404 for unknown models — provider untouched", async () => {
+    expect(
+      (await POST(request({ model_id: CARD.id, prompt: "x" }))).status
+    ).toBe(401);
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(
+      request({ model_id: "nope/unknown", prompt: "x" }, token)
+    );
+    expect(res.status).toBe(404);
+    expect(h.imageCalls).toBe(0);
+    expect(mockedGetEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("402 for blocked orgs, before the provider call", async () => {
+    mockedGetEntitlement.mockResolvedValue({
+      allowed: false,
+      reason: "no_balance",
+      cachedBalanceCents: 0,
+      cachedAt: null,
+    } as never);
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(request({ model_id: CARD.id, prompt: "x" }, token));
+    expect(res.status).toBe(402);
+    expect(h.imageCalls).toBe(0);
+    expect(mockedIngest).not.toHaveBeenCalled();
+  });
+});

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.test.ts
@@ -149,6 +149,21 @@ describe("POST /api/v1/ai/images/generations", () => {
     expect(mockedIngest.mock.calls[0]![1]).toBe(expected);
   });
 
+  it("forwards the requested quality tier to the origin provider", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(
+      request({ model_id: CARD.id, prompt: "x", quality: "high" }, token)
+    );
+    expect(res.status).toBe(200);
+    // The billed tier must actually reach the provider (Vercel AI Gateway
+    // keys providerOptions by origin provider, e.g. `openai`).
+    const originProvider = CARD.id.slice(0, CARD.id.indexOf("/"));
+    const opts = h.lastOptions as {
+      providerOptions?: Record<string, Record<string, unknown>>;
+    };
+    expect(opts.providerOptions?.[originProvider]?.quality).toBe("high");
+  });
+
   it("401 without token; 404 for unknown models — provider untouched", async () => {
     expect(
       (await POST(request({ model_id: CARD.id, prompt: "x" }))).status

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
@@ -1,0 +1,109 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+// GRIDA-EE: billing — see ee-billing
+/**
+ * `POST /api/v1/ai/images/generations` — hosted image generation for
+ * the desktop sidecar. Grida-native wire (the agent package's
+ * `ImageGenerateRequest`/`ImageGenerateResult` protocol — NOT OpenAI's
+ * images API, despite the OpenAI-style path; the sidecar's BYOK image
+ * adapters already speak these shapes). Text-to-image only in v1 (the
+ * protocol carries no reference images; the sidecar resolver routes
+ * i2i to BYOK providers).
+ *
+ * Auth: scoped AI token only (GRIDA-SEC-006). Billing: pre-priced via
+ * the shared `computeImageCostMills` and threaded through the seam's
+ * image middleware (`providerOptions.grida.costMills`). NO library
+ * upload — the daemon owns persistence.
+ */
+import { generateImage } from "ai";
+import { z } from "zod";
+import type { ImageGenerateResult } from "@grida/agent";
+import { verifyGgToken } from "@/lib/auth/gg-token";
+import ai from "@/lib/ai";
+import { computeImageCostMills } from "@/lib/ai/image-cost";
+import { methods } from "@/lib/ai/server";
+import {
+  fromUnknownError,
+  modelNotFound,
+  parseJsonRequest,
+  rateLimited,
+} from "@/lib/ai/openai-compat/errors";
+import { allowAiRequest } from "@/lib/ai/openai-compat/limits";
+
+export const maxDuration = 120;
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+const requestSchema = z.looseObject({
+  model_id: z.string().min(1),
+  prompt: z.string().min(1),
+  width: z.number().int().positive().nullish(),
+  height: z.number().int().positive().nullish(),
+  aspect_ratio: z.string().nullish(),
+  n: z.number().int().min(1).max(4).nullish(),
+  seed: z.number().int().nullish(),
+  quality: z.string().nullish(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const claims = await verifyGgToken(request);
+    const rl = await allowAiRequest("images", claims.sub);
+    if (!rl.success) return rateLimited(rl.retryAfterSeconds);
+
+    const p = await parseJsonRequest(request, requestSchema);
+    if (!p.ok) return p.res;
+    const req = p.data;
+
+    const card = ai.image.findImageModelCard(req.model_id);
+    if (!card) return modelNotFound(req.model_id);
+    // Hosted serving goes through the gateway — a card without a
+    // vercel binding is not servable here (the sidecar's BYOK
+    // adapters cover the rest).
+    if (!ai.image.binding(card, "vercel")) return modelNotFound(req.model_id);
+
+    const resolved = methods.getSDKImageModel(card.id);
+    if (!resolved) return modelNotFound(req.model_id);
+
+    const n = req.n ?? 1;
+    const costMills = computeImageCostMills(card, {
+      n,
+      width: req.width ?? undefined,
+      height: req.height ?? undefined,
+      quality: req.quality ?? undefined,
+    });
+
+    const size =
+      req.width && req.height
+        ? (`${req.width}x${req.height}` as `${number}x${number}`)
+        : undefined;
+
+    const generation = await generateImage({
+      model: resolved.model,
+      prompt: req.prompt,
+      n,
+      size,
+      aspectRatio: req.aspect_ratio as `${number}:${number}` | undefined,
+      seed: req.seed ?? undefined,
+      providerOptions: {
+        grida: {
+          organizationId: claims.org,
+          feature: "v1/ai/images",
+          costMills,
+        },
+      },
+    });
+
+    const result: ImageGenerateResult = {
+      model_id: card.id,
+      provider_id: "vercel",
+      images: generation.images.map((file) => ({
+        base64: file.base64,
+        media_type: file.mediaType,
+      })),
+    };
+    return Response.json(result, { headers: NO_STORE });
+  } catch (err) {
+    return fromUnknownError(err, "v1/ai/images");
+  }
+}

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
@@ -78,6 +78,17 @@ export async function POST(request: Request) {
         ? (`${req.width}x${req.height}` as `${number}x${number}`)
         : undefined;
 
+    // Forward the requested quality tier to the ORIGIN provider so the
+    // tier we just billed (`computeImageCostMills`) is the tier actually
+    // delivered — otherwise a `per_image_tiered` card (e.g. gpt-image-*)
+    // charges "high" while the provider renders its default. The Vercel
+    // AI Gateway keys providerOptions by origin provider (`openai` for
+    // `openai/gpt-image-2`).
+    const slash = card.id.indexOf("/");
+    const originProvider = slash > 0 ? card.id.slice(0, slash) : undefined;
+    const quality =
+      req.quality && req.quality !== "auto" ? req.quality : undefined;
+
     const generation = await generateImage({
       model: resolved.model,
       prompt: req.prompt,
@@ -91,6 +102,7 @@ export async function POST(request: Request) {
           feature: "v1/ai/images",
           costMills,
         },
+        ...(originProvider && quality ? { [originProvider]: { quality } } : {}),
       },
     });
 

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
@@ -39,7 +39,12 @@ const requestSchema = z.looseObject({
   prompt: z.string().min(1),
   width: z.number().int().positive().nullish(),
   height: z.number().int().positive().nullish(),
-  aspect_ratio: z.string().nullish(),
+  // Reject malformed ratios at the boundary — a bad value otherwise reaches
+  // the provider and comes back as an SDK warning + a fallback-rendered 200.
+  aspect_ratio: z
+    .string()
+    .regex(/^\d+:\d+$/, 'aspect_ratio must be "<w>:<h>"')
+    .nullish(),
   n: z.number().int().min(1).max(4).nullish(),
   seed: z.number().int().nullish(),
   quality: z.string().nullish(),

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -1,0 +1,63 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * GET /api/v1/ai/models — token-gated allowlist composed from the ONE
+ * catalog: all text entries (deprecated flagged), image/video cards
+ * with vercel bindings; tier annotation from the reverse tier map; no
+ * pricing fields anywhere in the payload.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Rate limits are pinned by their own module; route tests must NEVER
+// reach the real Upstash instance (vitest loads .env.local).
+vi.mock("@/lib/ai/openai-compat/limits", () => ({
+  allowAiRequest: async () => ({ success: true }),
+}));
+
+import { GET } from "./route";
+import { signGgToken } from "@/lib/auth/gg-token";
+
+const SECRET = "models-secret-0123456789abcdef0123456789abcdef";
+
+function request(token?: string): Request {
+  return new Request("http://grida.test/api/v1/ai/models", {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+});
+
+type Entry = {
+  id: string;
+  grida: { modality: string; tier: string | null; deprecated: boolean };
+};
+
+describe("GET /api/v1/ai/models", () => {
+  it("401 without a valid token", async () => {
+    expect((await GET(request())).status).toBe(401);
+    expect((await GET(request("junk"))).status).toBe(401);
+  });
+
+  it("lists text+image+video with tiers, deprecation flags, and no pricing", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const res = await GET(request(token));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as { object: string; data: Entry[] };
+    expect(body.object).toBe("list");
+
+    const byId = new Map(body.data.map((entry) => [entry.id, entry]));
+    // Tier annotation via the reverse TIER_MODEL_IDS map.
+    expect(byId.get("anthropic/claude-sonnet-5")?.grida).toMatchObject({
+      modality: "text",
+      tier: "pro",
+    });
+    // Every modality is represented.
+    const modalities = new Set(body.data.map((e) => e.grida.modality));
+    expect(modalities).toEqual(new Set(["text", "image", "video"]));
+    // No pricing leaks into the payload.
+    expect(JSON.stringify(body)).not.toMatch(/cost|price|usd|mills/i);
+  });
+});

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.ts
@@ -1,0 +1,30 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+// GRIDA-EE: billing — see ee-billing
+/**
+ * `GET /api/v1/ai/models` — the hosted-model allowlist, OpenAI list
+ * shape with a `grida` extension (`modality`, `tier`, `label`,
+ * `deprecated`). Same auth as every `/api/v1/ai/*` route: the scoped
+ * AI token only. No pricing in the payload (billing-page concern).
+ */
+import { verifyGgToken } from "@/lib/auth/gg-token";
+import { fromUnknownError, rateLimited } from "@/lib/ai/openai-compat/errors";
+import { hostedModelList } from "@/lib/ai/openai-compat/hosted-models";
+import { allowAiRequest } from "@/lib/ai/openai-compat/limits";
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export async function GET(request: Request) {
+  try {
+    const claims = await verifyGgToken(request);
+    const rl = await allowAiRequest("models", claims.sub);
+    if (!rl.success) return rateLimited(rl.retryAfterSeconds);
+
+    return Response.json(
+      { object: "list", data: hostedModelList() },
+      { headers: NO_STORE }
+    );
+  } catch (err) {
+    return fromUnknownError(err, "v1/ai/models");
+  }
+}

--- a/editor/app/(api)/(public)/api/v1/ai/videos/generations/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/videos/generations/route.test.ts
@@ -1,0 +1,119 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * POST /api/v1/ai/videos/generations — route-level pins (the seam's
+ * `generateVideo` behavior is pinned by `generate-video.test.ts`):
+ * token-gated, org from the claim, InvalidAiRequestError → 400,
+ * blocked → 402, verbatim result passthrough, no-store.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Rate limits are pinned by their own module; route tests must NEVER
+// reach the real Upstash instance (vitest loads .env.local).
+vi.mock("@/lib/ai/openai-compat/limits", () => ({
+  allowAiRequest: async () => ({ success: true }),
+}));
+
+const generateVideo = vi.fn<(org: number, req: unknown) => Promise<unknown>>();
+vi.mock("@/lib/ai/server", () => {
+  class InvalidAiRequestError extends Error {
+    code = "invalid_request";
+  }
+  return {
+    InvalidAiRequestError,
+    methods: {
+      generateVideo: (org: number, req: unknown) => generateVideo(org, req),
+    },
+  };
+});
+
+import { POST } from "./route";
+import { signGgToken } from "@/lib/auth/gg-token";
+
+const SECRET = "videos-secret-0123456789abcdef0123456789abcdef";
+
+function request(body: unknown, token?: string): Request {
+  return new Request("http://grida.test/api/v1/ai/videos/generations", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+  generateVideo.mockReset();
+});
+
+describe("POST /api/v1/ai/videos/generations", () => {
+  it("401 without a token; seam never invoked", async () => {
+    const res = await POST(
+      request({ model_id: "google/veo-3.1", prompt: "x" })
+    );
+    expect(res.status).toBe(401);
+    expect(generateVideo).not.toHaveBeenCalled();
+  });
+
+  it("passes the claim org + request through and returns the result verbatim", async () => {
+    const result = {
+      model_id: "google/veo-3.1",
+      provider_id: "vercel",
+      videos: [{ base64: "AAAA", media_type: "video/mp4" }],
+    };
+    generateVideo.mockResolvedValue(result);
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(
+      request(
+        { model_id: "google/veo-3.1", prompt: "ocean", duration: 8 },
+        token
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.json()).toEqual(result);
+    expect(generateVideo).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        model_id: "google/veo-3.1",
+        prompt: "ocean",
+        duration: 8,
+      })
+    );
+  });
+
+  it("maps seam validation failures to 400 and blocked to 402", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const { InvalidAiRequestError } = await import("@/lib/ai/server");
+    generateVideo.mockRejectedValue(
+      new InvalidAiRequestError("unsupported resolution")
+    );
+    const res400 = await POST(
+      request({ model_id: "google/veo-3.1", prompt: "x" }, token)
+    );
+    expect(res400.status).toBe(400);
+    expect(JSON.stringify(await res400.json())).toContain(
+      "unsupported resolution"
+    );
+
+    generateVideo.mockRejectedValue(
+      Object.assign(new Error("gate: below_floor"), { code: "blocked" })
+    );
+    const res402 = await POST(
+      request({ model_id: "google/veo-3.1", prompt: "x" }, token)
+    );
+    expect(res402.status).toBe(402);
+    expect(JSON.stringify(await res402.json())).toContain(
+      "insufficient_credits"
+    );
+  });
+
+  it("400 on malformed body without touching the seam", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const res = await POST(request({ prompt: "no model" }, token));
+    expect(res.status).toBe(400);
+    expect(generateVideo).not.toHaveBeenCalled();
+  });
+});

--- a/editor/app/(api)/(public)/api/v1/ai/videos/generations/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/videos/generations/route.ts
@@ -1,0 +1,64 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+// GRIDA-EE: billing — see ee-billing
+/**
+ * `POST /api/v1/ai/videos/generations` — hosted video generation for
+ * the desktop sidecar. Grida-native wire (`VideoGenerateRequest` /
+ * `VideoGenerateResult`; base64 bytes per the v1 contract — never
+ * URLs). All validation, pricing, and the gate → generate → ingest
+ * envelope live in the seam's `methods.generateVideo`.
+ *
+ * Sync request/response — Veo-class latency runs minutes, hence the
+ * large `maxDuration`. If the deployment plan caps below this,
+ * restrict the video allowlist before shipping (plan risk item).
+ */
+import { z } from "zod";
+import { verifyGgToken } from "@/lib/auth/gg-token";
+import { methods } from "@/lib/ai/server";
+import {
+  fromUnknownError,
+  parseJsonRequest,
+  rateLimited,
+} from "@/lib/ai/openai-compat/errors";
+import { allowAiRequest } from "@/lib/ai/openai-compat/limits";
+
+export const maxDuration = 600;
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+const requestSchema = z.looseObject({
+  model_id: z.string().min(1),
+  prompt: z.string().min(1),
+  aspect_ratio: z.string().nullish(),
+  resolution: z.string().nullish(),
+  duration: z.number().positive().nullish(),
+  fps: z.number().int().positive().nullish(),
+  seed: z.number().int().nullish(),
+  image_url: z.string().nullish(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const claims = await verifyGgToken(request);
+    const rl = await allowAiRequest("video", claims.sub);
+    if (!rl.success) return rateLimited(rl.retryAfterSeconds);
+
+    const p = await parseJsonRequest(request, requestSchema);
+    if (!p.ok) return p.res;
+    const req = p.data;
+
+    const result = await methods.generateVideo(claims.org, {
+      model_id: req.model_id,
+      prompt: req.prompt,
+      aspect_ratio: req.aspect_ratio ?? undefined,
+      resolution: req.resolution ?? undefined,
+      duration: req.duration ?? undefined,
+      fps: req.fps ?? undefined,
+      seed: req.seed ?? undefined,
+      image_url: req.image_url ?? undefined,
+    });
+    return Response.json(result, { headers: NO_STORE });
+  } catch (err) {
+    return fromUnknownError(err, "v1/ai/videos");
+  }
+}

--- a/editor/app/desktop/auth/token/route.test.ts
+++ b/editor/app/desktop/auth/token/route.test.ts
@@ -1,0 +1,169 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: token — see docs/wg/platform/hosted-ai.md
+/**
+ * POST /desktop/auth/token — the hosted-AI token mint.
+ *
+ * Pins: signed-out is 401 and never reaches signing; the default org is
+ * the session resolution (no request/header input ever reaches the org
+ * resolver); an explicit org_id goes through the membership-verified
+ * resolver as INPUT (not header); no-usable-org collapses to 409;
+ * unconfigured secret is 503; all responses are no-store; failures stay
+ * opaque.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getUser =
+  vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>();
+const maybeSingle =
+  vi.fn<() => Promise<{ data: { id: number; name: string } | null }>>();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser },
+    from: () => ({
+      select: () => ({ eq: () => ({ maybeSingle }) }),
+    }),
+  }),
+}));
+
+const resolveSessionOrganization =
+  vi.fn<(user_id: string) => Promise<{ id: number; name: string } | null>>();
+const requireOrganizationId = vi.fn<(opts: unknown) => Promise<number>>();
+vi.mock("@/lib/auth/organization", () => ({
+  resolveSessionOrganization: (user_id: string) =>
+    resolveSessionOrganization(user_id),
+  requireOrganizationId: (opts: unknown) => requireOrganizationId(opts),
+}));
+
+const signGgToken =
+  vi.fn<
+    (sub: string, org: number) => Promise<{ token: string; expiresAt: Date }>
+  >();
+const allowGgTokenMint = vi.fn<(userId: string) => Promise<boolean>>();
+vi.mock("@/lib/auth/gg-token", () => {
+  class GgTokenError extends Error {
+    code: string;
+    constructor(code: string) {
+      super(code);
+      this.code = code;
+    }
+  }
+  return {
+    GgTokenError,
+    signGgToken: (sub: string, org: number) => signGgToken(sub, org),
+    allowGgTokenMint: (userId: string) => allowGgTokenMint(userId),
+  };
+});
+
+import { POST } from "./route";
+import { GgTokenError } from "@/lib/auth/gg-token";
+
+const EXPIRES = new Date("2026-07-03T12:00:00.000Z");
+
+function request(body?: unknown): Request {
+  return new Request("https://grida.test/desktop/auth/token", {
+    method: "POST",
+    ...(body !== undefined
+      ? {
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }
+      : {}),
+  });
+}
+
+beforeEach(() => {
+  getUser.mockReset();
+  maybeSingle.mockReset();
+  resolveSessionOrganization.mockReset();
+  requireOrganizationId.mockReset();
+  signGgToken.mockReset();
+  allowGgTokenMint.mockReset();
+  getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  allowGgTokenMint.mockResolvedValue(true);
+  signGgToken.mockResolvedValue({ token: "jwt-abc", expiresAt: EXPIRES });
+  resolveSessionOrganization.mockResolvedValue({ id: 7, name: "acme" });
+});
+
+describe("POST /desktop/auth/token", () => {
+  it("401 when signed out; signing never runs", async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(request());
+    expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(signGgToken).not.toHaveBeenCalled();
+  });
+
+  it("mints against the session organization by default", async () => {
+    const res = await POST(request());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      token: "jwt-abc",
+      expires_at: EXPIRES.toISOString(),
+      organization: { id: 7, name: "acme" },
+    });
+    expect(signGgToken).toHaveBeenCalledWith("user-1", 7);
+    expect(requireOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("409 no_organization when the session resolves no org", async () => {
+    resolveSessionOrganization.mockResolvedValue(null);
+    const res = await POST(request());
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: { code: "no_organization" } });
+    expect(signGgToken).not.toHaveBeenCalled();
+  });
+
+  it("explicit org_id goes through the membership-verified resolver as input, never a header", async () => {
+    requireOrganizationId.mockResolvedValue(42);
+    maybeSingle.mockResolvedValue({ data: { id: 42, name: "other" } });
+    const res = await POST(request({ org_id: 42 }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).organization).toEqual({ id: 42, name: "other" });
+    expect(requireOrganizationId).toHaveBeenCalledWith({
+      user_id: "user-1",
+      inputOrgId: 42,
+    });
+    expect(signGgToken).toHaveBeenCalledWith("user-1", 42);
+  });
+
+  it("membership failure on explicit org_id → 409", async () => {
+    requireOrganizationId.mockRejectedValue(
+      Object.assign(new Error("not a member"), { code: "not_member" })
+    );
+    const res = await POST(request({ org_id: 999 }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: { code: "no_organization" } });
+  });
+
+  it("malformed org_id → 400", async () => {
+    const res = await POST(request({ org_id: { nested: true } }));
+    expect(res.status).toBe(400);
+    expect(signGgToken).not.toHaveBeenCalled();
+  });
+
+  it("503 when the signing secret is not configured", async () => {
+    signGgToken.mockRejectedValue(new GgTokenError("not_configured"));
+    const res = await POST(request());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: { code: "not_configured" } });
+  });
+
+  it("429 when the mint limiter refuses", async () => {
+    allowGgTokenMint.mockResolvedValue(false);
+    const res = await POST(request());
+    expect(res.status).toBe(429);
+    expect(signGgToken).not.toHaveBeenCalled();
+  });
+
+  it("unexpected failures are opaque", async () => {
+    resolveSessionOrganization.mockRejectedValue(
+      new Error("connect ECONNREFUSED postgres")
+    );
+    const res = await POST(request());
+    expect(res.status).toBe(500);
+    const body = JSON.stringify(await res.json());
+    expect(body).toBe(JSON.stringify({ error: { code: "mint_failed" } }));
+    expect(body).not.toContain("ECONNREFUSED");
+  });
+});

--- a/editor/app/desktop/auth/token/route.ts
+++ b/editor/app/desktop/auth/token/route.ts
@@ -1,0 +1,149 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: token — see docs/wg/platform/hosted-ai.md
+/**
+ * Desktop hosted-AI token mint, same-origin.
+ *
+ * Exchanges the webview's cookie session for a short-lived, org-scoped
+ * AI token (aud `gg:ai`, 15 min) that the renderer hands to the
+ * sidecar daemon. The webview session stays the only durable credential
+ * (GRIDA-SEC-005): the daemon receives ONLY this scoped token, holds it
+ * in memory, and comes back here — via the renderer — for a fresh one.
+ *
+ * Org binding happens at mint time: the optional `{org_id}` body field
+ * is membership-verified (`requireOrganizationId` → `assertOrgMember`);
+ * without it the session org resolution applies (last-accessed project's
+ * org → first membership — the same priority AI billing uses). The
+ * request object is deliberately NOT passed to the resolver: this route
+ * accepts no org header, so it adds no new org-id trust input
+ * (GRIDA-SEC-003 posture).
+ *
+ * CSRF posture: responses are only readable same-origin (no CORS on
+ * /desktop/*), and the Supabase auth cookies are SameSite=Lax, so a
+ * cross-site POST neither carries the session nor reads the token.
+ */
+import {
+  requireOrganizationId,
+  resolveSessionOrganization,
+} from "@/lib/auth/organization";
+import {
+  GgTokenError,
+  allowGgTokenMint,
+  signGgToken,
+} from "@/lib/auth/gg-token";
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export async function POST(request: Request) {
+  const client = await createClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "unauthorized" } },
+      { status: 401, headers: NO_STORE }
+    );
+  }
+
+  if (!(await allowGgTokenMint(user.id))) {
+    return NextResponse.json(
+      { error: { code: "rate_limited" } },
+      { status: 429, headers: NO_STORE }
+    );
+  }
+
+  try {
+    const org = await resolveMintOrganization(request, user.id, client);
+    if (org === null) {
+      return NextResponse.json(
+        { error: { code: "no_organization" } },
+        { status: 409, headers: NO_STORE }
+      );
+    }
+
+    const { token, expiresAt } = await signGgToken(user.id, org.id);
+    return NextResponse.json(
+      {
+        token,
+        expires_at: expiresAt.toISOString(),
+        organization: { id: org.id, name: org.name },
+      },
+      { headers: NO_STORE }
+    );
+  } catch (err) {
+    return errorResponse(err);
+  }
+}
+
+type MintOrganization = { id: number; name: string };
+
+async function resolveMintOrganization(
+  request: Request,
+  user_id: string,
+  client: Awaited<ReturnType<typeof createClient>>
+): Promise<MintOrganization | null> {
+  const body = await request.json().catch(() => ({}));
+  const inputOrgId = (body as { org_id?: unknown }).org_id;
+
+  if (inputOrgId == null) {
+    return await resolveSessionOrganization(user_id);
+  }
+
+  if (typeof inputOrgId !== "number" && typeof inputOrgId !== "string") {
+    throw new MintRequestError("invalid org_id");
+  }
+  // Membership-verified (assertOrgMember inside); note: no `request`
+  // passed — body input only, never a header.
+  const id = await requireOrganizationId({ user_id, inputOrgId });
+  const { data: org } = await client
+    .from("organization")
+    .select("id, name")
+    .eq("id", id)
+    .maybeSingle();
+  // Member-verified id must be readable under RLS; treat a miss as an
+  // internal inconsistency rather than minting with an unknown slug.
+  if (!org) throw new Error("organization row unreadable");
+  return { id: org.id, name: org.name };
+}
+
+class MintRequestError extends Error {}
+
+function errorResponse(err: unknown): NextResponse {
+  if (err instanceof GgTokenError && err.code === "not_configured") {
+    return NextResponse.json(
+      { error: { code: "not_configured" } },
+      { status: 503, headers: NO_STORE }
+    );
+  }
+  if (err instanceof MintRequestError) {
+    return NextResponse.json(
+      { error: { code: "invalid_request" } },
+      { status: 400, headers: NO_STORE }
+    );
+  }
+  // `requireOrganizationId` throws BillingError (duck-typed here — the
+  // class itself is lint-barred under app/desktop/**). Membership /
+  // resolution failures collapse into the no-usable-org state; malformed
+  // input is a 400; everything else stays opaque.
+  const code = (err as { code?: unknown })?.code;
+  if (code === "not_member" || code === "org_not_found") {
+    return NextResponse.json(
+      { error: { code: "no_organization" } },
+      { status: 409, headers: NO_STORE }
+    );
+  }
+  if (code === "invalid_input") {
+    return NextResponse.json(
+      { error: { code: "invalid_request" } },
+      { status: 400, headers: NO_STORE }
+    );
+  }
+  console.error("[desktop-ai-token] mint failed:", err);
+  return NextResponse.json(
+    { error: { code: "mint_failed" } },
+    { status: 500, headers: NO_STORE }
+  );
+}

--- a/editor/app/desktop/auth/token/route.ts
+++ b/editor/app/desktop/auth/token/route.ts
@@ -36,26 +36,28 @@ import { NextResponse } from "next/server";
 const NO_STORE = { "cache-control": "no-store" } as const;
 
 export async function POST(request: Request) {
-  const client = await createClient();
-  const {
-    data: { user },
-  } = await client.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json(
-      { error: { code: "unauthorized" } },
-      { status: 401, headers: NO_STORE }
-    );
-  }
-
-  if (!(await allowGgTokenMint(user.id))) {
-    return NextResponse.json(
-      { error: { code: "rate_limited" } },
-      { status: 429, headers: NO_STORE }
-    );
-  }
-
   try {
+    // Inside the try so a throw from createClient / getUser / the Upstash
+    // limiter still yields the JSON no-store envelope, not Next's default 500.
+    const client = await createClient();
+    const {
+      data: { user },
+    } = await client.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: { code: "unauthorized" } },
+        { status: 401, headers: NO_STORE }
+      );
+    }
+
+    if (!(await allowGgTokenMint(user.id))) {
+      return NextResponse.json(
+        { error: { code: "rate_limited" } },
+        { status: 429, headers: NO_STORE }
+      );
+    }
+
     const org = await resolveMintOrganization(request, user.id, client);
     if (org === null) {
       return NextResponse.json(

--- a/editor/app/desktop/billing/summary/route.test.ts
+++ b/editor/app/desktop/billing/summary/route.test.ts
@@ -1,0 +1,76 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * GET /desktop/billing/summary.
+ *
+ * Pins: signed-out is a 200 state (never an error, seam never invoked),
+ * the seam result crosses the wire verbatim for the session user, seam
+ * failures collapse to an opaque `summary_failed` (internal error text —
+ * Metronome/Postgres — must never reach the renderer), and every response
+ * is `no-store`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getUser =
+  vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({ auth: { getUser } }),
+}));
+
+const getDesktopBillingSummary = vi.fn<(user_id: string) => Promise<unknown>>();
+vi.mock("@/lib/desktop/billing", () => ({
+  getDesktopBillingSummary: (user_id: string) =>
+    getDesktopBillingSummary(user_id),
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  getUser.mockReset();
+  getDesktopBillingSummary.mockReset();
+});
+
+describe("GET /desktop/billing/summary", () => {
+  it("responds 200 signed_out without invoking the seam", async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ state: "signed_out" });
+    expect(getDesktopBillingSummary).not.toHaveBeenCalled();
+  });
+
+  it("returns the seam summary verbatim for the session user", async () => {
+    getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const summary = {
+      state: "ready",
+      organization: { id: 7, name: "acme", display_name: "Acme Inc." },
+      plan: "pro",
+      credits: {
+        balance_cents: 512,
+        entitled: true,
+        blocked_reason: null,
+        as_of: "2026-07-03T00:00:00Z",
+      },
+      manage_path: "/organizations/acme/settings/billing",
+    };
+    getDesktopBillingSummary.mockResolvedValue(summary);
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual(summary);
+    expect(getDesktopBillingSummary).toHaveBeenCalledWith("user-1");
+  });
+
+  it("collapses seam failures to an opaque summary_failed", async () => {
+    getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    getDesktopBillingSummary.mockRejectedValue(
+      new Error("METRONOME_API_TOKEN is required")
+    );
+    const response = await GET();
+    expect(response.status).toBe(500);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = JSON.stringify(await response.json());
+    expect(body).toBe(JSON.stringify({ error: "summary_failed" }));
+    expect(body).not.toContain("METRONOME");
+  });
+});

--- a/editor/app/desktop/billing/summary/route.ts
+++ b/editor/app/desktop/billing/summary/route.ts
@@ -1,0 +1,43 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Desktop AI-credits summary, same-origin.
+ *
+ * The `/desktop/*` CSP keeps `connect-src` closed to `'self'` (+ loopback),
+ * so the desktop renderer reads billing state through this route — never
+ * from Supabase or Metronome directly. Read-only: every billing CONTROL
+ * lives on the web billing page (`manage_path` in the payload), which the
+ * app opens in the OS browser.
+ *
+ * Signed-out is an expected state, not an error: responds 200 with
+ * `{ state: "signed_out" }` (the `/desktop/auth/me` philosophy). The org
+ * is always session-resolved server-side — the route takes no org
+ * parameter, so it adds no new org-id trust input (GRIDA-SEC-003 posture).
+ */
+import { createClient } from "@/lib/supabase/server";
+import { getDesktopBillingSummary } from "@/lib/desktop/billing";
+import { NextResponse } from "next/server";
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export async function GET() {
+  const client = await createClient();
+  const {
+    data: { user },
+  } = await client.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ state: "signed_out" }, { headers: NO_STORE });
+  }
+
+  try {
+    const summary = await getDesktopBillingSummary(user.id);
+    return NextResponse.json(summary, { headers: NO_STORE });
+  } catch {
+    // Opaque on purpose — never leak Metronome/Postgres error text to the
+    // renderer.
+    return NextResponse.json(
+      { error: "summary_failed" },
+      { status: 500, headers: NO_STORE }
+    );
+  }
+}

--- a/editor/app/desktop/billing/summary/route.ts
+++ b/editor/app/desktop/billing/summary/route.ts
@@ -32,9 +32,11 @@ export async function GET() {
   try {
     const summary = await getDesktopBillingSummary(user.id);
     return NextResponse.json(summary, { headers: NO_STORE });
-  } catch {
-    // Opaque on purpose — never leak Metronome/Postgres error text to the
-    // renderer.
+  } catch (err) {
+    // Opaque to the renderer — never leak Metronome/Postgres error text —
+    // but log server-side so a real regression is distinguishable from
+    // expected upstream flakiness.
+    console.error("[desktop/billing/summary] summary_failed", err);
     return NextResponse.json(
       { error: "summary_failed" },
       { status: 500, headers: NO_STORE }

--- a/editor/app/desktop/settings/_components/credits-section.tsx
+++ b/editor/app/desktop/settings/_components/credits-section.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Thin, read-only AI-credits card for desktop settings.
+ *
+ * Shows the balance for the user's session organization and delegates every
+ * billing CONTROL to the web billing page, opened in the OS browser (the
+ * iOS "manage your account on the web" pattern). Reads go through the
+ * same-origin `/desktop/billing/summary` route — the desktop CSP blocks
+ * everything else, and `@/lib/billing/**` is lint-barred from this tree
+ * (GRIDA-SEC-004); only TYPES cross, via `@/lib/desktop/billing`.
+ *
+ * Behavior spec: test/desktop-settings-billing-credits.md
+ */
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@app/ui/components/badge";
+import { Button } from "@app/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@app/ui/components/card";
+import { Skeleton } from "@app/ui/components/skeleton";
+import { getDesktopBridge } from "@/lib/desktop/bridge";
+import type { DesktopBillingSummaryResponse } from "@/lib/desktop/billing";
+
+type ReadySummary = Extract<DesktopBillingSummaryResponse, { state: "ready" }>;
+
+type CreditsState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "no-organization" }
+  | { kind: "ready"; summary: ReadySummary }
+  | { kind: "error"; message: string };
+
+const PLAN_LABELS: Record<ReadySummary["plan"], string> = {
+  free: "Free",
+  pro: "Pro",
+  team: "Team",
+};
+
+const BLOCKED_HINTS: Record<
+  NonNullable<ReadySummary["credits"]["blocked_reason"]>,
+  string
+> = {
+  not_provisioned:
+    "AI credits aren't set up yet — manage billing to get started.",
+  below_floor:
+    "Balance too low for AI runs — add credit from the billing page.",
+  no_balance: "Balance too low for AI runs — add credit from the billing page.",
+};
+
+export function CreditsSection() {
+  const [state, setState] = useState<CreditsState>({ kind: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const res = await fetch("/desktop/billing/summary");
+      if (!res.ok) throw new Error("summary_failed");
+      const summary = (await res.json()) as DesktopBillingSummaryResponse;
+      switch (summary.state) {
+        case "signed_out":
+          setState({ kind: "signed-out" });
+          return;
+        case "no_organization":
+          setState({ kind: "no-organization" });
+          return;
+        case "ready":
+          setState({ kind: "ready", summary });
+          return;
+      }
+    } catch {
+      setState({
+        kind: "error",
+        message: "Couldn't load your credit balance.",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      // `load` only touches state after awaits; guard against unmount.
+      if (!cancelled) await load();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  const openBilling = async (manage_path: string) => {
+    try {
+      const bridge = getDesktopBridge();
+      if (!bridge) throw new Error("bridge_missing");
+      // Same-origin path → absolute URL; correct in dev (localhost) and
+      // prod (grida.co). The ipc handler refuses non-http(s).
+      await bridge.shell.open_external(
+        new URL(manage_path, window.location.origin).toString()
+      );
+    } catch {
+      setState({
+        kind: "error",
+        message: "Couldn't open the billing page in your browser.",
+      });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Credits</CardTitle>
+        <CardDescription>
+          AI credit balance for your organization. Top-ups and plan changes are
+          managed on the web.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {state.kind === "loading" ? (
+          <Skeleton className="h-9 w-full" />
+        ) : state.kind === "signed-out" ? (
+          <span className="text-sm text-muted-foreground">
+            Sign in to see your AI credits.
+          </span>
+        ) : state.kind === "no-organization" ? (
+          <span className="text-sm text-muted-foreground">
+            No organization yet — set one up on grida.co.
+          </span>
+        ) : state.kind === "error" ? (
+          <button
+            type="button"
+            role="alert"
+            aria-live="polite"
+            onClick={() => void load()}
+            className="self-start text-left text-sm text-destructive underline-offset-4 hover:underline"
+          >
+            {state.message} (click to retry)
+          </button>
+        ) : (
+          <CreditsRow
+            summary={state.summary}
+            onManage={() => void openBilling(state.summary.manage_path)}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CreditsRow({
+  summary,
+  onManage,
+}: {
+  summary: ReadySummary;
+  onManage: () => void;
+}) {
+  const { organization, plan, credits } = summary;
+  const balance =
+    credits.balance_cents === null
+      ? "—"
+      : `$${(credits.balance_cents / 100).toFixed(2)}`;
+  const hint = credits.blocked_reason
+    ? BLOCKED_HINTS[credits.blocked_reason]
+    : null;
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 text-sm">
+          {organization.display_name}
+          <Badge variant="secondary">{PLAN_LABELS[plan]}</Badge>
+        </span>
+        <span className="text-2xl font-semibold tabular-nums">{balance}</span>
+        {hint ? (
+          <span className="text-xs text-muted-foreground">{hint}</span>
+        ) : null}
+      </div>
+      <Button size="sm" variant="outline" onClick={onManage}>
+        Manage billing
+      </Button>
+    </div>
+  );
+}

--- a/editor/app/desktop/settings/page.tsx
+++ b/editor/app/desktop/settings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+// GRIDA-GG: desktop — GG sign-out + BYOK precedence copy (docs/wg/platform/hosted-ai.md)
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, Trash2 } from "lucide-react";
@@ -35,6 +36,8 @@ import {
   DesktopPageContent,
   DesktopPageShell,
 } from "@/scaffolds/desktop/chrome/page-shell";
+import * as gridaGateway from "@/lib/desktop/gg-session";
+import { CreditsSection } from "./_components/credits-section";
 
 /**
  * Desktop settings — BYOK key slots, version/platform.
@@ -58,11 +61,12 @@ export default function DesktopSettingsPage() {
         <header>
           <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Account, AI provider keys, local models, and app info.
+            Account, credits, AI provider keys, local models, and app info.
           </p>
         </header>
 
         <AccountSection />
+        <CreditsSection />
         <ByokSection />
         <ImageModelsSection />
         <VideoModelsSection />
@@ -118,6 +122,9 @@ function AccountSection() {
   const signOut = async () => {
     setState({ kind: "signing-out" });
     try {
+      // GRIDA-SEC-006 — drop the sidecar's hosted-AI session first
+      // (best-effort; the token's 15-min expiry is the backstop).
+      await gridaGateway.clear();
       await fetch("/desktop/auth/sign-out", { method: "POST" });
     } finally {
       window.location.assign("/desktop/auth/sign-in");
@@ -177,7 +184,8 @@ function ByokSection() {
       <CardHeader>
         <CardTitle>AI Provider Keys</CardTitle>
         <CardDescription>
-          V1 agent runs require a BYOK key. Provider precedence: {precedence}.
+          Optional — when you&apos;re signed in, Grida-included AI is available
+          without a key. Keys you add here take precedence: {precedence}.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-6">

--- a/editor/lib/agent-chat/bridge-transport.ts
+++ b/editor/lib/agent-chat/bridge-transport.ts
@@ -1,6 +1,8 @@
 "use client";
+// GRIDA-GG: desktop — re-mint the GG token before each send (docs/wg/platform/hosted-ai.md)
 
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import * as gridaGateway from "@/lib/desktop/gg-session";
 import {
   AGENT_SKILL_IDS,
   asAgentMode,
@@ -62,6 +64,12 @@ export namespace desktopAgentTransport {
     };
     return {
       async sendMessages(options) {
+        // GRIDA-SEC-006 — keep the sidecar's hosted-AI session fresh before
+        // every send (covers the agent pane, the ai-sidebar, and the AI
+        // SDK's body-less auto-resubmits in one place). Single-flight,
+        // one compare when fresh, and it NEVER throws — hosted AI
+        // degrading must never break a BYOK run.
+        await gridaGateway.ensureFresh();
         const body = readBodyOptions(options.body);
         if (body.session_id) liveSessionId = body.session_id;
         // Backfill the live renderer context (model/provider/mode) so a body-less

--- a/editor/lib/agent-chat/web-daemon-bridge.ts
+++ b/editor/lib/agent-chat/web-daemon-bridge.ts
@@ -1,4 +1,5 @@
 "use client";
+// GRIDA-GG: desktop — the `gg` dev bridge mirror (docs/wg/platform/hosted-ai.md)
 
 /**
  * Web daemon bridge — a `DesktopBridge` implementation for a PLAIN BROWSER
@@ -240,6 +241,12 @@ export function createWebDaemonBridge(
       delete_endpoint: (id) => client.providers.delete_endpoint(id),
       info: () => client.providers.info(),
       probe_endpoint: (baseUrl) => client.providers.probe_endpoint(baseUrl),
+    },
+    // GRIDA-SEC-006 — hosted-session custody push (dev parity with preload).
+    gg: {
+      set_session: (session) => client.gg.set_session(session),
+      clear_session: () => client.gg.clear_session(),
+      status: () => client.gg.status(),
     },
 
     agent: {

--- a/editor/lib/ai/__tests__/generate-video.test.ts
+++ b/editor/lib/ai/__tests__/generate-video.test.ts
@@ -1,0 +1,174 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * `methods.generateVideo` — hosted video through the seam.
+ *
+ * Pins: request validation (unknown/unlisted model, aspect, duration
+ * bounds, resolution label mapping, unpriced (label,mode) pairs,
+ * image_url shape), pre-priced billing (rate × duration, gate BEFORE
+ * the provider call, ingest with the exact mills), and the base64
+ * result contract. Expected mills are computed from the REAL catalog
+ * card so price updates don't rot the test.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { models as ai_models } from "@grida/ai-models";
+
+vi.mock("@/lib/billing/metronome", () => ({
+  getEntitlement: vi.fn<(...args: never[]) => unknown>(),
+  ingestUsageEvent: vi.fn<(...args: never[]) => unknown>(),
+  refreshBalance: vi.fn<(...args: never[]) => unknown>(),
+  BillingMetronomeError: class BillingMetronomeError extends Error {
+    code: string;
+    status: number;
+    constructor(message: string, code: string, status = 500) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  },
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createLibraryClient: vi.fn<(...args: never[]) => unknown>(),
+}));
+vi.mock("@/lib/auth/organization", () => ({
+  requireOrganizationId: vi.fn<(...args: never[]) => unknown>(),
+}));
+vi.mock("ai", async (orig) => ({
+  ...(await orig<typeof import("ai")>()),
+  experimental_generateVideo: vi.fn<(...args: never[]) => unknown>(),
+}));
+
+import { experimental_generateVideo } from "ai";
+import { getEntitlement, ingestUsageEvent } from "@/lib/billing/metronome";
+import { methods, InvalidAiRequestError } from "../server";
+import ai from "@/lib/ai";
+
+const mockedGenerate = vi.mocked(experimental_generateVideo);
+const mockedGetEntitlement = vi.mocked(getEntitlement);
+const mockedIngest = vi.mocked(ingestUsageEvent);
+
+const MODEL_ID = "google/veo-3.1";
+const CARD = ai_models.video.models[MODEL_ID]!;
+const BINDING = ai_models.video.binding(CARD, "vercel")!;
+
+const ORG = 7;
+
+function stubGeneration() {
+  mockedGenerate.mockResolvedValue({
+    video: { base64: "AAAA", mediaType: "video/mp4" },
+    videos: [{ base64: "AAAA", mediaType: "video/mp4" }],
+    warnings: [],
+    responses: [],
+    providerMetadata: {},
+  } as never);
+}
+
+beforeEach(() => {
+  mockedGenerate.mockReset();
+  mockedGetEntitlement.mockReset();
+  mockedIngest.mockReset();
+  mockedGetEntitlement.mockResolvedValue({
+    allowed: true,
+    cachedBalanceCents: 500,
+    cachedAt: null,
+  } as never);
+  mockedIngest.mockResolvedValue({ transactionId: "tx" } as never);
+  stubGeneration();
+});
+
+describe("methods.generateVideo", () => {
+  it("happy path: gates, generates via the vercel binding, ingests rate×duration", async () => {
+    const duration = CARD.default.duration;
+    const result = await methods.generateVideo(ORG, {
+      model_id: MODEL_ID,
+      prompt: "a calm ocean",
+    });
+
+    expect(result).toEqual({
+      model_id: MODEL_ID,
+      provider_id: "vercel",
+      videos: [{ base64: "AAAA", media_type: "video/mp4" }],
+    });
+    expect(mockedGetEntitlement).toHaveBeenCalledWith(ORG);
+
+    const mode = CARD.default.audio ? "audio" : "silent";
+    const rate =
+      BINDING.pricing.usd_per_second[CARD.default.resolution]![mode]!;
+    const expectedMills = ai.toMills(rate * duration);
+    expect(mockedIngest).toHaveBeenCalledTimes(1);
+    expect(mockedIngest.mock.calls[0]![0]).toBe(ORG);
+    expect(mockedIngest.mock.calls[0]![1]).toBe(expectedMills);
+
+    const args = mockedGenerate.mock.calls[0]![0] as {
+      prompt: unknown;
+      duration: number;
+    };
+    expect(args.prompt).toBe("a calm ocean");
+    expect(args.duration).toBe(duration);
+  });
+
+  it("maps an explicit {width}x{height} resolution to the pricing label", async () => {
+    await methods.generateVideo(ORG, {
+      model_id: MODEL_ID,
+      prompt: "x",
+      resolution: "1280x720",
+    });
+    const mode = CARD.default.audio ? "audio" : "silent";
+    const rate = BINDING.pricing.usd_per_second["720p"]![mode]!;
+    expect(mockedIngest.mock.calls[0]![1]).toBe(
+      ai.toMills(rate * CARD.default.duration)
+    );
+  });
+
+  it("rejects unknown models, bad aspect ratios, and out-of-bounds durations", async () => {
+    await expect(
+      methods.generateVideo(ORG, { model_id: "nope/none", prompt: "x" })
+    ).rejects.toBeInstanceOf(InvalidAiRequestError);
+    await expect(
+      methods.generateVideo(ORG, {
+        model_id: MODEL_ID,
+        prompt: "x",
+        aspect_ratio: "7:3",
+      })
+    ).rejects.toBeInstanceOf(InvalidAiRequestError);
+    await expect(
+      methods.generateVideo(ORG, {
+        model_id: MODEL_ID,
+        prompt: "x",
+        duration: CARD.max_duration + 1,
+      })
+    ).rejects.toBeInstanceOf(InvalidAiRequestError);
+    await expect(
+      methods.generateVideo(ORG, {
+        model_id: MODEL_ID,
+        prompt: "x",
+        resolution: "999x111",
+      })
+    ).rejects.toBeInstanceOf(InvalidAiRequestError);
+    expect(mockedGenerate).not.toHaveBeenCalled();
+    expect(mockedIngest).not.toHaveBeenCalled();
+  });
+
+  it("rejects image-to-video (t2v-only v1 — no server-side URL fetch)", async () => {
+    await expect(
+      methods.generateVideo(ORG, {
+        model_id: MODEL_ID,
+        prompt: "x",
+        image_url: "https://example.com/frame.png",
+      })
+    ).rejects.toBeInstanceOf(InvalidAiRequestError);
+    expect(mockedGenerate).not.toHaveBeenCalled();
+  });
+
+  it("blocked orgs never reach the provider", async () => {
+    mockedGetEntitlement.mockResolvedValue({
+      allowed: false,
+      reason: "below_floor",
+      cachedBalanceCents: 5,
+      cachedAt: null,
+    } as never);
+    await expect(
+      methods.generateVideo(ORG, { model_id: MODEL_ID, prompt: "x" })
+    ).rejects.toMatchObject({ code: "blocked" });
+    expect(mockedGenerate).not.toHaveBeenCalled();
+  });
+});

--- a/editor/lib/ai/actions/image-generate.ts
+++ b/editor/lib/ai/actions/image-generate.ts
@@ -17,6 +17,7 @@ import mime from "mime-types";
 import imageSize from "image-size";
 import { service_role } from "@/lib/supabase/server";
 import ai from "@/lib/ai";
+import { computeImageCostMills } from "@/lib/ai/image-cost";
 import { methods, withAiAuth, type AiActionResult } from "@/lib/ai/server";
 
 export type GenerateAiImageInput = {
@@ -46,27 +47,6 @@ export type GenerateAiImageData = {
 
 export type GenerateAiImageResponse = AiActionResult<GenerateAiImageData>;
 
-function computeCostMills(
-  card: ai.image.ImageModelCard,
-  request: { n: number; width?: number; height?: number }
-): number {
-  const n = Math.max(1, request.n);
-  switch (card.pricing.type) {
-    case "per_image_flat":
-      return ai.toMills(card.pricing.usd * n);
-    case "per_image_tiered": {
-      const w = request.width;
-      const h = request.height;
-      const tierKey = w && h ? `medium/${w}x${h}` : undefined;
-      const perImage =
-        (tierKey && card.pricing.tiers[tierKey]) || card.avg_cost_usd;
-      return ai.toMills(perImage * n);
-    }
-    case "per_token":
-      return ai.toMills(card.avg_cost_usd * n);
-  }
-}
-
 export async function generateAiImage(
   input: GenerateAiImageInput
 ): Promise<GenerateAiImageResponse> {
@@ -84,7 +64,7 @@ export async function generateAiImage(
     "ai/image/generate",
     input.organizationId,
     async (organizationId) => {
-      const costMills = computeCostMills(model.card, {
+      const costMills = computeImageCostMills(model.card, {
         n: 1,
         width: input.width,
         height: input.height,

--- a/editor/lib/ai/image-cost.test.ts
+++ b/editor/lib/ai/image-cost.test.ts
@@ -1,0 +1,63 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Shared image cost math. Pins the tier-key shape
+ * `${quality}/${width}x${height}` (the quality axis was previously
+ * hardcoded to `medium` — load-bearing for PerImageTieredPricing),
+ * the off-tier fallback to `avg_cost_usd`, and n-multiplication.
+ */
+import { describe, it, expect } from "vitest";
+import type ai from "@/lib/ai";
+import { computeImageCostMills } from "./image-cost";
+
+type Card = ai.image.ImageModelCard;
+
+const FLAT = {
+  avg_cost_usd: 0.04,
+  pricing: { type: "per_image_flat", usd: 0.03 },
+} as unknown as Card;
+
+const TIERED = {
+  avg_cost_usd: 0.05,
+  pricing: {
+    type: "per_image_tiered",
+    tiers: {
+      "low/1024x1024": 0.011,
+      "medium/1024x1024": 0.042,
+      "high/1024x1024": 0.167,
+    },
+  },
+} as unknown as Card;
+
+const PER_TOKEN = {
+  avg_cost_usd: 0.02,
+  pricing: { type: "per_token" },
+} as unknown as Card;
+
+describe("computeImageCostMills", () => {
+  it("flat: usd × n, ceiled to mills", () => {
+    expect(computeImageCostMills(FLAT, { n: 1 })).toBe(30);
+    expect(computeImageCostMills(FLAT, { n: 3 })).toBe(90);
+    expect(computeImageCostMills(FLAT, {})).toBe(30); // n defaults to 1
+  });
+
+  it("tiered: quality selects the tier (not hardcoded medium)", () => {
+    const size = { width: 1024, height: 1024 };
+    expect(computeImageCostMills(TIERED, { ...size, quality: "low" })).toBe(11);
+    expect(computeImageCostMills(TIERED, { ...size, quality: "high" })).toBe(
+      167
+    );
+    expect(computeImageCostMills(TIERED, { ...size })).toBe(42); // default medium
+    expect(computeImageCostMills(TIERED, { ...size, quality: "auto" })).toBe(
+      42
+    );
+  });
+
+  it("tiered: off-tier sizes and missing sizes fall back to avg_cost_usd", () => {
+    expect(computeImageCostMills(TIERED, { width: 640, height: 480 })).toBe(50);
+    expect(computeImageCostMills(TIERED, {})).toBe(50);
+  });
+
+  it("per_token: bills the card average × n", () => {
+    expect(computeImageCostMills(PER_TOKEN, { n: 2 })).toBe(40);
+  });
+});

--- a/editor/lib/ai/image-cost.ts
+++ b/editor/lib/ai/image-cost.ts
@@ -1,0 +1,50 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Image-generation cost math — the single mills computation shared by
+ * every billed image surface (web server action + hosted
+ * `/api/v1/ai/images/generations`). A billing-correctness surface: do
+ * not fork per call site.
+ */
+import "server-only";
+
+import ai from "@/lib/ai";
+
+const QUALITY_TIERS = new Set(["high", "medium", "low"]);
+
+/**
+ * Pre-computed cost (integer mills) for an image-generation request
+ * against a card's real pricing:
+ *
+ * - `per_image_flat` — flat USD × n.
+ * - `per_image_tiered` — tier key `${quality}/${width}x${height}`
+ *   (quality defaults to `medium`; `auto`/unknown values normalize to
+ *   `medium`). Off-tier requests fall back to the card's
+ *   `avg_cost_usd` — the documented pricing-anchor behavior for
+ *   in-envelope but off-preset sizes.
+ * - `per_token` — priced post-hoc by providers; billed at the card's
+ *   average (the card's documented approximation).
+ */
+export function computeImageCostMills(
+  card: ai.image.ImageModelCard,
+  request: { n?: number; width?: number; height?: number; quality?: string }
+): number {
+  const n = Math.max(1, request.n ?? 1);
+  switch (card.pricing.type) {
+    case "per_image_flat":
+      return ai.toMills(card.pricing.usd * n);
+    case "per_image_tiered": {
+      const { width, height } = request;
+      const quality =
+        request.quality && QUALITY_TIERS.has(request.quality)
+          ? request.quality
+          : "medium";
+      const tierKey =
+        width && height ? `${quality}/${width}x${height}` : undefined;
+      const perImage =
+        (tierKey && card.pricing.tiers[tierKey]) || card.avg_cost_usd;
+      return ai.toMills(perImage * n);
+    }
+    case "per_token":
+      return ai.toMills(card.avg_cost_usd * n);
+  }
+}

--- a/editor/lib/ai/image-cost.ts
+++ b/editor/lib/ai/image-cost.ts
@@ -40,8 +40,11 @@ export function computeImageCostMills(
           : "medium";
       const tierKey =
         width && height ? `${quality}/${width}x${height}` : undefined;
-      const perImage =
-        (tierKey && card.pricing.tiers[tierKey]) || card.avg_cost_usd;
+      // Distinguish an ABSENT tier from a legitimately $0 tier: `|| avg`
+      // would bill a free tier at the average. Only fall back when the
+      // tier entry is truly missing.
+      const tierPrice = tierKey ? card.pricing.tiers[tierKey] : undefined;
+      const perImage = tierPrice !== undefined ? tierPrice : card.avg_cost_usd;
       return ai.toMills(perImage * n);
     }
     case "per_token":

--- a/editor/lib/ai/openai-compat/codec.test.ts
+++ b/editor/lib/ai/openai-compat/codec.test.ts
@@ -1,0 +1,484 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+/**
+ * OpenAI-wire ⇄ LanguageModelV3 codec.
+ *
+ * Pins the pure translation: message decode (incl. tool-name
+ * reconstruction and the parse-on-decode / verbatim-on-encode
+ * tool-argument asymmetry), tool/tool_choice/response_format mapping,
+ * the SSE chunk grammar the `@ai-sdk/openai-compatible` parser
+ * requires (first tool_calls frame carries id+name; usage chunk only
+ * when requested; error frame closes without `[DONE]`).
+ */
+import { describe, it, expect } from "vitest";
+import type {
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+import {
+  WireDecodeError,
+  decodeRequest,
+  encodeCompletion,
+  encodeFinishReason,
+  encodeUsage,
+  streamEncoder,
+} from "./codec";
+import type { ChatCompletionRequest } from "./wire";
+
+const USAGE: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 100,
+    noCache: 90,
+    cacheRead: 10,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 20, text: 15, reasoning: 5 },
+};
+
+function request(
+  partial: Partial<ChatCompletionRequest>
+): ChatCompletionRequest {
+  return {
+    model: "vendor/model",
+    messages: [{ role: "user", content: "hi" }],
+    ...partial,
+  } as ChatCompletionRequest;
+}
+
+describe("decodeRequest", () => {
+  it("decodes the full message roundtrip incl. tool-name reconstruction", () => {
+    const { callOptions } = decodeRequest(
+      request({
+        messages: [
+          { role: "system", content: "be helpful" },
+          { role: "user", content: "weather?" },
+          {
+            role: "assistant",
+            content: "checking",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"city":"Seoul"}',
+                },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "sunny" },
+        ],
+      })
+    );
+    expect(callOptions.prompt).toEqual([
+      { role: "system", content: "be helpful" },
+      { role: "user", content: [{ type: "text", text: "weather?" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "checking" },
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "get_weather",
+            input: { city: "Seoul" }, // parsed on decode (prompt side)
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "get_weather", // reconstructed
+            output: { type: "text", value: "sunny" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects a tool message with an unknown tool_call_id", () => {
+    expect(() =>
+      decodeRequest(
+        request({
+          messages: [{ role: "tool", tool_call_id: "ghost", content: "x" }],
+        })
+      )
+    ).toThrow(WireDecodeError);
+  });
+
+  it("keeps malformed history tool arguments as a raw string", () => {
+    const { callOptions } = decodeRequest(
+      request({
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "c1", function: { name: "t", arguments: "not-json{" } },
+            ],
+          },
+        ],
+      })
+    );
+    const assistant = callOptions.prompt[0] as {
+      content: Array<{ type: string; input?: unknown }>;
+    };
+    expect(assistant.content[0]!.input).toBe("not-json{");
+  });
+
+  it("decodes image parts: data URL → base64 file, http URL → URL", () => {
+    const { callOptions } = decodeRequest(
+      request({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,QUJD" },
+              },
+              {
+                type: "image_url",
+                image_url: { url: "https://grida.test/a.png" },
+              },
+            ],
+          },
+        ],
+      })
+    );
+    const user = callOptions.prompt[0] as { content: unknown[] };
+    expect(user.content[1]).toEqual({
+      type: "file",
+      mediaType: "image/png",
+      data: "QUJD",
+    });
+    expect(user.content[2]).toEqual({
+      type: "file",
+      mediaType: "image/*",
+      data: new URL("https://grida.test/a.png"),
+    });
+  });
+
+  it("rejects unsupported content parts", () => {
+    expect(() =>
+      decodeRequest(
+        request({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "input_audio" } as never],
+            },
+          ],
+        })
+      )
+    ).toThrow(WireDecodeError);
+  });
+
+  it("passes tool definitions through unvalidated and maps tool_choice", () => {
+    const parameters = {
+      type: "object",
+      properties: { q: { madeUpKeyword: true } },
+    };
+    const { callOptions } = decodeRequest(
+      request({
+        tools: [
+          {
+            type: "function",
+            function: { name: "search", description: "d", parameters },
+          },
+        ],
+        tool_choice: { type: "function", function: { name: "search" } },
+      })
+    );
+    expect(callOptions.tools).toEqual([
+      {
+        type: "function",
+        name: "search",
+        description: "d",
+        inputSchema: parameters, // verbatim
+      },
+    ]);
+    expect(callOptions.toolChoice).toEqual({
+      type: "tool",
+      toolName: "search",
+    });
+    expect(
+      decodeRequest(request({ tool_choice: "required" })).callOptions.toolChoice
+    ).toEqual({ type: "required" });
+  });
+
+  it("maps response_format and sampling params", () => {
+    const decoded = decodeRequest(
+      request({
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "out", schema: { type: "object" } },
+        },
+        max_tokens: 100,
+        max_completion_tokens: 200,
+        stop: "END",
+        temperature: 0.5,
+        seed: 42,
+      })
+    );
+    expect(decoded.callOptions.responseFormat).toEqual({
+      type: "json",
+      schema: { type: "object" },
+      name: "out",
+      description: undefined,
+    });
+    expect(decoded.callOptions.maxOutputTokens).toBe(200); // prefer max_completion_tokens
+    expect(decoded.callOptions.stopSequences).toEqual(["END"]);
+    expect(decoded.callOptions.temperature).toBe(0.5);
+    expect(decoded.callOptions.seed).toBe(42);
+    expect(
+      decodeRequest(request({ response_format: { type: "json_object" } }))
+        .callOptions.responseFormat
+    ).toEqual({ type: "json" });
+  });
+
+  it("reads stream flags", () => {
+    const d = decodeRequest(
+      request({ stream: true, stream_options: { include_usage: true } })
+    );
+    expect(d.stream).toBe(true);
+    expect(d.includeUsage).toBe(true);
+    expect(decodeRequest(request({})).stream).toBe(false);
+  });
+});
+
+describe("encodeCompletion / encodeUsage / encodeFinishReason", () => {
+  it("encodes content, reasoning, and verbatim tool arguments", () => {
+    const res = encodeCompletion("vendor/model", {
+      content: [
+        { type: "reasoning", text: "thinking" },
+        { type: "text", text: "done" },
+        {
+          type: "tool-call",
+          toolCallId: "call_9",
+          toolName: "t",
+          input: '{"x":1}', // response side: already a string — verbatim
+        },
+      ],
+      finishReason: { unified: "tool-calls", raw: "tool_calls" },
+      usage: USAGE,
+      warnings: [],
+    });
+    const message = res.choices[0]!.message;
+    expect(message.content).toBe("done");
+    expect(message.reasoning_content).toBe("thinking");
+    expect(message.tool_calls).toEqual([
+      {
+        id: "call_9",
+        type: "function",
+        function: { name: "t", arguments: '{"x":1}' },
+      },
+    ]);
+    expect(res.choices[0]!.finish_reason).toBe("tool_calls");
+    expect(res.usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+      prompt_tokens_details: { cached_tokens: 10 },
+      completion_tokens_details: { reasoning_tokens: 5 },
+    });
+  });
+
+  it("nulls content when only tool calls are present", () => {
+    const res = encodeCompletion("m", {
+      content: [
+        { type: "tool-call", toolCallId: "c", toolName: "t", input: "{}" },
+      ],
+      finishReason: { unified: "tool-calls", raw: undefined },
+      usage: USAGE,
+      warnings: [],
+    });
+    expect(res.choices[0]!.message.content).toBeNull();
+  });
+
+  it("maps finish reasons", () => {
+    expect(encodeFinishReason({ unified: "stop", raw: undefined })).toBe(
+      "stop"
+    );
+    expect(encodeFinishReason({ unified: "length", raw: undefined })).toBe(
+      "length"
+    );
+    expect(
+      encodeFinishReason({ unified: "content-filter", raw: undefined })
+    ).toBe("content_filter");
+    expect(encodeFinishReason({ unified: "error", raw: undefined })).toBe(
+      "stop"
+    );
+    expect(encodeUsage(USAGE).total_tokens).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream encoder
+// ---------------------------------------------------------------------------
+
+async function encodeStream(
+  parts: LanguageModelV3StreamPart[],
+  includeUsage = true
+): Promise<{ frames: unknown[]; done: boolean; raw: string }> {
+  const source = new ReadableStream<LanguageModelV3StreamPart>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+  const reader = source
+    .pipeThrough(streamEncoder("vendor/model", { includeUsage }))
+    .getReader();
+  const decoder = new TextDecoder();
+  let raw = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    raw += decoder.decode(value);
+  }
+  const payloads = raw
+    .split("\n\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length));
+  const done = payloads.at(-1) === "[DONE]";
+  const frames = (done ? payloads.slice(0, -1) : payloads).map((p) =>
+    JSON.parse(p)
+  );
+  return { frames, done, raw };
+}
+
+const FINISH: LanguageModelV3StreamPart = {
+  type: "finish",
+  finishReason: { unified: "stop", raw: "stop" },
+  usage: USAGE,
+};
+
+describe("streamEncoder", () => {
+  it("emits role once, then text deltas, finish, usage, [DONE]", async () => {
+    const { frames, done } = await encodeStream([
+      { type: "stream-start", warnings: [] },
+      { type: "text-start", id: "t0" },
+      { type: "text-delta", id: "t0", delta: "Hel" },
+      { type: "text-delta", id: "t0", delta: "lo" },
+      { type: "text-end", id: "t0" },
+      FINISH,
+    ]);
+    expect(done).toBe(true);
+    const [first, second, finishFrame, usageFrame] = frames as Array<{
+      choices: Array<{
+        delta?: Record<string, unknown>;
+        finish_reason?: string;
+      }>;
+      usage?: { prompt_tokens: number };
+    }>;
+    expect(first!.choices[0]!.delta).toEqual({
+      role: "assistant",
+      content: "Hel",
+    });
+    expect(second!.choices[0]!.delta).toEqual({ content: "lo" });
+    expect(finishFrame!.choices[0]!.finish_reason).toBe("stop");
+    expect(usageFrame!.choices).toEqual([]);
+    expect(usageFrame!.usage!.prompt_tokens).toBe(100);
+  });
+
+  it("omits the usage chunk when include_usage is off", async () => {
+    const { frames } = await encodeStream(
+      [{ type: "text-delta", id: "t", delta: "x" }, FINISH],
+      false
+    );
+    expect(
+      frames.some((f) => (f as { usage?: unknown }).usage !== undefined)
+    ).toBe(false);
+  });
+
+  it("encodes streamed tool calls with id+name on the first frame", async () => {
+    const { frames } = await encodeStream([
+      { type: "tool-input-start", id: "call_1", toolName: "get_weather" },
+      { type: "tool-input-delta", id: "call_1", delta: '{"city":' },
+      { type: "tool-input-delta", id: "call_1", delta: '"Seoul"}' },
+      { type: "tool-input-end", id: "call_1" },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "get_weather",
+        input: '{"city":"Seoul"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_calls" },
+        usage: USAGE,
+      },
+    ]);
+    const toolFrames = (
+      frames as Array<{
+        choices: Array<{ delta?: { tool_calls?: unknown[] } }>;
+      }>
+    ).filter((f) => f.choices?.[0]?.delta?.tool_calls);
+    // start + 2 deltas; the complete tool-call part is a no-op (already streamed)
+    expect(toolFrames).toHaveLength(3);
+    expect(toolFrames[0]!.choices[0]!.delta!.tool_calls![0]).toMatchObject({
+      index: 0,
+      id: "call_1",
+      function: { name: "get_weather", arguments: "" },
+    });
+    expect(toolFrames[1]!.choices[0]!.delta!.tool_calls![0]).toMatchObject({
+      index: 0,
+      function: { arguments: '{"city":' },
+    });
+  });
+
+  it("encodes an atomic tool-call as one full frame", async () => {
+    const { frames } = await encodeStream([
+      {
+        type: "tool-call",
+        toolCallId: "call_2",
+        toolName: "t",
+        input: '{"a":1}',
+      },
+      FINISH,
+    ]);
+    const toolFrame = (
+      frames as Array<{
+        choices: Array<{
+          delta?: { tool_calls?: Array<Record<string, unknown>> };
+        }>;
+      }>
+    ).find((f) => f.choices?.[0]?.delta?.tool_calls);
+    expect(toolFrame!.choices[0]!.delta!.tool_calls![0]).toMatchObject({
+      index: 0,
+      id: "call_2",
+      function: { name: "t", arguments: '{"a":1}' },
+    });
+  });
+
+  it("maps reasoning deltas to reasoning_content", async () => {
+    const { frames } = await encodeStream([
+      { type: "reasoning-delta", id: "r", delta: "hmm" },
+      FINISH,
+    ]);
+    expect(
+      (frames[0] as { choices: Array<{ delta: Record<string, unknown> }> })
+        .choices[0]!.delta.reasoning_content
+    ).toBe("hmm");
+  });
+
+  it("sanitizes stream errors and closes without [DONE]", async () => {
+    const { frames, done, raw } = await encodeStream([
+      { type: "text-delta", id: "t", delta: "partial" },
+      {
+        type: "error",
+        error: new Error("secret: METRONOME_API_TOKEN missing"),
+      },
+    ]);
+    expect(done).toBe(false);
+    const errorFrame = frames.at(-1) as {
+      error?: { code: string; message: string };
+    };
+    expect(errorFrame.error!.code).toBe("stream_error");
+    expect(raw).not.toContain("METRONOME");
+  });
+});

--- a/editor/lib/ai/openai-compat/codec.test.ts
+++ b/editor/lib/ai/openai-compat/codec.test.ts
@@ -128,7 +128,7 @@ describe("decodeRequest", () => {
     expect(assistant.content[0]!.input).toBe("not-json{");
   });
 
-  it("decodes image parts: data URL → base64 file, http URL → URL", () => {
+  it("decodes a data: image part to base64", () => {
     const { callOptions } = decodeRequest(
       request({
         messages: [
@@ -139,10 +139,6 @@ describe("decodeRequest", () => {
               {
                 type: "image_url",
                 image_url: { url: "data:image/png;base64,QUJD" },
-              },
-              {
-                type: "image_url",
-                image_url: { url: "https://grida.test/a.png" },
               },
             ],
           },
@@ -155,11 +151,26 @@ describe("decodeRequest", () => {
       mediaType: "image/png",
       data: "QUJD",
     });
-    expect(user.content[2]).toEqual({
-      type: "file",
-      mediaType: "image/*",
-      data: new URL("https://grida.test/a.png"),
-    });
+  });
+
+  it("rejects a remote image_url (SSRF surface — data: only)", () => {
+    expect(() =>
+      decodeRequest(
+        request({
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image_url",
+                  image_url: { url: "https://grida.test/a.png" },
+                },
+              ],
+            },
+          ],
+        })
+      )
+    ).toThrow(/data:/);
   });
 
   it("rejects unsupported content parts", () => {

--- a/editor/lib/ai/openai-compat/codec.ts
+++ b/editor/lib/ai/openai-compat/codec.ts
@@ -1,0 +1,526 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * OpenAI chat-completions wire ⇄ AI SDK LanguageModelV3 codec.
+ *
+ * Deliberately at the **LanguageModelV3** level (`doGenerate`/`doStream`
+ * call options and stream parts), not `streamText`: this is the exact
+ * mirror image of what `@ai-sdk/openai-compatible` does client-side, so
+ * tool definitions pass through unvalidated, tool-argument text streams
+ * byte-for-byte, and the billing middleware baked into the seam's model
+ * objects (gate pre-upstream, ingest on finish — `lib/ai/server.ts`)
+ * applies with zero route-side billing code.
+ *
+ * Wire-fidelity notes pinned by the client's own dist:
+ * - PROMPT-side tool-call `input` is a parsed object (the client
+ *   `JSON.stringify`s it when re-encoding history); RESPONSE-side
+ *   `LanguageModelV3ToolCall.input` is already the raw arguments
+ *   string — decode parses, encode passes through verbatim.
+ * - OpenAI `tool` messages carry no tool name; V3 `tool-result` parts
+ *   require one — reconstructed from prior assistant `tool_calls`;
+ *   an unresolvable `tool_call_id` is a 400.
+ * - The client's chunk parser requires the FIRST `tool_calls` delta of
+ *   an index to carry `id` + `function.name`, accumulates argument
+ *   deltas, and completes a call as soon as the accumulated string
+ *   parses as JSON (flush covers the remainder).
+ *
+ * Pure codec — no IO, no billing, no auth. Pinned by `codec.test.ts`
+ * and driven end-to-end by the route contract tests with
+ * `@ai-sdk/openai-compatible` as the client.
+ */
+import type {
+  JSONSchema7,
+  LanguageModelV3CallOptions,
+  LanguageModelV3FinishReason,
+  LanguageModelV3FunctionTool,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3Message,
+  LanguageModelV3StreamPart,
+  LanguageModelV3ToolChoice,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider";
+import type {
+  ChatCompletionChunk,
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  WireFinishReason,
+  WireResponseToolCall,
+  WireUsage,
+} from "./wire";
+
+/** Request-shape failure the routes map to an OpenAI 400 envelope. */
+export class WireDecodeError extends Error {}
+
+export type DecodedChatRequest = {
+  callOptions: Omit<LanguageModelV3CallOptions, "providerOptions">;
+  stream: boolean;
+  includeUsage: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Decode: OpenAI request → V3 call options
+// ---------------------------------------------------------------------------
+
+export function decodeRequest(req: ChatCompletionRequest): DecodedChatRequest {
+  const prompt = decodeMessages(req.messages);
+
+  const tools = req.tools?.map(
+    (tool): LanguageModelV3FunctionTool => ({
+      type: "function",
+      name: tool.function.name,
+      description: tool.function.description ?? undefined,
+      // Passthrough, unvalidated — the JSON Schema body is the model's
+      // contract with the caller, not ours.
+      inputSchema: (tool.function.parameters ?? {}) as JSONSchema7,
+    })
+  );
+
+  let toolChoice: LanguageModelV3ToolChoice | undefined;
+  if (req.tool_choice != null) {
+    if (typeof req.tool_choice === "string") {
+      toolChoice = { type: req.tool_choice };
+    } else {
+      toolChoice = { type: "tool", toolName: req.tool_choice.function.name };
+    }
+  }
+
+  let responseFormat: LanguageModelV3CallOptions["responseFormat"];
+  if (req.response_format?.type === "json_object") {
+    responseFormat = { type: "json" };
+  } else if (req.response_format?.type === "json_schema") {
+    responseFormat = {
+      type: "json",
+      schema: (req.response_format.json_schema.schema ?? undefined) as
+        | JSONSchema7
+        | undefined,
+      name: req.response_format.json_schema.name ?? undefined,
+      description: req.response_format.json_schema.description ?? undefined,
+    };
+  } else if (req.response_format?.type === "text") {
+    responseFormat = { type: "text" };
+  }
+
+  return {
+    callOptions: {
+      prompt,
+      maxOutputTokens: req.max_completion_tokens ?? req.max_tokens ?? undefined,
+      temperature: req.temperature ?? undefined,
+      topP: req.top_p ?? undefined,
+      frequencyPenalty: req.frequency_penalty ?? undefined,
+      presencePenalty: req.presence_penalty ?? undefined,
+      stopSequences:
+        req.stop == null
+          ? undefined
+          : Array.isArray(req.stop)
+            ? req.stop
+            : [req.stop],
+      seed: req.seed ?? undefined,
+      responseFormat,
+      tools,
+      toolChoice,
+    },
+    stream: req.stream === true,
+    includeUsage: req.stream_options?.include_usage === true,
+  };
+}
+
+function decodeMessages(
+  messages: ChatCompletionRequest["messages"]
+): LanguageModelV3Message[] {
+  // OpenAI `tool` messages carry no tool name — reconstruct from the
+  // assistant turns seen so far.
+  const toolNameById = new Map<string, string>();
+  const prompt: LanguageModelV3Message[] = [];
+
+  for (const message of messages) {
+    switch (message.role) {
+      case "system": {
+        prompt.push({ role: "system", content: message.content });
+        break;
+      }
+      case "user": {
+        prompt.push({
+          role: "user",
+          content: decodeUserContent(message.content),
+        });
+        break;
+      }
+      case "assistant": {
+        const content: Extract<
+          LanguageModelV3Message,
+          { role: "assistant" }
+        >["content"] = [];
+        if (message.reasoning_content) {
+          content.push({ type: "reasoning", text: message.reasoning_content });
+        }
+        if (message.content) {
+          content.push({ type: "text", text: message.content });
+        }
+        for (const call of message.tool_calls ?? []) {
+          toolNameById.set(call.id, call.function.name);
+          content.push({
+            type: "tool-call",
+            toolCallId: call.id,
+            toolName: call.function.name,
+            input: parseToolArguments(call.function.arguments),
+          });
+        }
+        prompt.push({ role: "assistant", content });
+        break;
+      }
+      case "tool": {
+        const toolName = toolNameById.get(message.tool_call_id);
+        if (!toolName) {
+          throw new WireDecodeError(
+            `tool message references unknown tool_call_id "${message.tool_call_id}"`
+          );
+        }
+        prompt.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: message.tool_call_id,
+              toolName,
+              output: { type: "text", value: message.content },
+            },
+          ],
+        });
+        break;
+      }
+    }
+  }
+  return prompt;
+}
+
+function decodeUserContent(
+  content: string | Array<{ type: string } & Record<string, unknown>>
+): Extract<LanguageModelV3Message, { role: "user" }>["content"] {
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  return content.map((part) => {
+    switch (part.type) {
+      case "text":
+        return { type: "text" as const, text: part.text as string };
+      case "image_url": {
+        const url = (part.image_url as { url: string }).url;
+        return decodeImageUrl(url);
+      }
+      default:
+        throw new WireDecodeError(
+          `unsupported content part type "${part.type}"`
+        );
+    }
+  });
+}
+
+const DATA_URL = /^data:([^;,]+);base64,([\s\S]*)$/;
+
+function decodeImageUrl(url: string): {
+  type: "file";
+  data: string | URL;
+  mediaType: string;
+} {
+  const dataMatch = DATA_URL.exec(url);
+  if (dataMatch) {
+    return {
+      type: "file",
+      mediaType: dataMatch[1]!,
+      data: dataMatch[2]!,
+    };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new WireDecodeError("image_url must be a data: URL or absolute URL");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new WireDecodeError("image_url must use http(s) or data:");
+  }
+  return { type: "file", mediaType: "image/*", data: parsed };
+}
+
+/**
+ * History tool-call arguments arrive as a JSON string; the V3
+ * PROMPT-side part wants the parsed value (providers re-stringify it).
+ * An unparseable string is passed through as-is rather than crashing —
+ * degraded fidelity beats a hard failure on a forwardable value.
+ */
+function parseToolArguments(args: string): unknown {
+  try {
+    return JSON.parse(args);
+  } catch {
+    return args;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Encode: V3 results → OpenAI wire
+// ---------------------------------------------------------------------------
+
+export function encodeUsage(usage: LanguageModelV3Usage): WireUsage {
+  const prompt = usage.inputTokens.total ?? 0;
+  const completion = usage.outputTokens.total ?? 0;
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+    prompt_tokens_details: { cached_tokens: usage.inputTokens.cacheRead ?? 0 },
+    completion_tokens_details: {
+      reasoning_tokens: usage.outputTokens.reasoning ?? 0,
+    },
+  };
+}
+
+export function encodeFinishReason(
+  reason: LanguageModelV3FinishReason
+): WireFinishReason {
+  switch (reason.unified) {
+    case "length":
+      return "length";
+    case "content-filter":
+      return "content_filter";
+    case "tool-calls":
+      return "tool_calls";
+    case "stop":
+    case "error":
+    case "other":
+      return "stop";
+  }
+}
+
+export function encodeCompletion(
+  modelId: string,
+  result: LanguageModelV3GenerateResult
+): ChatCompletionResponse {
+  let text = "";
+  let reasoning = "";
+  const toolCalls: WireResponseToolCall[] = [];
+
+  for (const part of result.content) {
+    switch (part.type) {
+      case "text":
+        text += part.text;
+        break;
+      case "reasoning":
+        reasoning += part.text;
+        break;
+      case "tool-call":
+        // RESPONSE-side V3 `input` is already the raw arguments string.
+        toolCalls.push({
+          id: part.toolCallId,
+          type: "function",
+          function: { name: part.toolName, arguments: part.input },
+        });
+        break;
+      default:
+        break; // files/sources/provider-tool parts have no wire slot
+    }
+  }
+
+  return {
+    id: chunkId(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: modelId,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: toolCalls.length > 0 ? text || null : text,
+          ...(reasoning ? { reasoning_content: reasoning } : {}),
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: encodeFinishReason(result.finishReason),
+      },
+    ],
+    usage: encodeUsage(result.usage),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stream encode: V3 parts → OpenAI SSE
+// ---------------------------------------------------------------------------
+
+function chunkId(): string {
+  return `chatcmpl-${crypto.randomUUID()}`;
+}
+
+/**
+ * Encodes the V3 stream as OpenAI SSE. Frames:
+ * - content chunks (`role` on the first content-bearing delta),
+ * - `tool_calls` deltas (`index`-keyed; first frame per call carries
+ *   `id` + `function.name`, per the client parser's hard requirement),
+ * - a `finish_reason` chunk, then — iff requested — a `choices: []`
+ *   usage chunk, then `data: [DONE]`.
+ * - a V3 `error` part becomes an OpenAI error frame (sanitized) and the
+ *   stream closes WITHOUT `[DONE]` — the client surfaces a stream error.
+ */
+export function streamEncoder(
+  modelId: string,
+  opts: { includeUsage: boolean }
+): TransformStream<LanguageModelV3StreamPart, Uint8Array> {
+  const textEncoder = new TextEncoder();
+  const id = chunkId();
+  const created = Math.floor(Date.now() / 1000);
+
+  let sentRole = false;
+  let errored = false;
+  let finish: {
+    reason: LanguageModelV3FinishReason;
+    usage: LanguageModelV3Usage;
+  } | null = null;
+  const toolIndexById = new Map<string, number>();
+
+  function frame(payload: unknown): Uint8Array {
+    return textEncoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+  }
+
+  function contentChunk(
+    delta: ChatCompletionChunk["choices"][0]["delta"]
+  ): ChatCompletionChunk {
+    if (!sentRole) {
+      sentRole = true;
+      delta = { role: "assistant", ...delta };
+    }
+    return {
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model: modelId,
+      choices: [{ index: 0, delta }],
+    };
+  }
+
+  return new TransformStream<LanguageModelV3StreamPart, Uint8Array>({
+    transform(part, controller) {
+      if (errored) return;
+      switch (part.type) {
+        case "text-delta":
+          controller.enqueue(frame(contentChunk({ content: part.delta })));
+          break;
+        case "reasoning-delta":
+          controller.enqueue(
+            frame(contentChunk({ reasoning_content: part.delta }))
+          );
+          break;
+        case "tool-input-start": {
+          const index = toolIndexById.size;
+          toolIndexById.set(part.id, index);
+          controller.enqueue(
+            frame(
+              contentChunk({
+                tool_calls: [
+                  {
+                    index,
+                    id: part.id,
+                    type: "function",
+                    function: { name: part.toolName, arguments: "" },
+                  },
+                ],
+              })
+            )
+          );
+          break;
+        }
+        case "tool-input-delta": {
+          const index = toolIndexById.get(part.id);
+          if (index === undefined) break;
+          controller.enqueue(
+            frame(
+              contentChunk({
+                tool_calls: [{ index, function: { arguments: part.delta } }],
+              })
+            )
+          );
+          break;
+        }
+        case "tool-call": {
+          // Providers may emit a complete call without input-start/deltas
+          // (atomic emission) — encode it as one full frame. Calls that
+          // already streamed are complete client-side; skip.
+          if (toolIndexById.has(part.toolCallId)) break;
+          const index = toolIndexById.size;
+          toolIndexById.set(part.toolCallId, index);
+          controller.enqueue(
+            frame(
+              contentChunk({
+                tool_calls: [
+                  {
+                    index,
+                    id: part.toolCallId,
+                    type: "function",
+                    function: {
+                      name: part.toolName,
+                      arguments: part.input, // raw string, verbatim
+                    },
+                  },
+                ],
+              })
+            )
+          );
+          break;
+        }
+        case "finish":
+          finish = { reason: part.finishReason, usage: part.usage };
+          break;
+        case "error": {
+          errored = true;
+          // Never leak upstream error detail to the wire.
+          console.error(
+            `[v1/ai/chat] stream error (model=${modelId}):`,
+            part.error
+          );
+          controller.enqueue(
+            frame({
+              error: {
+                message: "The model stream ended with an error.",
+                type: "server_error",
+                code: "stream_error",
+              },
+            })
+          );
+          break;
+        }
+        default:
+          break; // stream-start / *-start / *-end / metadata / raw / files
+      }
+    },
+    flush(controller) {
+      if (errored) return; // no [DONE] after an error frame
+      if (finish) {
+        controller.enqueue(
+          frame({
+            id,
+            object: "chat.completion.chunk",
+            created,
+            model: modelId,
+            choices: [
+              {
+                index: 0,
+                delta: {},
+                finish_reason: encodeFinishReason(finish.reason),
+              },
+            ],
+          } satisfies ChatCompletionChunk)
+        );
+        if (opts.includeUsage) {
+          controller.enqueue(
+            frame({
+              id,
+              object: "chat.completion.chunk",
+              created,
+              model: modelId,
+              choices: [],
+              usage: encodeUsage(finish.usage),
+            })
+          );
+        }
+      }
+      controller.enqueue(textEncoder.encode("data: [DONE]\n\n"));
+    },
+  });
+}

--- a/editor/lib/ai/openai-compat/codec.ts
+++ b/editor/lib/ai/openai-compat/codec.ts
@@ -219,7 +219,7 @@ const DATA_URL = /^data:([^;,]+);base64,([\s\S]*)$/;
 
 function decodeImageUrl(url: string): {
   type: "file";
-  data: string | URL;
+  data: string;
   mediaType: string;
 } {
   const dataMatch = DATA_URL.exec(url);
@@ -230,16 +230,14 @@ function decodeImageUrl(url: string): {
       data: dataMatch[2]!,
     };
   }
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new WireDecodeError("image_url must be a data: URL or absolute URL");
-  }
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    throw new WireDecodeError("image_url must use http(s) or data:");
-  }
-  return { type: "file", mediaType: "image/*", data: parsed };
+  // Reject remote URLs. Passing one through as a file part lets the AI SDK
+  // fetch it SERVER-SIDE when the provider doesn't declare it supported — an
+  // SSRF surface behind this authenticated seam. v1 accepts inline `data:`
+  // images only (the desktop sidecar sends base64), mirroring the hosted
+  // video route's text-to-video-only posture.
+  throw new WireDecodeError(
+    "image_url must be a data: URL — remote URLs are not accepted"
+  );
 }
 
 /**

--- a/editor/lib/ai/openai-compat/errors.ts
+++ b/editor/lib/ai/openai-compat/errors.ts
@@ -122,6 +122,12 @@ export function fromUnknownError(err: unknown, scope: string): Response {
           type: "server_error",
           message: "Hosted AI is not configured on this deployment.",
         });
+      default: {
+        // Compile-time guard: a new GgTokenError code must be handled here
+        // rather than silently collapsing to the generic 500 below.
+        const _exhaustive: never = err.code;
+        return _exhaustive;
+      }
     }
   }
   if (err instanceof WireDecodeError) {

--- a/editor/lib/ai/openai-compat/errors.ts
+++ b/editor/lib/ai/openai-compat/errors.ts
@@ -1,0 +1,154 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * OpenAI-wire error envelope for the hosted `/api/v1/ai/*` chat/models
+ * routes: `{ error: { message, type, code } }`.
+ *
+ * Mapping discipline mirrors `editor/lib/ai/error.ts`: the billing
+ * "blocked" message is the only failure a client sees verbatim (it is
+ * curated for end users); everything unexpected collapses to a
+ * sanitized `internal` with the raw error logged server-side only.
+ */
+import "server-only";
+
+import { z } from "zod";
+import { GgTokenError } from "@/lib/auth/gg-token";
+import { WireDecodeError } from "./codec";
+
+const NO_STORE = { "cache-control": "no-store" } as const;
+
+export type OpenAIErrorCode =
+  | "token_expired"
+  | "invalid_token"
+  | "not_configured"
+  | "insufficient_credits"
+  | "model_not_found"
+  | "invalid_request_error"
+  | "rate_limit_exceeded"
+  | "internal";
+
+export function openaiError(
+  status: number,
+  body: { code: OpenAIErrorCode; type: string; message: string },
+  headers?: Record<string, string>
+): Response {
+  return Response.json(
+    { error: body },
+    { status, headers: { ...NO_STORE, ...headers } }
+  );
+}
+
+export function modelNotFound(modelId: string): Response {
+  return openaiError(404, {
+    code: "model_not_found",
+    type: "invalid_request_error",
+    message: `The model \`${modelId}\` does not exist or is not available.`,
+  });
+}
+
+export function invalidRequest(message: string): Response {
+  return openaiError(400, {
+    code: "invalid_request_error",
+    type: "invalid_request_error",
+    message,
+  });
+}
+
+/**
+ * Read + validate a JSON request body against a zod schema — the single
+ * body-parse path shared by the POST gateway routes. On failure returns a
+ * ready `invalidRequest` Response (non-JSON body, or the first schema issue
+ * formatted `path: message`); on success returns the parsed data.
+ */
+export async function parseJsonRequest<S extends z.ZodType>(
+  request: Request,
+  schema: S
+): Promise<{ ok: true; data: z.infer<S> } | { ok: false; res: Response }> {
+  const body = await request.json().catch(() => null);
+  if (body === null) {
+    return { ok: false, res: invalidRequest("request body must be JSON") };
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return {
+      ok: false,
+      res: invalidRequest(
+        issue
+          ? `${issue.path.join(".") || "body"}: ${issue.message}`
+          : "invalid request"
+      ),
+    };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+export function rateLimited(retryAfterSeconds?: number): Response {
+  return openaiError(
+    429,
+    {
+      code: "rate_limit_exceeded",
+      type: "rate_limit_error",
+      message: "Rate limit exceeded. Please retry later.",
+    },
+    retryAfterSeconds !== undefined
+      ? { "retry-after": String(Math.max(1, Math.ceil(retryAfterSeconds))) }
+      : undefined
+  );
+}
+
+/**
+ * Terminal catch for the hosted chat/models routes. Never leaks
+ * Metronome/Postgres/provider internals.
+ */
+export function fromUnknownError(err: unknown, scope: string): Response {
+  if (err instanceof GgTokenError) {
+    switch (err.code) {
+      case "token_expired":
+        return openaiError(401, {
+          code: "token_expired",
+          type: "authentication_error",
+          message: "The access token has expired. Mint a new one.",
+        });
+      case "invalid_token":
+        return openaiError(401, {
+          code: "invalid_token",
+          type: "authentication_error",
+          message: "Invalid access token.",
+        });
+      case "not_configured":
+        return openaiError(503, {
+          code: "not_configured",
+          type: "server_error",
+          message: "Hosted AI is not configured on this deployment.",
+        });
+    }
+  }
+  if (err instanceof WireDecodeError) {
+    return invalidRequest(err.message);
+  }
+  // Seam request-shape failures (`InvalidAiRequestError` — duck-typed):
+  // the message describes the request, never internals.
+  if (
+    err instanceof Error &&
+    (err as { code?: unknown }).code === "invalid_request"
+  ) {
+    return invalidRequest(err.message);
+  }
+  // Billing gate — `BillingMetronomeError` code "blocked" (duck-typed to
+  // keep this module's import surface minimal). The message is curated
+  // for end-user display; pass it through.
+  if (err instanceof Error && (err as { code?: unknown }).code === "blocked") {
+    return openaiError(402, {
+      code: "insufficient_credits",
+      type: "insufficient_quota",
+      message: err.message,
+    });
+  }
+  console.error(`[${scope}]`, err);
+  return openaiError(500, {
+    code: "internal",
+    type: "server_error",
+    message: "Something went wrong. Please try again.",
+  });
+}

--- a/editor/lib/ai/openai-compat/hosted-models.ts
+++ b/editor/lib/ai/openai-compat/hosted-models.ts
@@ -1,0 +1,114 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Hosted-model allowlist — the single availability source for the
+ * `/api/v1/ai/*` endpoints, composed from the ONE catalog
+ * (`@grida/ai-models`) so nothing drifts:
+ *
+ * - text: every catalog entry (a catalog entry IS hosted-servable by
+ *   construction — the seam's cost math resolves from it). Deprecated
+ *   entries stay CALLABLE (a pinned client id must not break the day a
+ *   sibling supersedes it; removal from the catalog is the kill
+ *   switch) and are flagged on `/models`.
+ * - image/video: listed cards carrying a `vercel` binding (what the
+ *   seam can serve through the gateway).
+ *
+ * Deliberately NO pricing in the payload — pricing is a billing-page
+ * concern; exposing per-token USD here invites client-side cost math
+ * that drifts from Metronome.
+ */
+import { models, TIER_MODEL_IDS, type ModelTier } from "@grida/ai-models";
+import { catalog } from "../models";
+
+export type HostedModelEntry = {
+  id: string;
+  object: "model";
+  created: number;
+  owned_by: string;
+  grida: {
+    modality: "text" | "image" | "video";
+    tier: ModelTier | null;
+    label: string;
+    deprecated: boolean;
+  };
+};
+
+export function isHostedTextModel(modelId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(catalog, modelId);
+}
+
+const TIER_BY_MODEL_ID: Readonly<Record<string, ModelTier>> =
+  Object.fromEntries(
+    (Object.entries(TIER_MODEL_IDS) as [ModelTier, string][]).map(
+      ([tier, id]) => [id, tier]
+    )
+  );
+
+function ownerOf(modelId: string): string {
+  const slash = modelId.indexOf("/");
+  return slash > 0 ? modelId.slice(0, slash) : "grida";
+}
+
+let _hostedModelList: readonly HostedModelEntry[] | null = null;
+
+/**
+ * The `/models` listing. Derived purely from static catalog constants, so
+ * it is built once and cached — every request returns the same array.
+ */
+export function hostedModelList(): readonly HostedModelEntry[] {
+  return (_hostedModelList ??= buildHostedModelList());
+}
+
+function buildHostedModelList(): HostedModelEntry[] {
+  const entries: HostedModelEntry[] = [];
+
+  for (const spec of Object.values(catalog)) {
+    entries.push({
+      id: spec.id,
+      object: "model",
+      created: 0,
+      owned_by: ownerOf(spec.id),
+      grida: {
+        modality: "text",
+        tier: TIER_BY_MODEL_ID[spec.id] ?? null,
+        label: spec.label,
+        deprecated: spec.deprecated === true,
+      },
+    });
+  }
+
+  for (const card of models.image.listed_models()) {
+    if (!models.image.binding(card, "vercel")) continue;
+    entries.push({
+      id: card.id,
+      object: "model",
+      created: 0,
+      owned_by: ownerOf(card.id),
+      grida: {
+        modality: "image",
+        tier: null,
+        label: card.label,
+        deprecated: false,
+      },
+    });
+  }
+
+  for (const card of models.video.listed_models()) {
+    if (!models.video.binding(card, "vercel")) continue;
+    entries.push({
+      id: card.id,
+      object: "model",
+      created: 0,
+      owned_by: ownerOf(card.id),
+      grida: {
+        modality: "video",
+        tier: null,
+        label: card.label,
+        deprecated: false,
+      },
+    });
+  }
+
+  return entries;
+}

--- a/editor/lib/ai/openai-compat/limits.ts
+++ b/editor/lib/ai/openai-compat/limits.ts
@@ -1,0 +1,62 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * Per-user rate limits for the hosted `/api/v1/ai/*` endpoints.
+ *
+ * Abuse damping only — the billing gate (entitlement + balance floor)
+ * is the real spend control. Keyed on the token's `sub` (per-user, not
+ * per-org: org-keying would let one member starve another; the
+ * entitlement gate already bounds org spend). Upstash sliding window
+ * when configured; fail-open in unconfigured envs (local dev) — the
+ * same posture as the library search limiter.
+ */
+import "server-only";
+
+type Limiter = {
+  limit(key: string): Promise<{ success: boolean; reset: number }>;
+};
+
+type LimiterName = "chat" | "models" | "images" | "video";
+
+const CONFIG: Record<LimiterName, { tokens: number; window: `${number} s` }> = {
+  chat: { tokens: 60, window: "60 s" },
+  models: { tokens: 60, window: "60 s" },
+  images: { tokens: 12, window: "60 s" },
+  video: { tokens: 4, window: "600 s" },
+};
+
+const _limiters = new Map<LimiterName, Limiter | null>();
+
+async function limiterFor(name: LimiterName): Promise<Limiter | null> {
+  if (_limiters.has(name)) return _limiters.get(name)!;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    _limiters.set(name, null);
+    return null;
+  }
+  const [{ Ratelimit }, { Redis }] = await Promise.all([
+    import("@upstash/ratelimit"),
+    import("@upstash/redis"),
+  ]);
+  const { tokens, window } = CONFIG[name];
+  const limiter = new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(tokens, window),
+    prefix: `rl:v1-ai:${name}`,
+  });
+  _limiters.set(name, limiter);
+  return limiter;
+}
+
+export async function allowAiRequest(
+  name: LimiterName,
+  userId: string
+): Promise<{ success: boolean; retryAfterSeconds?: number }> {
+  const limiter = await limiterFor(name);
+  if (!limiter) return { success: true };
+  const { success, reset } = await limiter.limit(userId);
+  return success
+    ? { success }
+    : { success, retryAfterSeconds: Math.max(1, (reset - Date.now()) / 1000) };
+}

--- a/editor/lib/ai/openai-compat/wire.ts
+++ b/editor/lib/ai/openai-compat/wire.ts
@@ -1,0 +1,200 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: gateway — see docs/wg/platform/hosted-ai.md
+/**
+ * OpenAI chat-completions WIRE contract — hand-written types + request
+ * schema for the hosted `/api/v1/ai/chat/completions` endpoint.
+ *
+ * This file is the contract, not a vendor mirror: no `openai` SDK
+ * import. The shapes are pinned by what our own consumer sends and
+ * parses — `@ai-sdk/openai-compatible` (the desktop sidecar's client),
+ * whose zod schemas the contract tests drive end-to-end. Tolerant
+ * reader: unknown fields are ignored (`looseObject`), unsupported parts
+ * are rejected explicitly in the codec with a 400.
+ */
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+const textPartSchema = z.looseObject({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+const imagePartSchema = z.looseObject({
+  type: z.literal("image_url"),
+  image_url: z.looseObject({ url: z.string() }),
+});
+
+/** Recognized but unsupported in v1 — the codec rejects with a 400. */
+const unsupportedPartSchema = z.looseObject({
+  type: z.enum(["input_audio", "file"]),
+});
+
+const userContentPartSchema = z.union([
+  textPartSchema,
+  imagePartSchema,
+  unsupportedPartSchema,
+]);
+
+const wireToolCallSchema = z.looseObject({
+  id: z.string(),
+  type: z.literal("function").nullish(),
+  function: z.looseObject({
+    name: z.string(),
+    arguments: z.string(),
+  }),
+});
+
+const messageSchema = z.union([
+  z.looseObject({
+    role: z.literal("system"),
+    content: z.string(),
+  }),
+  z.looseObject({
+    role: z.literal("user"),
+    content: z.union([z.string(), z.array(userContentPartSchema)]),
+  }),
+  z.looseObject({
+    role: z.literal("assistant"),
+    content: z.string().nullish(),
+    reasoning_content: z.string().nullish(),
+    tool_calls: z.array(wireToolCallSchema).nullish(),
+  }),
+  z.looseObject({
+    role: z.literal("tool"),
+    tool_call_id: z.string(),
+    content: z.string(),
+  }),
+]);
+
+export const chatCompletionRequestSchema = z.looseObject({
+  model: z.string(),
+  messages: z.array(messageSchema).min(1),
+  tools: z
+    .array(
+      z.looseObject({
+        type: z.literal("function"),
+        function: z.looseObject({
+          name: z.string(),
+          description: z.string().nullish(),
+          parameters: z.record(z.string(), z.unknown()).nullish(),
+        }),
+      })
+    )
+    .nullish(),
+  tool_choice: z
+    .union([
+      z.enum(["auto", "none", "required"]),
+      z.looseObject({
+        type: z.literal("function"),
+        function: z.looseObject({ name: z.string() }),
+      }),
+    ])
+    .nullish(),
+  max_tokens: z.number().int().positive().nullish(),
+  max_completion_tokens: z.number().int().positive().nullish(),
+  temperature: z.number().nullish(),
+  top_p: z.number().nullish(),
+  frequency_penalty: z.number().nullish(),
+  presence_penalty: z.number().nullish(),
+  stop: z.union([z.string(), z.array(z.string())]).nullish(),
+  seed: z.number().int().nullish(),
+  response_format: z
+    .union([
+      z.looseObject({ type: z.literal("text") }),
+      z.looseObject({ type: z.literal("json_object") }),
+      z.looseObject({
+        type: z.literal("json_schema"),
+        json_schema: z.looseObject({
+          name: z.string().nullish(),
+          description: z.string().nullish(),
+          schema: z.record(z.string(), z.unknown()).nullish(),
+        }),
+      }),
+    ])
+    .nullish(),
+  stream: z.boolean().nullish(),
+  stream_options: z
+    .looseObject({ include_usage: z.boolean().nullish() })
+    .nullish(),
+});
+
+export type ChatCompletionRequest = z.infer<typeof chatCompletionRequestSchema>;
+export type WireMessage = z.infer<typeof messageSchema>;
+
+// ---------------------------------------------------------------------------
+// Response (what we emit — mirrors what the openai-compatible client parses)
+// ---------------------------------------------------------------------------
+
+export type WireUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  prompt_tokens_details: { cached_tokens: number };
+  completion_tokens_details: { reasoning_tokens: number };
+};
+
+export type WireResponseToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+};
+
+export type ChatCompletionResponse = {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: 0;
+    message: {
+      role: "assistant";
+      content: string | null;
+      reasoning_content?: string;
+      tool_calls?: WireResponseToolCall[];
+    };
+    finish_reason: WireFinishReason;
+  }>;
+  usage: WireUsage;
+};
+
+export type WireFinishReason =
+  | "stop"
+  | "length"
+  | "content_filter"
+  | "tool_calls";
+
+export type ChatCompletionChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: 0;
+    delta: {
+      role?: "assistant";
+      content?: string;
+      reasoning_content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason?: WireFinishReason | null;
+  }>;
+  usage?: WireUsage;
+};
+
+/** Trailing usage-only chunk (only when `stream_options.include_usage`). */
+export type ChatCompletionUsageChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: [];
+  usage: WireUsage;
+};

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: gateway — the generateVideo seam method the GG video route bills through (docs/wg/platform/hosted-ai.md)
 import "server-only";
 
 /**
@@ -35,7 +36,9 @@ import type {
   ImageModelMiddleware,
   ImageModel,
 } from "ai";
-import { embed, wrapProvider } from "ai";
+import { embed, experimental_generateVideo, wrapProvider } from "ai";
+import { models as ai_models } from "@grida/ai-models";
+import type { VideoGenerateRequest, VideoGenerateResult } from "@grida/agent";
 import Replicate from "replicate";
 import OpenAI from "openai";
 import { createLibraryClient } from "@/lib/supabase/server";
@@ -134,6 +137,21 @@ export class MissingOrgIdError extends Error {
   constructor(msg = "AI seam called without a verified organizationId.") {
     super(msg);
     this.name = "MissingOrgIdError";
+  }
+}
+
+/**
+ * Caller-shape failure from a seam method (unknown model, unsupported
+ * resolution, out-of-bounds duration, …). Routes map `code
+ * "invalid_request"` to a 400 — the message is safe for clients (it
+ * describes the request, never internals).
+ */
+export class InvalidAiRequestError extends Error {
+  readonly code = "invalid_request";
+  readonly status = 400;
+  constructor(msg: string) {
+    super(msg);
+    this.name = "InvalidAiRequestError";
   }
 }
 
@@ -746,7 +764,129 @@ export namespace methods {
     if (!card) return null;
     return { model: grida.imageModel(card.id), card };
   }
+
+  /**
+   * Hosted video generation — gate → `experimental_generateVideo` via
+   * the RAW gateway → ingest. Explicit `withTransaction` because
+   * `wrapProvider` has no video middleware (unlike text/image).
+   *
+   * Billing is **pre-priced by requested duration** against the vercel
+   * binding's `(resolution-label, audio-mode)` per-second rate — the
+   * same pre-computed-cost pattern as every Replicate/image call.
+   * Actual output duration may differ slightly (bounded by the card's
+   * max); documented approximation, reconcilable later. The pricing
+   * keys double as the provider's support matrix: an unpriced
+   * `(label, mode)` pair is an invalid request, not a $0 call.
+   */
+  export async function generateVideo(
+    organizationId: number,
+    req: VideoGenerateRequest
+  ): Promise<VideoGenerateResult> {
+    const card = ai_models.video.models[req.model_id];
+    if (!card || !card.listed) {
+      throw new InvalidAiRequestError(`unknown video model "${req.model_id}"`);
+    }
+    const binding = ai_models.video.binding(card, "vercel");
+    if (!binding) {
+      throw new InvalidAiRequestError(
+        `model "${card.id}" is not available on the hosted provider`
+      );
+    }
+
+    const aspect_ratio = req.aspect_ratio ?? card.default.aspect_ratio;
+    if (!(card.aspect_ratios as readonly string[]).includes(aspect_ratio)) {
+      throw new InvalidAiRequestError(
+        `unsupported aspect_ratio "${aspect_ratio}" (supported: ${card.aspect_ratios.join(", ")})`
+      );
+    }
+
+    const duration = req.duration ?? card.default.duration;
+    if (
+      !Number.isFinite(duration) ||
+      duration < card.min_duration ||
+      duration > card.max_duration
+    ) {
+      throw new InvalidAiRequestError(
+        `duration must be within [${card.min_duration}, ${card.max_duration}] seconds`
+      );
+    }
+
+    // Wire resolution is "{width}x{height}"; pricing is keyed by label.
+    // The short edge is the "p" line (1280x720 → 720p in either
+    // orientation). No resolution ⇒ provider default, priced at the
+    // card's default label.
+    let resolutionLabel = card.default.resolution;
+    if (req.resolution) {
+      const match = /^(\d+)x(\d+)$/.exec(req.resolution);
+      if (!match) {
+        throw new InvalidAiRequestError(
+          `resolution must be "{width}x{height}", got "${req.resolution}"`
+        );
+      }
+      const shortEdge = Math.min(Number(match[1]), Number(match[2]));
+      const label = VIDEO_RESOLUTION_LABEL_BY_SHORT_EDGE[shortEdge];
+      if (!label) {
+        throw new InvalidAiRequestError(
+          `unsupported resolution "${req.resolution}"`
+        );
+      }
+      resolutionLabel = label;
+    }
+
+    // The wire has no audio-mode field (protocol gap, accepted v1) —
+    // bill the card's default mode.
+    const audioMode = card.default.audio ? "audio" : "silent";
+    const rate = binding.pricing.usd_per_second[resolutionLabel]?.[audioMode];
+    if (rate === undefined) {
+      throw new InvalidAiRequestError(
+        `resolution "${resolutionLabel}" (${audioMode}) is not served for "${card.id}"`
+      );
+    }
+    const costMills = ai.toMills(rate * duration);
+
+    // Text-to-video only in v1 — the SDK's image input takes raw bytes
+    // (`DataContent`), and fetching a caller-supplied URL server-side
+    // would be SSRF surface. Mirrors the hosted image t2i-only
+    // decision; the sidecar resolver routes image-to-video to BYOK
+    // providers.
+    if (req.image_url) {
+      throw new InvalidAiRequestError(
+        "image-to-video is not supported on the hosted provider"
+      );
+    }
+
+    return withTransaction(
+      { organizationId, feature: "v1/ai/video", model_id: card.id },
+      async () => {
+        const generation = await experimental_generateVideo({
+          model: gateway.videoModel(binding.id),
+          prompt: req.prompt,
+          aspectRatio: aspect_ratio as `${number}:${number}`,
+          resolution: req.resolution as `${number}x${number}` | undefined,
+          duration,
+          fps: req.fps,
+          seed: req.seed,
+        });
+        const result: VideoGenerateResult = {
+          model_id: card.id,
+          provider_id: "vercel",
+          videos: generation.videos.map((file) => ({
+            base64: file.base64,
+            media_type: file.mediaType,
+          })),
+        };
+        return { result, costMills };
+      }
+    );
+  }
 }
+
+const VIDEO_RESOLUTION_LABEL_BY_SHORT_EDGE: Record<number, string> = {
+  480: "480p",
+  720: "720p",
+  1080: "1080p",
+  2160: "4k",
+};
 
 // ===========================================================================
 // Server-action helper

--- a/editor/lib/auth/gg-token.test.ts
+++ b/editor/lib/auth/gg-token.test.ts
@@ -1,0 +1,157 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: token — see docs/wg/platform/hosted-ai.md
+/**
+ * Scoped AI-token mint/verify.
+ *
+ * Pins: the token is HS256 with a pinned algorithm list and the
+ * `gg:ai` audience; expiry maps to `token_expired` while every other
+ * failure (tamper, wrong audience, malformed claims, foreign issuer)
+ * collapses to `invalid_token`; the secret is fail-closed (unset or
+ * short → `not_configured`, never a weaker fallback); rotation accepts
+ * the previous secret for verification but never for signing semantics.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SignJWT } from "jose";
+import {
+  GG_TOKEN_AUDIENCE,
+  GG_TOKEN_TTL_SECONDS,
+  GgTokenError,
+  signGgToken,
+  verifyGgToken,
+} from "./gg-token";
+
+const SECRET = "test-secret-0123456789abcdef0123456789abcdef";
+const OTHER_SECRET = "other-secret-0123456789abcdef0123456789abcdef";
+
+function requestWith(token: string | null): Request {
+  return new Request("https://grida.test/api/v1/ai/models", {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+async function expectCode(
+  promise: Promise<unknown>,
+  code: GgTokenError["code"]
+) {
+  await expect(promise).rejects.toSatisfy(
+    (err: unknown) => err instanceof GgTokenError && err.code === code
+  );
+}
+
+beforeEach(() => {
+  process.env.GG_TOKEN_SECRET = SECRET;
+  delete process.env.GG_TOKEN_SECRET_PREVIOUS;
+});
+
+afterEach(() => {
+  delete process.env.GG_TOKEN_SECRET;
+  delete process.env.GG_TOKEN_SECRET_PREVIOUS;
+  vi.useRealTimers();
+});
+
+describe("signGgToken / verifyGgToken roundtrip", () => {
+  it("carries sub, org, audience, and a 900s window", async () => {
+    const { token, expiresAt } = await signGgToken("user-uuid-1", 7);
+    const claims = await verifyGgToken(requestWith(token));
+    expect(claims.sub).toBe("user-uuid-1");
+    expect(claims.org).toBe(7);
+    expect(claims.aud).toBe(GG_TOKEN_AUDIENCE);
+    expect(claims.exp - claims.iat).toBe(GG_TOKEN_TTL_SECONDS);
+    expect(expiresAt.getTime()).toBe(claims.exp * 1000);
+  });
+
+  it("rejects invalid sign inputs", async () => {
+    await expectCode(signGgToken("", 7), "invalid_token");
+    await expectCode(signGgToken("user", 0), "invalid_token");
+    await expectCode(signGgToken("user", 1.5), "invalid_token");
+  });
+});
+
+describe("verification failures", () => {
+  it("expired token → token_expired (past the 60s tolerance)", async () => {
+    const { token } = await signGgToken("user-uuid-1", 7);
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + (GG_TOKEN_TTL_SECONDS + 120) * 1000);
+    await expectCode(verifyGgToken(requestWith(token)), "token_expired");
+  });
+
+  it("still valid inside the clock tolerance", async () => {
+    const { token } = await signGgToken("user-uuid-1", 7);
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + (GG_TOKEN_TTL_SECONDS + 30) * 1000);
+    const claims = await verifyGgToken(requestWith(token));
+    expect(claims.org).toBe(7);
+  });
+
+  it("missing / malformed authorization header → invalid_token", async () => {
+    await expectCode(verifyGgToken(requestWith(null)), "invalid_token");
+    await expectCode(verifyGgToken(requestWith("not-a-jwt")), "invalid_token");
+  });
+
+  it("tampered signature → invalid_token", async () => {
+    const { token } = await signGgToken("user-uuid-1", 7);
+    const forged = token.slice(0, -4) + "AAAA";
+    await expectCode(verifyGgToken(requestWith(forged)), "invalid_token");
+  });
+
+  it("wrong audience → invalid_token (a non-AI token never passes)", async () => {
+    const foreign = await new SignJWT({ org: 7 })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-uuid-1")
+      .setAudience("authenticated") // Supabase-style audience
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode(SECRET));
+    await expectCode(verifyGgToken(requestWith(foreign)), "invalid_token");
+  });
+
+  it("malformed claims → invalid_token", async () => {
+    const noOrg = await new SignJWT({})
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-uuid-1")
+      .setAudience(GG_TOKEN_AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode(SECRET));
+    await expectCode(verifyGgToken(requestWith(noOrg)), "invalid_token");
+  });
+});
+
+describe("secret handling", () => {
+  it("unset secret → not_configured on both sign and verify", async () => {
+    delete process.env.GG_TOKEN_SECRET;
+    await expectCode(signGgToken("user", 7), "not_configured");
+    await expectCode(verifyGgToken(requestWith("x.y.z")), "not_configured");
+  });
+
+  it("short secret (< 32 bytes) → not_configured", async () => {
+    process.env.GG_TOKEN_SECRET = "too-short";
+    await expectCode(signGgToken("user", 7), "not_configured");
+  });
+
+  it("rotation: previous secret verifies, expired-under-previous still maps", async () => {
+    process.env.GG_TOKEN_SECRET = OTHER_SECRET;
+    process.env.GG_TOKEN_SECRET_PREVIOUS = SECRET;
+    const previous = await new SignJWT({ org: 7 })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-uuid-1")
+      .setAudience(GG_TOKEN_AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode(SECRET));
+    const claims = await verifyGgToken(requestWith(previous));
+    expect(claims.org).toBe(7);
+
+    // Signed with a secret that is neither current nor previous.
+    const alien = await new SignJWT({ org: 7 })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("user-uuid-1")
+      .setAudience(GG_TOKEN_AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(
+        new TextEncoder().encode("neither-secret-0123456789abcdef012345678")
+      );
+    await expectCode(verifyGgToken(requestWith(alien)), "invalid_token");
+  });
+});

--- a/editor/lib/auth/gg-token.ts
+++ b/editor/lib/auth/gg-token.ts
@@ -1,0 +1,197 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: token — see docs/wg/platform/hosted-ai.md
+/**
+ * Scoped AI-access token — mint + verify.
+ *
+ * The desktop app's hosted-AI calls are authenticated by a short-lived,
+ * purpose-scoped JWT (aud `gg:ai`, 15-minute expiry, org bound at mint
+ * time) — never by a Supabase access token and never by cookies. This
+ * module is the single mint/verify point: the same-origin
+ * `/desktop/auth/token` route signs, the `/api/v1/ai/*` handlers verify.
+ * A future non-desktop client (CLI) would mint the same audience, which
+ * is why this lives in `@/lib/auth`, not `@/lib/desktop`.
+ *
+ * Secret: `GG_TOKEN_SECRET` (server-only, >= 32 bytes). Rotation:
+ * verification also accepts `GG_TOKEN_SECRET_PREVIOUS`; signing
+ * always uses the current secret. Rotate by moving current -> previous,
+ * setting a new current, and dropping previous after > 15 minutes.
+ * Fail-closed: when unset (or too short) sign/verify throw
+ * `not_configured` and callers respond 503 — hosted AI is unavailable,
+ * nothing falls back to a weaker credential.
+ */
+import "server-only";
+
+import { SignJWT, jwtVerify, errors as joseErrors } from "jose";
+
+export const GG_TOKEN_AUDIENCE = "gg:ai";
+export const GG_TOKEN_TTL_SECONDS = 900;
+
+/** HS256 needs a key at least as long as the hash output. */
+const MIN_SECRET_BYTES = 32;
+/** Absorbs daemon/server clock skew without materially extending the window. */
+const CLOCK_TOLERANCE_SECONDS = 60;
+
+export type GgTokenClaims = {
+  /** User uuid. */
+  sub: string;
+  /** Organization id — membership was verified at mint time. */
+  org: number;
+  aud: typeof GG_TOKEN_AUDIENCE;
+  iat: number;
+  exp: number;
+};
+
+export class GgTokenError extends Error {
+  readonly code: "token_expired" | "invalid_token" | "not_configured";
+  constructor(
+    code: "token_expired" | "invalid_token" | "not_configured",
+    message?: string
+  ) {
+    super(message ?? code);
+    this.name = "GgTokenError";
+    this.code = code;
+  }
+}
+
+function secretFromEnv(name: string): Uint8Array | null {
+  const raw = process.env[name]?.trim();
+  if (!raw) return null;
+  const bytes = new TextEncoder().encode(raw);
+  if (bytes.byteLength < MIN_SECRET_BYTES) return null;
+  return bytes;
+}
+
+/** Read per call (not cached): per-request cost is nil and tests stay honest. */
+function currentSecret(): Uint8Array {
+  const secret = secretFromEnv("GG_TOKEN_SECRET");
+  if (!secret) {
+    throw new GgTokenError(
+      "not_configured",
+      "GG_TOKEN_SECRET is unset or shorter than 32 bytes"
+    );
+  }
+  return secret;
+}
+
+export async function signGgToken(
+  sub: string,
+  org: number
+): Promise<{ token: string; expiresAt: Date }> {
+  if (typeof sub !== "string" || sub.length === 0) {
+    throw new GgTokenError("invalid_token", "signGgToken: missing sub");
+  }
+  if (!Number.isInteger(org) || org <= 0) {
+    throw new GgTokenError("invalid_token", "signGgToken: invalid org id");
+  }
+  const secret = currentSecret();
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + GG_TOKEN_TTL_SECONDS;
+  const token = await new SignJWT({ org })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setSubject(sub)
+    .setAudience(GG_TOKEN_AUDIENCE)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(secret);
+  return { token, expiresAt: new Date(exp * 1000) };
+}
+
+/**
+ * Verifies the `Authorization: Bearer <token>` header of a hosted-AI
+ * request. Only this token kind is ever accepted — a Supabase access
+ * token structurally fails (different issuer/keys/audience), which is
+ * the point: a leaked AI token buys <= 15 minutes of AI calls, nothing
+ * else, and nothing else can be presented here.
+ */
+export async function verifyGgToken(request: Request): Promise<GgTokenClaims> {
+  const header = request.headers.get("authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) {
+    throw new GgTokenError("invalid_token", "missing bearer token");
+  }
+  const token = match[1]!;
+
+  const payload = await verifyWithRotation(token);
+
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+    throw new GgTokenError("invalid_token", "missing sub claim");
+  }
+  const org = payload.org;
+  if (typeof org !== "number" || !Number.isInteger(org) || org <= 0) {
+    throw new GgTokenError("invalid_token", "invalid org claim");
+  }
+  return {
+    sub: payload.sub,
+    org,
+    aud: GG_TOKEN_AUDIENCE,
+    iat: payload.iat as number,
+    exp: payload.exp as number,
+  };
+}
+
+async function verifyWithRotation(token: string) {
+  const options = {
+    audience: GG_TOKEN_AUDIENCE,
+    algorithms: ["HS256"],
+    clockTolerance: CLOCK_TOLERANCE_SECONDS,
+  };
+  const current = currentSecret();
+  try {
+    return (await jwtVerify(token, current, options)).payload;
+  } catch (err) {
+    if (err instanceof joseErrors.JWTExpired) {
+      throw new GgTokenError("token_expired");
+    }
+    // Signature mismatch may mean the token was signed with the
+    // previous secret mid-rotation — try it before rejecting.
+    const previous = secretFromEnv("GG_TOKEN_SECRET_PREVIOUS");
+    if (previous && err instanceof joseErrors.JWSSignatureVerificationFailed) {
+      try {
+        return (await jwtVerify(token, previous, options)).payload;
+      } catch (prevErr) {
+        if (prevErr instanceof joseErrors.JWTExpired) {
+          throw new GgTokenError("token_expired");
+        }
+        throw new GgTokenError("invalid_token");
+      }
+    }
+    throw new GgTokenError("invalid_token");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mint rate limit — abuse damping on the token mint itself. The billing
+// gate on the AI endpoints is the real spend control; this only bounds
+// mint-endpoint hammering. Fail-open when Upstash is unconfigured
+// (local dev), same posture as the library search limiter.
+// ---------------------------------------------------------------------------
+
+type MintLimiter = { limit(key: string): Promise<{ success: boolean }> };
+let _mintLimiter: MintLimiter | null | undefined;
+
+async function mintLimiter(): Promise<MintLimiter | null> {
+  if (_mintLimiter !== undefined) return _mintLimiter;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    _mintLimiter = null;
+    return _mintLimiter;
+  }
+  const [{ Ratelimit }, { Redis }] = await Promise.all([
+    import("@upstash/ratelimit"),
+    import("@upstash/redis"),
+  ]);
+  _mintLimiter = new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(10, "60 s"),
+    prefix: "rl:v1-ai:mint",
+  });
+  return _mintLimiter;
+}
+
+export async function allowGgTokenMint(userId: string): Promise<boolean> {
+  const limiter = await mintLimiter();
+  if (!limiter) return true;
+  const { success } = await limiter.limit(userId);
+  return success;
+}

--- a/editor/lib/desktop/billing.test.ts
+++ b/editor/lib/desktop/billing.test.ts
@@ -1,0 +1,184 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Desktop credits summary seam.
+ *
+ * Pins: the seam is a passive read (never provisions, refresh is
+ * best-effort and bounded), unprovisioned orgs surface `balance_cents:
+ * null` (render "—", never "$0.00"), the manage path is built from the
+ * org SLUG, and every degraded dependency (Metronome down/slow, missing
+ * subscription row, missing org row) still yields a `ready` summary from
+ * cached data.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const resolveSessionOrganization =
+  vi.fn<(user_id: string) => Promise<{ id: number; name: string } | null>>();
+vi.mock("@/lib/auth/organization", () => ({
+  resolveSessionOrganization: (user_id: string) =>
+    resolveSessionOrganization(user_id),
+}));
+
+type Entitlement = {
+  allowed: boolean;
+  reason?: "no_balance" | "below_floor" | "not_provisioned";
+  cachedBalanceCents: number;
+  cachedAt: string | null;
+};
+const getEntitlement = vi.fn<(orgId: number) => Promise<Entitlement>>();
+const refreshBalance = vi.fn<(orgId: number) => Promise<{ cents: number }>>();
+vi.mock("@/lib/billing/metronome", () => ({
+  getEntitlement: (orgId: number) => getEntitlement(orgId),
+  refreshBalance: (orgId: number) => refreshBalance(orgId),
+}));
+
+type TableRow = { data: unknown; error: unknown };
+let tables: Record<string, TableRow>;
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => tables[table] ?? { data: null, error: null },
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { getDesktopBillingSummary } from "./billing";
+
+const ORG = { id: 7, name: "acme", display_name: "Acme Inc." };
+
+const ENTITLED: Entitlement = {
+  allowed: true,
+  cachedBalanceCents: 512,
+  cachedAt: "2026-07-03T00:00:00Z",
+};
+const NOT_PROVISIONED: Entitlement = {
+  allowed: false,
+  reason: "not_provisioned",
+  cachedBalanceCents: 0,
+  cachedAt: null,
+};
+const BELOW_FLOOR: Entitlement = {
+  allowed: false,
+  reason: "below_floor",
+  cachedBalanceCents: 12,
+  cachedAt: "2026-07-03T00:00:00Z",
+};
+
+beforeEach(() => {
+  resolveSessionOrganization.mockReset();
+  getEntitlement.mockReset();
+  refreshBalance.mockReset();
+  resolveSessionOrganization.mockResolvedValue({ id: ORG.id, name: ORG.name });
+  refreshBalance.mockResolvedValue({ cents: 512 });
+  tables = {
+    organization: { data: { display_name: ORG.display_name }, error: null },
+    v_billing_subscription: { data: { plan: "pro" }, error: null },
+  };
+});
+
+describe("getDesktopBillingSummary", () => {
+  it("short-circuits to no_organization without touching billing", async () => {
+    resolveSessionOrganization.mockResolvedValue(null);
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(summary).toEqual({ state: "no_organization" });
+    expect(getEntitlement).not.toHaveBeenCalled();
+    expect(refreshBalance).not.toHaveBeenCalled();
+  });
+
+  it("unprovisioned org: skips refresh, surfaces null balance (not $0.00)", async () => {
+    getEntitlement.mockResolvedValue(NOT_PROVISIONED);
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(refreshBalance).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({
+      state: "ready",
+      credits: {
+        balance_cents: null,
+        entitled: false,
+        blocked_reason: "not_provisioned",
+      },
+      // Built from the SLUG — display_name would 404 the web route.
+      manage_path: "/organizations/acme/settings/billing",
+    });
+  });
+
+  it("happy path: refreshes once and reports the post-refresh entitlement", async () => {
+    getEntitlement
+      .mockResolvedValueOnce(ENTITLED)
+      .mockResolvedValueOnce({ ...ENTITLED, cachedBalanceCents: 700 });
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(refreshBalance).toHaveBeenCalledTimes(1);
+    expect(refreshBalance).toHaveBeenCalledWith(ORG.id);
+    expect(getEntitlement).toHaveBeenCalledTimes(2);
+    expect(summary).toMatchObject({
+      state: "ready",
+      organization: ORG,
+      plan: "pro",
+      credits: { balance_cents: 700, entitled: true, blocked_reason: null },
+    });
+  });
+
+  it("falls back to cached entitlement when the live refresh fails", async () => {
+    getEntitlement.mockResolvedValue(ENTITLED);
+    refreshBalance.mockRejectedValue(
+      new Error("METRONOME_API_TOKEN is required")
+    );
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(getEntitlement).toHaveBeenCalledTimes(1);
+    expect(summary).toMatchObject({
+      state: "ready",
+      credits: { balance_cents: 512, entitled: true },
+    });
+  });
+
+  it("falls back to cached entitlement when the live refresh hangs past the timeout", async () => {
+    getEntitlement.mockResolvedValue(ENTITLED);
+    refreshBalance.mockReturnValue(new Promise(() => {})); // never settles
+    const summary = await getDesktopBillingSummary("user-1", {
+      liveRefreshTimeoutMs: 10,
+    });
+    expect(getEntitlement).toHaveBeenCalledTimes(1);
+    expect(summary).toMatchObject({
+      state: "ready",
+      credits: { balance_cents: 512, entitled: true },
+    });
+  });
+
+  it("maps a missing or unknown subscription row to the free plan", async () => {
+    getEntitlement.mockResolvedValue(ENTITLED);
+    tables.v_billing_subscription = { data: null, error: null };
+    expect((await getDesktopBillingSummary("user-1")) as never).toMatchObject({
+      plan: "free",
+    });
+    tables.v_billing_subscription = {
+      data: { plan: "enterprise" },
+      error: null,
+    };
+    expect((await getDesktopBillingSummary("user-1")) as never).toMatchObject({
+      plan: "free",
+    });
+  });
+
+  it("falls back to the slug when the org display row is unavailable", async () => {
+    getEntitlement.mockResolvedValue(ENTITLED);
+    tables.organization = { data: null, error: null };
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(summary).toMatchObject({
+      organization: { id: ORG.id, name: "acme", display_name: "acme" },
+    });
+  });
+
+  it("passes below-floor balances through with the blocked reason", async () => {
+    getEntitlement.mockResolvedValue(BELOW_FLOOR);
+    const summary = await getDesktopBillingSummary("user-1");
+    expect(summary).toMatchObject({
+      credits: {
+        balance_cents: 12,
+        entitled: false,
+        blocked_reason: "below_floor",
+      },
+    });
+  });
+});

--- a/editor/lib/desktop/billing.ts
+++ b/editor/lib/desktop/billing.ts
@@ -1,0 +1,151 @@
+// GRIDA-EE: billing — see ee-billing
+/**
+ * Desktop AI-credits summary — server-only seam for the same-origin
+ * `/desktop/billing/summary` route.
+ *
+ * Lives in `@/lib/desktop` because `app/desktop/**` is lint-barred from
+ * `@/lib/billing/**` (GRIDA-SEC-004 renderer boundary) — including type
+ * imports — but not from `@/lib/desktop`. Server-side precedent: `csp.ts`;
+ * rationale precedent: `auth-deeplink.ts`. The renderer may import the
+ * TYPES from this module; the `server-only` guard breaks the build if a
+ * value import ever reaches client code.
+ *
+ * Deliberate divergences from the web billing page's summary action
+ * (`getAiCreditsSummary`): this is a passive READ — it never lazily
+ * provisions a Metronome account, and it exposes no drift/auto-reload/
+ * Stripe fields. The desktop card is thin by design; every control
+ * delegates to the web billing page (`manage_path`).
+ */
+import "server-only";
+
+import { resolveSessionOrganization } from "@/lib/auth/organization";
+import { getEntitlement, refreshBalance } from "@/lib/billing/metronome";
+import type { PlanId } from "@/lib/billing/plans";
+import { createClient } from "@/lib/supabase/server";
+
+export type { PlanId } from "@/lib/billing/plans";
+
+export type DesktopBillingCredits = {
+  /** `null` ⇔ org not provisioned in Metronome — render "—", never "$0.00". */
+  balance_cents: number | null;
+  /** The gate decision the AI seam would make right now. */
+  entitled: boolean;
+  blocked_reason: "no_balance" | "below_floor" | "not_provisioned" | null;
+  /** Cache timestamp of the balance shown (post-refresh when it succeeded). */
+  as_of: string | null;
+};
+
+export type DesktopBillingSummary =
+  | { state: "no_organization" }
+  | {
+      state: "ready";
+      organization: { id: number; name: string; display_name: string };
+      plan: PlanId;
+      credits: DesktopBillingCredits;
+      /** Web billing page for the org — built from the slug `name`. */
+      manage_path: string;
+    };
+
+/**
+ * Wire shape of `GET /desktop/billing/summary` — the route adds the
+ * signed-out discriminant (auth is the route's concern, not the seam's).
+ */
+export type DesktopBillingSummaryResponse =
+  | { state: "signed_out" }
+  | DesktopBillingSummary;
+
+/**
+ * Ceiling on the best-effort live balance sync. Keeps the settings page
+ * open latency bounded when Metronome is slow or unreachable — the cached
+ * balance (webhooks + hourly reconcile cron keep it honest) is the
+ * fallback, same data the AI gate itself reads.
+ */
+export const LIVE_REFRESH_TIMEOUT_MS = 2_000;
+
+/**
+ * Read-only credits summary for the user's session organization — the
+ * same org-resolution fallback the AI billing path uses
+ * (last-accessed project's org → first membership), so the number shown
+ * is the balance AI calls would actually drain.
+ */
+export async function getDesktopBillingSummary(
+  user_id: string,
+  opts: { liveRefreshTimeoutMs?: number } = {}
+): Promise<DesktopBillingSummary> {
+  const org = await resolveSessionOrganization(user_id);
+  if (!org) return { state: "no_organization" };
+
+  const client = await createClient();
+  const [cached, orgRow, subRow] = await Promise.all([
+    getEntitlement(org.id),
+    // RLS member-read; display-only fields. Deliberately not widening the
+    // GRIDA-SEC-003-tagged resolver's select.
+    client
+      .from("organization")
+      .select("display_name")
+      .eq("id", org.id)
+      .maybeSingle(),
+    client
+      .from("v_billing_subscription")
+      .select("plan")
+      .eq("organization_id", org.id)
+      .maybeSingle(),
+  ]);
+
+  // Best-effort live sync, bounded. Skipped for unprovisioned orgs (there
+  // is nothing to sync). On success, re-read the entitlement so the card
+  // shows the canonical post-refresh gate decision; on timeout or failure
+  // (e.g. no METRONOME_API_TOKEN on contributor machines) the cached
+  // values stand. Never provisions — a passive read must not mutate.
+  let ent = cached;
+  if (cached.reason !== "not_provisioned") {
+    const refreshed = await tryLiveRefresh(
+      org.id,
+      opts.liveRefreshTimeoutMs ?? LIVE_REFRESH_TIMEOUT_MS
+    );
+    if (refreshed) ent = await getEntitlement(org.id);
+  }
+
+  const rawPlan = subRow.data?.plan;
+  const plan: PlanId =
+    rawPlan === "pro" || rawPlan === "team" ? rawPlan : "free";
+
+  return {
+    state: "ready",
+    organization: {
+      id: org.id,
+      name: org.name,
+      display_name: orgRow.data?.display_name || org.name,
+    },
+    plan,
+    credits: {
+      balance_cents:
+        ent.reason === "not_provisioned" ? null : ent.cachedBalanceCents,
+      entitled: ent.allowed,
+      blocked_reason: ent.allowed ? null : (ent.reason ?? null),
+      as_of: ent.cachedAt,
+    },
+    manage_path: `/organizations/${org.name}/settings/billing`,
+  };
+}
+
+async function tryLiveRefresh(
+  organizationId: number,
+  timeoutMs: number
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      refreshBalance(organizationId).then(() => true as const),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } catch {
+    return false;
+  } finally {
+    // A timed-out refresh may still complete later; that's a harmless
+    // idempotent cache write. The timer must not outlive the call.
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/editor/lib/desktop/gg-session.test.ts
+++ b/editor/lib/desktop/gg-session.test.ts
@@ -1,0 +1,132 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: desktop — see docs/wg/platform/hosted-ai.md
+/**
+ * Renderer token-lifecycle owner.
+ *
+ * Pins: single-flight mint, the 5-min refresh window (fresh sessions
+ * are one compare, no IO), 401→signed_out / 409→no_organization with a
+ * daemon clear, unsupported bridge = all no-ops, never-throws, the
+ * token is pushed to the daemon but NOT retained renderer-side, and
+ * the message-substring error detectors.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const set_session = vi.fn<(s: unknown) => Promise<void>>();
+const clear_session = vi.fn<() => Promise<void>>();
+let bridgeCloud: object | null = {
+  set_session,
+  clear_session,
+  status: async () => ({ active: false }),
+};
+vi.mock("@/lib/desktop/bridge", () => ({
+  getDesktopBridge: () => (bridgeCloud ? { gg: bridgeCloud } : null),
+}));
+
+import * as gridaGateway from "./gg-session";
+
+const realFetch = globalThis.fetch;
+const fetchMock = vi.fn<() => Promise<Response>>();
+
+function mintOk(expiresInMs = 900_000): void {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        token: "jwt-abc",
+        expires_at: new Date(Date.now() + expiresInMs).toISOString(),
+        organization: { id: 7, name: "acme" },
+      }),
+      { status: 200 }
+    )
+  );
+}
+
+beforeEach(() => {
+  gridaGateway.__unsafe_reset_for_tests();
+  bridgeCloud = { set_session, clear_session, status: async () => ({}) };
+  set_session.mockReset().mockResolvedValue(undefined);
+  clear_session.mockReset().mockResolvedValue(undefined);
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("ensureFresh", () => {
+  it("mints, pushes to the daemon, retains only expiry+org", async () => {
+    mintOk();
+    const state = await gridaGateway.ensureFresh();
+    expect(state.kind).toBe("active");
+    expect(fetchMock).toHaveBeenCalledWith("/desktop/auth/token", {
+      method: "POST",
+    });
+    expect(set_session).toHaveBeenCalledTimes(1);
+    const pushed = set_session.mock.calls[0]![0] as { access_token: string };
+    expect(pushed.access_token).toBe("jwt-abc");
+    // Renderer-side state never contains the token.
+    expect(JSON.stringify(gridaGateway.peek())).not.toContain("jwt-abc");
+  });
+
+  it("is a no-op while >5min remain; re-mints when close to expiry", async () => {
+    mintOk(900_000);
+    await gridaGateway.ensureFresh();
+    await gridaGateway.ensureFresh();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // fresh → one compare
+
+    gridaGateway.__unsafe_reset_for_tests();
+    mintOk(4 * 60_000); // less than the 5-min slack
+    await gridaGateway.ensureFresh();
+    await gridaGateway.ensureFresh(); // near-expiry → re-mint
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("single-flight: concurrent callers share one mint", async () => {
+    mintOk();
+    await Promise.all([
+      gridaGateway.ensureFresh(),
+      gridaGateway.ensureFresh(),
+      gridaGateway.ensureFresh(),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("401 → signed_out + daemon clear; 409 → no_organization", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 401 }));
+    expect((await gridaGateway.ensureFresh()).kind).toBe("signed_out");
+    expect(clear_session).toHaveBeenCalled();
+    expect(set_session).not.toHaveBeenCalled();
+
+    gridaGateway.__unsafe_reset_for_tests();
+    fetchMock.mockResolvedValue(new Response("{}", { status: 409 }));
+    expect((await gridaGateway.ensureFresh()).kind).toBe("no_organization");
+  });
+
+  it("never throws: network failure degrades to error state", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+    expect((await gridaGateway.ensureFresh()).kind).toBe("error");
+  });
+
+  it("unsupported bridge: everything is a no-op", async () => {
+    bridgeCloud = null;
+    expect(gridaGateway.isSupported()).toBe(false);
+    expect((await gridaGateway.ensureFresh()).kind).toBe("unsupported");
+    await gridaGateway.clear(); // must not throw
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("error detectors (contextBridge-flattened messages)", () => {
+  it("detect by leading literal code substring", () => {
+    expect(
+      gridaGateway.isGgTokenExpired(
+        new Error("gg_token_expired: the Grida session token is missing")
+      )
+    ).toBe(true);
+    expect(gridaGateway.isGgTokenExpired("gg_token_expired")).toBe(true);
+    expect(
+      gridaGateway.isGgInsufficientCredits(new Error("insufficient_credits"))
+    ).toBe(true);
+    expect(gridaGateway.isGgTokenExpired(new Error("other"))).toBe(false);
+    expect(gridaGateway.isGgInsufficientCredits(undefined)).toBe(false);
+  });
+});

--- a/editor/lib/desktop/gg-session.ts
+++ b/editor/lib/desktop/gg-session.ts
@@ -34,6 +34,12 @@ const REFRESH_SLACK_MS = 5 * 60_000;
 
 let cached: GridaGatewaySessionState | null = null;
 let inflight: Promise<GridaGatewaySessionState> | null = null;
+/**
+ * Bumped by every `clear()` (sign-out). An in-flight `mintAndPush` captures
+ * the value at start and refuses to push / go `active` if it changed — so a
+ * mint that resolves AFTER sign-out can't resurrect the session.
+ */
+let epoch = 0;
 
 function ggBridge() {
   return getDesktopBridge()?.gg ?? null;
@@ -72,6 +78,7 @@ export async function forceRefresh(): Promise<GridaGatewaySessionState> {
 
 /** Best-effort daemon clear + cache drop. Called on sign-out; never throws. */
 export async function clear(): Promise<void> {
+  epoch++; // invalidate any in-flight mint — sign-out wins the race
   cached = isSupported() ? { kind: "signed_out" } : { kind: "unsupported" };
   try {
     await ggBridge()?.clear_session();
@@ -83,6 +90,7 @@ export async function clear(): Promise<void> {
 async function mintAndPush(
   bridge: NonNullable<ReturnType<typeof ggBridge>>
 ): Promise<GridaGatewaySessionState> {
+  const startedAt = epoch;
   try {
     const res = await fetch("/desktop/auth/token", { method: "POST" });
     if (res.status === 401) {
@@ -99,6 +107,9 @@ async function mintAndPush(
       expires_at: string;
       organization: { id: number; name: string };
     };
+    // A sign-out landed while we were minting: drop this token rather than
+    // pushing it and flipping the session back to `active` after logout.
+    if (epoch !== startedAt) return cached ?? { kind: "signed_out" };
     const expires_at = Date.parse(data.expires_at);
     await bridge.set_session({
       access_token: data.token,

--- a/editor/lib/desktop/gg-session.ts
+++ b/editor/lib/desktop/gg-session.ts
@@ -1,0 +1,146 @@
+// GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-GG: desktop — see docs/wg/platform/hosted-ai.md
+/**
+ * Grida Cloud session — the renderer-side token lifecycle owner.
+ *
+ * The webview cookie session is the only durable credential
+ * (GRIDA-SEC-005). This module turns it into hosted-AI access: it mints
+ * the short-lived scoped token from the same-origin
+ * `POST /desktop/auth/token` route and PUSHES it to the sidecar daemon
+ * (`bridge.gg.set_session`), keeping only `{expires_at, organization}`
+ * renderer-side — the token itself is never retained here after the push.
+ *
+ * Contract for callers: `ensureFresh()` before anything that may use the
+ * hosted provider (the agent transport pre-send hook, the playgrounds'
+ * generate). It is SINGLE-FLIGHT, cheap when fresh (>5 min left = one
+ * compare), and **never throws** — hosted AI degrading must never break
+ * a BYOK run. Sign-out paths call `clear()`.
+ */
+import { getDesktopBridge } from "@/lib/desktop/bridge";
+
+export type GridaGatewaySessionState =
+  | { kind: "unsupported" } // no bridge.gg (web, or an older binary)
+  | { kind: "signed_out" }
+  | { kind: "no_organization" }
+  | {
+      kind: "active";
+      expires_at: number;
+      organization: { id: number; name: string };
+    }
+  | { kind: "error" };
+
+/** Re-mint when less than this remains — well inside the 15-min token. */
+const REFRESH_SLACK_MS = 5 * 60_000;
+
+let cached: GridaGatewaySessionState | null = null;
+let inflight: Promise<GridaGatewaySessionState> | null = null;
+
+function ggBridge() {
+  return getDesktopBridge()?.gg ?? null;
+}
+
+export function isSupported(): boolean {
+  return ggBridge() !== null;
+}
+
+/** Synchronous cached state for UI affordances (never triggers IO). */
+export function peek(): GridaGatewaySessionState {
+  if (cached) return cached;
+  return isSupported() ? { kind: "signed_out" } : { kind: "unsupported" };
+}
+
+export async function ensureFresh(): Promise<GridaGatewaySessionState> {
+  const bridge = ggBridge();
+  if (!bridge) return setCached({ kind: "unsupported" });
+  if (
+    cached?.kind === "active" &&
+    cached.expires_at - Date.now() > REFRESH_SLACK_MS
+  ) {
+    return cached;
+  }
+  inflight ??= mintAndPush(bridge).finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}
+
+/** Drop the cache and re-mint (e.g. after a `gg_token_expired` error). */
+export async function forceRefresh(): Promise<GridaGatewaySessionState> {
+  cached = null;
+  return ensureFresh();
+}
+
+/** Best-effort daemon clear + cache drop. Called on sign-out; never throws. */
+export async function clear(): Promise<void> {
+  cached = isSupported() ? { kind: "signed_out" } : { kind: "unsupported" };
+  try {
+    await ggBridge()?.clear_session();
+  } catch {
+    // The daemon may be restarting — its in-memory store is gone anyway.
+  }
+}
+
+async function mintAndPush(
+  bridge: NonNullable<ReturnType<typeof ggBridge>>
+): Promise<GridaGatewaySessionState> {
+  try {
+    const res = await fetch("/desktop/auth/token", { method: "POST" });
+    if (res.status === 401) {
+      await clear();
+      return setCached({ kind: "signed_out" });
+    }
+    if (res.status === 409) {
+      await clear();
+      return setCached({ kind: "no_organization" });
+    }
+    if (!res.ok) return setCached({ kind: "error" });
+    const data = (await res.json()) as {
+      token: string;
+      expires_at: string;
+      organization: { id: number; name: string };
+    };
+    const expires_at = Date.parse(data.expires_at);
+    await bridge.set_session({
+      access_token: data.token,
+      expires_at,
+      organization: data.organization,
+    });
+    return setCached({
+      kind: "active",
+      expires_at,
+      organization: data.organization,
+    });
+  } catch {
+    return setCached({ kind: "error" });
+  }
+}
+
+function setCached(state: GridaGatewaySessionState): GridaGatewaySessionState {
+  cached = state;
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Error detection — the daemon's typed errors cross Electron's
+// contextBridge, which strips custom props; the LITERAL CODE leads the
+// message (the `isWriteConflict` idiom). Detect by substring.
+// ---------------------------------------------------------------------------
+
+function errorText(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return typeof err === "string" ? err : JSON.stringify(err ?? "");
+}
+
+export function isGgTokenExpired(err: unknown): boolean {
+  return errorText(err).includes("gg_token_expired");
+}
+
+export function isGgInsufficientCredits(err: unknown): boolean {
+  return errorText(err).includes("insufficient_credits");
+}
+
+/** Test-only: reset module singletons between cases. */
+export function __unsafe_reset_for_tests(): void {
+  cached = null;
+  inflight = null;
+}

--- a/editor/package.json
+++ b/editor/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ai-sdk/openai": "3.0.0",
     "@ai-sdk/openai-compatible": "2.0.48",
+    "@ai-sdk/provider": "3.0.10",
     "@ai-sdk/react": "3.0.199",
     "@ai-sdk/replicate": "2.0.0",
     "@ai-sdk/rsc": "2.0.1",

--- a/editor/scaffolds/desktop/image-gen/image-playground.tsx
+++ b/editor/scaffolds/desktop/image-gen/image-playground.tsx
@@ -1,4 +1,7 @@
 "use client";
+// GRIDA-GG: desktop — ensure a fresh GG token before generate (docs/wg/platform/hosted-ai.md)
+
+import * as gridaGateway from "@/lib/desktop/gg-session";
 
 import { useState } from "react";
 import { Check, Download, Sparkles, SlidersHorizontal, X } from "lucide-react";
@@ -166,6 +169,10 @@ export function DesktopImagePlayground({
   };
 
   const runGenerate = async (rawPrompt: string) => {
+    // GRIDA-SEC-006 — keep the sidecar's hosted-AI session fresh so a
+    // signed-in keyless user generates through the included provider.
+    // Never throws; BYOK runs are unaffected when it degrades.
+    await gridaGateway.ensureFresh();
     const prompt = rawPrompt.trim();
     if (!prompt) return;
     const id = crypto.randomUUID();

--- a/editor/scaffolds/desktop/shared/model-picker.tsx
+++ b/editor/scaffolds/desktop/shared/model-picker.tsx
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — the GG-included picker affordance (docs/wg/platform/hosted-ai.md)
 /**
  * Desktop model picker — every catalog model grouped by provider, plus
  * the Claude Code agent-provider options (issue #813) and any user-
@@ -39,6 +40,8 @@ import type {
   EndpointProviderConfig,
 } from "@/lib/desktop/bridge";
 import { registered_models } from "./registered-models";
+import { GG_PROVIDER_METADATA } from "@grida/agent";
+import * as gridaGateway from "@/lib/desktop/gg-session";
 
 const catalog = _models.text.catalog;
 type CatalogId = _models.text.CatalogId;
@@ -132,6 +135,31 @@ export function DesktopModelPicker({
    *  (grouped under the endpoint's label). */
   endpoints?: readonly EndpointProviderConfig[];
 }) {
+  // GRIDA-SEC-006 — hosted-session affordance: a header line stating how
+  // the catalog is served (included via the Grida session, or a sign-in
+  // hint). Warm on mount so the label is accurate on first open; the
+  // catalog itself is NEVER hidden — BYOK keys can still serve it.
+  const [gridaGatewayState, setGridaGatewayState] = useState<
+    "active" | "signed_out" | "hidden"
+  >("hidden");
+  useEffect(() => {
+    if (!gridaGateway.isSupported()) return;
+    let cancelled = false;
+    void gridaGateway.ensureFresh().then((state) => {
+      if (cancelled) return;
+      setGridaGatewayState(
+        state.kind === "active"
+          ? "active"
+          : state.kind === "signed_out" || state.kind === "no_organization"
+            ? "signed_out"
+            : "hidden"
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <PromptInputSelect value={value} onValueChange={onValueChange}>
       <PromptInputSelectTrigger
@@ -152,6 +180,16 @@ export function DesktopModelPicker({
           ))}
         </SelectGroup>
         {/* Hosted catalog, grouped by provider (Anthropic first) */}
+        {gridaGatewayState !== "hidden" && (
+          <SelectGroup>
+            <SelectSeparator />
+            <SelectLabel className="text-[10px] font-normal text-muted-foreground">
+              {gridaGatewayState === "active"
+                ? GG_PROVIDER_METADATA.included_label
+                : "Sign in to use included AI"}
+            </SelectLabel>
+          </SelectGroup>
+        )}
         {CATALOG_GROUPS.map((group) => (
           <SelectGroup key={group.vendor}>
             <SelectSeparator />

--- a/editor/scaffolds/desktop/video-gen/video-playground.tsx
+++ b/editor/scaffolds/desktop/video-gen/video-playground.tsx
@@ -1,4 +1,7 @@
 "use client";
+// GRIDA-GG: desktop — ensure a fresh GG token before generate (docs/wg/platform/hosted-ai.md)
+
+import * as gridaGateway from "@/lib/desktop/gg-session";
 
 import { useState } from "react";
 import { Check, Download, Sparkles, SlidersHorizontal, X } from "lucide-react";
@@ -148,6 +151,10 @@ export function DesktopVideoPlayground({
   };
 
   const runGenerate = async (rawPrompt: string) => {
+    // GRIDA-SEC-006 — keep the sidecar's hosted-AI session fresh so a
+    // signed-in keyless user generates through the included provider.
+    // Never throws; BYOK runs are unaffected when it degrades.
+    await gridaGateway.ensureFresh();
     const prompt = rawPrompt.trim();
     if (!prompt) return;
     const id = crypto.randomUUID();

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — GG token/credit error UX (docs/wg/platform/hosted-ai.md)
 /**
  * Workspace agent pane — the generic agent over the user's workspace.
  *
@@ -46,10 +47,12 @@ import { cn } from "@app/ui/lib/utils";
 import { Button } from "@app/ui/components/button";
 import {
   AGENT_SESSION_AGENT,
+  getDesktopBridge,
   sessions as bridgeSessions,
   type AgentRunOptions,
   type Workspace,
 } from "@/lib/desktop/bridge";
+import * as gridaGateway from "@/lib/desktop/gg-session";
 import {
   welcome_handoff,
   type WelcomeHandoff,
@@ -344,6 +347,15 @@ function AgentPaneContent({
     setMessages,
     resumeStream,
   } = useChat({ chat });
+
+  // GRIDA-SEC-006 — a mid-run `gg_token_expired` means the pushed
+  // session lapsed during a long turn: re-mint in the background so the
+  // retry (or the next send) rides a fresh token.
+  useEffect(() => {
+    if (error && gridaGateway.isGgTokenExpired(error)) {
+      void gridaGateway.forceRefresh();
+    }
+  }, [error]);
   // `isStreaming` = a turn is actively streaming THROUGH THIS CLIENT. Used
   // where that is the honest concept: the typing indicator, the Stop/Send
   // button, and "did I start this turn?" (vs. the core). It is the AI-SDK
@@ -766,7 +778,26 @@ function AgentPaneContent({
 
       {error && (
         <div className="flex items-start gap-2 border-t bg-destructive/10 px-3 py-2 text-xs text-destructive">
-          <span className="flex-1">{error.message}</span>
+          {/* GRIDA-SEC-006 — the two hosted-AI codes cross the bridge as
+              bare code-led messages; translate to actionable copy. A
+              token-expired error also fires a background re-mint so the
+              user's next send just works. */}
+          <span className="flex-1">
+            {gridaGateway.isGgTokenExpired(error)
+              ? "Your Grida session needed a refresh — try sending again."
+              : gridaGateway.isGgInsufficientCredits(error)
+                ? "Your organization is out of AI credits."
+                : error.message}
+          </span>
+          {gridaGateway.isGgInsufficientCredits(error) && (
+            <button
+              type="button"
+              onClick={() => void openManageBilling()}
+              className="underline"
+            >
+              add credits
+            </button>
+          )}
           <button
             type="button"
             onClick={clearError}
@@ -974,3 +1005,23 @@ const ChatMessageMemo = memo(function ChatMessageMemo({
     />
   );
 });
+
+/**
+ * GRIDA-SEC-006 — "add credits" delegation: resolve the org's billing
+ * path from the same-origin summary route and open it in the OS browser
+ * (the Part-2a Manage-billing pattern; the webview never navigates).
+ */
+async function openManageBilling(): Promise<void> {
+  try {
+    const res = await fetch("/desktop/billing/summary");
+    const summary = (await res.json()) as { manage_path?: string };
+    const path = summary.manage_path ?? "/";
+    const bridge = getDesktopBridge();
+    if (!bridge) return;
+    await bridge.shell.open_external(
+      new URL(path, window.location.origin).toString()
+    );
+  } catch {
+    // Best-effort affordance; the settings Credits card is the fallback.
+  }
+}

--- a/editor/scripts/audit-ai-seam.ts
+++ b/editor/scripts/audit-ai-seam.ts
@@ -39,6 +39,11 @@ const ALLOWLIST = [
   "lib/ai/models.ts",
   "grida-canvas-hosted/ai/agent/server-agent.ts",
   "app/(api)/private/ai/models/openai/route.ts",
+  // Contract tests for the hosted OpenAI-compat endpoint (GRIDA-SEC-006):
+  // value-import `@ai-sdk/openai-compatible` as the wire-contract driver
+  // (the desktop sidecar's actual client), not for billed calls.
+  "app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts",
+  "app/(api)/(public)/api/v1/ai/chat/completions/route.byok.test.ts",
 ];
 
 /**

--- a/packages/grida-ai-agent/src/cli.ts
+++ b/packages/grida-ai-agent/src/cli.ts
@@ -512,7 +512,10 @@ export function parseRunArgs(args: string[]): {
 
 async function createHost(
   config: CliConfig,
-  flags?: Pick<ServeFlags, "allow_origins" | "allow_referer_paths">,
+  flags?: Pick<
+    ServeFlags,
+    "allow_origins" | "allow_referer_paths" | "editor_base_url"
+  >,
   // Whether this host serves a human UI (RFC `tools` §question). A long-lived
   // `serve` daemon is driven by a human client (the desktop-from-web bridge),
   // so the locked `question` tool pauses for their answer. The throwaway
@@ -547,7 +550,7 @@ async function createHost(
     // session — which is correct and free. Default from env so a
     // desktop-from-web bridge daemon serves hosted AI without a flag.
     gg_base_url:
-      (flags as ServeFlags | undefined)?.editor_base_url ??
+      flags?.editor_base_url ??
       process.env.GRIDA_EDITOR_BASE_URL ??
       "https://grida.co",
   });

--- a/packages/grida-ai-agent/src/cli.ts
+++ b/packages/grida-ai-agent/src/cli.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `--editor-base-url` GG base URL flag (docs/wg/platform/hosted-ai.md)
 /**
  * grida-agent CLI — the canonical, host-agnostic entrypoint to the agent
  * system.
@@ -116,6 +117,8 @@ export type ServeFlags = {
   register: boolean;
   allow_origins: string[];
   allow_referer_paths: string[];
+  /** GRIDA-SEC-006 — hosted-AI origin; enables the `grida` provider. */
+  editor_base_url?: string;
 };
 
 /** Parse `serve`'s options. Exported for unit testing. */
@@ -129,12 +132,17 @@ export function parseServeArgs(args: string[]): ServeFlags {
     const arg = args[i];
     if (arg === "--register") {
       flags.register = true;
-    } else if (arg === "--allow-origin" || arg === "--allow-referer-path") {
+    } else if (
+      arg === "--allow-origin" ||
+      arg === "--allow-referer-path" ||
+      arg === "--editor-base-url"
+    ) {
       const value = args[i + 1];
       if (!value || value.startsWith("-")) {
         throw new Error(`${arg} requires a value`);
       }
       if (arg === "--allow-origin") flags.allow_origins.push(value);
+      else if (arg === "--editor-base-url") flags.editor_base_url = value;
       else flags.allow_referer_paths.push(value);
       i += 1;
     } else {
@@ -534,6 +542,14 @@ async function createHost(
     // a UI (the `serve` daemon driven by the desktop-from-web bridge). A
     // throwaway embedded host (one-shot `run`) is headless → fixed refusal.
     interactive,
+    // GRIDA-SEC-006 — hosted "included" AI. The CLI daemon has no webview
+    // to mint tokens, so this stays dormant unless a client pushes a
+    // session — which is correct and free. Default from env so a
+    // desktop-from-web bridge daemon serves hosted AI without a flag.
+    gg_base_url:
+      (flags as ServeFlags | undefined)?.editor_base_url ??
+      process.env.GRIDA_EDITOR_BASE_URL ??
+      "https://grida.co",
   });
 }
 

--- a/packages/grida-ai-agent/src/gg-daemon.test.ts
+++ b/packages/grida-ai-agent/src/gg-daemon.test.ts
@@ -1,0 +1,122 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — composed-daemon pins for the hosted "included" AI
+ * surface. Caught live: `createAgentDaemon` forwards tenant options
+ * EXPLICITLY, so forgetting `gg_base_url` ships the whole
+ * provider silently dormant — the with-URL daemon here pins the
+ * forwarding, the without-URL daemon pins dormancy (no routes, no
+ * capability).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createAgentDaemon, type DaemonServer } from "./server";
+import { AgentTransport } from "./transport";
+
+const PASSWORD = "test-password-abc123";
+const VALID_REFERER = "https://client.example/client/doc";
+const VALID_ORIGIN = "https://client.example";
+
+const authed = (): Record<string, string> => ({
+  authorization: AgentTransport.buildBasicAuthHeader(PASSWORD),
+  referer: VALID_REFERER,
+  origin: VALID_ORIGIN,
+  "content-type": "application/json",
+});
+
+function makeDaemon(baseDir: string, gridaBaseUrl?: string): DaemonServer {
+  return createAgentDaemon({
+    password: PASSWORD,
+    user_data_path: baseDir,
+    scratch_base: `${baseDir}-scratch`,
+    http_access: {
+      allowed_origins: [VALID_ORIGIN],
+      allowed_referer_paths: ["/client"],
+    },
+    port: 0,
+    gg_base_url: gridaBaseUrl,
+  });
+}
+
+describe("composed daemon WITH gg_base_url", () => {
+  let daemon: DaemonServer;
+  let base: string;
+
+  beforeAll(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gg-on-"));
+    daemon = makeDaemon(dir, "https://grida.test");
+    await daemon.start();
+    base = `http://127.0.0.1:${daemon.port}`;
+  });
+  afterAll(async () => {
+    await daemon.stop();
+  });
+
+  it("handshake reports gg: true (the forwarding pin)", async () => {
+    const res = await fetch(`${base}/handshake`, {
+      method: "POST",
+      headers: authed(),
+    });
+    const body = (await res.json()) as {
+      capabilities: Record<string, boolean>;
+    };
+    expect(body.capabilities.gg).toBe(true);
+  });
+
+  it("serves /auth/gg/* behind the perimeter", async () => {
+    // Unauthenticated → rejected by the perimeter.
+    const unauthed = await fetch(`${base}/auth/gg/status`, {
+      method: "POST",
+    });
+    expect(unauthed.status).toBeGreaterThanOrEqual(400);
+
+    const set = await fetch(`${base}/auth/gg/set`, {
+      method: "POST",
+      headers: authed(),
+      body: JSON.stringify({
+        access_token: "tok",
+        expires_at: Date.now() + 900_000,
+      }),
+    });
+    expect(set.status).toBe(200);
+    const status = await fetch(`${base}/auth/gg/status`, {
+      method: "POST",
+      headers: authed(),
+      body: "{}",
+    });
+    expect(((await status.json()) as { active: boolean }).active).toBe(true);
+  });
+});
+
+describe("composed daemon WITHOUT gg_base_url (dormant)", () => {
+  let daemon: DaemonServer;
+  let base: string;
+
+  beforeAll(async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gg-off-"));
+    daemon = makeDaemon(dir);
+    await daemon.start();
+    base = `http://127.0.0.1:${daemon.port}`;
+  });
+  afterAll(async () => {
+    await daemon.stop();
+  });
+
+  it("handshake reports gg: false and the routes are absent", async () => {
+    const res = await fetch(`${base}/handshake`, {
+      method: "POST",
+      headers: authed(),
+    });
+    const body = (await res.json()) as {
+      capabilities: Record<string, boolean>;
+    };
+    expect(body.capabilities.gg).toBe(false);
+    const status = await fetch(`${base}/auth/gg/status`, {
+      method: "POST",
+      headers: authed(),
+      body: "{}",
+    });
+    expect(status.status).toBe(404);
+  });
+});

--- a/packages/grida-ai-agent/src/http/routes/gg-auth.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/gg-auth.test.ts
@@ -1,0 +1,113 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — /auth/gg/* routes + the secrets-boundary split.
+ *
+ * Pins: set→status→clear roundtrip (status never echoes the token),
+ * validation 400s (empty token, past expiry), and the DELIBERATE gate
+ * split — the run-input accepts `grida` as a provider pick while
+ * `/secrets/set` keeps REJECTING it (nobody may store a key under the
+ * hosted provider's id).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { registerGridaAuthRoutes } from "./gg-auth";
+import { registerSecretsRoutes } from "./secrets";
+import { GridaGatewaySessionStore } from "../../providers/gg-session";
+import type { SecretsStore } from "@grida/daemon/server";
+
+let app: Hono;
+let store: GridaGatewaySessionStore;
+
+function post(path: string, body?: unknown): Promise<Response> {
+  return Promise.resolve(
+    app.request(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body ?? {}),
+    })
+  );
+}
+
+beforeEach(() => {
+  app = new Hono();
+  store = new GridaGatewaySessionStore();
+  registerGridaAuthRoutes(app, { store });
+});
+
+describe("/auth/gg/*", () => {
+  it("set → status → clear roundtrip; status never echoes the token", async () => {
+    const expires_at = Date.now() + 900_000;
+    const set = await post("/auth/gg/set", {
+      access_token: "jwt-abc",
+      expires_at,
+      organization: { id: 7, name: "acme" },
+    });
+    expect(set.status).toBe(200);
+
+    const status = await post("/auth/gg/status");
+    const body = (await status.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      active: true,
+      expires_at,
+      organization: { id: 7, name: "acme" },
+    });
+    expect(JSON.stringify(body)).not.toContain("jwt-abc");
+    expect(store.getAccessToken()).toBe("jwt-abc");
+
+    const clear = await post("/auth/gg/clear");
+    expect(clear.status).toBe(200);
+    expect(store.getAccessToken()).toBeNull();
+    expect(
+      ((await (await post("/auth/gg/status")).json()) as { active: boolean })
+        .active
+    ).toBe(false);
+  });
+
+  it("validation: empty token and past expiry are 400s", async () => {
+    expect(
+      (
+        await post("/auth/gg/set", {
+          access_token: "   ",
+          expires_at: Date.now() + 1000,
+        })
+      ).status
+    ).toBe(400);
+    expect(
+      (
+        await post("/auth/gg/set", {
+          access_token: "jwt",
+          expires_at: Date.now() - 1000,
+        })
+      ).status
+    ).toBe(400);
+    expect(store.getAccessToken()).toBeNull();
+  });
+
+  it("malformed organization is dropped, not fatal", async () => {
+    const res = await post("/auth/gg/set", {
+      access_token: "jwt",
+      expires_at: Date.now() + 900_000,
+      organization: { id: "not-a-number" },
+    });
+    expect(res.status).toBe(200);
+    expect(store.status().organization).toBeUndefined();
+  });
+});
+
+describe("secrets boundary split (GRIDA-SEC-006)", () => {
+  it("/secrets/set keeps rejecting the grida id", async () => {
+    const secretsApp = new Hono();
+    registerSecretsRoutes(secretsApp, {
+      store: {
+        has: async () => false,
+        set: async () => {},
+      } as unknown as SecretsStore,
+    });
+    const res = await secretsApp.request("/secrets/set", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider_id: "gg", key: "sneaky" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/grida-ai-agent/src/http/routes/gg-auth.ts
+++ b/packages/grida-ai-agent/src/http/routes/gg-auth.ts
@@ -1,0 +1,78 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — `/auth/gg/*` routes (hosted "included" AI session).
+ *
+ * The renderer mints a short-lived, org-scoped AI token from the
+ * webview's cookie session and PUSHES it here; the daemon holds it in
+ * memory only ({@link GridaGatewaySessionStore}) and spends it as the
+ * Bearer credential of the `grida` provider. There is deliberately no
+ * `/auth/gg/get`: like `/secrets/*`, presence (`status`) is
+ * readable, the credential is not — and the token is NEVER logged.
+ *
+ * Mounted behind the daemon's CORS → Referer → BasicAuth perimeter like
+ * every tenant route; no SSE, so no query-token path.
+ */
+
+import type { Hono } from "hono";
+import { body, v } from "@grida/daemon/server";
+import type { GridaGatewaySessionStore } from "../../providers/gg-session";
+
+export type GridaAuthRoutesDeps = {
+  store: GridaGatewaySessionStore;
+};
+
+export function registerGridaAuthRoutes(app: Hono, deps: GridaAuthRoutesDeps) {
+  const { store } = deps;
+
+  app.post("/auth/gg/set", async (c) => {
+    const r = await body(c, {
+      access_token: v.string,
+      expires_at: v.number,
+    });
+    if (!r.ok) return r.res;
+    if (r.data.access_token.trim().length === 0) {
+      return c.json({ error: "access_token must not be empty" }, 400);
+    }
+    if (
+      !Number.isFinite(r.data.expires_at) ||
+      r.data.expires_at <= Date.now()
+    ) {
+      return c.json(
+        { error: "expires_at must be a future epoch-ms timestamp" },
+        400
+      );
+    }
+    // Optional display-only org context; malformed shapes are dropped,
+    // not fatal (it never authorizes anything here).
+    const rawOrg = (await c.req.json().catch(() => ({}))) as {
+      organization?: { id?: unknown; name?: unknown };
+    };
+    const organization =
+      rawOrg.organization &&
+      typeof rawOrg.organization.id === "number" &&
+      typeof rawOrg.organization.name === "string"
+        ? { id: rawOrg.organization.id, name: rawOrg.organization.name }
+        : undefined;
+
+    store.set({
+      access_token: r.data.access_token,
+      expires_at: r.data.expires_at,
+      organization,
+    });
+    console.info(
+      `[agent-host-gg-auth] session set` +
+        (organization ? ` org=${organization.id}` : "") +
+        ` expires_in=${Math.round((r.data.expires_at - Date.now()) / 1000)}s`
+    );
+    return c.json({ ok: true });
+  });
+
+  app.post("/auth/gg/clear", (c) => {
+    store.clear();
+    return c.json({ ok: true });
+  });
+
+  app.post("/auth/gg/status", (c) => {
+    return c.json(store.status());
+  });
+}

--- a/packages/grida-ai-agent/src/http/routes/gg-media-errors.ts
+++ b/packages/grida-ai-agent/src/http/routes/gg-media-errors.ts
@@ -1,0 +1,55 @@
+// GRIDA-GG: provider — hosted media-generation error mapping (docs/wg/platform/hosted-ai.md)
+/**
+ * GRIDA-SEC-004/006 — the shared renderer-safe error posture for the hosted
+ * image + video generation routes.
+ *
+ * 401/402 are ACTIONABLE for the renderer, so the bare code is surfaced
+ * (GRIDA-SEC-006); every other failure logs its detail — which can embed
+ * upstream body text (fal/OpenRouter adapters call `safeText(res)`) — in the
+ * sidecar ONLY and returns a generic 502. Single-sourced so both routes keep
+ * the identical, non-leaking contract.
+ */
+
+import type { Context } from "hono";
+
+export function hostedGenerationError(
+  c: Context,
+  args: {
+    error: unknown;
+    /** Log tag, e.g. `agent-host-images`. */
+    scope: string;
+    /** Renderer-facing generic 502 message, e.g. `image generation failed`. */
+    label: string;
+    model_id: string;
+    provider_id: string;
+  }
+): Response {
+  const code = (args.error as { code?: unknown })?.code;
+  if (code === "gg_token_expired") {
+    return c.json(
+      { error: "gg session expired", code, provider_id: "gg" },
+      401
+    );
+  }
+  if (code === "insufficient_credits") {
+    return c.json(
+      { error: "insufficient AI credits", code, provider_id: "gg" },
+      402
+    );
+  }
+  const detail =
+    args.error instanceof Error ? args.error.message : String(args.error);
+  const upstream = (args.error as { responseBody?: unknown })?.responseBody;
+  console.error(
+    `[${args.scope}] failed provider=${args.provider_id} model=${args.model_id}: ${detail}` +
+      (upstream ? ` — ${String(upstream).slice(0, 300)}` : "")
+  );
+  return c.json(
+    {
+      error: args.label,
+      model_id: args.model_id,
+      provider_id: args.provider_id,
+    },
+    502
+  );
+}

--- a/packages/grida-ai-agent/src/http/routes/images.ts
+++ b/packages/grida-ai-agent/src/http/routes/images.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` hosted image arm (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — `/images/generate` route (BYOK image generation, #908).
  *
@@ -14,11 +15,13 @@
  *     user-supplied base URL, so this opens no new egress beyond the three
  *     fixed provider hosts (unlike the endpoint routes, issue #806).
  *
- * Billing contract (#908, Phase 4): this path NEVER enters the web
- * Grida-billed image seam (`editor/lib/ai/server.ts`). It calls `generateImage`
- * WITHOUT `providerOptions.grida` — the field that triggers Grida's billing
- * middleware — so the user's own key pays the provider directly and no Grida
- * credit is metered. Do not add `providerOptions.grida` here.
+ * Billing contract (#908, Phase 4 + GRIDA-SEC-006): the BYOK arms NEVER
+ * enter the web Grida-billed image seam (`editor/lib/ai/server.ts`) — the
+ * user's own key pays the provider directly, no Grida credit is metered,
+ * and this sidecar route never sets the WEB seam's billing trigger. The
+ * `grida` HOSTED arm is not a billing leak: its billing happens
+ * server-side at the hosted endpoint (Bearer session token; the seam
+ * gates + meters there), never in this process.
  */
 
 import type { Hono } from "hono";
@@ -28,16 +31,20 @@ import {
   ImageModelUnavailableError,
   resolveImageModel,
 } from "../../providers/resolve-image";
+import { hostedGenerationError } from "./gg-media-errors";
 import { body, v } from "@grida/daemon/server";
 
-const IMAGE_PROVIDERS = ["vercel", "fal", "openrouter"] as const;
+const IMAGE_PROVIDERS = ["vercel", "fal", "openrouter", "gg"] as const;
 
 export type ImagesRoutesDeps = {
   secrets: SecretsStore;
+  /** GRIDA-SEC-006 — hosted provider deps; absent ⇒ grida never resolves. */
+  gg?: import("../../providers/gg-session").GridaGatewaySessionStore;
+  gg_base_url?: string;
 };
 
 export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
-  const { secrets } = deps;
+  const { secrets, gg, gg_base_url } = deps;
 
   app.post("/images/generate", async (c) => {
     const r = await body(c, {
@@ -67,7 +74,7 @@ export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
     let resolved;
     try {
       resolved = await resolveImageModel(
-        { secrets },
+        { secrets, gg, gg_base_url },
         model_id,
         provider ? { explicit: provider } : {}
       );
@@ -106,24 +113,13 @@ export function registerImagesRoutes(app: Hono, deps: ImagesRoutesDeps) {
         ...(providerOptions ? { providerOptions } : {}),
       });
     } catch (e) {
-      // Detail (e.message can include upstream body text — the fal/OpenRouter
-      // adapters embed safeText(res)) + the raw responseBody stay in the sidecar
-      // log ONLY; the renderer gets a generic message.
-      const detail = e instanceof Error ? e.message : String(e);
-      const upstreamBody = (e as { responseBody?: unknown })?.responseBody;
-      console.error(
-        `[agent-host-images] failed provider=${resolved.provider_id} model=${model_id}: ${detail}${
-          upstreamBody ? ` — ${String(upstreamBody).slice(0, 300)}` : ""
-        }`
-      );
-      return c.json(
-        {
-          error: "image generation failed",
-          model_id,
-          provider_id: resolved.provider_id,
-        },
-        502
-      );
+      return hostedGenerationError(c, {
+        error: e,
+        scope: "agent-host-images",
+        label: "image generation failed",
+        model_id,
+        provider_id: resolved.provider_id,
+      });
     }
 
     return c.json({

--- a/packages/grida-ai-agent/src/http/routes/video.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` hosted video arm (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — `/video/generate` route (BYOK video generation, #908).
  *
@@ -31,16 +32,20 @@ import {
   resolveVideoModel,
 } from "../../providers/resolve-video";
 import { assertHttpsUrl } from "../../providers/fetch-helpers";
+import { hostedGenerationError } from "./gg-media-errors";
 import { body, v } from "@grida/daemon/server";
 
-const VIDEO_PROVIDERS = ["vercel", "fal", "openrouter"] as const;
+const VIDEO_PROVIDERS = ["vercel", "fal", "openrouter", "gg"] as const;
 
 export type VideoRoutesDeps = {
   secrets: SecretsStore;
+  /** GRIDA-SEC-006 — hosted provider deps; absent ⇒ grida never resolves. */
+  gg?: import("../../providers/gg-session").GridaGatewaySessionStore;
+  gg_base_url?: string;
 };
 
 export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
-  const { secrets } = deps;
+  const { secrets, gg, gg_base_url } = deps;
 
   app.post("/video/generate", async (c) => {
     const r = await body(c, {
@@ -64,7 +69,7 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
     let resolved;
     try {
       resolved = await resolveVideoModel(
-        { secrets },
+        { secrets, gg, gg_base_url },
         d.model_id,
         d.provider ? { explicit: d.provider } : {}
       );
@@ -95,24 +100,13 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
     try {
       generation = await resolved.model.doGenerate(callOptions);
     } catch (e) {
-      // Detail (which can include upstream body text — fal adapters embed
-      // safeText(res) in their thrown messages) stays in the sidecar log only;
-      // the renderer gets a generic message.
-      const detail = e instanceof Error ? e.message : String(e);
-      const upstream = (e as { responseBody?: unknown })?.responseBody;
-      console.error(
-        `[agent-host-video] failed provider=${resolved.provider_id} model=${d.model_id}: ${detail}${
-          upstream ? ` — ${String(upstream).slice(0, 300)}` : ""
-        }`
-      );
-      return c.json(
-        {
-          error: "video generation failed",
-          model_id: d.model_id,
-          provider_id: resolved.provider_id,
-        },
-        502
-      );
+      return hostedGenerationError(c, {
+        error: e,
+        scope: "agent-host-video",
+        label: "video generation failed",
+        model_id: d.model_id,
+        provider_id: resolved.provider_id,
+      });
     }
 
     // Normalize every result to base64 bytes. Providers return large clips as

--- a/packages/grida-ai-agent/src/http/routes/video.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.ts
@@ -71,7 +71,12 @@ export function registerVideoRoutes(app: Hono, deps: VideoRoutesDeps) {
       resolved = await resolveVideoModel(
         { secrets, gg, gg_base_url },
         d.model_id,
-        d.provider ? { explicit: d.provider } : {}
+        // `image` skips the t2v-only hosted `gg` arm for i2v requests so the
+        // start frame isn't silently dropped — falls back to a BYOK route.
+        {
+          ...(d.provider ? { explicit: d.provider } : {}),
+          image: !!d.image_url,
+        }
       );
     } catch (e) {
       if (e instanceof VideoModelUnavailableError) {

--- a/packages/grida-ai-agent/src/index.ts
+++ b/packages/grida-ai-agent/src/index.ts
@@ -7,11 +7,21 @@ export {
   BYOK_PROVIDER_IDS,
   byokProvidersFor,
   isByokProviderId,
+  GG_PROVIDER_ID,
+  GG_PROVIDER_METADATA,
+  isGgProviderId,
   type ByokModality,
   type ByokProviderMetadata,
   type ByokProviderId,
   type ProviderId,
 } from "./protocol/provider-ids";
+// GRIDA-SEC-006 — hosted-session wire shapes (types only; the store is
+// internal daemon state).
+export type {
+  GridaGatewaySession,
+  GridaGatewaySessionStatus,
+  GridaGatewayOrganization,
+} from "./providers/gg-session";
 export type {
   ImageGenProvider,
   ImageGenerateRequest,

--- a/packages/grida-ai-agent/src/protocol/images.ts
+++ b/packages/grida-ai-agent/src/protocol/images.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — `gg` in the image provider union (docs/wg/platform/hosted-ai.md)
 /**
  * Image-generation wire protocol (#908). Client-safe: request/result shapes
  * for the `/images/generate` route, no provider SDK imports.
@@ -13,7 +14,7 @@ export type ImageGenerateRequest = {
   model_id: string;
   prompt: string;
   /** Optional explicit provider override; otherwise the resolver picks. */
-  provider?: ImageGenProvider;
+  provider?: ImageGenProvider | "gg";
   width?: number;
   height?: number;
   aspect_ratio?: string;
@@ -38,6 +39,6 @@ export type ImageGeneratedImage = {
 export type ImageGenerateResult = {
   model_id: string;
   /** The provider that actually served the request. */
-  provider_id: ImageGenProvider;
+  provider_id: ImageGenProvider | "gg";
   images: ImageGeneratedImage[];
 };

--- a/packages/grida-ai-agent/src/protocol/provider-ids.ts
+++ b/packages/grida-ai-agent/src/protocol/provider-ids.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` hosted provider id + metadata (docs/wg/platform/hosted-ai.md)
 /**
  * BYOK provider identity + neutral metadata.
  *
@@ -55,9 +56,32 @@ export function byokProvidersFor(
 }
 
 /**
- * A provider id anywhere on the wire (run options, session rows, secrets):
- * a BYOK id or a configured endpoint id (issue #806). `string & {}` keeps
- * literal completion for the BYOK ids while admitting endpoint ids, which
- * are user-chosen slugs validated at the boundary.
+ * The Grida hosted ("included") provider — GRIDA-SEC-006. Deliberately
+ * NOT in {@link BYOK_PROVIDER_METADATA}: that list is honestly
+ * BYOK-labeled and drives the secrets UI + `/secrets/*` allowlist, and
+ * grida has no user key — its credential is the short-lived session
+ * token the renderer pushes (`/auth/gg/set`). The run-input gate
+ * accepts this id; the secrets routes must keep REJECTING it.
  */
-export type ProviderId = ByokProviderId | (string & {});
+export const GG_PROVIDER_ID = "gg" as const;
+
+export const GG_PROVIDER_METADATA = {
+  id: GG_PROVIDER_ID,
+  label: "Grida",
+  /** Picker affordance copy — one source of truth for the UI. */
+  included_label: "Grida — included",
+  modalities: ["text", "image", "video"],
+} as const;
+
+export function isGgProviderId(id: string): id is typeof GG_PROVIDER_ID {
+  return id === GG_PROVIDER_ID;
+}
+
+/**
+ * A provider id anywhere on the wire (run options, session rows, secrets):
+ * a BYOK id, the grida hosted id, or a configured endpoint id (issue
+ * #806). `string & {}` keeps literal completion for the known ids while
+ * admitting endpoint ids, which are user-chosen slugs validated at the
+ * boundary.
+ */
+export type ProviderId = ByokProviderId | typeof GG_PROVIDER_ID | (string & {});

--- a/packages/grida-ai-agent/src/protocol/video.ts
+++ b/packages/grida-ai-agent/src/protocol/video.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — `gg` in the video provider union (docs/wg/platform/hosted-ai.md)
 /**
  * Video-generation wire protocol (#908). Client-safe: request/result shapes
  * for the `/video/generate` route, no provider SDK imports.
@@ -13,7 +14,7 @@ export type VideoGenerateRequest = {
   model_id: string;
   prompt: string;
   /** Optional explicit provider override; otherwise the resolver picks. */
-  provider?: VideoGenProvider;
+  provider?: VideoGenProvider | "gg";
   aspect_ratio?: string;
   /** `"{width}x{height}"`. */
   resolution?: string;
@@ -38,6 +39,6 @@ export type GeneratedVideo = {
 
 export type VideoGenerateResult = {
   model_id: string;
-  provider_id: VideoGenProvider;
+  provider_id: VideoGenProvider | "gg";
   videos: GeneratedVideo[];
 };

--- a/packages/grida-ai-agent/src/providers/gg-media.test.ts
+++ b/packages/grida-ai-agent/src/providers/gg-media.test.ts
@@ -1,0 +1,77 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ImageModelV3CallOptions } from "@ai-sdk/provider";
+import { GridaGatewayImageModel } from "./gg-media";
+import { GridaGatewaySessionStore } from "./gg-session";
+
+/** Minimal full ImageModelV3CallOptions with overridable fields. */
+function callOptions(
+  over: Partial<ImageModelV3CallOptions> = {}
+): ImageModelV3CallOptions {
+  return {
+    prompt: "a red apple",
+    n: 1,
+    size: "1024x1024",
+    aspectRatio: undefined,
+    seed: undefined,
+    files: undefined,
+    mask: undefined,
+    providerOptions: {},
+    ...over,
+  };
+}
+
+function liveStore(): GridaGatewaySessionStore {
+  const store = new GridaGatewaySessionStore();
+  store.set({ access_token: "tok", expires_at: Date.now() + 900_000 });
+  return store;
+}
+
+function stubFetch(): () => Record<string, unknown> | undefined {
+  let body: Record<string, unknown> | undefined;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: { body?: string }) => {
+      body = JSON.parse(init.body ?? "{}");
+      return new Response(
+        JSON.stringify({
+          model_id: "m",
+          provider_id: "gg",
+          images: [{ base64: "Zm9v", media_type: "image/png" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    })
+  );
+  return () => body;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GridaGatewayImageModel.doGenerate", () => {
+  it("forwards providerOptions.gg.quality into the hosted request body", async () => {
+    const readBody = stubFetch();
+    const model = new GridaGatewayImageModel(
+      liveStore(),
+      "https://grida.test",
+      "openai/gpt-image-2"
+    );
+    await model.doGenerate(
+      callOptions({ providerOptions: { gg: { quality: "high" } } })
+    );
+    const body = readBody();
+    expect(body?.quality).toBe("high");
+    expect(body?.model_id).toBe("openai/gpt-image-2");
+  });
+
+  it("omits quality when none is set", async () => {
+    const readBody = stubFetch();
+    const model = new GridaGatewayImageModel(
+      liveStore(),
+      "https://grida.test",
+      "m"
+    );
+    await model.doGenerate(callOptions());
+    expect(readBody()?.quality).toBeUndefined();
+  });
+});

--- a/packages/grida-ai-agent/src/providers/gg-media.ts
+++ b/packages/grida-ai-agent/src/providers/gg-media.ts
@@ -1,0 +1,162 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — Grida hosted image/video adapters.
+ *
+ * The media counterparts of `./grida.ts`: `ImageModelV3` /
+ * `VideoModelV3` over the hosted `/api/v1/ai/{images,videos}/generations`
+ * endpoints (Grida-native protocol — the same request/result shapes the
+ * BYOK routes speak). The daemon contacts ONLY the configured editor
+ * origin for this provider; results are base64 by contract, so nothing
+ * from the response body is ever followed as a URL.
+ *
+ * Credential: the session token, read PER CALL from the store (never
+ * captured at construction). Error posture mirrors the BYOK adapters'
+ * GRIDA-SEC-004 rule, stricter: thrown messages are model-safe BY
+ * CONSTRUCTION (no `safeText` body embedding at all) — 401/402 map to
+ * the typed code-led errors, everything else is a generic status line.
+ */
+
+import type {
+  ImageModelV3,
+  ImageModelV3CallOptions,
+  Experimental_VideoModelV3 as VideoModelV3,
+  Experimental_VideoModelV3CallOptions as VideoModelV3CallOptions,
+} from "@ai-sdk/provider";
+import type { GridaGatewaySessionStore } from "./gg-session";
+import { readGgToken, throwOnGgHttpError } from "./gg";
+import type { ImageGenerateResult } from "../protocol/images";
+import type { VideoGenerateResult } from "../protocol/video";
+
+function joinApi(baseUrl: string, path: string): string {
+  return new URL(path, baseUrl).toString();
+}
+
+async function postHosted<T>(args: {
+  session: GridaGatewaySessionStore;
+  url: string;
+  body: unknown;
+  scope: string;
+  abortSignal?: AbortSignal;
+}): Promise<T> {
+  const res = await fetch(args.url, {
+    method: "POST",
+    signal: args.abortSignal,
+    headers: {
+      authorization: `Bearer ${readGgToken(args.session)}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(args.body),
+  });
+  throwOnGgHttpError(res.status);
+  if (!res.ok) {
+    // Model-safe by construction: status only, never the body.
+    throw new Error(`[${args.scope}] hosted request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
+export class GridaGatewayImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "gg";
+  readonly maxImagesPerCall = 4;
+
+  constructor(
+    private readonly session: GridaGatewaySessionStore,
+    private readonly baseUrl: string,
+    readonly modelId: string
+  ) {}
+
+  async doGenerate(
+    options: ImageModelV3CallOptions
+  ): Promise<Awaited<ReturnType<ImageModelV3["doGenerate"]>>> {
+    const { prompt, n, size, aspectRatio, seed, abortSignal } = options;
+    let width: number | undefined;
+    let height: number | undefined;
+    if (size) {
+      const match = /^(\d+)x(\d+)$/.exec(size);
+      if (match) {
+        width = Number(match[1]);
+        height = Number(match[2]);
+      }
+    }
+    const result = await postHosted<ImageGenerateResult>({
+      session: this.session,
+      url: joinApi(this.baseUrl, "/api/v1/ai/images/generations"),
+      scope: "grida-images",
+      abortSignal,
+      body: {
+        model_id: this.modelId,
+        prompt,
+        n,
+        width,
+        height,
+        aspect_ratio: aspectRatio,
+        seed,
+      },
+    });
+    return {
+      images: result.images.map((image) => image.base64),
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    };
+  }
+}
+
+export class GridaGatewayVideoModel implements VideoModelV3 {
+  readonly specificationVersion = "v3" as const;
+  readonly provider = "gg";
+  readonly maxVideosPerCall = 1;
+
+  constructor(
+    private readonly session: GridaGatewaySessionStore,
+    private readonly baseUrl: string,
+    readonly modelId: string
+  ) {}
+
+  async doGenerate(
+    options: VideoModelV3CallOptions
+  ): Promise<Awaited<ReturnType<VideoModelV3["doGenerate"]>>> {
+    const {
+      prompt,
+      aspectRatio,
+      resolution,
+      duration,
+      fps,
+      seed,
+      abortSignal,
+    } = options;
+    const result = await postHosted<VideoGenerateResult>({
+      session: this.session,
+      url: joinApi(this.baseUrl, "/api/v1/ai/videos/generations"),
+      scope: "grida-video",
+      abortSignal,
+      body: {
+        model_id: this.modelId,
+        prompt,
+        aspect_ratio: aspectRatio,
+        resolution,
+        duration,
+        fps,
+        seed,
+      },
+    });
+    return {
+      videos: result.videos.map((video) => ({
+        type: "base64" as const,
+        data: video.base64,
+        mediaType: video.media_type,
+      })),
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+      providerMetadata: {},
+    };
+  }
+}

--- a/packages/grida-ai-agent/src/providers/gg-media.ts
+++ b/packages/grida-ai-agent/src/providers/gg-media.ts
@@ -69,7 +69,8 @@ export class GridaGatewayImageModel implements ImageModelV3 {
   async doGenerate(
     options: ImageModelV3CallOptions
   ): Promise<Awaited<ReturnType<ImageModelV3["doGenerate"]>>> {
-    const { prompt, n, size, aspectRatio, seed, abortSignal } = options;
+    const { prompt, n, size, aspectRatio, seed, abortSignal, providerOptions } =
+      options;
     let width: number | undefined;
     let height: number | undefined;
     if (size) {
@@ -79,6 +80,11 @@ export class GridaGatewayImageModel implements ImageModelV3 {
         height = Number(match[2]);
       }
     }
+    // The desktop image route sets the picker's quality tier under
+    // `providerOptions.gg` (keyed by provider id); forward it so the hosted
+    // endpoint bills AND delivers the requested tier rather than dropping it.
+    const rawQuality = providerOptions?.gg?.quality;
+    const quality = typeof rawQuality === "string" ? rawQuality : undefined;
     const result = await postHosted<ImageGenerateResult>({
       session: this.session,
       url: joinApi(this.baseUrl, "/api/v1/ai/images/generations"),
@@ -91,6 +97,7 @@ export class GridaGatewayImageModel implements ImageModelV3 {
         width,
         height,
         aspect_ratio: aspectRatio,
+        quality,
         seed,
       },
     });

--- a/packages/grida-ai-agent/src/providers/gg-media.ts
+++ b/packages/grida-ai-agent/src/providers/gg-media.ts
@@ -47,9 +47,11 @@ async function postHosted<T>(args: {
     },
     body: JSON.stringify(args.body),
   });
-  throwOnGgHttpError(res.status);
+  await throwOnGgHttpError(res);
   if (!res.ok) {
-    // Model-safe by construction: status only, never the body.
+    // Model-safe by construction: status only, never the body. Drain the
+    // body first so undici releases the socket.
+    await res.body?.cancel().catch(() => {});
     throw new Error(`[${args.scope}] hosted request failed (${res.status})`);
   }
   return (await res.json()) as T;

--- a/packages/grida-ai-agent/src/providers/gg-resolution.test.ts
+++ b/packages/grida-ai-agent/src/providers/gg-resolution.test.ts
@@ -1,0 +1,113 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — grida hosted provider resolution.
+ *
+ * Pins the locked precedence (explicit wins; implicit = BYOK → grida →
+ * endpoints), the live-token + base-URL gating, and the explicit-pick
+ * failure shape (ProviderUnavailableError with provider_id "gg" →
+ * the renderer's "Sign in to use included AI").
+ */
+import { describe, expect, it } from "vitest";
+import type { SecretsStore } from "@grida/daemon/server";
+import type { EndpointProviderConfig } from "../protocol/endpoints";
+import type { EndpointProvidersStore } from "./endpoints";
+import { ProviderUnavailableError, resolveProvider } from "./index";
+import { GridaGatewaySessionStore } from "./gg-session";
+
+const BASE = "https://grida.test";
+
+function liveSession(): GridaGatewaySessionStore {
+  const s = new GridaGatewaySessionStore();
+  s.set({ access_token: "tok", expires_at: Date.now() + 900_000 });
+  return s;
+}
+
+function expiredSession(): GridaGatewaySessionStore {
+  const s = new GridaGatewaySessionStore();
+  s.set({ access_token: "tok", expires_at: Date.now() - 1 });
+  return s;
+}
+
+const OLLAMA: EndpointProviderConfig = {
+  id: "ollama",
+  label: "Ollama",
+  base_url: "http://localhost:11434/v1",
+  models: [{ id: "llama3.1:8b" }],
+};
+
+function deps(args: {
+  keys?: Record<string, string>;
+  gg?: GridaGatewaySessionStore;
+  base?: string | null;
+  endpoints?: EndpointProviderConfig[];
+}) {
+  return {
+    secrets: {
+      _getKey: async (providerId: string) => args.keys?.[providerId] ?? null,
+    } as SecretsStore,
+    endpoints: args.endpoints
+      ? ({
+          list: async () => args.endpoints,
+          get: async (id: string) =>
+            args.endpoints!.find((e) => e.id === id) ?? null,
+        } as EndpointProvidersStore)
+      : undefined,
+    gg: args.gg,
+    gg_base_url: args.base === null ? undefined : (args.base ?? BASE),
+  };
+}
+
+describe("grida hosted resolution", () => {
+  it("implicit: BYOK beats grida; grida beats endpoints", async () => {
+    const byokFirst = await resolveProvider(
+      deps({ keys: { openrouter: "sk" }, gg: liveSession() })
+    );
+    expect(byokFirst.provider_id).toBe("openrouter");
+
+    const gridaOverEndpoint = await resolveProvider(
+      deps({ gg: liveSession(), endpoints: [OLLAMA] })
+    );
+    expect(gridaOverEndpoint.provider_id).toBe("gg");
+    expect(gridaOverEndpoint.kind).toBe("gg");
+  });
+
+  it("implicit: expired token falls through to endpoints; absent store too", async () => {
+    const fellThrough = await resolveProvider(
+      deps({ gg: expiredSession(), endpoints: [OLLAMA] })
+    );
+    expect(fellThrough.provider_id).toBe("ollama");
+
+    const noStore = await resolveProvider(deps({ endpoints: [OLLAMA] }));
+    expect(noStore.provider_id).toBe("ollama");
+  });
+
+  it("never resolves grida without a base URL (dormant host)", async () => {
+    await expect(
+      resolveProvider(deps({ gg: liveSession(), base: null }))
+    ).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  it("explicit grida: resolves with a live token; typed 'provider_down' without", async () => {
+    const resolved = await resolveProvider(deps({ gg: liveSession() }), {
+      explicit: "gg",
+    });
+    expect(resolved.provider_id).toBe("gg");
+
+    await expect(
+      resolveProvider(deps({ gg: expiredSession() }), { explicit: "gg" })
+    ).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof ProviderUnavailableError &&
+        err.provider_id === "gg" &&
+        err.code === "provider_down"
+    );
+  });
+
+  it("explicit BYOK still wins over a live grida session", async () => {
+    const resolved = await resolveProvider(
+      deps({ keys: { vercel: "vk" }, gg: liveSession() }),
+      { explicit: "vercel" }
+    );
+    expect(resolved.provider_id).toBe("vercel");
+  });
+});

--- a/packages/grida-ai-agent/src/providers/gg-session.test.ts
+++ b/packages/grida-ai-agent/src/providers/gg-session.test.ts
@@ -1,0 +1,52 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — GridaGatewaySessionStore.
+ *
+ * Pins: in-memory lifecycle (set/read/clear), the 30s expiry slack
+ * boundary (expiring-soon reads as ABSENT — resolve-time refusal beats
+ * an upstream 401), and that `status()` never contains the token.
+ */
+import { describe, it, expect } from "vitest";
+import { GridaGatewaySessionStore } from "./gg-session";
+
+const NOW = 1_700_000_000_000;
+
+function store(expiresInMs: number): GridaGatewaySessionStore {
+  const s = new GridaGatewaySessionStore();
+  s.set({
+    access_token: "jwt-secret-token",
+    expires_at: NOW + expiresInMs,
+    organization: { id: 7, name: "acme" },
+  });
+  return s;
+}
+
+describe("GridaGatewaySessionStore", () => {
+  it("set → read → clear lifecycle", () => {
+    const s = store(900_000);
+    expect(s.getAccessToken(NOW)).toBe("jwt-secret-token");
+    s.clear();
+    expect(s.getAccessToken(NOW)).toBeNull();
+    expect(s.status(NOW)).toEqual({ active: false });
+    s.clear(); // idempotent
+  });
+
+  it("expiry slack: <=30s left reads as absent, 31s reads live", () => {
+    expect(store(30_000).getAccessToken(NOW)).toBeNull();
+    expect(store(29_000).getAccessToken(NOW)).toBeNull();
+    expect(store(31_000).getAccessToken(NOW)).toBe("jwt-secret-token");
+    expect(store(-1).getAccessToken(NOW)).toBeNull();
+  });
+
+  it("status reports presence + org but NEVER the token", () => {
+    const s = store(900_000);
+    const status = s.status(NOW);
+    expect(status).toEqual({
+      active: true,
+      expires_at: NOW + 900_000,
+      organization: { id: 7, name: "acme" },
+    });
+    expect(JSON.stringify(status)).not.toContain("jwt-secret-token");
+    expect(store(10_000).status(NOW)).toEqual({ active: false });
+  });
+});

--- a/packages/grida-ai-agent/src/providers/gg-session.ts
+++ b/packages/grida-ai-agent/src/providers/gg-session.ts
@@ -1,0 +1,89 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — Grida Cloud session store (hosted "included" AI).
+ *
+ * Holds the short-lived, org-scoped AI token the renderer mints from the
+ * webview's cookie session (`POST /desktop/auth/token`) and pushes over
+ * the daemon perimeter (`/auth/gg/set`). IN MEMORY ONLY, by design:
+ * never `auth.json` / `AuthStore` (those are durable credential stores;
+ * this token expires in minutes), never disk, never logs. The webview
+ * session remains the only durable credential (GRIDA-SEC-005 custodian
+ * doctrine) — the daemon never sees a refresh token; the renderer
+ * re-mints and re-pushes. Lost on daemon restart, also by design: the
+ * renderer's ensure-fresh-before-run re-seeds it.
+ */
+
+export type GridaGatewayOrganization = { id: number; name: string };
+
+export type GridaGatewaySession = {
+  /** The scoped AI JWT (aud `gg:ai`). Opaque to the daemon. */
+  access_token: string;
+  /** Expiry, epoch milliseconds (renderer normalizes the mint response). */
+  expires_at: number;
+  /** Display-only org context (never used for authorization here). */
+  organization?: GridaGatewayOrganization;
+};
+
+export type GridaGatewaySessionStatus = {
+  active: boolean;
+  expires_at?: number;
+  organization?: GridaGatewayOrganization;
+};
+
+/**
+ * Reads treat a token expiring within this slack as absent — a
+ * resolve-time refusal beats a guaranteed upstream 401 one hop later.
+ * The renderer owns proactive refresh at a much wider margin (5 min).
+ */
+const EXPIRY_SLACK_MS = 30_000;
+
+export class GridaGatewaySessionStore {
+  private session: GridaGatewaySession | null = null;
+
+  set(session: GridaGatewaySession): void {
+    this.session = session;
+  }
+
+  /** Idempotent. Pushed by the renderer on sign-out. */
+  clear(): void {
+    this.session = null;
+  }
+
+  /** Live token, or `null` when absent / expired / within the slack. */
+  getAccessToken(now: number = Date.now()): string | null {
+    const s = this.session;
+    if (!s) return null;
+    if (s.expires_at - now <= EXPIRY_SLACK_MS) return null;
+    return s.access_token;
+  }
+
+  /** Presence + expiry + org for `/auth/gg/status` — NEVER the token. */
+  status(now: number = Date.now()): GridaGatewaySessionStatus {
+    const s = this.session;
+    if (!s || s.expires_at - now <= EXPIRY_SLACK_MS) {
+      return { active: false };
+    }
+    return {
+      active: true,
+      expires_at: s.expires_at,
+      organization: s.organization,
+    };
+  }
+}
+
+/**
+ * The single liveness gate shared by the language / image / video
+ * resolvers: the Grida Gateway provider resolves only when a base URL is
+ * configured AND the store holds a live (unexpired) token. Returns the
+ * resolved-endpoint tuple, or `null` when it can't serve. The token is
+ * re-read per request inside each factory's fetch — this only gates
+ * resolution.
+ */
+export function liveGgMediaDeps(deps: {
+  gg?: GridaGatewaySessionStore;
+  gg_base_url?: string;
+}): { session: GridaGatewaySessionStore; base_url: string } | null {
+  if (!deps.gg || !deps.gg_base_url) return null;
+  if (deps.gg.getAccessToken() === null) return null;
+  return { session: deps.gg, base_url: deps.gg_base_url };
+}

--- a/packages/grida-ai-agent/src/providers/gg.test.ts
+++ b/packages/grida-ai-agent/src/providers/gg.test.ts
@@ -1,0 +1,146 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — the grida hosted text factory.
+ *
+ * Pins: the token is read AT REQUEST TIME (a fresh push between calls is
+ * honored), the base URL is `<origin>/api/v1/ai`, tiers map through the
+ * canonical TIER_MODEL_IDS table (NOT the endpoint collapse), and
+ * 401/402 map to the typed errors whose literal code LEADS the message
+ * (the contextBridge detection contract).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TIER_MODEL_IDS } from "@grida/ai-models";
+import {
+  GridaGatewayAuthError,
+  GridaGatewayCreditsError,
+  gridaGatewayApiBase,
+  makeGridaGatewayFactory,
+} from "./gg";
+import { GridaGatewaySessionStore } from "./gg-session";
+
+const realFetch = globalThis.fetch;
+const fetchMock =
+  vi.fn<(input: unknown, init?: RequestInit) => Promise<Response>>();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function liveStore(token = "tok-1"): GridaGatewaySessionStore {
+  const store = new GridaGatewaySessionStore();
+  store.set({ access_token: token, expires_at: Date.now() + 900_000 });
+  return store;
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Minimal V3 generate roundtrip through the model's real request path. */
+async function callModel(
+  store: GridaGatewaySessionStore,
+  modelId?: string
+): Promise<void> {
+  const factory = makeGridaGatewayFactory(store, "https://grida.test");
+  const model = factory("pro", modelId) as unknown as {
+    doGenerate: (o: unknown) => Promise<unknown>;
+  };
+  fetchMock.mockResolvedValue(
+    okJson({
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      created: 0,
+      model: modelId ?? TIER_MODEL_IDS.pro,
+      choices: [
+        {
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    })
+  );
+  await model.doGenerate({
+    prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+  });
+}
+
+describe("makeGridaGatewayFactory", () => {
+  it("builds the /api/v1/ai base and sends the LIVE token per request", async () => {
+    expect(gridaGatewayApiBase("https://grida.co")).toBe(
+      "https://grida.co/api/v1/ai"
+    );
+    const store = liveStore("tok-first");
+    await callModel(store);
+    const [url1, init1] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(String(url1)).toBe("https://grida.test/api/v1/ai/chat/completions");
+    expect(new Headers(init1.headers).get("authorization")).toBe(
+      "Bearer tok-first"
+    );
+
+    // A fresh push between calls is honored — token read at request time.
+    store.set({ access_token: "tok-second", expires_at: Date.now() + 900_000 });
+    await callModel(store);
+    const [, init2] = fetchMock.mock.calls[1]! as [string, RequestInit];
+    expect(new Headers(init2.headers).get("authorization")).toBe(
+      "Bearer tok-second"
+    );
+  });
+
+  it("tiers map through TIER_MODEL_IDS; explicit ids pass through", async () => {
+    const store = liveStore();
+    await callModel(store);
+    const body1 = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string
+    ) as { model: string };
+    expect(body1.model).toBe(TIER_MODEL_IDS.pro);
+
+    await callModel(store, "openai/gpt-5.4-mini");
+    const body2 = JSON.parse(
+      (fetchMock.mock.calls[1]![1] as RequestInit).body as string
+    ) as { model: string };
+    expect(body2.model).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("missing/expired session → GridaGatewayAuthError before any fetch", async () => {
+    const store = new GridaGatewaySessionStore();
+    await expect(callModel(store)).rejects.toBeInstanceOf(
+      GridaGatewayAuthError
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("401/402 responses map to code-led typed errors", async () => {
+    const store = liveStore();
+    const factory = makeGridaGatewayFactory(store, "https://grida.test");
+    const model = factory("pro") as unknown as {
+      doGenerate: (o: unknown) => Promise<unknown>;
+    };
+    const prompt = {
+      prompt: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+    };
+
+    fetchMock.mockResolvedValue(new Response("{}", { status: 401 }));
+    await expect(model.doGenerate(prompt)).rejects.toSatisfy((err: unknown) => {
+      return (
+        err instanceof GridaGatewayAuthError &&
+        err.message.startsWith("gg_token_expired")
+      );
+    });
+
+    fetchMock.mockResolvedValue(new Response("{}", { status: 402 }));
+    await expect(model.doGenerate(prompt)).rejects.toSatisfy((err: unknown) => {
+      return (
+        err instanceof GridaGatewayCreditsError &&
+        err.message.startsWith("insufficient_credits")
+      );
+    });
+  });
+});

--- a/packages/grida-ai-agent/src/providers/gg.ts
+++ b/packages/grida-ai-agent/src/providers/gg.ts
@@ -1,0 +1,96 @@
+// GRIDA-GG: provider — see docs/wg/platform/hosted-ai.md
+/**
+ * GRIDA-SEC-006 — the `grida` hosted ("included") text-model factory.
+ *
+ * Grida Cloud is just another OpenAI-compatible provider from the
+ * agent's point of view: `{EDITOR_BASE}/api/v1/ai` speaks the chat-
+ * completions wire, gated and metered server-side against the org's AI
+ * credits. What differs from BYOK is the credential: a short-lived
+ * scoped JWT read from the {@link GridaGatewaySessionStore} AT REQUEST
+ * TIME (a custom fetch), not a static key — agent turns can outlive the
+ * 15-minute token, and every step must ride the freshest token the
+ * renderer has pushed.
+ */
+
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { TIER_MODEL_IDS, type TierModelId } from "@grida/ai-models";
+import type { ModelFactory } from "../agent";
+import type { ModelTier } from "../tiers";
+import type { GridaGatewaySessionStore } from "./gg-session";
+
+const MODEL_BY_TIER: Record<ModelTier, TierModelId> = TIER_MODEL_IDS;
+
+/**
+ * The hosted session is missing or expired. The literal code LEADS the
+ * message: mid-run errors cross Electron's `contextBridge`, which strips
+ * custom props — the renderer detects by message substring (the
+ * `isWriteConflict` idiom).
+ */
+export class GridaGatewayAuthError extends Error {
+  readonly code = "gg_token_expired" as const;
+  constructor() {
+    super("gg_token_expired: the Grida session token is missing or expired");
+    this.name = "GridaGatewayAuthError";
+  }
+}
+
+/** The org's AI credit balance can't cover the call (server 402). */
+export class GridaGatewayCreditsError extends Error {
+  readonly code = "insufficient_credits" as const;
+  constructor() {
+    super(
+      "insufficient_credits: the organization's AI credit balance is too low"
+    );
+    this.name = "GridaGatewayCreditsError";
+  }
+}
+
+/** `<base>/api/v1/ai` — `@ai-sdk/openai-compatible` appends the paths. */
+export function gridaGatewayApiBase(baseUrl: string): string {
+  return new URL("/api/v1/ai", baseUrl).toString();
+}
+
+/** The live scoped token, or throw the typed auth error (never a bare null). */
+export function readGgToken(session: GridaGatewaySessionStore): string {
+  const token = session.getAccessToken();
+  if (!token) throw new GridaGatewayAuthError();
+  return token;
+}
+
+/**
+ * Map the two actionable hosted-response failures to typed, model-safe
+ * errors — the single source for this contract, shared by the text factory
+ * and the media adapters. Every other status is left to the caller. Never
+ * embed upstream body text (GRIDA-SEC-004 posture).
+ */
+export function throwOnGgHttpError(status: number): void {
+  if (status === 401) throw new GridaGatewayAuthError();
+  if (status === 402) throw new GridaGatewayCreditsError();
+}
+
+export function makeGridaGatewayFactory(
+  session: GridaGatewaySessionStore,
+  baseUrl: string
+): ModelFactory {
+  const provider = createOpenAICompatible({
+    name: "gg",
+    baseURL: gridaGatewayApiBase(baseUrl),
+    // Same load-bearing flag as the BYOK factories: without the usage
+    // chunk every streamed run records zero tokens.
+    includeUsage: true,
+    fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("authorization", `Bearer ${readGgToken(session)}`);
+      const response = await fetch(input, { ...init, headers });
+      // 401/402 → typed errors; everything else passes through to the SDK's
+      // own handling (already downgraded before reaching the renderer).
+      throwOnGgHttpError(response.status);
+      return response;
+    }) as typeof fetch,
+  });
+  // Catalog ids ARE the hosted call ids (the server allowlist is the
+  // same catalog) — explicit picks hand straight through, tiers resolve
+  // via the canonical table. Deliberately NOT the endpoint factory's
+  // collapse-to-default: Grida Cloud serves the catalog.
+  return (tier, modelId) => provider(modelId ?? MODEL_BY_TIER[tier]);
+}

--- a/packages/grida-ai-agent/src/providers/gg.ts
+++ b/packages/grida-ai-agent/src/providers/gg.ts
@@ -61,11 +61,16 @@ export function readGgToken(session: GridaGatewaySessionStore): string {
  * Map the two actionable hosted-response failures to typed, model-safe
  * errors — the single source for this contract, shared by the text factory
  * and the media adapters. Every other status is left to the caller. Never
- * embed upstream body text (GRIDA-SEC-004 posture).
+ * embed upstream body text (GRIDA-SEC-004 posture). Drains the unconsumed
+ * body before throwing so undici can return the socket to the pool
+ * (unconsumed bodies pin the connection).
  */
-export function throwOnGgHttpError(status: number): void {
-  if (status === 401) throw new GridaGatewayAuthError();
-  if (status === 402) throw new GridaGatewayCreditsError();
+export async function throwOnGgHttpError(res: Response): Promise<void> {
+  if (res.status === 401 || res.status === 402) {
+    await res.body?.cancel().catch(() => {});
+    if (res.status === 401) throw new GridaGatewayAuthError();
+    throw new GridaGatewayCreditsError();
+  }
 }
 
 export function makeGridaGatewayFactory(
@@ -84,7 +89,7 @@ export function makeGridaGatewayFactory(
       const response = await fetch(input, { ...init, headers });
       // 401/402 → typed errors; everything else passes through to the SDK's
       // own handling (already downgraded before reaching the renderer).
-      throwOnGgHttpError(response.status);
+      await throwOnGgHttpError(response);
       return response;
     }) as typeof fetch,
   });

--- a/packages/grida-ai-agent/src/providers/index.ts
+++ b/packages/grida-ai-agent/src/providers/index.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` provider resolution arm + precedence (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — provider resolver (in-package providers layer).
  *
@@ -28,8 +29,12 @@ import type { SecretsStore } from "@grida/daemon/server";
 import {
   byokProvidersFor,
   isByokProviderId,
+  isGgProviderId,
+  GG_PROVIDER_ID,
   type ByokProviderId,
 } from "../protocol/provider-ids";
+import { makeGridaGatewayFactory } from "./gg";
+import { liveGgMediaDeps, type GridaGatewaySessionStore } from "./gg-session";
 import {
   endpointDefaultModelId,
   type EndpointProviderConfig,
@@ -50,12 +55,15 @@ export type ResolvedProvider = {
   /** A BYOK provider id, a configured endpoint id, or an agent-provider id. */
   provider_id: string;
   /**
-   * `byok`/`endpoint` are MODEL providers (the host owns the loop, calls
-   * `model_factory`). `agent-provider` is an EXTERNAL agent that owns its own
-   * loop (issue #813); `model_factory` is never called — the runtime branches
-   * on this kind and streams from the agent-provider consumer instead.
+   * `byok`/`grida`/`endpoint` are MODEL providers (the host owns the
+   * loop, calls `model_factory`). `grida` is the hosted "included"
+   * provider (GRIDA-SEC-006) — credential is the pushed session token,
+   * not a stored key. `agent-provider` is an EXTERNAL agent that owns
+   * its own loop (issue #813); `model_factory` is never called — the
+   * runtime branches on this kind and streams from the agent-provider
+   * consumer instead.
    */
-  kind: "byok" | "endpoint" | "agent-provider";
+  kind: "byok" | "gg" | "endpoint" | "agent-provider";
   model_factory: ModelFactory;
 };
 
@@ -101,6 +109,15 @@ export type ResolveDeps = {
   /** Endpoint provider configs. Optional so key-only hosts/tests need not
    *  wire a store; absent ⇒ no endpoint providers resolve. */
   endpoints?: EndpointProvidersStore;
+  /**
+   * Grida Cloud session (GRIDA-SEC-006). Optional like `endpoints`;
+   * absent — or holding no live token — ⇒ the grida provider never
+   * resolves. Resolves only when `gg_base_url` is ALSO configured.
+   */
+  gg?: GridaGatewaySessionStore;
+  /** Origin the grida provider calls (e.g. `https://grida.co`). Host-
+   *  injected; absent ⇒ the grida provider is disabled. */
+  gg_base_url?: string;
 };
 
 export type ResolveOptions = {
@@ -129,6 +146,13 @@ export async function resolveProvider(
     }
   }
 
+  // Grida hosted (GRIDA-SEC-006) — after BYOK (existing BYOK users keep
+  // exact behavior; explicit choice always wins), before endpoints
+  // (fresh signed-in users get included AI without configuring
+  // anything). Resolves only with a LIVE session token.
+  const gridaResolved = maybeResolveGg(deps);
+  if (gridaResolved) return gridaResolved;
+
   if (deps.endpoints) {
     for (const endpoint of await deps.endpoints.list()) {
       const resolved = await maybeResolveEndpoint(endpoint, deps);
@@ -143,6 +167,14 @@ async function resolveExplicit(
   providerId: string,
   deps: ResolveDeps
 ): Promise<ResolvedProvider> {
+  if (isGgProviderId(providerId)) {
+    // Without a live token the pick surfaces as the existing 409
+    // `provider_down` with `provider_id: "gg"` — the renderer maps
+    // that to "Sign in to use included AI".
+    const resolved = maybeResolveGg(deps);
+    if (!resolved) throw new ProviderUnavailableError(providerId);
+    return resolved;
+  }
   if (isByokProviderId(providerId)) {
     const key = await deps.secrets._getKey(providerId);
     if (!key) throw new ProviderUnavailableError(providerId);
@@ -152,6 +184,22 @@ async function resolveExplicit(
   const resolved = endpoint && (await maybeResolveEndpoint(endpoint, deps));
   if (!resolved) throw new ProviderUnavailableError(providerId);
   return resolved;
+}
+
+/**
+ * Grida hosted resolves only when the host configured a base URL AND
+ * the renderer has pushed a live (unexpired) session token. The token
+ * is re-read per request inside the factory's fetch — this check only
+ * gates resolution.
+ */
+function maybeResolveGg(deps: ResolveDeps): ResolvedProvider | null {
+  const hosted = liveGgMediaDeps(deps);
+  if (!hosted) return null;
+  return {
+    provider_id: GG_PROVIDER_ID,
+    kind: "gg",
+    model_factory: makeGridaGatewayFactory(hosted.session, hosted.base_url),
+  };
 }
 
 function makeResolvedByok(

--- a/packages/grida-ai-agent/src/providers/resolve-image.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-image.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` image-provider arm (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — image-model provider resolver (in-package providers layer).
  *
@@ -19,8 +20,10 @@
 import { models } from "@grida/ai-models";
 import type { ImageModelV3 } from "@ai-sdk/provider";
 import type { SecretsStore } from "@grida/daemon/server";
-import { byokProvidersFor } from "../protocol/provider-ids";
+import { byokProvidersFor, GG_PROVIDER_ID } from "../protocol/provider-ids";
 import { makeImageModelFor } from "./image-byok";
+import { GridaGatewayImageModel } from "./gg-media";
+import { liveGgMediaDeps, type GridaGatewaySessionStore } from "./gg-session";
 import { DEFAULT_IMAGE_MODEL_ID } from "./preferences";
 
 type ImageProvider = models.image.ImageProvider;
@@ -36,7 +39,8 @@ function isImageProvider(id: string): id is ImageProvider {
 }
 
 export type ResolvedImageModel = {
-  provider_id: ImageProvider;
+  /** A BYOK image provider, or the hosted `grida` provider (GRIDA-SEC-006). */
+  provider_id: ImageProvider | typeof GG_PROVIDER_ID;
   /** Canonical catalog id (our key). */
   model_id: string;
   /** Provider-specific call id actually handed to the SDK. */
@@ -96,11 +100,16 @@ function referenceCapableProviders(
 
 export type ResolveImageDeps = {
   secrets: SecretsStore;
+  /** Grida Cloud session (GRIDA-SEC-006) — optional; absent or token-less
+   *  ⇒ the hosted provider never resolves. */
+  gg?: GridaGatewaySessionStore;
+  /** Origin of the hosted endpoints; absent ⇒ hosted provider disabled. */
+  gg_base_url?: string;
 };
 
 export type ResolveImageOptions = {
   /** Caller override. If set, precedence is skipped and only this provider is checked. */
-  explicit?: ImageProvider;
+  explicit?: ImageProvider | typeof GG_PROVIDER_ID;
   /**
    * Resolve for image-to-image. When true, only providers whose binding has a
    * `references` capability are eligible, and the resolved `binding_id` is the
@@ -141,7 +150,26 @@ export async function hasUsableImageProvider(
     if (!isImageProvider(p.id)) continue;
     if (await deps.secrets._getKey(p.id)) return true;
   }
-  return false;
+  // Grida hosted (GRIDA-SEC-006): a live session serves the curated list
+  // too — a signed-in keyless user gets in-chat image generation.
+  return liveGgMediaDeps(deps) !== null;
+}
+
+/**
+ * Build the resolved hosted image model — shared by the explicit-pick and
+ * post-BYOK fallback arms, which produce the identical descriptor.
+ */
+function resolvedGgImage(
+  modelId: string,
+  card: models.image.ImageModelCard,
+  hosted: { session: GridaGatewaySessionStore; base_url: string }
+): ResolvedImageModel {
+  return {
+    provider_id: GG_PROVIDER_ID,
+    model_id: modelId,
+    binding_id: card.id,
+    model: new GridaGatewayImageModel(hosted.session, hosted.base_url, card.id),
+  };
 }
 
 export async function resolveImageModel(
@@ -156,8 +184,19 @@ export async function resolveImageModel(
     throw new ImageModelUnavailableError(modelId, options.explicit);
   }
 
+  // Explicit hosted pick — only grida is checked (mirrors the BYOK
+  // explicit path). Hosted image is text-to-image only in v1: the wire
+  // has no references field, so i2i must ride a BYOK route.
+  if (options.explicit === GG_PROVIDER_ID) {
+    const hosted = !options.references && liveGgMediaDeps(deps);
+    if (!hosted || !models.image.binding(card, "vercel")) {
+      throw new ImageModelUnavailableError(modelId, GG_PROVIDER_ID);
+    }
+    return resolvedGgImage(modelId, card, hosted);
+  }
+
   const order: ImageProvider[] = options.explicit
-    ? [options.explicit]
+    ? [options.explicit as ImageProvider]
     : byokProvidersFor("image")
         .map((p) => p.id)
         .filter(isImageProvider);
@@ -180,6 +219,15 @@ export async function resolveImageModel(
         ? { references_max: binding.references!.max }
         : {}),
     };
+  }
+
+  // Grida hosted (GRIDA-SEC-006) — after BYOK, before giving up. Serves
+  // any card the hosted gateway can (a vercel binding), t2i only.
+  if (!options.explicit && !options.references) {
+    const hosted = liveGgMediaDeps(deps);
+    if (hosted && models.image.binding(card, "vercel")) {
+      return resolvedGgImage(modelId, card, hosted);
+    }
   }
 
   // No connected provider served the resolution. For an image-to-image call the

--- a/packages/grida-ai-agent/src/providers/resolve-video.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` video-provider arm (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — video-model provider resolver. The video counterpart of
  * {@link ./resolve-image.ts}.
@@ -16,8 +17,10 @@
 import { models } from "@grida/ai-models";
 import type { Experimental_VideoModelV3 as VideoModelV3 } from "@ai-sdk/provider";
 import type { SecretsStore } from "@grida/daemon/server";
-import { byokProvidersFor } from "../protocol/provider-ids";
+import { byokProvidersFor, GG_PROVIDER_ID } from "../protocol/provider-ids";
 import { makeVideoModelFor } from "./video-byok";
+import { GridaGatewayVideoModel } from "./gg-media";
+import { liveGgMediaDeps, type GridaGatewaySessionStore } from "./gg-session";
 
 type VideoProvider = models.video.VideoProvider;
 
@@ -32,7 +35,8 @@ function isVideoProvider(id: string): id is VideoProvider {
 }
 
 export type ResolvedVideoModel = {
-  provider_id: VideoProvider;
+  /** A BYOK video provider, or the hosted `grida` provider (GRIDA-SEC-006). */
+  provider_id: VideoProvider | typeof GG_PROVIDER_ID;
   model_id: string;
   binding_id: string;
   model: VideoModelV3;
@@ -55,11 +59,33 @@ export class VideoModelUnavailableError extends Error {
 
 export type ResolveVideoDeps = {
   secrets: SecretsStore;
+  /** Grida Cloud session (GRIDA-SEC-006) — optional; absent or token-less
+   *  ⇒ the hosted provider never resolves. */
+  gg?: GridaGatewaySessionStore;
+  /** Origin of the hosted endpoints; absent ⇒ hosted provider disabled. */
+  gg_base_url?: string;
 };
 
 export type ResolveVideoOptions = {
-  explicit?: VideoProvider;
+  explicit?: VideoProvider | typeof GG_PROVIDER_ID;
 };
+
+/**
+ * Build the resolved hosted video model — shared by the explicit-pick and
+ * post-BYOK fallback arms, which produce the identical descriptor.
+ */
+function resolvedGgVideo(
+  modelId: string,
+  card: models.video.VideoModelCard,
+  hosted: { session: GridaGatewaySessionStore; base_url: string }
+): ResolvedVideoModel {
+  return {
+    provider_id: GG_PROVIDER_ID,
+    model_id: modelId,
+    binding_id: card.id,
+    model: new GridaGatewayVideoModel(hosted.session, hosted.base_url, card.id),
+  };
+}
 
 export async function resolveVideoModel(
   deps: ResolveVideoDeps,
@@ -71,8 +97,18 @@ export async function resolveVideoModel(
     throw new VideoModelUnavailableError(modelId, options.explicit);
   }
 
+  // Explicit hosted pick (GRIDA-SEC-006). Hosted video is
+  // text-to-video only in v1 — the route rejects image_url server-side.
+  if (options.explicit === GG_PROVIDER_ID) {
+    const hosted = liveGgMediaDeps(deps);
+    if (!hosted || !models.video.binding(card, "vercel")) {
+      throw new VideoModelUnavailableError(modelId, GG_PROVIDER_ID);
+    }
+    return resolvedGgVideo(modelId, card, hosted);
+  }
+
   const order: VideoProvider[] = options.explicit
-    ? [options.explicit]
+    ? [options.explicit as VideoProvider]
     : byokProvidersFor("video")
         .map((p) => p.id)
         .filter(isVideoProvider);
@@ -88,6 +124,15 @@ export async function resolveVideoModel(
       binding_id: binding.id,
       model: makeVideoModelFor(provider, key.trim(), binding.id),
     };
+  }
+
+  // Grida hosted (GRIDA-SEC-006) — after BYOK, before giving up. Serves
+  // cards the hosted gateway can (a vercel binding).
+  if (!options.explicit) {
+    const hosted = liveGgMediaDeps(deps);
+    if (hosted && models.video.binding(card, "vercel")) {
+      return resolvedGgVideo(modelId, card, hosted);
+    }
   }
 
   throw new VideoModelUnavailableError(modelId, options.explicit);

--- a/packages/grida-ai-agent/src/providers/resolve-video.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.ts
@@ -68,6 +68,14 @@ export type ResolveVideoDeps = {
 
 export type ResolveVideoOptions = {
   explicit?: VideoProvider | typeof GG_PROVIDER_ID;
+  /**
+   * Image-to-video: the request carries a start frame. The hosted `gg`
+   * provider is text-to-video only and would drop the frame, so it is
+   * skipped (implicit) or rejected (explicit) here — the request falls back
+   * to a BYOK route that can honor the image instead of silently becoming
+   * text-to-video. Mirrors the image resolver's `references` guard.
+   */
+  image?: boolean;
 };
 
 /**
@@ -100,7 +108,8 @@ export async function resolveVideoModel(
   // Explicit hosted pick (GRIDA-SEC-006). Hosted video is
   // text-to-video only in v1 — the route rejects image_url server-side.
   if (options.explicit === GG_PROVIDER_ID) {
-    const hosted = liveGgMediaDeps(deps);
+    // t2v only — an image-to-video pick can't ride the hosted provider.
+    const hosted = !options.image && liveGgMediaDeps(deps);
     if (!hosted || !models.video.binding(card, "vercel")) {
       throw new VideoModelUnavailableError(modelId, GG_PROVIDER_ID);
     }
@@ -128,7 +137,7 @@ export async function resolveVideoModel(
 
   // Grida hosted (GRIDA-SEC-006) — after BYOK, before giving up. Serves
   // cards the hosted gateway can (a vercel binding).
-  if (!options.explicit) {
+  if (!options.explicit && !options.image) {
     const hosted = liveGgMediaDeps(deps);
     if (hosted && models.video.binding(card, "vercel")) {
       return resolvedGgVideo(modelId, card, hosted);

--- a/packages/grida-ai-agent/src/runtime/index.ts
+++ b/packages/grida-ai-agent/src/runtime/index.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — thread the `gg` session deps into resolution (docs/wg/platform/hosted-ai.md)
 /**
  * AgentRuntime — the agent loop + the in-flight stream registry behind
  * one object. `AgentHost` owns an instance; the HTTP layer
@@ -923,6 +924,9 @@ export class AgentRuntime {
       // they let `createWorkspaceAgentBindings` build the `generate_image`
       // binding (the produced bytes sink to scratch).
       secrets: this.deps.secrets,
+      // GRIDA-SEC-006 — hosted-session deps for the generate_image gate.
+      gg: this.deps.gg,
+      gg_base_url: this.deps.gg_base_url,
       image_gen_enabled: this.deps.image_gen_enabled === true,
       image_model_id: this.deps.image_model_id,
       // Host-level: gates the `question` tool's execute-or-pause in createAgent.

--- a/packages/grida-ai-agent/src/runtime/run-agent.ts
+++ b/packages/grida-ai-agent/src/runtime/run-agent.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — surface `gg_*` stream errors to the renderer (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — agent driver (`runAgent`).
  *
@@ -214,6 +215,23 @@ export async function runAgent(
   return await createAgentUIStreamResponse({
     agent,
     uiMessages: req.messages,
+    // GRIDA-SEC-006 — normalize the two ACTIONABLE hosted-AI failures to
+    // their bare literal codes: Electron's contextBridge strips custom
+    // error props, so the code-led message IS the renderer's detection
+    // contract (re-mint + retry / top-up CTA). Everything else keeps the
+    // SDK default's semantics (message pass-through, `getErrorMessage`
+    // shape) — tool refusals and provider errors surface exactly as
+    // before this hook existed.
+    onError: (error: unknown) => {
+      const code = (error as { code?: unknown })?.code;
+      if (code === "gg_token_expired" || code === "insufficient_credits") {
+        return String(code);
+      }
+      if (error == null) return "unknown error";
+      if (typeof error === "string") return error;
+      if (error instanceof Error) return error.message;
+      return JSON.stringify(error);
+    },
     // Advertise a stable assistant message id on every turn's stream. On a fresh
     // turn this mints a new id; on a supervised-approval RESUME the SDK reuses
     // the last assistant message's id from the rebuilt history (it continues

--- a/packages/grida-ai-agent/src/runtime/run-input.ts
+++ b/packages/grida-ai-agent/src/runtime/run-input.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — accept the `gg` provider id at the run gate (docs/wg/platform/hosted-ai.md)
 /**
  * Agent run request boundary.
  *
@@ -26,6 +27,7 @@ import {
   isKnownProviderId,
   type EndpointProvidersStore,
 } from "../providers/endpoints";
+import { isGgProviderId } from "../protocol/provider-ids";
 // Neutral (no node/SDK) import — just the synthetic-model-id contract.
 import { isAgentProviderModel } from "../agent-provider/types";
 
@@ -125,9 +127,15 @@ export async function parseRunBody(
   let explicit: string | undefined;
   if (b.provider_id !== undefined) {
     const providerId = typeof b.provider_id === "string" ? b.provider_id : "";
+    // `grida` is accepted HERE (a run may pick the hosted provider) but
+    // deliberately NOT in `isKnownProviderId` — that gate also guards
+    // the `/secrets/*` allowlist, and nobody may store a key under
+    // `grida` (GRIDA-SEC-006: its credential is the pushed session
+    // token, never a secret slot).
     const allowed =
       providerId.length > 0 &&
-      (await isKnownProviderId(providerId, deps.endpoints));
+      (isGgProviderId(providerId) ||
+        (await isKnownProviderId(providerId, deps.endpoints)));
     if (!allowed) {
       return Response.json(
         { error: `providerId not allowed: ${String(b.provider_id)}` },

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — thread the `gg` session deps into image gen (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — workspace-bound agent bindings.
  *
@@ -76,6 +77,10 @@ export async function createWorkspaceAgentBindings(
      * on paths that don't generate media.
      */
     secrets?: SecretsStore;
+    /** GRIDA-SEC-006 — hosted-session deps; lets `generate_image` serve a
+     *  signed-in keyless user through the hosted provider. */
+    gg?: import("../providers/gg-session").GridaGatewaySessionStore;
+    gg_base_url?: string;
     /**
      * Whether the host enables image generation (its `images` server
      * capability). With it off, no `generate_image` binding is built — the host
@@ -176,9 +181,16 @@ export async function createWorkspaceAgentBindings(
   let image_gen: AgentGen.ImageGenerator | undefined;
   if (deps.image_gen_enabled && deps.secrets && scratchDir) {
     const secrets = deps.secrets;
-    if (await hasUsableImageProvider({ secrets })) {
+    // GRIDA-SEC-006: a live hosted session also satisfies the gate — a
+    // signed-in keyless user gets in-chat image generation.
+    const imageDeps = {
+      secrets,
+      gg: deps.gg,
+      gg_base_url: deps.gg_base_url,
+    };
+    if (await hasUsableImageProvider(imageDeps)) {
       image_gen = createImageGenerator(
-        secrets,
+        imageDeps,
         scratchDir,
         // Same reader `view_image` uses — so an i2i reference path honors the
         // identical scoping + size cap as perceiving that file.
@@ -219,7 +231,7 @@ function extForMime(mime: string): string {
  * credit is metered. Do not add `providerOptions.grida` here.
  */
 function createImageGenerator(
-  secrets: SecretsStore,
+  imageDeps: import("../providers/resolve-image").ResolveImageDeps,
   scratchDir: string,
   reader: AgentVision.ByteReader,
   imageModelId?: string
@@ -244,7 +256,7 @@ function createImageGenerator(
       let resolved;
       try {
         resolved = await resolveImageModel(
-          { secrets },
+          imageDeps,
           modelId,
           wantsRefs ? { references: true } : {}
         );

--- a/packages/grida-ai-agent/src/sandbox/policy.ts
+++ b/packages/grida-ai-agent/src/sandbox/policy.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — allow sandbox egress to the GG host (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — the agent-daemon's outer sandbox policy.
  *
@@ -60,9 +61,22 @@ const AGENT_NETWORK_HOSTS: readonly string[] = [
 export function buildAgentDaemonSandboxPolicy(opts: {
   user_data: string;
   home: string;
+  /**
+   * GRIDA-SEC-006 — host serving the Grida hosted-AI endpoints (e.g.
+   * `grida.co`, or `localhost` in dev). Without it a packaged
+   * (srt-wrapped) daemon's `grida` provider calls are 403'd by the
+   * egress allowlist. The apex AND its subdomains are allowed (srt
+   * `*.host` matches subdomains only, so both are listed).
+   */
+  gg_host?: string;
 }): AgentDaemonSandboxPolicy {
+  const hosts = [...AGENT_NETWORK_HOSTS];
+  if (opts.gg_host) {
+    hosts.push(opts.gg_host, `*.${opts.gg_host}`);
+  }
   return buildDaemonSandboxPolicy({
-    ...opts,
-    allowed_network_hosts: AGENT_NETWORK_HOSTS,
+    user_data: opts.user_data,
+    home: opts.home,
+    allowed_network_hosts: hosts,
   });
 }

--- a/packages/grida-ai-agent/src/server.ts
+++ b/packages/grida-ai-agent/src/server.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — construct + wire the GG session store and routes (docs/wg/platform/hosted-ai.md)
 /**
  * `@grida/agent/server` — the agent TENANT of `@grida/daemon` (#927).
  *
@@ -28,7 +29,9 @@ import { registerImagesRoutes } from "./http/routes/images";
 import { registerVideoRoutes } from "./http/routes/video";
 import { registerAgentRoutes } from "./http/routes/agent";
 import { registerSessionsRoutes } from "./http/routes/sessions";
+import { registerGridaAuthRoutes } from "./http/routes/gg-auth";
 import { EndpointProvidersStore } from "./providers/endpoints";
+import { GridaGatewaySessionStore } from "./providers/gg-session";
 import { openSessionsDb } from "./session/db";
 import { SessionsStore } from "./session/store";
 import { AgentRuntime } from "./runtime";
@@ -125,6 +128,15 @@ export type AgentTenantOptions = {
    * `design_search` tool (client-resolved). The desktop sidecar sets this true.
    */
   library?: boolean;
+  /**
+   * GRIDA-SEC-006 — origin of the Grida hosted-AI endpoints (e.g.
+   * `https://grida.co`; the desktop supervisor passes its
+   * EDITOR_BASE_URL). Enables the `grida` "included" provider: the
+   * `/auth/gg/*` session routes mount, and the resolver may pick the
+   * hosted provider when the renderer has pushed a live token. Omit ⇒
+   * the provider is fully dormant (no routes, never resolves).
+   */
+  gg_base_url?: string;
 };
 
 /**
@@ -158,6 +170,17 @@ export function createAgentTenant(opts: AgentTenantOptions = {}): DaemonTenant {
       const endpointsStore = new EndpointProvidersStore(
         services.user_data_path
       );
+      // Grida Cloud session (GRIDA-SEC-006): in-memory only, per launch.
+      // The whole hosted-provider surface keys off the host passing a
+      // base URL — without it, no routes, no resolution, fully dormant.
+      const gridaGatewayBaseUrl =
+        typeof opts.gg_base_url === "string" && opts.gg_base_url.length > 0
+          ? opts.gg_base_url
+          : undefined;
+      const gridaSession = new GridaGatewaySessionStore();
+      if (gridaGatewayBaseUrl) {
+        registerGridaAuthRoutes(app, { store: gridaSession });
+      }
       // Chat sessions: SQLite at ${userData}/sessions.db — agent-tenant
       // domain data (#927). Opened once per launch and closed via the
       // returned cleanup. WAL mode in sessions/db.ts lets a CLI inspector
@@ -184,10 +207,18 @@ export function createAgentTenant(opts: AgentTenantOptions = {}): DaemonTenant {
         });
       }
       if (caps.images) {
-        registerImagesRoutes(app, { secrets: services.secrets });
+        registerImagesRoutes(app, {
+          secrets: services.secrets,
+          gg: gridaSession,
+          gg_base_url: gridaGatewayBaseUrl,
+        });
       }
       if (caps.video) {
-        registerVideoRoutes(app, { secrets: services.secrets });
+        registerVideoRoutes(app, {
+          secrets: services.secrets,
+          gg: gridaSession,
+          gg_base_url: gridaGatewayBaseUrl,
+        });
       }
       // GRIDA-SEC-004 — the single fail-closed shell decision. Shell execution
       // is off unless the host confirmed an OS sandbox confines the tree, or it
@@ -218,6 +249,10 @@ export function createAgentTenant(opts: AgentTenantOptions = {}): DaemonTenant {
       const runtime = new AgentRuntime({
         secrets: services.secrets,
         endpoints: endpointsStore,
+        // GRIDA-SEC-006 — hosted provider deps; dormant when the base
+        // URL is absent (resolver never picks grida).
+        gg: gridaSession,
+        gg_base_url: gridaGatewayBaseUrl,
         workspace_registry: services.workspaces,
         sessions_store: sessionsStore,
         streams,
@@ -245,7 +280,9 @@ export function createAgentTenant(opts: AgentTenantOptions = {}): DaemonTenant {
         registerSessionsRoutes(app, { store: sessionsStore, runtime });
 
       return {
-        capabilities: caps,
+        // `gg` reflects the feature actually being ON (base URL
+        // present) — clients feature-detect the hosted provider by it.
+        capabilities: { ...caps, gg: gridaGatewayBaseUrl !== undefined },
         // Abort in-flight runs (upstream model calls) BEFORE cleanup so a
         // recorder reacting to the abort can finalize its partial assistant
         // message against an open SQLite handle.
@@ -315,6 +352,9 @@ export function createAgentDaemon(opts: AgentDaemonOptions): DaemonServer {
         allow_unsandboxed_shell: opts.allow_unsandboxed_shell,
         interactive: opts.interactive,
         library: opts.library,
+        // GRIDA-SEC-006 — pinned by the composed-daemon e2e: forgetting
+        // this line silently ships the hosted provider dormant.
+        gg_base_url: opts.gg_base_url,
       }),
     ],
   });

--- a/packages/grida-ai-agent/src/transport.ts
+++ b/packages/grida-ai-agent/src/transport.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` client namespace (set/clear/status) (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — the agent tenant's HTTP transport.
  *
@@ -25,6 +26,12 @@ import type {
   ImageGenerateRequest,
   ImageGenerateResult,
 } from "./protocol/images";
+// Type-only (erased): the wire shapes of /auth/gg/* — the store class
+// itself never crosses to clients.
+import type {
+  GridaGatewaySession,
+  GridaGatewaySessionStatus,
+} from "./providers/gg-session";
 import type {
   VideoGenerateRequest,
   VideoGenerateResult,
@@ -167,6 +174,20 @@ export namespace AgentTransport {
         installed: boolean;
         path?: string;
       }> => await this.postJson("/providers/claude/detect"),
+    } as const;
+
+    /** Grida hosted ("included") AI session (GRIDA-SEC-006). Push-only
+     *  custody: the renderer mints and pushes the short-lived token;
+     *  `status` never returns it. Gated by the `gg` capability. */
+    readonly gg = {
+      set_session: async (session: GridaGatewaySession): Promise<void> => {
+        await this.postJson<unknown>("/auth/gg/set", session);
+      },
+      clear_session: async (): Promise<void> => {
+        await this.postJson<unknown>("/auth/gg/clear");
+      },
+      status: async (): Promise<GridaGatewaySessionStatus> =>
+        await this.postJson<GridaGatewaySessionStatus>("/auth/gg/status"),
     } as const;
 
     /** BYOK image generation (#908). Desktop-only; gated by the `images`

--- a/packages/grida-daemon/src/http/routes/handshake.ts
+++ b/packages/grida-daemon/src/http/routes/handshake.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — advertise the `gg` capability tag (docs/wg/platform/hosted-ai.md)
 import type { Hono } from "hono";
 import type {
   DaemonCapabilities,
@@ -30,6 +31,7 @@ const SUPPORTS_TAGS: Record<keyof DaemonCapabilities, string> = {
   agent: "agent@1",
   workspaces: "workspaces@1",
   sessions: "sessions@1",
+  gg: "gg",
   providers: "providers@1",
   images: "images@1",
   video: "video@1",

--- a/packages/grida-daemon/src/protocol/handshake.ts
+++ b/packages/grida-daemon/src/protocol/handshake.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: provider — the `gg` daemon capability flag (docs/wg/platform/hosted-ai.md)
 /**
  * Handshake protocol — capability negotiation a client performs against
  * the daemon. Client-safe: capability flags + the response shape, no
@@ -37,6 +38,15 @@ export type DaemonCapabilities = {
    * as "not served" and hide the video-generation UI.
    */
   video?: boolean;
+  /**
+   * `/auth/gg/*` — the Grida hosted ("included") AI session
+   * (GRIDA-SEC-006). True only when the host configured a hosted base
+   * URL. Optional so older host-supplied capability shapes stay valid;
+   * clients treat a missing flag as "not served" and show no hosted-AI
+   * affordances. Type-only from the daemon's perspective — the routes
+   * and store live in the agent tenant.
+   */
+  gg?: boolean;
   /** Reserved for future `/shell/*` route group; always `false` in V1. */
   shell: boolean;
 };

--- a/packages/grida-desktop-bridge/src/index.ts
+++ b/packages/grida-desktop-bridge/src/index.ts
@@ -1,3 +1,4 @@
+// GRIDA-GG: desktop — the optional `gg` bridge namespace (docs/wg/platform/hosted-ai.md)
 /**
  * GRIDA-SEC-004 — renderer-visible Desktop bridge protocol.
  *
@@ -25,6 +26,8 @@ import type {
   SessionListFilter,
   SessionListPage,
   SessionStatus,
+  GridaGatewaySession,
+  GridaGatewaySessionStatus,
 } from "@grida/agent";
 import type {
   DaemonHandshakeResponse,
@@ -332,6 +335,19 @@ export type DesktopBridge = {
      *  filesystem probe, NOT a login check (login surfaces on the first run).
      *  Optional — older binaries lack it; renderers feature-detect. */
     detect_claude?: () => Promise<{ installed: boolean; path?: string }>;
+  };
+  /**
+   * Grida hosted ("included") AI session — GRIDA-SEC-006. Push-only
+   * custody: the renderer mints the short-lived scoped token from the
+   * webview session and pushes it to the sidecar; `status` reports
+   * presence/expiry/org and NEVER the token. Optional — older binaries
+   * lack it; renderers feature-detect and show no hosted-AI affordances
+   * when absent.
+   */
+  gg?: {
+    set_session: (session: GridaGatewaySession) => Promise<void>;
+    clear_session: () => Promise<void>;
+    status: () => Promise<GridaGatewaySessionStatus>;
   };
   /**
    * BYOK image generation (#908). Desktop-only: the request resolves the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@react-three/drei':
         specifier: ^10.0.7
         version: 10.7.7(@react-three/fiber@9.1.2(@types/react@19.1.3)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0))(@types/react@19.1.3)(@types/three@0.170.0)(immer@9.0.21)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.170.0)
@@ -307,6 +307,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: 2.0.48
         version: 2.0.48(zod@4.3.6)
+      '@ai-sdk/provider':
+        specifier: 3.0.10
+        version: 3.0.10
       '@ai-sdk/react':
         specifier: 3.0.199
         version: 3.0.199(react@19.2.5)(zod@4.3.6)
@@ -483,7 +486,7 @@ importers:
         version: 16.2.6(@mdx-js/loader@3.1.1(acorn@8.17.0)(webpack@5.98.0))(@mdx-js/react@3.1.1(@types/react@19.1.3)(react@19.2.5))
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@number-flow/react':
         specifier: ^0.5.7
         version: 0.5.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18921,7 +18924,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5

--- a/test/desktop-agent-hosted-ai-included.md
+++ b/test/desktop-agent-hosted-ai-included.md
@@ -1,6 +1,6 @@
 ---
-id: TC-DESKTOP-HOSTED-AI-001
-title: Signed-in desktop runs AI without BYOK, billed to org credits (grida provider)
+id: TC-DESKTOP-AGENT-001
+title: Signed-in desktop runs AI without BYOK, billed to org credits (gg provider)
 module: desktop
 area: agent
 tags: [hosted-ai, no-byok, billing, credits, token, degraded-mode, sandbox]
@@ -10,11 +10,11 @@ date: 2026-07-03
 updated: 2026-07-03
 automatable: false
 covered_by:
-  - editor/lib/desktop/grida-cloud-session.test.ts
+  - editor/lib/desktop/gg-session.test.ts
   - editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
-  - packages/grida-ai-agent/src/providers/grida-resolution.test.ts
-  - packages/grida-ai-agent/src/providers/grida.test.ts
-  - packages/grida-ai-agent/src/http/routes/grida-auth.test.ts
+  - packages/grida-ai-agent/src/providers/gg-resolution.test.ts
+  - packages/grida-ai-agent/src/providers/gg.test.ts
+  - packages/grida-ai-agent/src/http/routes/gg-auth.test.ts
 ---
 
 ## Behavior
@@ -25,9 +25,9 @@ and metered against their organization's AI credits (GRIDA-SEC-006).
 The renderer mints a 15-minute scoped token from the webview session
 (`POST /desktop/auth/token`) before every send and pushes it to the
 sidecar, which holds it **in memory only** and spends it as the Bearer
-credential of the `grida` provider against
+credential of the `gg` provider against
 `{origin}/api/v1/ai/*`. Provider precedence is: explicit pick wins;
-implicitly **BYOK keys → grida (signed in) → endpoints** — existing
+implicitly **BYOK keys → gg (signed in) → endpoints** — existing
 BYOK users keep exactly their current behavior.
 
 Failure states are actionable, never raw: a mid-run token lapse surfaces
@@ -47,12 +47,12 @@ backstop for anything in flight.
 2. In the workspace agent pane, pick a catalog model (e.g. GPT-5.4
    Mini — the model picker shows "Grida — included") and send a prompt.
 3. Expected: the reply streams; the sidecar log shows
-   `providerId=grida kind=grida`; the settings Credits card balance
+   `providerId=gg kind=gg`; the settings Credits card balance
    drops after the run.
 4. Add an OpenRouter key and send again. Expected: the run uses
    `providerId=openrouter` (BYOK wins implicitly).
 5. Remove the key; generate in the Images playground. Expected: hosted
-   generation succeeds keylessly (grida provider), billed.
+   generation succeeds keylessly (gg provider), billed.
 6. Drain the balance below $0.25 (insiders ingest) and send a chat.
    Expected: the out-of-credits banner with "add credits" → OS browser
    opens `/organizations/{slug}/settings/billing`; webview unchanged.
@@ -64,10 +64,10 @@ backstop for anything in flight.
    the run succeeds without re-signing-in.
 9. **Packaged (srt) build**: repeat step 2 in a packaged app against the
    configured editor origin — pins the sandbox egress allowlist
-   (`grida_cloud_host`), the one thing dev mode can't prove. Also
+   (`gg_host`), the one thing dev mode can't prove. Also
    verify dev (`localhost:3000`) egress under srt once.
 10. Old-binary posture: with a renderer newer than the installed binary
-    (no `bridge.cloud`), no hosted-AI affordances appear and everything
+    (no `bridge.gg`), no hosted-AI affordances appear and everything
     else behaves exactly as before.
 
 ## Notes

--- a/test/desktop-hosted-ai-included.md
+++ b/test/desktop-hosted-ai-included.md
@@ -1,0 +1,81 @@
+---
+id: TC-DESKTOP-HOSTED-AI-001
+title: Signed-in desktop runs AI without BYOK, billed to org credits (grida provider)
+module: desktop
+area: agent
+tags: [hosted-ai, no-byok, billing, credits, token, degraded-mode, sandbox]
+status: untested
+severity: high
+date: 2026-07-03
+updated: 2026-07-03
+automatable: false
+covered_by:
+  - editor/lib/desktop/grida-cloud-session.test.ts
+  - editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
+  - packages/grida-ai-agent/src/providers/grida-resolution.test.ts
+  - packages/grida-ai-agent/src/providers/grida.test.ts
+  - packages/grida-ai-agent/src/http/routes/grida-auth.test.ts
+---
+
+## Behavior
+
+A **signed-in** desktop user with **no BYOK key** can run the workspace
+agent (and the image/video playgrounds) on Grida-hosted models, gated
+and metered against their organization's AI credits (GRIDA-SEC-006).
+The renderer mints a 15-minute scoped token from the webview session
+(`POST /desktop/auth/token`) before every send and pushes it to the
+sidecar, which holds it **in memory only** and spends it as the Bearer
+credential of the `grida` provider against
+`{origin}/api/v1/ai/*`. Provider precedence is: explicit pick wins;
+implicitly **BYOK keys → grida (signed in) → endpoints** — existing
+BYOK users keep exactly their current behavior.
+
+Failure states are actionable, never raw: a mid-run token lapse surfaces
+as a session-refresh banner (a background re-mint has already run — the
+next send just works); an out-of-credits 402 surfaces with an "add
+credits" affordance that opens the org's web billing page in the **OS
+browser** (the webview never navigates). Hosted AI degrading (signed
+out, no org, editor unreachable) NEVER breaks BYOK or local-endpoint
+runs. Sign-out clears the sidecar session; the 15-minute expiry is the
+backstop for anything in flight.
+
+## Steps
+
+1. Local stack up (supabase + editor :3000 with `GRIDA_AI_TOKEN_SECRET`
+   set). Remove all BYOK keys in desktop Settings. Sign in. Seed org
+   credits (web `/insiders/billing`, complimentary commit).
+2. In the workspace agent pane, pick a catalog model (e.g. GPT-5.4
+   Mini — the model picker shows "Grida — included") and send a prompt.
+3. Expected: the reply streams; the sidecar log shows
+   `providerId=grida kind=grida`; the settings Credits card balance
+   drops after the run.
+4. Add an OpenRouter key and send again. Expected: the run uses
+   `providerId=openrouter` (BYOK wins implicitly).
+5. Remove the key; generate in the Images playground. Expected: hosted
+   generation succeeds keylessly (grida provider), billed.
+6. Drain the balance below $0.25 (insiders ingest) and send a chat.
+   Expected: the out-of-credits banner with "add credits" → OS browser
+   opens `/organizations/{slug}/settings/billing`; webview unchanged.
+7. Sign out mid-session; send again. Expected: run fails cleanly to a
+   sign-in state (no hosted provider resolution), BYOK/endpoints (if
+   configured) still work.
+8. Kill the sidecar (Activity Monitor) mid-session; after it respawns,
+   send again. Expected: the pre-send `ensureFresh` re-pushes the token;
+   the run succeeds without re-signing-in.
+9. **Packaged (srt) build**: repeat step 2 in a packaged app against the
+   configured editor origin — pins the sandbox egress allowlist
+   (`grida_cloud_host`), the one thing dev mode can't prove. Also
+   verify dev (`localhost:3000`) egress under srt once.
+10. Old-binary posture: with a renderer newer than the installed binary
+    (no `bridge.cloud`), no hosted-AI affordances appear and everything
+    else behaves exactly as before.
+
+## Notes
+
+- Mid-run token expiry on a single >15-min agent turn is bounded, not
+  closed: per-request token reads + refresh-on-send shrink the window;
+  the banner + background re-mint is the v1 answer (a daemon-initiated
+  refresh is impossible by design — the webview owns the session).
+- Hosted image/video are t2i/t2v-only in v1: reference images and
+  image-to-video route to BYOK providers.
+- Part 2a's card: test/desktop-settings-billing-credits.md.

--- a/test/desktop-settings-billing-credits.md
+++ b/test/desktop-settings-billing-credits.md
@@ -1,0 +1,74 @@
+---
+id: TC-DESKTOP-SETTINGS-001
+title: Settings shows a thin AI-credits card; billing management delegates to the web
+module: desktop
+area: settings
+tags: [billing, credits, account, open-external, degraded-mode]
+status: untested
+severity: medium
+date: 2026-07-03
+updated: 2026-07-03
+automatable: false
+covered_by:
+  - editor/app/desktop/billing/summary/route.test.ts
+  - editor/lib/desktop/billing.test.ts
+---
+
+## Behavior
+
+Desktop Settings has a **Credits** card (between Account and AI Provider
+Keys) showing the AI credit balance for the user's **session
+organization** — the same org the AI billing path resolves (last-accessed
+project's org, else first membership) — as org name + plan badge +
+`$X.XX` balance. The card is **read-only**: the single control, **Manage
+billing**, opens the org's web billing page
+(`/organizations/{slug}/settings/billing`) in the **OS browser** — the
+webview itself never navigates (the iOS "manage your account on the web"
+pattern). Top-up, auto-reload, and plan changes all live on that web page.
+
+An org that has never been provisioned for AI credits shows **"—"**,
+never "$0.00" — zero is a real balance; "—" means "not set up yet". When
+the balance is below the AI floor (or depleted), a muted hint explains
+that AI runs are paused and points at the billing page. The card degrades
+gracefully: signed-out and no-organization are quiet one-liners, and when
+the billing backend (Metronome) is slow or unreachable the card falls
+back to the cached balance rather than erroring — the number shown is
+then at most as stale as the hourly reconcile.
+
+The card fetches on mount only (no polling): after topping up in the
+browser, the desktop number updates on the next visit to Settings.
+
+## Steps
+
+1. Local stack: Supabase + editor dev on :3000. Sign in on the **web**,
+   grant the org a complimentary credit (e.g. $5) from `/insiders/billing`
+   (dev-only). In the **desktop app**, sign in and open Settings.
+2. Expected: Credits card renders a skeleton, then the org's display
+   name, plan badge (Free/Pro/Team), and the granted balance as `$5.00`.
+3. Click **Manage billing**.
+4. Expected: the OS browser opens `/organizations/{slug}/settings/billing`
+   for that org; the desktop window stays on Settings (no webview
+   navigation).
+5. With an org that was never provisioned for AI credits, open Settings.
+6. Expected: balance renders **"—"** (not "$0.00") with the "not set up
+   yet" hint; Manage billing still works.
+7. Sign out (Account card) and revisit Settings.
+8. Expected: Credits card shows "Sign in to see your AI credits." — no
+   error state.
+9. Remove `METRONOME_API_TOKEN` from `editor/.env.local` (restart dev
+   server) and open Settings while signed in.
+10. Expected: the card still renders the cached balance (no error); the
+    page does not hang — the live sync gives up within ~2s.
+
+## Notes
+
+- Read path: `CreditsSection` → same-origin `GET /desktop/billing/summary`
+  (desktop CSP keeps `connect-src` at `'self'`) → server-only seam
+  `editor/lib/desktop/billing.ts` → `lib/billing/metronome.ts`
+  (`getEntitlement` + bounded best-effort `refreshBalance`; never
+  provisions).
+- The manage URL is built from the org **slug** (`name`), not
+  `display_name`.
+- Part of the desktop no-BYOK track (Part 2a). Part 2b (hosted "grida"
+  provider in the sidecar) will make this balance drain from desktop
+  agent runs.


### PR DESCRIPTION
## What

**Grida Gateway (GG)** — the desktop app's **no-BYOK hosted AI**. A signed-in user runs AI (chat, image, video) **without their own model key**, billed to the org's prepaid credit through the existing Stripe + Metronome seam. GG is a governed, greppable surface designed to spin out to a future `grida.gg`.

Domain spec: [`docs/wg/platform/hosted-ai.md`](docs/wg/platform/hosted-ai.md) · Security boundary: `GRIDA-SEC-006` in [`SECURITY.md`](SECURITY.md) · Engineering surface skill: [`.agents/skills/gg`](.agents/skills/gg/SKILL.md).

## Why / how it works

The billing rail (entitlement gate + metered usage) already lives server-side. The only design that lets it run **synchronously and authoritatively** is a first-party gateway — so an untrusted native client can spend credits without ever holding a durable credential:

1. Renderer mints a **purpose-scoped, short-lived (15 min), org-bound JWT** (`aud "gg:ai"`) from the webview cookie session.
2. The sidecar daemon holds it **in memory only** — never on disk, never a refresh token (`GRIDA-SEC-006`; the webview session stays the one durable credential).
3. Every AI call carries it to a first-party **OpenAI-compatible gateway** (`/api/v1/ai/*`). The billing middleware **gates entitlement before the upstream stream opens** (a hard pre-flight 402, never a mid-stream surprise) and ingests usage from tokens the server counted.

**BYOK keeps bypassing all of this.** Precedence: explicit choice → BYOK → `gg` → endpoints.

## Changes

**Server**
- `gg-token`: HS256 sign/verify, audience-pinned, rotation, fail-closed (`GG_TOKEN_SECRET`); `POST /desktop/auth/token` mint route.
- Gateway: OpenAI-compatible `chat/completions` + `models` — implemented at the **LanguageModelV3 codec level** so the existing billing middleware stays in force with **zero route-side billing code**; Grida-native `images`/`videos` generations.
- Part 2a: thin desktop **credits card** + web-delegated billing (the iOS-companion pattern — native shows state, browser owns money).

**Client** (`@grida/agent` + desktop + renderer)
- `gg` provider kind, in-memory session store, OpenAI-compat text factory + image/video adapters (token read per request; typed 401/402 errors that survive Electron's `contextBridge`).
- `/auth/gg/*` daemon routes; `gg` daemon capability; renderer token lifecycle (proactive mint/re-mint, memory-only custody); actionable error UX (token lapse → background re-mint; out of credits → "add credits" → OS browser).

**Governance**: `GRIDA-SEC-006` cross-referenced with the `GRIDA-GG` surface marker (60+ files) and the `gg` skill.

## Verification

- **Tests green**: agent **629** · daemon **142** · desktop **105** · editor GG suites (token, session, codec, contract routes where the real `@ai-sdk/openai-compatible` client drives the real handler).
- Editor + package typecheck clean · oxlint 0 errors · ai-seam audit 2043 files/0 violations · `just fmt`.
- E2E proven earlier: keyless daemon → `providerId=gg` → streamed reply; 402/401/sign-out paths verified.

## Reviewer notes — read before merging

**Scope.** This ships the hosted-AI *capability* + its security boundary. The onboarding *experience* (default-to-included model, a universal payment-required UX, the free-credit story) is deliberately deferred to the follow-ups below — this PR stands on its own. Please weigh:

- ⚠️ **Wants a security-focused review.** Touches `GRIDA-SEC-006` (+003/004/005) — please scrutinize the scoped token's memory-only custody, audience pinning (`gg:ai`), and fail-closed secret handling before merge.
- **First-run paywall (product decision).** A fresh org has zero balance and there is **no free-tier / trial / plan grant** today (billing Phase 5 deferred) — so the *first* hosted call 402s until the user tops up on the web. The 402 is handled gracefully; what's missing is a way to *start* with credits. → #943, #941.
- **Included model isn't the default.** `DEFAULT_MODEL_ID = "claude-code/opus-4.8-1m"` (runs its own Claude auth), so "Grida — included" is opt-in via the picker, not where a fresh user lands. → #942.
- **Org is a hard precondition.** The token mint returns `no_organization` for a user with no org; the deeper fix (a first-class personal org) is → #940.
- **Deploy-config prereqs** (owner-manual, not code): `GG_TOKEN_SECRET` in prod (else fail-closed 503); packaged **srt egress smoke** to `grida.co` (dev can't prove the sandbox allowlist); Part-1 `grida://auth/callback` Supabase allowlist.

All of the above are disclosed in the doc's "Current state (honest)" section.

## Deliberate carve-outs (not renamed to `gg`, on purpose)

Endpoint paths stay `/api/v1/ai/*` (versioned REST; the brand is the host + `gg:ai` audience); `providerOptions.grida` (billing seam key, `GRIDA-SEC-003`); the session-agent bucket `"grida"` and the `/models` `owned_by: "grida"` (= the company).

## Follow-ups (not blockers for this PR)

These are the deferred product/onboarding layers, split into their own issues so this PR stays "the hosted-AI capability + its boundary." Referenced here from the PR; they stand independently (no auto-close):

- #940 — **RFC: first-class personal organization** (collaboration-first → local-first workspace model). The org this feature needs is currently a hard precondition; the durable fix is a personal-org primitive.
- #941 — **Universal "payment required" UX harness** — one reusable out-of-credits / needs-credits pattern across every metered surface.
- #942 — **Default to the included (`gg`) model** when a GG session is active (today a keyless user still defaults to `claude-code`).
- #943 — **RFC: plan-included credit grants** (Billing Phase 5) — the first-run credit prerequisite (only top-ups create balance today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hosted AI experience for desktop users, including chat, image, video, and model browsing.
  * Added a Credits section in desktop settings with current balance, plan details, and a billing link.
  * Improved sign-in and session handling for hosted AI access, including automatic refresh and sign-out cleanup.

* **Bug Fixes**
  * Added clearer handling for expired sessions and insufficient credits.
  * Improved error responses for invalid requests and unsupported models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->