### PR TITLE
ci(desktop): restore macOS Intel (x64) builds via native dual-runner (#947)

### DIFF
--- a/.github/release-notes/desktop.md
+++ b/.github/release-notes/desktop.md
@@ -4,14 +4,14 @@
 
 ## Downloads
 
-| Platform | Arch  | Format | Signed | Download                                                                                                                        |
-| -------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-{{version}}-arm64.dmg) |
-| `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)    |
-| `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)   |
-| `linux`  | x64   | deb    |        | see Assets below                                                                                                                |
-| `linux`  | arm64 | deb    |        | see Assets below                                                                                                                |
-| `linux`  | x64   | rpm    |        | see Assets below                                                                                                                |
-| `linux`  | arm64 | rpm    |        | see Assets below                                                                                                                |
-
-> macOS arm64 only — Rosetta 2 cannot run arm64 binaries on Intel.
+| Platform | Arch  | Format | Signed | Download                                                                                                                          |
+| -------- | ----- | ------ | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `darwin` | arm64 | dmg    | ✓      | [Download for Mac (Apple Silicon)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-{{version}}-arm64.dmg)   |
+| `darwin` | arm64 | zip    | ✓      | [Download for Mac (zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-arm64-{{version}}.zip)      |
+| `darwin` | x64   | dmg    | ✓      | [Download for Mac (Intel)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-{{version}}-x64.dmg)             |
+| `darwin` | x64   | zip    | ✓      | [Download for Mac (Intel, zip)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida-darwin-x64-{{version}}.zip) |
+| `win32`  | x64   | exe    |        | [Download for Windows (x64)](https://github.com/gridaco/grida/releases/download/v{{version}}/Grida.Setup.{{version}}.x64.exe)     |
+| `linux`  | x64   | deb    |        | see Assets below                                                                                                                  |
+| `linux`  | arm64 | deb    |        | see Assets below                                                                                                                  |
+| `linux`  | x64   | rpm    |        | see Assets below                                                                                                                  |
+| `linux`  | arm64 | rpm    |        | see Assets below                                                                                                                  |

--- a/.github/workflows/realease-desktop-app.yml
+++ b/.github/workflows/realease-desktop-app.yml
@@ -23,8 +23,21 @@ jobs:
             image: ubuntu-latest
           - name: windows
             image: windows-latest
+          # macOS builds one arch per runner ON PURPOSE (issue #947): a single
+          # parallel --arch="x64,arm64" invocation hits the maker-dmg race
+          # (electron/forge#3517 — hdiutil EAGAIN + appdmg "Target already
+          # exists"), fixed only in Forge 8 (GA tracker: electron/forge#4082).
+          # Native per-arch runners also make pnpm resolve the per-platform
+          # native prebuilds (e.g. @parcel/watcher-darwin-<arch>) correctly.
           - name: macos-apple-silicon
             image: macos-26
+            mac_arch: arm64
+          - name: macos-intel
+            # GitHub's LAST x86_64 macOS image — retired Aug 2027
+            # (actions/runner-images#13045). When it dies, either Forge 8 GA
+            # has fixed the parallel-arch DMG race or we re-drop Intel.
+            image: macos-15-intel
+            mac_arch: x64
     runs-on: ${{ matrix.os.image }}
     env:
       HAS_SIGNING: ${{ secrets.APPLE_CERTIFICATE_P12 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.APPLE_SIGNING_IDENTITY != '' }}
@@ -81,7 +94,7 @@ jobs:
             --filter=@grida/home
 
       - name: Import Apple signing certificate
-        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' }}
+        if: ${{ matrix.os.mac_arch && env.HAS_SIGNING == 'true' }}
         uses: apple-actions/import-codesign-certs@v2
         with:
           keychain: build
@@ -89,7 +102,7 @@ jobs:
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
       - name: Stage App Store Connect API key
-        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_NOTARIZE == 'true' }}
+        if: ${{ matrix.os.mac_arch && env.HAS_NOTARIZE == 'true' }}
         shell: bash
         env:
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
@@ -116,14 +129,15 @@ jobs:
         run: pnpm run publish:prerelease --arch="x64,arm64"
 
       - name: Publish App (MacOS)
