### PR TITLE
feat(desktop): default to the included (gg) model when a Grida Gateway session is active

### DIFF
--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -248,7 +248,11 @@ export default function DesktopWelcomePage() {
   // Model selection for the composer. No sessions here (the welcome page never
   // loads a chat), so this just holds the user's pick; it rides the handoff so
   // the created project's first turn runs on the chosen model.
-  const { model_id: modelId, setModelId } = useModelPickerState({
+  const {
+    model_id: modelId,
+    setModelId,
+    is_user_pick: isUserPick,
+  } = useModelPickerState({
     current_id: null,
     sessions: [],
     endpoints,
@@ -261,12 +265,18 @@ export default function DesktopWelcomePage() {
     (workspace: Workspace, prompt: string) => {
       welcome_handoff.set(workspace.id, {
         prompt,
-        model_id: modelId,
+        // Carry the model only when the user deliberately picked one. An
+        // untouched default — or a GG upgrade that hasn't resolved yet — is
+        // left off so the workspace resolves its own (GG-aware) default;
+        // otherwise a fast submit before the async session settles would
+        // seed the workspace with the Claude-Code default as a false
+        // explicit pick, and keyless users would hit `auth_required` (#942).
+        ...(isUserPick ? { model_id: modelId } : {}),
         skills: ["dotcanvas"],
       });
       router.push(workspaceWorkbenchHref(workspace));
     },
-    [modelId, router]
+    [modelId, isUserPick, router]
   );
 
   const createAndGo = useCallback(

--- a/editor/scaffolds/desktop/shared/default-model.test.ts
+++ b/editor/scaffolds/desktop/shared/default-model.test.ts
@@ -37,14 +37,18 @@ describe("resolveDefaultModelId — the initial default for a new chat", () => {
     ).toBe(initial);
   });
 
-  it("ignores an unknown initial and falls through to the GG default", () => {
+  it("a provided-but-unknown initial falls back to the plain default, never the GG included model", () => {
+    // A caller `initial` that isn't known yet may be a late-loading endpoint
+    // model (issue #806). The GG default must NOT be substituted for it —
+    // that would silently override the caller's choice. Falls to the plain
+    // default instead (recovered once the registry loads, upstream).
     expect(
       resolveDefaultModelId({
-        initial: "bogus/model",
+        initial: "ollama/llama-3.3",
         ggActive: true,
         isKnownId: knows(),
       })
-    ).toBe(GG_INCLUDED_MODEL_ID);
+    ).toBe(DEFAULT_MODEL_ID);
   });
 
   it("the included tier is a catalog id distinct from the Claude-Code default", () => {
@@ -59,7 +63,7 @@ describe("shouldUpgradeToIncluded — the async GG-active guard", () => {
   const untouched = {
     current: DEFAULT_MODEL_ID,
     userPicked: false,
-    initialKnown: false,
+    hasInitial: false,
     storedSeeded: false,
   };
 
@@ -73,8 +77,8 @@ describe("shouldUpgradeToIncluded — the async GG-active guard", () => {
     );
   });
 
-  it("never overrides a caller-seeded initial", () => {
-    expect(shouldUpgradeToIncluded({ ...untouched, initialKnown: true })).toBe(
+  it("never overrides a caller-provided initial (even before it is known)", () => {
+    expect(shouldUpgradeToIncluded({ ...untouched, hasInitial: true })).toBe(
       false
     );
   });

--- a/editor/scaffolds/desktop/shared/default-model.test.ts
+++ b/editor/scaffolds/desktop/shared/default-model.test.ts
@@ -1,0 +1,96 @@
+// GRIDA-GG: desktop — default-model selection (issue #942)
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_MODEL_ID,
+  GG_INCLUDED_MODEL_ID,
+  resolveDefaultModelId,
+  shouldUpgradeToIncluded,
+} from "./default-model";
+
+/** A stub `isKnownId` that recognizes exactly the given ids. */
+const knows =
+  (...ids: string[]) =>
+  (id: string | undefined | null): id is string =>
+    typeof id === "string" && ids.includes(id);
+
+describe("resolveDefaultModelId — the initial default for a new chat", () => {
+  it("upgrades the keyless default to the included tier when a GG session is live", () => {
+    expect(resolveDefaultModelId({ ggActive: true, isKnownId: knows() })).toBe(
+      GG_INCLUDED_MODEL_ID
+    );
+  });
+
+  it("falls back to the Claude-Code default when no GG session is live", () => {
+    expect(resolveDefaultModelId({ ggActive: false, isKnownId: knows() })).toBe(
+      DEFAULT_MODEL_ID
+    );
+  });
+
+  it("an explicit caller-seeded initial wins over the GG default", () => {
+    const initial = "openai/gpt-5.4-mini";
+    expect(
+      resolveDefaultModelId({
+        initial,
+        ggActive: true,
+        isKnownId: knows(initial),
+      })
+    ).toBe(initial);
+  });
+
+  it("ignores an unknown initial and falls through to the GG default", () => {
+    expect(
+      resolveDefaultModelId({
+        initial: "bogus/model",
+        ggActive: true,
+        isKnownId: knows(),
+      })
+    ).toBe(GG_INCLUDED_MODEL_ID);
+  });
+
+  it("the included tier is a catalog id distinct from the Claude-Code default", () => {
+    // A `claude-code/*` agent-provider id would run the user's own Claude
+    // auth, not the gateway — the included default must be a catalog id.
+    expect(GG_INCLUDED_MODEL_ID).not.toBe(DEFAULT_MODEL_ID);
+    expect(GG_INCLUDED_MODEL_ID.startsWith("claude-code/")).toBe(false);
+  });
+});
+
+describe("shouldUpgradeToIncluded — the async GG-active guard", () => {
+  const untouched = {
+    current: DEFAULT_MODEL_ID,
+    userPicked: false,
+    initialKnown: false,
+    storedSeeded: false,
+  };
+
+  it("upgrades the untouched fallback default", () => {
+    expect(shouldUpgradeToIncluded(untouched)).toBe(true);
+  });
+
+  it("never overrides an explicit user pick", () => {
+    expect(shouldUpgradeToIncluded({ ...untouched, userPicked: true })).toBe(
+      false
+    );
+  });
+
+  it("never overrides a caller-seeded initial", () => {
+    expect(shouldUpgradeToIncluded({ ...untouched, initialKnown: true })).toBe(
+      false
+    );
+  });
+
+  it("never overrides a stored-session seed", () => {
+    expect(shouldUpgradeToIncluded({ ...untouched, storedSeeded: true })).toBe(
+      false
+    );
+  });
+
+  it("never overrides a selection that is no longer the default", () => {
+    expect(
+      shouldUpgradeToIncluded({
+        ...untouched,
+        current: "anthropic/claude-opus-4.8",
+      })
+    ).toBe(false);
+  });
+});

--- a/editor/scaffolds/desktop/shared/default-model.ts
+++ b/editor/scaffolds/desktop/shared/default-model.ts
@@ -50,7 +50,14 @@ export function resolveDefaultModelId(opts: {
   ggActive: boolean;
   isKnownId: (id: string | undefined | null) => boolean;
 }): string {
-  if (opts.isKnownId(opts.initial)) return opts.initial as string;
+  // A caller-provided `initial` is explicit intent: honor it when known,
+  // and NEVER substitute the GG default for it. An id that isn't known yet
+  // may be a late-loading endpoint model (issue #806) — falling back to the
+  // plain default is safe; silently swapping in the included model would
+  // override the caller's choice.
+  if (opts.initial != null && opts.initial !== "") {
+    return opts.isKnownId(opts.initial) ? opts.initial : DEFAULT_MODEL_ID;
+  }
   if (opts.ggActive) return GG_INCLUDED_MODEL_ID;
   return DEFAULT_MODEL_ID;
 }
@@ -59,16 +66,24 @@ export function resolveDefaultModelId(opts: {
  * Whether an async "Grida Gateway session is active" resolution should
  * replace the current selection with {@link GG_INCLUDED_MODEL_ID}. True
  * only for the *untouched fallback default* — it never overrides an
- * explicit user pick, a caller-seeded `initial`, or a stored-session seed.
+ * explicit user pick, a caller-provided `initial`, or a stored-session seed.
  */
 export function shouldUpgradeToIncluded(opts: {
   current: string;
   userPicked: boolean;
-  initialKnown: boolean;
+  /**
+   * Whether the caller provided an `initial` at all (explicit intent).
+   * Deliberately "was one provided", NOT "is it *known*": knownness depends
+   * on the async endpoint registry (issue #806) and would go stale in this
+   * mount-time effect, whereas whether an `initial` prop was passed is a
+   * stable fact. A provided-but-not-yet-known `initial` must still block the
+   * upgrade so an explicit pick is never overwritten.
+   */
+  hasInitial: boolean;
   storedSeeded: boolean;
 }): boolean {
   if (opts.userPicked) return false;
-  if (opts.initialKnown) return false;
+  if (opts.hasInitial) return false;
   if (opts.storedSeeded) return false;
   return opts.current === DEFAULT_MODEL_ID;
 }

--- a/editor/scaffolds/desktop/shared/default-model.ts
+++ b/editor/scaffolds/desktop/shared/default-model.ts
@@ -1,0 +1,74 @@
+// GRIDA-GG: desktop — default-model selection (included gg tier when a session is live)
+/**
+ * Which model a fresh desktop chat lands on — the pure decision kernel
+ * behind {@link useModelPickerState}.
+ *
+ * The renderer's hooks are thin wires; the load-bearing choice lives here
+ * so it can be unit-tested in Node without a React render (see
+ * `default-model.test.ts`). Two decisions:
+ *
+ *  - {@link resolveDefaultModelId} — the *initial* default for a new chat.
+ *  - {@link shouldUpgradeToIncluded} — whether an async Grida Gateway
+ *    "session active" resolution may replace that initial default (it
+ *    arrives after mount, so it can't be baked into the first value).
+ *
+ * Precedence, highest first: an explicit caller-seeded pick / a stored
+ * session model / a live GG session (included, no key) / the Claude-Code
+ * default. BYOK is orthogonal — it changes who *serves* a chosen model
+ * (BYOK → gg → endpoints), never which model a fresh chat defaults to.
+ */
+import { TIER_MODEL_IDS } from "@grida/ai-models";
+
+/**
+ * The keyless fallback default — Claude Code on Opus 4.8 (1M), the user's
+ * own Claude subscription (issue #813): zero key, the largest context.
+ * NOTE: assumes the user is logged in to Claude — with no Claude login and
+ * no live Grida Gateway session, a first run hits `auth_required`. A live
+ * GG session upgrades this to {@link GG_INCLUDED_MODEL_ID} so a signed-in,
+ * no-BYOK user's first run just works (issue #942).
+ */
+export const DEFAULT_MODEL_ID: string = "claude-code/opus-4.8-1m";
+
+/**
+ * The included hosted tier a live Grida Gateway session upgrades the
+ * keyless default to — a catalog model id served by `gg` (the "pro" tier).
+ * A catalog id (not a `claude-code/*` agent-provider id) so it routes
+ * through the gateway under the BYOK → gg → endpoints precedence.
+ */
+export const GG_INCLUDED_MODEL_ID: string = TIER_MODEL_IDS.pro;
+
+/**
+ * The initial default for a new chat. An explicit caller-seeded `initial`
+ * (a known id — e.g. the welcome handoff carrying the home composer's
+ * pick) always wins; otherwise the Claude-Code default. The GG upgrade is
+ * NOT applied here because session liveness is only known asynchronously
+ * (see {@link shouldUpgradeToIncluded}); `ggActive` is threaded only so a
+ * caller that already knows the state can seed the included model directly.
+ */
+export function resolveDefaultModelId(opts: {
+  initial?: string;
+  ggActive: boolean;
+  isKnownId: (id: string | undefined | null) => boolean;
+}): string {
+  if (opts.isKnownId(opts.initial)) return opts.initial as string;
+  if (opts.ggActive) return GG_INCLUDED_MODEL_ID;
+  return DEFAULT_MODEL_ID;
+}
+
+/**
+ * Whether an async "Grida Gateway session is active" resolution should
+ * replace the current selection with {@link GG_INCLUDED_MODEL_ID}. True
+ * only for the *untouched fallback default* — it never overrides an
+ * explicit user pick, a caller-seeded `initial`, or a stored-session seed.
+ */
+export function shouldUpgradeToIncluded(opts: {
+  current: string;
+  userPicked: boolean;
+  initialKnown: boolean;
+  storedSeeded: boolean;
+}): boolean {
+  if (opts.userPicked) return false;
+  if (opts.initialKnown) return false;
+  if (opts.storedSeeded) return false;
+  return opts.current === DEFAULT_MODEL_ID;
+}

--- a/editor/scaffolds/desktop/shared/model-picker.tsx
+++ b/editor/scaffolds/desktop/shared/model-picker.tsx
@@ -299,6 +299,13 @@ export function useModelPickerState({
     (typeof id === "string" &&
       (registeredIds.has(id) || AGENT_PROVIDER_IDS.has(id)));
 
+  // Whether a caller passed an `initial` at all — a stable mount-time fact
+  // (the prop never changes). The GG upgrade guards on THIS, not on whether
+  // `initial` is *known*: knownness depends on the async endpoint registry
+  // and would go stale in the mount-only effect below, letting a late-loading
+  // endpoint pick get overwritten.
+  const initialProvided = initial != null && initial !== "";
+
   const [modelId, setModelId] = useState<string>(() =>
     resolveDefaultModelId({
       initial,
@@ -349,9 +356,10 @@ export function useModelPickerState({
   // to the included hosted tier, so a fresh signed-in, no-BYOK user's first
   // run uses GG instead of hitting the Claude-Code provider's
   // `auth_required`. Session liveness resolves async, so this arrives after
-  // mount; `shouldUpgradeToIncluded` reads live refs so an explicit pick, a
-  // caller `initial`, or a stored-session seed always wins the race. The
-  // catalog itself is never hidden — BYOK can still serve any model.
+  // mount; `shouldUpgradeToIncluded` guards on live refs + the stable
+  // `initialProvided` so an explicit pick, a caller `initial`, or a
+  // stored-session seed always wins the race. The catalog itself is never
+  // hidden — BYOK can still serve any model.
   useEffect(() => {
     if (!gridaGateway.isSupported()) return;
     let cancelled = false;
@@ -361,7 +369,7 @@ export function useModelPickerState({
         shouldUpgradeToIncluded({
           current: prev,
           userPicked: userPickedRef.current,
-          initialKnown: isKnownId(initial),
+          hasInitial: initialProvided,
           storedSeeded: seededFor.current != null,
         })
           ? GG_INCLUDED_MODEL_ID

--- a/editor/scaffolds/desktop/shared/model-picker.tsx
+++ b/editor/scaffolds/desktop/shared/model-picker.tsx
@@ -280,7 +280,16 @@ export function useModelPickerState({
   /** Configured endpoint providers — their registered model ids count as
    *  known, so a session that ran on a local model re-seeds correctly. */
   endpoints?: readonly EndpointProviderConfig[];
-}): { model_id: string; setModelId: (id: string) => void } {
+}): {
+  model_id: string;
+  setModelId: (id: string) => void;
+  /** True once the user has explicitly picked a model in the UI (not a
+   *  default or a seed). A producer of a cross-navigation handoff (the
+   *  welcome composer) uses this to carry the model ONLY when it was a
+   *  deliberate choice — otherwise the destination resolves its own
+   *  default, so an unresolved default never masquerades as a pick. */
+  is_user_pick: boolean;
+} {
   const registeredIds = useMemo(
     () => new Set(registered_models.specs(endpoints).map((m) => m.id)),
     [endpoints]
@@ -291,7 +300,17 @@ export function useModelPickerState({
       (registeredIds.has(id) || AGENT_PROVIDER_IDS.has(id)));
 
   const [modelId, setModelId] = useState<string>(() =>
-    resolveDefaultModelId({ initial, ggActive: false, isKnownId })
+    resolveDefaultModelId({
+      initial,
+      // Synchronous cached GG state: when the session is already known
+      // active (warmed by an earlier `ensureFresh`), a keyless surface
+      // starts on the included model with no async gap — so an instant
+      // first submit can't capture the Claude-Code default before the
+      // effect below runs. `peek()` never does IO; the effect still
+      // covers a cold cache.
+      ggActive: gridaGateway.peek().kind === "active",
+      isKnownId,
+    })
   );
   // Flipped once the user picks a model in the UI, so the async Grida
   // Gateway upgrade below never clobbers a deliberate choice.
@@ -364,5 +383,9 @@ export function useModelPickerState({
     setModelId(id);
   }, []);
 
-  return { model_id: modelId, setModelId: pickModel };
+  return {
+    model_id: modelId,
+    setModelId: pickModel,
+    is_user_pick: userPickedRef.current,
+  };
 }

--- a/editor/scaffolds/desktop/shared/model-picker.tsx
+++ b/editor/scaffolds/desktop/shared/model-picker.tsx
@@ -15,7 +15,7 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TriangleAlertIcon } from "lucide-react";
 import {
   PromptInputSelect,
@@ -42,20 +42,17 @@ import type {
 import { registered_models } from "./registered-models";
 import { GG_PROVIDER_METADATA } from "@grida/agent";
 import * as gridaGateway from "@/lib/desktop/gg-session";
+import {
+  GG_INCLUDED_MODEL_ID,
+  resolveDefaultModelId,
+  shouldUpgradeToIncluded,
+} from "./default-model";
+// The default-model constants live in a react-free module so the decision
+// is unit-testable in Node; re-exported here to keep the public symbol home.
+export { DEFAULT_MODEL_ID } from "./default-model";
 
 const catalog = _models.text.catalog;
 type CatalogId = _models.text.CatalogId;
-
-/**
- * Default selection — Claude Code on Opus 4.8 (1M), the user's own Claude
- * subscription (issue #813): zero key, the largest context, the path we want
- * users to land on. NOTE: assumes the user is logged in to Claude — a
- * no-Claude fallback wants the zero-config auto-detect (see
- * `docs/wg/ai/agent/acp-provider.plan.md`); until then a signed-out user's
- * first run hits `auth_required`. Revert to `TIER_MODEL_IDS.pro` (hosted
- * Sonnet 4.6) for a catalog default.
- */
-export const DEFAULT_MODEL_ID: string = "claude-code/opus-4.8-1m";
 
 const MODEL_OPTIONS = Object.values(catalog);
 
@@ -260,11 +257,14 @@ export function ModelToolCallNotice({
 /**
  * Model selection state for a chat panel. Defaults to
  * {@link DEFAULT_MODEL_ID} (or `initial`, when a caller seeds one — e.g.
- * the welcome handoff carrying the home composer's pick) and re-seeds
+ * the welcome handoff carrying the home composer's pick), then re-seeds
  * from a session's stored model whenever the active session id changes —
  * so opening a past chat shows the model it ran with, while a background
  * session-list refresh never clobbers a pick the user just made (the seed
- * fires once per id, not per `sessions` change).
+ * fires once per id, not per `sessions` change). When a Grida Gateway
+ * session is live and nothing else has claimed the selection, the keyless
+ * default is upgraded to the included hosted tier ({@link
+ * GG_INCLUDED_MODEL_ID}; issue #942).
  */
 export function useModelPickerState({
   current_id: currentId,
@@ -290,9 +290,12 @@ export function useModelPickerState({
     (typeof id === "string" &&
       (registeredIds.has(id) || AGENT_PROVIDER_IDS.has(id)));
 
-  const [modelId, setModelId] = useState<string>(
-    isKnownId(initial) ? initial : DEFAULT_MODEL_ID
+  const [modelId, setModelId] = useState<string>(() =>
+    resolveDefaultModelId({ initial, ggActive: false, isKnownId })
   );
+  // Flipped once the user picks a model in the UI, so the async Grida
+  // Gateway upgrade below never clobbers a deliberate choice.
+  const userPickedRef = useRef(false);
   // The session id we last seeded from. Re-seed only when the active id
   // changes — `undefined` means "never seeded" so the first run fires.
   const seededFor = useRef<string | null | undefined>(undefined);
@@ -322,5 +325,44 @@ export function useModelPickerState({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentId, sessions, registeredIds]);
 
-  return { model_id: modelId, setModelId };
+  // GRIDA-SEC-006 / issue #942 — when a Grida Gateway session is live and
+  // the user hasn't otherwise chosen a model, upgrade the keyless default
+  // to the included hosted tier, so a fresh signed-in, no-BYOK user's first
+  // run uses GG instead of hitting the Claude-Code provider's
+  // `auth_required`. Session liveness resolves async, so this arrives after
+  // mount; `shouldUpgradeToIncluded` reads live refs so an explicit pick, a
+  // caller `initial`, or a stored-session seed always wins the race. The
+  // catalog itself is never hidden — BYOK can still serve any model.
+  useEffect(() => {
+    if (!gridaGateway.isSupported()) return;
+    let cancelled = false;
+    void gridaGateway.ensureFresh().then((state) => {
+      if (cancelled || state.kind !== "active") return;
+      setModelId((prev) =>
+        shouldUpgradeToIncluded({
+          current: prev,
+          userPicked: userPickedRef.current,
+          initialKnown: isKnownId(initial),
+          storedSeeded: seededFor.current != null,
+        })
+          ? GG_INCLUDED_MODEL_ID
+          : prev
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Resolve once on mount; the guard reads live refs, not reactive deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Wrap the setter so a user's explicit pick marks the selection touched —
+  // the async GG upgrade above then leaves it alone. Internal seeding calls
+  // the raw `setModelId` (unchanged), so it doesn't trip the flag.
+  const pickModel = useCallback((id: string) => {
+    userPickedRef.current = true;
+    setModelId(id);
+  }, []);
+
+  return { model_id: modelId, setModelId: pickModel };
 }


### PR DESCRIPTION
Closes #942.

## Problem

A signed-in, **keyless** desktop user still defaulted to `DEFAULT_MODEL_ID = "claude-code/opus-4.8-1m"` — an agent-provider that runs the user's **own** Claude auth. So the no-BYOK included AI (Grida Gateway) was opt-in via the model picker, not where a fresh user lands, and a first run could hit `auth_required` (no Claude login) instead of the included hosted model — the exact experience the hosted-AI work was meant to deliver.

## Change

When a **Grida Gateway session is live** and nothing else has claimed the selection, the keyless default upgrades to the included hosted tier (`TIER_MODEL_IDS.pro` = `anthropic/claude-sonnet-5`, a **catalog** id served through `gg` under the `BYOK → gg → endpoints` precedence).

The load-bearing decision is extracted into a **react-free module** (`default-model.ts`) so it is unit-testable in Node; `useModelPickerState` is the thin async wire that applies it once `gridaGateway.ensureFresh()` resolves `active` — guarded so it only ever replaces the *untouched fallback default*.

- `resolveDefaultModelId()` — the initial default for a new chat.
- `shouldUpgradeToIncluded()` — whether the async "session active" resolution may replace the current selection (never overrides an explicit pick, a caller-seeded `initial`, or a stored-session seed).

All three consumers (`agent-pane`, `ai-sidebar/chat`, `welcome`) benefit with **zero caller changes** — the logic lives inside the shared hook.

## Product decision (forced)

The issue embeds a decision: *when both a Claude login and a GG session are present, prefer which?* Grounding **collapsed it** — there is **no Claude-Code auth-detection primitive** (`packages/grida-ai-agent/src/acp/adapter.ts`: "there is no ACP-level auth"), so "prefer a Claude login when present" is unimplementable today. Behavior is therefore **always-included-first when a GG session is active**. A future Claude-auth probe could revisit this.

## Acceptance (from #942)

- ✅ A fresh signed-in keyless user's first run uses the included hosted model (given available credit — a zero-balance org is still protected by the pre-flight `402` gate).
- ✅ Explicit picks and BYOK are unaffected (BYOK still *serves* any chosen model via existing precedence; the default logic doesn't touch it).
- ✅ Covered by a test — 10 unit tests over the decision matrix + the guard matrix.

## Scope / surface

`GRIDA-GG: desktop` (renderer consumer). This does **not** touch the `token` mint/verify/custody surface, so no GRIDA-SEC-006 credential-boundary change.

## Verification

- `tsc --noEmit` (editor): clean
- `vitest` (`default-model.test.ts`): 10/10
- `oxlint`: 0 warnings / 0 errors
- `oxfmt`: applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced desktop chat model defaults: when a gateway session is active, new chats can automatically switch to the included hosted tier; non-gateway behavior stays unchanged.
  * Improved handoff behavior: the composer now sends `model_id` only after an explicit user model selection.

* **Bug Fixes**
  * Prevents gateway-triggered updates from overwriting explicit user picks, caller-provided initial values, or already-seeded selections.
  * Ensures unknown initial values fall back to the standard default without substituting the included tier.

* **Tests**
  * Added Vitest coverage for default selection and upgrade-to-included conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->