### PR TITLE
fix(desktop): reliable dev grida:// deep-link routing — unique dev bundle id + per-env grida-dev:// scheme (GRIDA-SEC-005)

### DIFF
--- a/.agents/skills/desktop/SKILL.md
+++ b/.agents/skills/desktop/SKILL.md
@@ -211,15 +211,15 @@ judging the bridge state.
 
 ## Boundaries
 
-| Concern                   | Lives in                                              | Notes                                            |
-| ------------------------- | ----------------------------------------------------- | ------------------------------------------------ |
-| Window/menu/dialog wiring | `desktop/src/main/**`                                 | Native shell behavior                            |
-| Protocol and file routing | `desktop/src/main/**`, `desktop/Info.plist`           | `grida://`, open-file, argv queue                |
-| Agent sidecar supervision | `desktop/src/main/**`, `desktop/src/agent-sidecar.ts` | Adapter only; core is `agent-system`             |
-| Preload bridge            | `desktop/src/preload.ts`                              | Path-scoped `window.grida`, auth held in closure |
-| Renderer desktop routes   | `editor/app/desktop/**`                               | No server actions, no `next/headers`             |
-| Renderer scaffolds        | `editor/scaffolds/desktop/**`                         | UI using `@/lib/desktop/*`                       |
-| Typed bridge client       | `editor/lib/desktop/**`                               | Pure TS client, no server-only imports           |
+| Concern                   | Lives in                                              | Notes                                                                 |
+| ------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| Window/menu/dialog wiring | `desktop/src/main/**`                                 | Native shell behavior                                                 |
+| Protocol and file routing | `desktop/src/main/**`, `desktop/Info.plist`           | `grida://` (prod) / `grida-dev://` (dev, #955), open-file, argv queue |
+| Agent sidecar supervision | `desktop/src/main/**`, `desktop/src/agent-sidecar.ts` | Adapter only; core is `agent-system`                                  |
+| Preload bridge            | `desktop/src/preload.ts`                              | Path-scoped `window.grida`, auth held in closure                      |
+| Renderer desktop routes   | `editor/app/desktop/**`                               | No server actions, no `next/headers`                                  |
+| Renderer scaffolds        | `editor/scaffolds/desktop/**`                         | UI using `@/lib/desktop/*`                                            |
+| Typed bridge client       | `editor/lib/desktop/**`                               | Pure TS client, no server-only imports                                |
 
 Do not put OPFS or IndexedDB desktop storage in `editor/app/desktop/**`.
 Desktop storage goes through the bridge and agent host.
@@ -266,8 +266,9 @@ For non-trivial desktop changes:
 - Preload bridge: `desktop/src/preload.ts`
 - Forge config: `desktop/forge.config.ts`
 - File associations: `desktop/Info.plist`
+- Deep-link scheme + router: `desktop/src/env.ts` (`DEEP_LINK_SCHEME`) + `desktop/src/main/protocol-router.ts` — per-environment `grida://` (prod) / `grida-dev://` (dev + insiders), so a dev build never fights an installed prod Grida over one OS handler. Dev registration is `CFBundleURLTypes` via `scripts/prepare-dev-electron-branding.mjs` (macOS `setAsDefaultProtocolClient` no-ops unpackaged). Full context: #955.
 - Renderer routes: `editor/app/desktop/`
 - Renderer scaffolds: `editor/scaffolds/desktop/`
 - Typed bridge client: `editor/lib/desktop/bridge.ts`
 - CSP for `/desktop/*`: `editor/proxy.ts`
-- Threat model: `SECURITY.md` (`GRIDA-SEC-004`)
+- Threat model: `SECURITY.md` (`GRIDA-SEC-004` bridge · `GRIDA-SEC-005` sign-in deep link)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -815,10 +815,22 @@ paths, and params are public, so the design must not rely on obscurity.
    `shell.openExternal`'d — logging the user out of their OS browser.
 6. **Ceremony in the system browser only** — the launch URL travels
    renderer → `shell.open_external` (http/https-validated IPC); the
-   webview never loads a provider page, and the `grida://auth/callback`
+   webview never loads a provider page, and the `…://auth/callback`
    redirect is allowlisted in Supabase
    ([supabase/config.toml](supabase/config.toml) locally; the hosted
-   project's dashboard in production).
+   project's dashboard in production). The scheme is **per-environment**
+   (#955): production returns to `grida://`, while local dev/insiders
+   builds register and return to `grida-dev://` — so a machine running
+   BOTH a dev build and the installed production Grida never has the two
+   fight over one OS handler. The target is chosen from the build channel
+   (`process.env.NODE_ENV` in the editor's
+   [auth-deeplink.ts](editor/lib/desktop/auth-deeplink.ts);
+   `app.isPackaged`/insiders in the desktop's `env.ts`), **never from
+   request input**, so it stays a fixed, non-attacker-controllable
+   constant. The router
+   ([protocol-router.ts](desktop/src/main/protocol-router.ts)) accepts
+   either scheme with byte-identical fixed-target behavior; the OS only
+   ever delivers a build its own declared scheme.
 
 The Electron main process remains credential-free, and the sidecar
 holds at most the purpose-scoped, short-lived hosted-AI token
@@ -832,7 +844,8 @@ calls.
 **Files bound by this id.** Run `grep -rn GRIDA-SEC-005 .` to enumerate.
 Today:
 
-- [supabase/config.toml](supabase/config.toml) — `grida://auth/callback` redirect allowlist entry.
+- [supabase/config.toml](supabase/config.toml) — redirect allowlist entries: `grida://auth/callback` (production) + `grida-dev://auth/callback` (local dev/insiders, #955). The hosted dashboard allowlists only the production `grida://` target.
+- [editor/lib/desktop/auth-deeplink.ts](editor/lib/desktop/auth-deeplink.ts) — the single, per-environment `…://auth/callback` redirect-target constant (build-time, never request input). Must stay aligned with the desktop's `DEEP_LINK_SCHEME` (`desktop/src/env.ts`).
 - [editor/app/desktop/auth/start/route.ts](editor/app/desktop/auth/start/route.ts) — PKCE start; verifier cookie + launch-page URL (method-neutral; the desktop never names a provider).
 - [editor/app/(untracked)/desktop-auth/page.tsx](<editor/app/(untracked)/desktop-auth/page.tsx>) + [editor/app/(untracked)/layout.tsx](<editor/app/(untracked)/layout.tsx>) — the web launch page and its analytics-free root layout. Shares the sign-in shell ([editor/components/auth/sign-in-shell.tsx](editor/components/auth/sign-in-shell.tsx)) and Google button (`authorize_url` mode); validates the challenge, binds the offered method's GoTrue flow to it, mirrors the web sign-in's insiders routing (`NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH` → redirect to the insiders page with the challenge forwarded). Deliberately NOT a `(site)` sibling: `(site)` loads Google/Vercel analytics that would beacon the challenge-bearing URL. The `(untracked)` group must never gain a URL-reporting script.
 - [editor/host/auth/desktop-auth-flow.ts](editor/host/auth/desktop-auth-flow.ts) — the flow vocabulary shared by the launch page and the insiders route: challenge validation, challenge-bound authorize/OTP builders, verify-link extraction pinned to the Supabase origin (pinned by `desktop-auth-flow.test.ts`).

--- a/desktop/forge.config.ts
+++ b/desktop/forge.config.ts
@@ -29,6 +29,11 @@ dotenv.config();
 const productName = IS_INSIDERS ? "Grida Insiders" : "Grida";
 const appBundleId = IS_INSIDERS ? "co.grida.insiders" : "co.grida.desktop";
 const icon = IS_INSIDERS ? "./images/insiders/icon" : "./images/icon";
+// GRIDA-SEC-005 / #955 — deep-link scheme. Insiders targets the localhost editor
+// (like dev) and so registers `grida-dev` to match the editor's dev redirect
+// target; production owns `grida`. Must agree with `DEEP_LINK_SCHEME` in
+// `src/env.ts` and the editor's `DESKTOP_AUTH_REDIRECT`.
+const deepLinkScheme = IS_INSIDERS ? "grida-dev" : "grida";
 
 const signingIdentity = process.env.APPLE_SIGNING_IDENTITY;
 const entitlementsPath = path.join(
@@ -142,7 +147,7 @@ const config: ForgeConfig = {
     protocols: [
       {
         name: "Grida",
-        schemes: ["grida"],
+        schemes: [deepLinkScheme],
       },
     ],
     extendInfo: "./Info.plist",
@@ -235,8 +240,8 @@ const config: ForgeConfig = {
         name: productName,
         icon: "./images/icon.png",
         mimeType: [
-          // grida:// deep linking
-          "x-scheme-handler/grida",
+          // grida:// (prod) / grida-dev:// (insiders) deep linking
+          `x-scheme-handler/${deepLinkScheme}`,
         ],
         // GRIDA-SEC-004 — srt's Linux backend shells out to these.
         // bubblewrap = namespace+seccomp sandbox; socat = unix-socket
@@ -252,8 +257,8 @@ const config: ForgeConfig = {
         name: productName,
         icon: "./images/icon.png",
         mimeType: [
-          // grida:// deep linking
-          "x-scheme-handler/grida",
+          // grida:// (prod) / grida-dev:// (insiders) deep linking
+          `x-scheme-handler/${deepLinkScheme}`,
         ],
         // GRIDA-SEC-004 — see MakerRpm comment above.
         depends: ["bubblewrap", "socat", "ripgrep"],

--- a/desktop/scripts/prepare-dev-electron-branding.mjs
+++ b/desktop/scripts/prepare-dev-electron-branding.mjs
@@ -14,14 +14,19 @@ const backupIcon = path.join(backup, "electron.icns");
 const insidersIcon = path.join(root, "images/insiders/icon.icns");
 const isInsiders = process.argv.includes("--insiders");
 
-// Electron's macOS docs describe full rebranding as a packaging step:
-// rename Electron.app plus CFBundleDisplayName / CFBundleIdentifier /
-// CFBundleName and the helper apps. In `electron-forge start`, the
-// launched bundle is still node_modules/electron/dist/Electron.app, so
-// this dev patch is intentionally best-effort for the Dock icon only.
-// Calling this script without --insiders restores the original Electron
-// bundle; normal dev/package/make/publish scripts do that first so this
-// dev-only branding cannot leak into non-insiders or packaged builds.
+// Two dev-only patches to node_modules/electron/dist/Electron.app — the bundle
+// `electron-forge start` actually launches (full rebranding is otherwise a
+// packaging step, and macOS keys off this live bundle):
+//
+//   1. Dock icon + name (insiders only) — best-effort cosmetic.
+//   2. A unique CFBundleIdentifier per channel — FUNCTIONAL: it fixes `grida://`
+//      deep-link routing (GRIDA-SEC-005; see the block near the bottom).
+//
+// Calling this script without --insiders restores the original icon/name;
+// normal dev/package/make/publish scripts do that first so cosmetic insiders
+// branding cannot leak. Packaged builds are unaffected either way — forge
+// packages from the @electron/get cache with its own appBundleId
+// (co.grida.desktop), not this node_modules bundle.
 // See:
 // https://www.electronjs.org/docs/latest/tutorial/application-distribution#rebranding-with-downloaded-binaries
 // https://www.electronjs.org/docs/latest/api/dock#dockseticonimage-macos
@@ -60,4 +65,88 @@ if (isInsiders) {
 } else {
   fs.copyFileSync(backupPlist, plist);
   fs.copyFileSync(backupIcon, path.join(resources, "electron.icns"));
+}
+
+// GRIDA-SEC-005 / #955 — make the DEV Electron a proper `grida-dev://` deep-link
+// handler. Dev (and insiders) use their OWN scheme — `grida-dev`, NOT the
+// packaged production `grida` — so the two builds can never fight over one
+// scheme in LaunchServices when both are installed. Full context/history: #955.
+// Two Info.plist patches are needed because the runtime
+// `app.setAsDefaultProtocolClient(...)` is documented to take effect only for
+// PACKAGED apps on macOS — in `electron-forge start` it silently no-ops, so the
+// OS would otherwise have no handler ("There is no application set to open …").
+//
+//   (a) CFBundleURLTypes — the DECLARATIVE scheme registration LaunchServices
+//       actually reads (exactly what forge's `protocols` config bakes into
+//       packaged builds). This is what registers the app as a handler at all,
+//       and it declares `grida-dev` (prod isolation).
+//   (b) A globally-unique CFBundleIdentifier per channel — so the scheme
+//       resolves to THIS app, not another Electron project (all un-rebranded
+//       dev Electrons share `com.github.Electron`). Belt-and-suspenders with the
+//       dev scheme above.
+//
+// Applied after the branding branch above so the non-insiders restore can't
+// clobber them.
+const devBundleId = isInsiders
+  ? "co.grida.insiders.dev"
+  : "co.grida.desktop.dev";
+setPlistValue("CFBundleIdentifier", devBundleId);
+
+// (a) Declare the `grida-dev` scheme. Idempotent: drop any prior block first
+// (this script re-runs every `pnpm dev`), then add ours. Mirrors the packaged
+// insiders `protocols: [{ name: "Grida", schemes: ["grida-dev"] }]`.
+try {
+  execFileSync(
+    "/usr/libexec/PlistBuddy",
+    ["-c", "Delete :CFBundleURLTypes", plist],
+    { stdio: "ignore" }
+  );
+} catch {
+  // no prior CFBundleURLTypes — nothing to clear
+}
+execFileSync("/usr/libexec/PlistBuddy", [
+  "-c",
+  "Add :CFBundleURLTypes array",
+  "-c",
+  "Add :CFBundleURLTypes:0 dict",
+  "-c",
+  "Add :CFBundleURLTypes:0:CFBundleURLName string Grida",
+  "-c",
+  "Add :CFBundleURLTypes:0:CFBundleURLSchemes array",
+  "-c",
+  "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string grida-dev",
+  plist,
+]);
+
+// Re-sign ad-hoc so the signature matches the patched Info.plist (id + scheme).
+// The stock bundle is ad-hoc/linker-signed (`Identifier=Electron`); editing
+// Info.plist alone leaves the signature stale, which macOS can prefer over
+// Info.plist when registering the handler. `--sign -` re-derives the identifier
+// from the (now unique) CFBundleIdentifier. Must run AFTER all plist edits.
+// Best-effort: a codesign failure must not break `pnpm dev`.
+try {
+  execFileSync("/usr/bin/codesign", ["--force", "--sign", "-", appBundle], {
+    stdio: "ignore",
+  });
+} catch (err) {
+  console.warn(
+    `[dev-branding] ad-hoc re-sign failed (${err.message}); continuing.`
+  );
+}
+
+// Force LaunchServices to register the patched bundle NOW. `electron-forge
+// start` launches the raw binary, which doesn't trigger LS registration on its
+// own, so without this the freshly-declared scheme isn't picked up until a
+// later system scan. Best-effort.
+try {
+  execFileSync(
+    "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
+    ["-f", appBundle],
+    { stdio: "ignore" }
+  );
+} catch (err) {
+  console.warn(
+    `[dev-branding] lsregister refresh failed (${err.message}); ` +
+      `LaunchServices will re-scan later.`
+  );
 }

--- a/desktop/src/deep-link.ts
+++ b/desktop/src/deep-link.ts
@@ -1,0 +1,18 @@
+/**
+ * GRIDA-SEC-005 / #955 — the deep-link URL schemes Grida owns, in one place.
+ *
+ * `grida` is production; `grida-dev` is local dev/insiders (a dev build registers
+ * its own scheme so it never fights an installed production Grida over a single OS
+ * handler). A build REGISTERS exactly one — see `DEEP_LINK_SCHEME` in `env.ts`,
+ * which needs `electron` to pick the active channel — but the protocol router and
+ * the argv classifier ACCEPT the whole set: the OS only ever delivers a build its
+ * own scheme, so accepting both keeps those paths env-agnostic.
+ *
+ * Deliberately electron-free (no `env.ts` import) so the isolated, electron-free
+ * argv classifier (`main/open-handoff.ts`, tested without an Electron mock) can
+ * share this source of truth. Rename or add a variant here and the router +
+ * classifier follow automatically.
+ */
+export const DEEP_LINK_SCHEMES = ["grida", "grida-dev"] as const;
+
+export type DeepLinkScheme = (typeof DEEP_LINK_SCHEMES)[number];

--- a/desktop/src/env.ts
+++ b/desktop/src/env.ts
@@ -1,4 +1,5 @@
 import { app } from "electron";
+import type { DeepLinkScheme } from "./deep-link";
 
 export const IS_INSIDERS = INSIDERS === 1;
 // Use Electron's own packaging signal — `app.isPackaged` is true only
@@ -25,4 +26,5 @@ export const EDITOR_BASE_URL =
 // schemes are the only durable isolation. Mirrors the EDITOR_BASE_URL local/prod
 // split exactly, so the desktop's registered scheme and the editor's redirect
 // target (editor/lib/desktop/auth-deeplink.ts) always agree.
-export const DEEP_LINK_SCHEME = IS_INSIDERS || IS_DEV ? "grida-dev" : "grida";
+export const DEEP_LINK_SCHEME: DeepLinkScheme =
+  IS_INSIDERS || IS_DEV ? "grida-dev" : "grida";

--- a/desktop/src/env.ts
+++ b/desktop/src/env.ts
@@ -15,3 +15,14 @@ export const IS_DEV = !app.isPackaged;
 // dropping it would silently route an insiders build at grida.co.
 export const EDITOR_BASE_URL =
   IS_INSIDERS || IS_DEV ? "http://localhost:3000" : "https://grida.co";
+
+// GRIDA-SEC-005 / #955 — the custom URL scheme THIS build registers as its
+// `…://auth/callback` deep-link handler. Local builds (dev + insiders, which
+// target the localhost editor) use `grida-dev`; production uses `grida`. Split
+// so a dev machine that ALSO runs the packaged production Grida (which owns
+// `grida://`) doesn't have the two builds fight over one scheme — macOS
+// LaunchServices resolves a scheme to a single default handler, so distinct
+// schemes are the only durable isolation. Mirrors the EDITOR_BASE_URL local/prod
+// split exactly, so the desktop's registered scheme and the editor's redirect
+// target (editor/lib/desktop/auth-deeplink.ts) always agree.
+export const DEEP_LINK_SCHEME = IS_INSIDERS || IS_DEV ? "grida-dev" : "grida";

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -6,7 +6,7 @@ import create_menu, {
   rebuild_application_menu,
 } from "./menu";
 import { open_welcome_window, open_document_window } from "./window";
-import { EDITOR_BASE_URL } from "./env";
+import { DEEP_LINK_SCHEME, EDITOR_BASE_URL } from "./env";
 import {
   RUNTIME_APP_NAME,
   USE_DEV_INSIDERS_BRANDING,
@@ -73,7 +73,13 @@ app.commandLine.appendSwitch("js-flags", "--expose-gc");
 // #endregion chrome flags
 
 app.setName(RUNTIME_APP_NAME);
-app.setAsDefaultProtocolClient("grida");
+// GRIDA-SEC-005 / #955 — register this build's channel-specific deep-link scheme
+// (`grida-dev` for local builds, `grida` for production) so dev and an installed
+// production Grida don't fight over one scheme. On macOS the reliable, declarative
+// registration is the dev bundle's CFBundleURLTypes (dev: prepare-dev-electron-
+// branding.mjs; packaged: forge.config `protocols`); this runtime call is the
+// Windows/Linux path and a macOS best-effort.
+app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
 
 // GRIDA-SEC-004 — register the `grida-workspace://` privileged media scheme
 // (#924). `registerSchemesAsPrivileged` MUST run before `app.whenReady()`; the

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { app, shell, BrowserWindow, Menu, dialog } from "electron";
+import path from "node:path";
 import { updateElectronApp } from "update-electron-app";
 import started from "electron-squirrel-startup";
 import create_menu, {
@@ -79,7 +80,18 @@ app.setName(RUNTIME_APP_NAME);
 // registration is the dev bundle's CFBundleURLTypes (dev: prepare-dev-electron-
 // branding.mjs; packaged: forge.config `protocols`); this runtime call is the
 // Windows/Linux path and a macOS best-effort.
-app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
+if (process.defaultApp && process.argv.length >= 2) {
+  // Dev (`electron-forge start` → `process.defaultApp`): the one-arg form would
+  // register the bare Electron executable WITHOUT our app entry, so on Windows a
+  // `grida-dev://` deep link could relaunch a blank Electron instead of delivering
+  // the URL. Point the registration at the app entry (Electron's documented dev
+  // pattern: setAsDefaultProtocolClient(scheme, execPath, [appPath])).
+  app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME, process.execPath, [
+    path.resolve(process.argv[1]),
+  ]);
+} else {
+  app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
+}
 
 // GRIDA-SEC-004 — register the `grida-workspace://` privileged media scheme
 // (#924). `registerSchemesAsPrivileged` MUST run before `app.whenReady()`; the

--- a/desktop/src/main/open-handoff.ts
+++ b/desktop/src/main/open-handoff.ts
@@ -25,11 +25,11 @@
  */
 
 import path from "node:path";
+// GRIDA-SEC-005 / #955 — shared, electron-free scheme set (both `grida` and
+// `grida-dev`; see `../deep-link`). Classify both so this Windows/Linux argv path
+// stays env-agnostic, mirroring the protocol router; `routeDeepLink` re-validates.
+import { DEEP_LINK_SCHEMES } from "../deep-link";
 
-// GRIDA-SEC-005 / #955 — a build receives only its own scheme (`grida://` prod,
-// `grida-dev://` local), but classify both so this Windows/Linux argv path stays
-// env-agnostic, mirroring the protocol router. `routeDeepLink` re-validates.
-const DEEP_LINK_SCHEMES = ["grida://", "grida-dev://"] as const;
 const SUPPORTED_FILE_EXTENSIONS = new Set([".svg", ".grida"]);
 /** A `.canvas` is a directory (a macOS package), not a file — routed to the
  * slides editor rather than the single-document/docId flow. Recognized by the
@@ -71,7 +71,7 @@ export namespace open_handoff {
   export function fromArgv(argv: readonly string[]): Open[] {
     const opens: Open[] = [];
     for (const arg of argv) {
-      if (DEEP_LINK_SCHEMES.some((scheme) => arg.startsWith(scheme)))
+      if (DEEP_LINK_SCHEMES.some((scheme) => arg.startsWith(`${scheme}://`)))
         opens.push({ kind: "url", url: arg });
       else if (isSupportedFile(arg) || isCanvasBundle(arg))
         opens.push({ kind: "file", path: arg });

--- a/desktop/src/main/open-handoff.ts
+++ b/desktop/src/main/open-handoff.ts
@@ -26,7 +26,10 @@
 
 import path from "node:path";
 
-const DEEP_LINK_SCHEME = "grida://";
+// GRIDA-SEC-005 / #955 — a build receives only its own scheme (`grida://` prod,
+// `grida-dev://` local), but classify both so this Windows/Linux argv path stays
+// env-agnostic, mirroring the protocol router. `routeDeepLink` re-validates.
+const DEEP_LINK_SCHEMES = ["grida://", "grida-dev://"] as const;
 const SUPPORTED_FILE_EXTENSIONS = new Set([".svg", ".grida"]);
 /** A `.canvas` is a directory (a macOS package), not a file — routed to the
  * slides editor rather than the single-document/docId flow. Recognized by the
@@ -68,7 +71,7 @@ export namespace open_handoff {
   export function fromArgv(argv: readonly string[]): Open[] {
     const opens: Open[] = [];
     for (const arg of argv) {
-      if (arg.startsWith(DEEP_LINK_SCHEME))
+      if (DEEP_LINK_SCHEMES.some((scheme) => arg.startsWith(scheme)))
         opens.push({ kind: "url", url: arg });
       else if (isSupportedFile(arg) || isCanvasBundle(arg))
         opens.push({ kind: "file", path: arg });

--- a/desktop/src/main/protocol-router.test.ts
+++ b/desktop/src/main/protocol-router.test.ts
@@ -89,6 +89,18 @@ describe("routeDeepLink — auth/callback", () => {
     );
   });
 
+  // #955 — local dev/insiders builds register their own `grida-dev://` scheme so
+  // they never fight an installed production Grida over `grida://`. The router
+  // must route it identically to the fixed same-origin callback.
+  it("routes the dev scheme (grida-dev://) identically", async () => {
+    const window = makeWindow("https://grida.test/desktop/auth/sign-in");
+    state.all = [window];
+    await routeDeepLink("grida-dev://auth/callback?code=dev-123");
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "https://grida.test/desktop/auth/callback?code=dev-123"
+    );
+  });
+
   it("forwards only known params — attacker extras are dropped", async () => {
     const window = makeWindow("https://grida.test/desktop/auth/sign-in");
     state.all = [window];

--- a/desktop/src/main/protocol-router.ts
+++ b/desktop/src/main/protocol-router.ts
@@ -16,6 +16,7 @@
  */
 import { BrowserWindow } from "electron";
 import { EDITOR_BASE_URL } from "../env";
+import { DEEP_LINK_SCHEMES } from "../deep-link";
 import { findWindowByUrl } from "./window-focus";
 
 /**
@@ -77,12 +78,13 @@ export async function routeDeepLink(url: string): Promise<boolean> {
     console.warn(`[grida] malformed deep link, ignoring: ${url}`);
     return true;
   }
-  // GRIDA-SEC-005 / #955 — accept both `grida:` (production) and `grida-dev:`
-  // (local dev + insiders). A build only ever RECEIVES its own scheme (the OS
-  // routes by the declared CFBundleURLTypes / forge `protocols`), so accepting
-  // both keeps this router env-agnostic and testable; routing is byte-identical
-  // either way — the fixed-target, verifier-gated exchange doesn't depend on it.
-  if (parsed.protocol !== "grida:" && parsed.protocol !== "grida-dev:") {
+  // GRIDA-SEC-005 / #955 — accept every scheme Grida owns (`grida:` prod,
+  // `grida-dev:` local); the shared set is `../deep-link`. A build only ever
+  // RECEIVES its own (the OS routes by the declared CFBundleURLTypes / forge
+  // `protocols`), so accepting both keeps this router env-agnostic and testable;
+  // routing is byte-identical either way — the fixed-target, verifier-gated
+  // exchange doesn't depend on the scheme.
+  if (!DEEP_LINK_SCHEMES.some((scheme) => parsed.protocol === `${scheme}:`)) {
     console.warn(`[grida] unrecognized protocol, ignoring: ${parsed.protocol}`);
     return true;
   }

--- a/desktop/src/main/protocol-router.ts
+++ b/desktop/src/main/protocol-router.ts
@@ -77,8 +77,13 @@ export async function routeDeepLink(url: string): Promise<boolean> {
     console.warn(`[grida] malformed deep link, ignoring: ${url}`);
     return true;
   }
-  if (parsed.protocol !== "grida:") {
-    console.warn(`[grida] non-grida protocol, ignoring: ${parsed.protocol}`);
+  // GRIDA-SEC-005 / #955 — accept both `grida:` (production) and `grida-dev:`
+  // (local dev + insiders). A build only ever RECEIVES its own scheme (the OS
+  // routes by the declared CFBundleURLTypes / forge `protocols`), so accepting
+  // both keeps this router env-agnostic and testable; routing is byte-identical
+  // either way — the fixed-target, verifier-gated exchange doesn't depend on it.
+  if (parsed.protocol !== "grida:" && parsed.protocol !== "grida-dev:") {
+    console.warn(`[grida] unrecognized protocol, ignoring: ${parsed.protocol}`);
     return true;
   }
   // Custom-scheme hosts are NOT lowercased by the URL parser (unlike

--- a/editor/lib/desktop/auth-deeplink.ts
+++ b/editor/lib/desktop/auth-deeplink.ts
@@ -1,8 +1,8 @@
 /**
  * GRIDA-SEC-005 — desktop sign-in deep-link contract.
  *
- * The single source for the `grida://auth/callback` return target, shared by
- * the parts that must agree on it: the PKCE start route
+ * The single source for the `…://auth/callback` return target, shared by the
+ * parts that must agree on it: the PKCE start route
  * (`app/desktop/auth/start/route.ts`), the launch-page flow builders
  * (`host/auth/desktop-auth-flow.ts`), the Electron protocol router, and the
  * Supabase redirect allowlist (`supabase/config.toml`). It lives in
@@ -10,5 +10,17 @@
  * `@/host/**` (GRIDA-SEC-004) but not from `@/lib/desktop` — so both the
  * route and the flow module import ONE constant instead of duplicating the
  * literal and risking drift across the contract.
+ *
+ * Scheme is per-environment (#955): the dev editor (`next dev`) returns to
+ * `grida-dev://` — the scheme the dev/insiders desktop builds register — while
+ * production returns to `grida://`, so a dev machine running BOTH builds never
+ * has them fight over one scheme in the OS handler registry. This mirrors the
+ * desktop's own `DEEP_LINK_SCHEME` (which keys off `app.isPackaged`/insiders);
+ * the two derive the same split from opposite sides and must stay aligned. The
+ * value is a build-time constant (NOT request input), so the redirect target
+ * stays non-attacker-controllable — the property GRIDA-SEC-005 depends on.
  */
-export const DESKTOP_AUTH_REDIRECT = "grida://auth/callback";
+export const DESKTOP_AUTH_REDIRECT =
+  process.env.NODE_ENV === "development"
+    ? "grida-dev://auth/callback"
+    : "grida://auth/callback";

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -164,7 +164,11 @@ site_url = "http://127.0.0.1:3000"
 # they don't fight an installed production Grida over one handler. The hosted
 # project's dashboard allowlists only `grida://auth/callback` (prod); `grida-dev` is
 # local-only and never belongs in the hosted allowlist.
-additional_redirect_urls = ["https://127.0.0.1:3000", "grida://auth/callback", "grida-dev://auth/callback"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "grida://auth/callback",
+  "grida-dev://auth/callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -158,10 +158,13 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-# GRIDA-SEC-005 — `grida://auth/callback` is the desktop deep-link return for the
-# PKCE sign-in flow (see /SECURITY.md). The hosted project's dashboard must
-# allowlist the same URL before a desktop release that enables sign-in.
-additional_redirect_urls = ["https://127.0.0.1:3000", "grida://auth/callback"]
+# GRIDA-SEC-005 — the desktop deep-link returns for the PKCE sign-in flow (see
+# /SECURITY.md). `grida://auth/callback` is production; `grida-dev://auth/callback`
+# is the LOCAL dev/insiders scheme (#955) — dev builds register their own scheme so
+# they don't fight an installed production Grida over one handler. The hosted
+# project's dashboard allowlists only `grida://auth/callback` (prod); `grida-dev` is
+# local-only and never belongs in the hosted allowlist.
+additional_redirect_urls = ["https://127.0.0.1:3000", "grida://auth/callback", "grida-dev://auth/callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
Makes desktop sign-in's deep-link handoff route reliably to the **dev** app on macOS and coexist with an installed **production** Grida — the GRIDA-SEC-005 PKCE return path. Full context/history: #955.

## Problem

Desktop sign-in returns through a `grida://auth/callback` deep link. In dev on macOS this was unreliable in three compounding ways:

1. **Wrong app.** Every un-rebranded dev Electron shares the generic `com.github.Electron` bundle id, and macOS LaunchServices resolves a URL scheme by bundle id — so the link could open *another project's* Electron.
2. **No app.** `app.setAsDefaultProtocolClient` is documented to take effect only for **packaged** apps on macOS, so an unpackaged dev build never registered a handler at all ("There is no application set to open the URL grida://").
3. **Collision with prod.** Once fixed, dev still collided with an installed production Grida — both declare `grida://`, so LaunchServices picks a default handler nondeterministically (the `/Applications` app tends to win).

## Fix (two layers)

**1. Unique dev identity + declarative registration** — `scripts/prepare-dev-electron-branding.mjs` (already runs before every `electron-forge start`) now stamps a globally-unique `CFBundleIdentifier` on the dev Electron (`co.grida.desktop.dev` / `co.grida.insiders.dev`), declares the scheme via `CFBundleURLTypes` (the registration LaunchServices actually reads — what forge bakes into packaged builds), ad-hoc re-signs so the signature id matches the patched plist, and `lsregister -f`s it.

**2. Per-environment scheme** — local dev/insiders register and return to **`grida-dev://`**; production keeps **`grida://`**, so they can never fight over one OS handler when both are installed. Single source `DEEP_LINK_SCHEME` in `desktop/src/env.ts` (mirrors `EDITOR_BASE_URL`); `main.ts` registers it; the protocol router + argv classifier accept both; `forge.config` bakes the channel-appropriate scheme for packaged builds; the editor's `DESKTOP_AUTH_REDIRECT` is env-derived; supabase local allowlists `grida-dev://auth/callback`.

## Security — GRIDA-SEC-005

Reviewed and **security-neutral**:
- The router stays stateless / fixed-target / verifier-gated for both schemes (proven by tests).
- The redirect target is a **build-time constant** (`NODE_ENV` / `app.isPackaged`), never request input → stays non-attacker-controllable, the property the boundary depends on.
- Production is entirely unchanged; dev adds `grida-dev://` with identical enforcement.

`SECURITY.md` (enforcement step 6 + Files-bound list) and the `desktop` skill are aligned in this PR.

## Verification

- desktop `tsc` + **106 tests** (incl. a new `grida-dev://` routing case)
- editor `tsc` + **25 GRIDA-SEC-005 tests**
- supabase reloaded → `GOTRUE_URI_ALLOW_LIST` carries `grida-dev://auth/callback`
- confirmed the dev bundle is the **sole** `grida-dev://` claimant, and the live sign-in round-trip lands in the dev app

## Reviewer notes

- macOS-centric (the collision is macOS LaunchServices behavior); Windows/Linux ride the same `DEEP_LINK_SCHEME` via `setAsDefaultProtocolClient` + forge MIME/`protocols`.
- Packaged **insiders** targets the localhost editor, so it registers `grida-dev` too (forge `protocols` is channel-aware) to stay aligned with the editor's dev redirect.
- The supabase change is **local-only**; the hosted dashboard keeps only `grida://` (prod). `grida-dev` never belongs in the hosted allowlist.

Closes #955