-        if: ${{ matrix.os.name == 'macos-apple-silicon' && env.HAS_SIGNING == 'true' && env.HAS_NOTARIZE == 'true' }}
+        if: ${{ matrix.os.mac_arch && env.HAS_SIGNING == 'true' && env.HAS_NOTARIZE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRERELEASE: ${{ inputs.prerelease }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: pnpm run publish:prerelease --arch="arm64"
+        # One arch per runner (matrix.os.mac_arch) — see the matrix comment.
+        run: pnpm run publish:prerelease --arch="${{ matrix.os.mac_arch }}"
 
       - name: Update release notes from template
         # Runs once (gated to the linux row, which has no signing-secret

--- a/docs/contributing/desktop-release.md
+++ b/docs/contributing/desktop-release.md
@@ -22,17 +22,20 @@ Runbook for cutting desktop releases — macOS / Windows / Linux signed, notariz
 
    Or via UI: **Actions → Publish Desktop App → Run workflow**.
 
-3. **Approve in the environment gate.** Each platform job (mac/win/linux) pauses at the `release` environment. Open the run in Actions and click "Review deployments → Approve and deploy."
+3. **Approve in the environment gate.** Each platform job pauses at the `release` environment — that's **four** jobs to approve: `macos-apple-silicon`, `macos-intel`, `windows`, `linux` (macOS builds one arch per runner, see [Hard constraints](#hard-constraints)). Open the run in Actions and click "Review deployments → Approve and deploy."
 
-4. **Verify.** When the run finishes, the GitHub Release page has `Grida-darwin-arm64-<version>.zip`, `Grida-darwin-x64-<version>.zip`, the `.dmg` siblings, Windows `.exe` + nupkg, and Linux `.deb` / `.rpm`. Confirm the feed serves it:
+4. **Verify.** When the run finishes, the GitHub Release page has both macOS arches — `Grida-darwin-arm64-<version>.zip` + `Grida-darwin-x64-<version>.zip` and their `.dmg` siblings (`Grida-<version>-arm64.dmg`, `Grida-<version>-x64.dmg`) — plus Windows `.exe` + nupkg and Linux `.deb` / `.rpm`. Confirm the feed serves **each arch** (the autoupdate feed URL is per-`<platform>-<arch>`):
 
    ```sh
-   BASE=https://update.electronjs.org/gridaco/grida/darwin-arm64
-   curl -s -w "\n%{http_code}\n" "$BASE/0.0.0"
-   # WANT: 200 + JSON pointing at the new .zip
+   for ARCH in arm64 x64; do
+     BASE="https://update.electronjs.org/gridaco/grida/darwin-$ARCH"
+     echo "== darwin-$ARCH =="
+     curl -s -w "\n%{http_code}\n" "$BASE/0.0.0"
+     # WANT: 200 + JSON pointing at the new .zip
 
-   curl -s -o /dev/null -w "%{http_code}\n" "$BASE/<just-released-version>"
-   # WANT: 204 (no update — correct)
+     curl -s -o /dev/null -w "%{http_code}\n" "$BASE/<just-released-version>"
+     # WANT: 204 (no update — correct)
+   done
    ```
 
    If the old-client request returns 204, either the release is marked prerelease or the tag isn't valid semver. See [Troubleshooting](#troubleshooting).
@@ -79,6 +82,7 @@ These are silent footguns. Pinned, do not change without a plan:
 - **Plain semver tags.** `update.electronjs.org` skips tags that don't pass `semver.valid()`. No `desktop-v…` or other prefixes.
 - **`hardenedRuntime: true`** in `osxSign.optionsForFile`. Required for notarization; required for the entitlements plist to apply.
 - **`allowBuilds` in `pnpm-workspace.yaml`** (not `package.json`). pnpm 11 replaced the old `onlyBuiltDependencies` list with the `allowBuilds` map and ignores the `pnpm` field in `package.json` entirely. The native deps (`electron`, `electron-winstaller`, `fs-xattr`, `macos-alias`) must be set to `true` so their install scripts run; pnpm otherwise silently disables native module builds. Removing them breaks the DMG maker (`Cannot find module '../build/Release/volume.node'`).
+- **macOS builds one arch per runner** — `macos-apple-silicon` (`macos-26`, arm64) and `macos-intel` (`macos-15-intel`, x64) are separate matrix rows, each running a single-arch `publish --arch=…`. Do **not** collapse them into one parallel `--arch="x64,arm64"` invocation: it hits the maker-dmg race (electron/forge#3517 — `hdiutil` EAGAIN + appdmg "Target already exists"), which is why Intel was dropped in the first place (issue #947). Separate native runners also let pnpm resolve each arch's per-platform prebuilds (`@parcel/watcher-darwin-<arch>`). `macos-15-intel` is GitHub's last x86_64 image, retired **Aug 2027** (actions/runner-images#13045); revisit once Forge 8 GA (electron/forge#4082) fixes the race.
 
 ---
 

--- a/editor/app/(www)/(downloads)/downloads/downloads.ts
+++ b/editor/app/(www)/(downloads)/downloads/downloads.ts
@@ -9,6 +9,12 @@ export namespace downloads {
 
   export interface DownloadLinks {
     mac_dmg_arm64: string;
+    // Nullable: the editor deploys on merge to main, before the first
+    // x64-bearing desktop release is cut (issue #947). A non-null type would
+    // make getLinks() throw on the missing asset and getLinksForPage's catch
+    // would degrade ALL platforms to the static v0.0.1 fallback during that
+    // window. The Intel button is hidden while this is null.
+    mac_dmg_x64: string | null;
     linux_deb_x64: string;
     linux_rpm_x64: string;
     linux_deb_arm64: string;
@@ -43,6 +49,7 @@ export namespace downloads {
         ext: "dmg",
         arch: {
           arm64: "arm64",
+          x64: "x64",
         },
       },
     ],
@@ -94,6 +101,8 @@ export namespace downloads {
     const f = new Fetcher();
 
     const mac_dmg_arm64 = await f.getAsset("mac", "dmg", "arm64");
+    // May be absent until the first x64-bearing release ships (issue #947).
+    const mac_dmg_x64 = await f.getAsset("mac", "dmg", "x64");
     const linux_deb_x64 = await f.getAsset("linux", "deb", "x64");
     const linux_rpm_x64 = await f.getAsset("linux", "rpm", "x64");
     const linux_deb_arm64 = await f.getAsset("linux", "deb", "arm64");
@@ -102,6 +111,7 @@ export namespace downloads {
 
     return {
       mac_dmg_arm64: mac_dmg_arm64.browser_download_url,
+      mac_dmg_x64: mac_dmg_x64?.browser_download_url ?? null,
       linux_deb_x64: linux_deb_x64.browser_download_url,
       linux_rpm_x64: linux_rpm_x64.browser_download_url,
       linux_deb_arm64: linux_deb_arm64.browser_download_url,
@@ -201,6 +211,8 @@ export namespace downloads {
     const links: DownloadLinks = {
       mac_dmg_arm64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-arm64.dmg",
+      mac_dmg_x64:
+        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-x64.dmg",
       linux_deb_x64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/grida_0.0.1_amd64.deb",
       linux_rpm_x64:
@@ -252,6 +264,8 @@ export namespace downloads {
       default: d,
       mac_dmg_arm64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-arm64.dmg",
+      mac_dmg_x64:
+        "https://github.com/gridaco/grida/releases/download/v0.0.1/Grida-0.0.1-x64.dmg",
       linux_deb_x64:
         "https://github.com/gridaco/grida/releases/download/v0.0.1/grida_0.0.1_amd64.deb",
       linux_rpm_x64:

--- a/editor/app/(www)/(downloads)/downloads/page.tsx
+++ b/editor/app/(www)/(downloads)/downloads/page.tsx
@@ -103,6 +103,17 @@ function DownloadButtons({ links }: { links: downloads.DownloadLinks }) {
         </Button>
       </Link>
 
+      {/* macOS Intel — hidden until the first x64-bearing release ships
+          (issue #947); mac_dmg_x64 is null until then. */}
+      {links.mac_dmg_x64 && (
+        <Link href={links.mac_dmg_x64} download>
+          <Button size="lg" variant="outline">
+            <AppleLogo className="size-4" /> Download for macOS (Intel-based
+            Macs)
+          </Button>
+        </Link>
+      )}
+
       {/* Windows x64 */}
       <Link href={links.windows_exe_x64} download>
         <Button size="lg" variant="outline">


### PR DESCRIPTION
Closes #947.

## What

macOS shipped **arm64-only** since #731, which fled the maker-dmg parallel-arch race (electron/forge#3517 — `hdiutil` EAGAIN + appdmg "Target already exists", fixed only in Forge 8, still alpha). #732 then removed the Intel download buttons. A paying Intel-Mac customer is now blocked — this is the "add it back when there's demand" trigger the #731 commit anticipated.

This brings x64 back with the one shape that **sidesteps** the race instead of suppressing it: **one arch per native runner.**

## Why native dual-runner (not the issue's Option A/B)

- **One arch per machine → both DMG-race failure modes are structurally impossible** (no parallel makers). The issue's Option B leans on a "PR #730 sync hook" that doesn't exist — the speculative `sync` hook (`243c04a30`) was abandoned in #731, so the `hdiutil` EAGAIN mode has no working mitigation.
- **Native x64 dep resolution.** `@parcel/watcher-darwin-x64` is a platform-gated optional dep; on an arm64 host pnpm installs only `-darwin-arm64`, and the packaged-bundle oracle deliberately tolerates missing optionals (#805) — a cross-packaged x64 app would ship **silently broken**. A native Intel runner resolves it with zero config.
- **Zero `forge.config.ts` changes** → DMG filenames stay `Grida-{version}-{arch}.dmg`, so the downloads restoration is a clean partial revert of #732.
- `macos-15-intel` is GitHub's **last x86_64 image**, retired **Aug 2027** (actions/runner-images#13045) — a natural sunset, documented inline; exit is Forge 8 GA (electron/forge#4082).

## Changes

- **Workflow** — add a `macos-intel` (`macos-15-intel`, x64) matrix row beside `macos-apple-silicon` (`macos-26`, arm64); generalize the mac-gated steps to `matrix.os.mac_arch`; arch-parameterize the publish.
- **downloads.ts / page.tsx** — restore `mac_dmg_x64` as `string | null` + a conditionally-rendered Intel button (nullable so the editor deploying before the first x64 release doesn't degrade all platforms to the static v0.0.1 fallback).
- **release-notes template** — add darwin-x64 dmg + zip rows; drop the arm64-only footnote.
- **desktop-release.md runbook** — four approvals, per-arch feed check, pinned one-arch-per-runner constraint.

No `desktop/src` / `forge.config.ts` changes (node-pty ships both darwin prebuilds, sandbox-runtime vendors both arches, `update-electron-app`'s feed is already `darwin-${process.arch}`).

## Verification

- ✅ `turbo typecheck --filter=editor` clean; `oxlint` clean; all PR CI green.
- ✅ **Dry run passed** — dispatched this change (with a throwaway `0.0.7-intel-test.1` bump, *not* in this diff) via run `28813086645`. **All four jobs green, including `build (macos-intel, macos-15-intel, x64)`.** The release carried the correctly-named x64 assets, built + signed + notarized natively on the Intel runner:
  - `Grida-0.0.7-intel-test.1-x64.dmg` (144.7 MB)
  - `Grida-darwin-x64-0.0.7-intel-test.1.zip` (143.9 MB) — matches `update-electron-app`'s `darwin-x64` feed
  - `@parcel/watcher-darwin-x64` resolved natively. Throwaway prerelease + tag + branch deleted after.

## Not in this PR

- **The version bump / cutting the release.** This restores x64 build *capability*; the actual x64 release ships when the next version is bumped (`desktop/package.json`) and the workflow dispatched — see `docs/contributing/desktop-release.md`. Kept version-neutral on purpose so capability and release-cut stay separate commits.