### PR TITLE
Refine agent file discovery and context accounting

### DIFF
--- a/docs/wg/ai/agent/foundations.md
+++ b/docs/wg/ai/agent/foundations.md
@@ -117,9 +117,10 @@ session.
 
 ## Locked fundamental tools
 
-Every implementation MUST ship the locked tool set. The 13 ids are
-`read`, `write`, `edit`, `glob`, `grep`, `bash`, `todo`, `task`,
-`question`, `web_search`, `web_fetch`, `skill`, `tool_search`.
+Every implementation that advertises the locked structured-tool
+profile MUST ship the locked tool set. The 13 ids are `read`,
+`write`, `edit`, `glob`, `grep`, `bash`, `todo`, `task`, `question`,
+`web_search`, `web_fetch`, `skill`, `tool_search`.
 
 The set is **non-opinionated**: each tool is the smallest thing it
 can be. Models trained on tool use have learned these names; the

--- a/docs/wg/ai/agent/persistency.md
+++ b/docs/wg/ai/agent/persistency.md
@@ -60,7 +60,7 @@ list can render token counts without replaying chunks.
 | `cache_read`        | INTEGER | required | Sum of `usage.cache_read`. Default `0`.                                                                                                                                                      |
 | `cache_write`       | INTEGER | required | Sum of `usage.cache_write`. Default `0`.                                                                                                                                                     |
 | `total_tokens`      | INTEGER | required | `prompt_tokens + completion_tokens + reasoning_tokens + cache_read + cache_write`. Equals `context_window_used` per [session](./session.md#what-the-context-window-means-here). Default `0`. |
-| `cost_usd`          | REAL    | required | Default `0`. The store never **computes** cost; a writer (a hosted route, a metadata hook) MAY populate it.                                                                                  |
+| `cost_usd`          | REAL    | required | Default `0`. Compatibility/cache field only; canonical cost is derived from assistant-message `{ model, usage }` plus the model catalog, not from this persisted value.                      |
 | `created_at`        | INTEGER | required | Epoch ms.                                                                                                                                                                                    |
 | `updated_at`        | INTEGER | required | Epoch ms.                                                                                                                                                                                    |
 | `archived_at`       | INTEGER | optional | Epoch ms when archived. Conforming session-list operations MUST filter rows with non-null `archived_at` by default, and MUST expose a way to include them. **Not** a delete.                 |
@@ -160,7 +160,9 @@ The schema promotes only the fields the picker, filter, or recorder
 needs to columns. Everything else lives in JSON:
 
 - **Picker reads, indexable filters, rollups → columns.** Tokens,
-  cost, `archived_at`, `updated_at`, `parent_id`.
+  `archived_at`, `updated_at`, `parent_id`. Cost MAY be cached for
+  compatibility, but its canonical source is per-turn metadata plus the
+  model catalog.
 - **Per-turn payload → `data_json`, `metadata_json`.** The full part
   object verbatim. New part types (a future `tool-input-progress`, a
   `media-*` chunk) ship without a migration.

--- a/docs/wg/ai/agent/session.md
+++ b/docs/wg/ai/agent/session.md
@@ -71,10 +71,10 @@ chat_messages.metadata_json: {
 }
 ```
 
-Session-level rollups (`prompt_tokens`, `completion_tokens`,
-`reasoning_tokens`, `cache_read`, `cache_write`, `total_tokens`,
-`cost_usd`) are sums of the above across the session's assistant
-messages.
+Session-level token rollups (`prompt_tokens`, `completion_tokens`,
+`reasoning_tokens`, `cache_read`, `cache_write`, `total_tokens`) are
+sums of the above across the assistant messages that currently count
+toward the model context.
 
 ### Why the breakdown
 
@@ -107,10 +107,17 @@ for the exact formula and the per-component mapping.
 
 ### Cost
 
-`cost_usd` is recorded when a writer (a hosted route, a metadata
-hook) supplies it. The agent system MUST NOT compute cost from a
-pricing table inside the recorder. Pricing lives next to the model
-catalog, not next to the session store.
+Cost is a derived view over per-turn `{ model, usage }`, not
+authoritative session state. An implementation MAY keep a legacy or
+cached cost column for compatibility, but the canonical cost input is
+the assistant message metadata plus the current model catalog pricing.
+Cost is cumulative spend: it includes assistant turns that were later
+hidden by rewind or excluded from the live context by compaction,
+because those turns were still charged.
+
+The recorder MUST NOT hard-code pricing. It records provider usage and
+the model that produced the turn; the pricing table lives with the
+model catalog.
 
 ### What "the context window" means here
 

--- a/docs/wg/ai/agent/tools.md
+++ b/docs/wg/ai/agent/tools.md
@@ -46,17 +46,18 @@ sandbox; the manifest does not need a parallel update.
 
 ## Locked fundamental tools
 
-Every implementation MUST ship the locked set. Models trained on tool
-use have learned these names; renaming `read` to something else
-measurably degrades quality. The set is the smallest union of what a
-code agent, a design agent, and a research agent all need.
+Every implementation that advertises the locked structured-tool
+profile MUST ship the locked set. Models trained on tool use have
+learned these names; renaming `read` to something else measurably
+degrades quality. The set is the smallest union of what a code agent,
+a design agent, and a research agent all need.
 
 | Id            | Purpose                                                                   | Capability declared                                |
 | ------------- | ------------------------------------------------------------------------- | -------------------------------------------------- |
 | `read`        | Read a file from the root                                                 | `fs.read`                                          |
 | `write`       | Create or overwrite a file in the root                                    | `fs.write`                                         |
 | `edit`        | String-replace edit on an existing file                                   | `fs.read` + `fs.write`                             |
-| `glob`        | List files by pattern                                                     | `fs.read`                                          |
+| `glob`        | Discover filesystem entries by path / pattern                             | `fs.read`                                          |
 | `grep`        | Regex search across the root                                              | `fs.read`                                          |
 | `bash`        | Run a shell command under a sub-policy                                    | `shell.run` (per-call sub-policy)                  |
 | `todo`        | Write a todo list to a session-scoped store                               | none (session-internal)                            |
@@ -78,6 +79,20 @@ it can be:
 Implementors who need richer behavior layer it via MCP, plugin tools,
 or agent-specific tools. They MUST NOT redefine the locked id with a
 richer shape — the lock guarantees portability.
+
+Filesystem discovery is in the lock because an agent often needs to
+orient itself before it knows what to read. The shape must stay
+**scoped**: a conforming `glob` / directory-listing binding returns
+entries for an explicit path or pattern, marks truncation, and never
+implies that a partial result is the whole workspace. Whole-repository
+enumeration is a poor default on real filesystems because it competes
+with faster native search tools, leaks backend indexing limits into
+reasoning, and can make the model trust an incomplete inventory. Hosts
+with a virtual filesystem may still need the structured discovery tool
+because there may be no shell, no `find`, and no `rg`. A real-fs
+profile that intentionally relies on shell/search commands for
+discovery should document that product choice in its binding instead
+of shipping a misleading whole-index list tool.
 
 **Common extensions seen on top of the lock.** A code-shaped agent
 typically ships additional tools beyond the lock. Names are not

--- a/docs/wg/ai/grida/tools-fundamentals.md
+++ b/docs/wg/ai/grida/tools-fundamentals.md
@@ -38,7 +38,7 @@ tool](#adding-a-new-fundamental-tool)).
 | `read`        | `read_file`                | Same shape; Grida's name is more specific.                                                                                                                      |
 | `write`       | `write_file`               | Same shape; Grida adds an optional `version` for stale-check.                                                                                                   |
 | `edit`        | `edit_file`                | Same shape; Grida adds a strict ambiguity rule on multi-match.                                                                                                  |
-| `glob`        | `list_files`               | Today a flat enumerate; promote to glob-shape when needed.                                                                                                      |
+| `glob`        | `list_files`               | Grida binding uses a path-scoped directory-listing shape; VFS hosts should provide it, real-fs hosts may omit it when command/search tools are stronger.        |
 | `grep`        | `grep_files`               | Same shape; literal substring search (regex is not shipped).                                                                                                    |
 | `bash`        | `run_command`              | Honest name — Grida's host does not always launch a shell.                                                                                                      |
 | `todo`        | `todo_write`               | Same shape; replace-all semantics.                                                                                                                              |
@@ -95,9 +95,51 @@ fresh-start writes).
 
 ### `list_files`
 
-Today a flat enumeration of every known path, sorted absolute. If we
-need filename pattern matching later we will promote to a glob-shape
-(`glob` in the RFC).
+Grida adopts a path-scoped directory-listing shape for the RFC's
+filesystem-discovery primitive. Despite the current Grida id, this
+tool is **not** a whole-workspace inventory.
+
+```ts
+list_files({
+  path?: string,   // defaults to "/"
+  offset?: number,
+  limit?: number,
+}) -> {
+  path: string,
+  folders: string[],
+  files: string[],
+  truncated: boolean,
+  next_offset?: number,
+}
+```
+
+Contract:
+
+- `path` is rooted in the agent workspace or virtual filesystem. It
+  must not be a general host-absolute path.
+- The result lists only the direct children of `path`, grouped into
+  folders and files.
+- The result is sorted, paginated, and explicit about truncation.
+- `list_files` discovers names only. It does not search file content,
+  and it does not count as `read_file`.
+- For filename-pattern search, use a separate glob / find-path tool
+  rather than overloading this directory-listing result.
+
+Implementation guidance:
+
+- **VFS / OPFS / memory backends:** provide `list_files`. A virtual
+  filesystem may not have a shell, `find`, `tree`, or `rg`, so the
+  structured directory-listing tool is the portable way for the agent
+  to discover reachable paths.
+- **Real filesystem backends:** treat this tool as optional. A
+  shell-capable real-fs agent often gets better behavior from explicit
+  commands (`rg --files`, `find`, `ls`, `tree`) because those tools
+  follow mature ignore rules, stream large output, and make scope
+  visible in the command. A flat "all known files" tool can degrade
+  agent quality by confusing the model into trusting an incomplete or
+  stale index as ground truth.
+- **Do not hide truncation.** If a backend is indexed, capped, or
+  ignore-filtered, the tool result must say so in-band.
 
 ### `grep_files`
 

--- a/editor/lib/agent-chat/context-usage.test.ts
+++ b/editor/lib/agent-chat/context-usage.test.ts
@@ -8,9 +8,9 @@ import {
   usageTokenTotal,
 } from "./context-usage";
 
-// The ring % is REAL (provider usage / context window); the role breakdown
-// is an ESTIMATE (chars/4) with `other` as the residual. These tests pin
-// both halves of that contract — see the module header.
+// The ring % is an estimate from visible transcript parts. Provider usage is
+// exposed separately as last-turn usage because tool loops can consume far more
+// cumulative tokens than the final transcript occupies.
 
 describe("estimateTokens", () => {
   it("is chars/4, rounded up, and 0 for empty", () => {
@@ -87,20 +87,26 @@ describe("estimateContextBreakdown", () => {
     },
   ];
 
-  it("buckets user / assistant(text+reasoning) / tools and folds the rest into other", () => {
-    // accounted = 10 + (20 + 4) + 3 = 37; other = 150 - 37 = 113
-    expect(estimateContextBreakdown(messages, 150)).toEqual({
+  it("buckets visible user / assistant(text+reasoning) / tools", () => {
+    expect(estimateContextBreakdown(messages)).toEqual({
       user: 10,
       assistant: 24,
       tools: 3,
-      other: 113,
+      other: 0,
     });
   });
 
-  it("clamps other to 0 when estimates exceed the real used total", () => {
-    const b = estimateContextBreakdown(messages, 10);
-    expect(b.other).toBe(0);
-    expect(b.user + b.assistant + b.tools).toBeGreaterThan(10);
+  it("puts visible unclassified roles in other", () => {
+    expect(
+      estimateContextBreakdown([
+        { role: "system", parts: [{ type: "text", text: "s".repeat(12) }] },
+      ])
+    ).toEqual({
+      user: 0,
+      assistant: 0,
+      tools: 0,
+      other: 3,
+    });
   });
 });
 
@@ -114,41 +120,54 @@ describe("computeContextUsage", () => {
     },
   ];
 
-  it("computes a real % from usage / contextWindow", () => {
+  it("computes context % from visible transcript estimates", () => {
     const u = computeContextUsage(messages, 1000);
-    expect(u.usedTokens).toBe(150);
+    expect(u.usedTokens).toBe(30);
     expect(u.maxTokens).toBe(1000);
-    expect(u.percent).toBeCloseTo(0.15);
+    expect(u.percent).toBeCloseTo(0.03);
     expect(u.breakdown).toEqual({
       user: 10,
       assistant: 20,
       tools: 0,
-      other: 120,
+      other: 0,
     });
+    expect(u.turnUsageTokens).toBe(150);
+    expect(u.usage).toEqual({ input: 100, output: 50 });
   });
 
-  it("yields percent 0 and used 0 when the window or usage is unknown", () => {
+  it("yields percent 0 when the window is unknown", () => {
     expect(computeContextUsage(messages, undefined).percent).toBe(0);
-    expect(
-      computeContextUsage(
-        [{ role: "user", parts: [{ type: "text", text: "hi" }] }],
-        1000
-      ).usedTokens
-    ).toBe(0);
+    expect(computeContextUsage(messages, undefined).usedTokens).toBe(30);
   });
 
-  it("clamps percent to 1 when usage exceeds the window", () => {
-    // A turn can report usage above the catalog window (provider drift / an
-    // over-budget request); percent must honor its [0, 1] contract.
+  it("does not use provider turn usage as context occupancy", () => {
+    const u = computeContextUsage(
+      [
+        { role: "user", parts: [{ type: "text", text: "fix this" }] },
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }],
+          metadata: { usage: { input: 191031, output: 2708 } },
+        },
+      ],
+      1_000_000
+    );
+    expect(u.turnUsageTokens).toBe(193739);
+    expect(u.usedTokens).toBe(3);
+    expect(u.percent).toBeCloseTo(0.000003);
+  });
+
+  it("clamps percent to 1 when the visible estimate exceeds the window", () => {
     const over = [
       {
         role: "assistant",
-        parts: [{ type: "text", text: "y" }],
+        parts: [{ type: "text", text: "y".repeat(4004) }],
         metadata: { usage: { input: 900, output: 400 } },
       },
     ];
     const u = computeContextUsage(over, 1000);
-    expect(u.usedTokens).toBe(1300);
+    expect(u.usedTokens).toBe(1001);
     expect(u.percent).toBe(1);
+    expect(u.turnUsageTokens).toBe(1300);
   });
 });

--- a/editor/lib/agent-chat/context-usage.ts
+++ b/editor/lib/agent-chat/context-usage.ts
@@ -1,31 +1,27 @@
 /**
- * Context-window usage — the data behind the desktop context meter.
+ * Context-window estimate — the data behind the desktop context meter.
  *
  * Pure + framework-free (no react, no AI-SDK imports) so the math is one
  * testable unit. The view (`scaffolds/desktop/shared/context-meter.tsx`)
  * memoizes {@link computeContextUsage} and renders the ring + popover.
  *
- * ## Two numbers, two sources of truth
+ * ## Two numbers, two meanings
  *
- * The ring **%** is REAL: it reads the provider-reported token usage the
- * agent sidecar stamps onto the latest assistant message
- * (`metadata.usage`, the `MessageUsage` shape from
- * `@grida/ai-agent`'s `session/rows.ts`) and divides by the model's
- * `contextWindow` from the catalog. This mirrors the system's own
- * compaction signal (`session.total_tokens` vs the model limit, see
- * `wg/ai/agent/session.md#context-window-tracking`).
+ * The ring **%** is an estimate of the current transcript's context
+ * footprint. The desktop client does not have the exact prompt that the
+ * runtime will send next: hidden system prompt, skill blocks, tool schemas,
+ * provider framing, and server-side compaction state all live outside this
+ * UI message list. Until the runtime exposes a prompt-token preflight value,
+ * the honest client-side value is chars/4 over the visible message parts.
  *
- * The role **breakdown** (user / assistant / tools / other) is
- * ESTIMATED. The provider reports tokens by *type* (input / output /
- * reasoning / cache), never by *who authored them*, so a per-role split
- * is impossible to read off the usage object. We approximate it the same
- * way the agent's own compactor does — chars/4 over each message's text
- * — and let `other` absorb the residual (the server-side system prompt,
- * skill blocks, tool definitions, and estimation drift), which is never
- * present in the client message list.
+ * Provider-reported `metadata.usage` is still surfaced separately as
+ * last-turn usage. That number is useful for cost/debugging, but it is not
+ * current context occupancy: multi-step tool loops can resend context and
+ * accumulate far more provider input tokens than the final live transcript
+ * occupies.
  *
- * This is the same shape opencode ships (`session-context-breakdown.ts`):
- * a real ring over an approximate, clearly-labeled composition.
+ * The role **breakdown** (user / assistant / tools / other) is estimated
+ * from visible message parts only.
  */
 
 /** chars/4 — the portable token approximation the RFC + compactor use. */
@@ -52,7 +48,7 @@ export type MessageUsage = {
   cache_write?: number;
 };
 
-/** All five buckets count toward the window (RFC `session`). */
+/** Provider usage total for a settled turn; not current context occupancy. */
 export function usageTokenTotal(usage: MessageUsage): number {
   return (
     (usage.input ?? 0) +
@@ -144,26 +140,25 @@ export type ContextBreakdown = {
   /** Tool calls + their results. */
   tools: number;
   /**
-   * Residual: the real used total minus the estimated roles above —
-   * the server-side system prompt, skill blocks, tool definitions,
-   * protocol overhead, and chars/4 drift. Clamped to ≥ 0.
+   * Visible parts with roles the meter does not classify. This does not
+   * include hidden system prompt, skill blocks, tool definitions, provider
+   * framing, or estimation drift.
    */
   other: number;
 };
 
 /**
- * Estimate the per-role composition of the context window. `user`,
- * `assistant`, and `tools` are chars/4 estimates over the visible
- * messages; `other` is whatever real used budget those estimates don't
- * account for (so the parts sum to at least `usedTokens`).
+ * Estimate the per-role composition of the visible transcript. This is not a
+ * provider-token accounting API; it is the best client-side approximation of
+ * what the current chat contents occupy before hidden runtime prompt parts.
  */
 export function estimateContextBreakdown(
-  messages: readonly MessageLike[],
-  usedTokens: number
+  messages: readonly MessageLike[]
 ): ContextBreakdown {
   let user = 0;
   let assistant = 0;
   let tools = 0;
+  let other = 0;
 
   for (const m of messages) {
     const parts = m.parts ?? [];
@@ -175,20 +170,17 @@ export function estimateContextBreakdown(
       } else if (m.role === "assistant") {
         if (isToolPart(part)) tools += toks;
         else assistant += toks;
+      } else {
+        other += toks;
       }
-      // Other roles (system, synthetic) aren't shown verbatim client-side;
-      // their tokens land in `other` via the residual below.
     }
   }
 
-  const accounted = user + assistant + tools;
-  const other = Math.max(0, usedTokens - accounted);
   return { user, assistant, tools, other };
 }
 
 export type ContextUsage = {
-  /** Real provider-reported tokens in the current window (0 until the
-   * first turn settles). */
+  /** Estimated visible transcript tokens. */
   usedTokens: number;
   /** Model context window from the catalog (0 when unknown). */
   maxTokens: number;
@@ -196,27 +188,30 @@ export type ContextUsage = {
   percent: number;
   /** Estimated per-role composition (see {@link ContextBreakdown}). */
   breakdown: ContextBreakdown;
-  /** The raw last-turn usage the ring is computed from, if any. */
+  /** The raw provider-reported last-turn usage, if any. */
   usage: MessageUsage | undefined;
+  /** Provider-reported tokens consumed by the latest settled assistant turn. */
+  turnUsageTokens: number;
 };
 
 /**
- * Compute everything the meter needs: the real ring %, and the estimated
- * role breakdown. `contextWindow` is the model's limit (from
- * `@grida/ai-models`); pass 0/undefined when unknown — `percent` is then 0
- * and the view hides itself.
+ * Compute everything the meter needs: the estimated context ring %, visible
+ * role breakdown, and provider-reported last-turn usage. `contextWindow` is
+ * the model's limit (from `@grida/ai-models`); pass 0/undefined when unknown
+ * — `percent` is then 0 and the view hides itself.
  */
 export function computeContextUsage(
   messages: readonly MessageLike[],
   contextWindow: number | undefined
 ): ContextUsage {
   const usage = lastAssistantUsage(messages);
-  const usedTokens = usage ? usageTokenTotal(usage) : 0;
+  const turnUsageTokens = usage ? usageTokenTotal(usage) : 0;
+  const breakdown = estimateContextBreakdown(messages);
+  const usedTokens =
+    breakdown.user + breakdown.assistant + breakdown.tools + breakdown.other;
   const maxTokens = contextWindow ?? 0;
-  // Clamp to the documented [0, 1] contract — a turn can report usage above the
-  // catalog window (provider drift, an over-budget request), and an unbounded
-  // ratio would mis-scale the ring math downstream.
+  // Clamp to the documented [0, 1] contract; estimates can still exceed a
+  // catalog window for stale model metadata or oversized local transcripts.
   const percent = maxTokens > 0 ? Math.min(1, usedTokens / maxTokens) : 0;
-  const breakdown = estimateContextBreakdown(messages, usedTokens);
-  return { usedTokens, maxTokens, percent, breakdown, usage };
+  return { usedTokens, maxTokens, percent, breakdown, usage, turnUsageTokens };
 }

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -513,6 +513,9 @@ export function AISidebarChat({
   // to mount on. Bridge that dead-air window with a tail indicator until an
   // assistant turn begins.
   const pendingTurn = isStreaming && messages.at(-1)?.role !== "assistant";
+  // Restored transcripts can hydrate after the scroll container has already
+  // mounted. Keep that entry stable; reserve smooth follow for live turns.
+  const conversationResize = busy ? "smooth" : "instant";
 
   return (
     <div className={cn("flex h-full flex-col bg-background", className)}>
@@ -524,7 +527,11 @@ export function AISidebarChat({
         conversationEmpty={isEmpty}
       />
 
-      <Conversation className="flex-1 min-h-0">
+      <Conversation
+        className="flex-1 min-h-0"
+        initial="instant"
+        resize={conversationResize}
+      >
         <ConversationContent className="gap-4 px-3 py-4">
           {isEmpty ? (
             <ConversationEmptyState

--- a/editor/scaffolds/desktop/shared/context-meter.tsx
+++ b/editor/scaffolds/desktop/shared/context-meter.tsx
@@ -1,16 +1,9 @@
 /**
- * Desktop context meter — a ring showing how full the model's context
- * window is. Hover for the exact %, click for the per-role breakdown.
+ * Desktop context meter — a ring estimating how much of the model's context
+ * window the visible transcript occupies. Click for the breakdown.
  *
- * The ring **%** is real (provider-reported usage over the model's context
- * window; see `@/lib/agent-chat/context-usage`). The breakdown
- * (user / assistant / tools / other) is ESTIMATED — the provider never
- * reports tokens by author, so we approximate with chars/4 and let "Other"
- * absorb the system prompt, tools, and overhead. Shape follows opencode's
- * context view: a real ring over a clearly-marked estimate.
- *
- * Renders nothing until a turn settles with usage AND the model's window is
- * known — there's no honest number to show before that.
+ * Renders nothing until the model's window is known and the visible transcript
+ * has something estimateable.
  */
 
 "use client";
@@ -39,8 +32,6 @@ const percent = new Intl.NumberFormat("en-US", {
   style: "percent",
   maximumFractionDigits: 0,
 });
-// Per-row share of the window. One decimal so small categories (a few K
-// against a 1M window) still read as a nonzero slice instead of "0%".
 const rowPercent = new Intl.NumberFormat("en-US", {
   style: "percent",
   maximumFractionDigits: 1,
@@ -50,14 +41,11 @@ const usd = new Intl.NumberFormat("en-US", {
   currency: "USD",
 });
 
-/**
- * Breakdown categories, in render order — drive both bar and rows.
- *
- * Conversation content (user / assistant) keeps a distinct hue so it pops;
- * tooling + overhead recede into a grey ramp that *darkens* toward the left
- * (tools darkest, then other), so the unfilled track — the lightest grey of
- * all — clearly reads as available headroom.
- */
+function formatCostUsd(value: number): string {
+  if (value > 0 && value < 0.01) return "<$0.01";
+  return usd.format(value);
+}
+
 const CATEGORIES = [
   { key: "user", label: "User", color: "bg-sky-500" },
   { key: "assistant", label: "Assistant", color: "bg-violet-500" },
@@ -74,7 +62,7 @@ export function DesktopContextMeter({
   messages: UIMessage[];
   /** Active model id — its resolved spec supplies the context window. */
   modelId: string;
-  /** Real session cost so far, in USD. Shown when > 0. */
+  /** Session cumulative model cost, already computed from per-turn model usage. */
   costUsd?: number;
   /** Configured endpoint providers (issue #806) — registered local models
    *  resolve their real (often small) windows through these. */
@@ -99,9 +87,6 @@ export function DesktopContextMeter({
   if (maxTokens === 0 || usedTokens === 0) return null;
 
   const pct = percent.format(ratio);
-  // Every row is measured against the full window; "Free space" is the exact
-  // unused remainder (matches the bar's empty track), so the rows decompose
-  // 100% of the context window.
   const rows = [
     ...CATEGORIES.map((c) => ({
       key: c.key as string,
@@ -134,7 +119,7 @@ export function DesktopContextMeter({
               </Button>
             </PopoverTrigger>
           </TooltipTrigger>
-          <TooltipContent>{pct} of context used</TooltipContent>
+          <TooltipContent>Context {pct}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
 
@@ -146,9 +131,6 @@ export function DesktopContextMeter({
               {compact.format(usedTokens)} / {compact.format(maxTokens)}
             </span>
           </div>
-          {/* Segments are sized against the *full* window (maxTokens), so the
-              colored fill mirrors the ring's used ratio and the light grey
-              track (= the "Free space" row) shows the remaining headroom. */}
           <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/15">
             {CATEGORIES.map((c) =>
               breakdown[c.key] > 0 ? (
@@ -179,20 +161,14 @@ export function DesktopContextMeter({
             </div>
           ))}
         </div>
-
-        {typeof costUsd === "number" && costUsd > 0 && (
-          <div className="flex items-center justify-between border-t bg-secondary px-3 py-2 text-xs">
+        {typeof costUsd === "number" && costUsd > 0 ? (
+          <div className="flex items-center justify-between border-t px-3 py-2 text-xs">
             <span className="text-muted-foreground">Cost</span>
             <span className="font-mono tabular-nums">
-              {usd.format(costUsd)}
+              {formatCostUsd(costUsd)}
             </span>
           </div>
-        )}
-
-        <p className="border-t px-3 py-2 text-[10px] leading-snug text-muted-foreground">
-          The ring is exact. The breakdown is estimated (≈ chars/4) — “Other”
-          includes the system prompt, tools &amp; overhead.
-        </p>
+        ) : null}
       </PopoverContent>
     </Popover>
   );

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -719,6 +719,9 @@ function AgentPaneContent({
   // to mount on. Bridge that dead-air window with a tail indicator until an
   // assistant turn begins.
   const pendingTurn = isStreaming && messages.at(-1)?.role !== "assistant";
+  // Restored transcripts can hydrate after the scroll container has already
+  // mounted. Keep that entry stable; reserve smooth follow for live turns.
+  const conversationResize = busy ? "smooth" : "instant";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -728,7 +731,11 @@ function AgentPaneContent({
         onSelect={(id) => chatSession.select(id)}
         conversationEmpty={messages.length === 0}
       />
-      <Conversation className="flex-1 min-h-0">
+      <Conversation
+        className="flex-1 min-h-0"
+        initial="instant"
+        resize={conversationResize}
+      >
         <ConversationContent className="gap-4 px-3 py-4">
           {/* Empty state intentionally omitted — the chat starts blank
               and the prompt input below is the only affordance the

--- a/packages/grida-ai-agent/src/fs/README.md
+++ b/packages/grida-ai-agent/src/fs/README.md
@@ -65,6 +65,8 @@ class AgentFs {
 
   // File ops
   list(): string[];
+  list_directory(args?: AgentFs.ListArgs): AgentFs.ListResult;
+  list_directory_fresh(args?: AgentFs.ListArgs): Promise<AgentFs.ListResult>;
   exists(path: string): boolean;
   read(path: string): AgentFs.ReadResult | null;
   write(
@@ -84,16 +86,30 @@ All types (`AgentFs.Backend`, `AgentFs.LiveBinding`, `AgentFs.ReadResult`, the r
 
 `AgentFs.tools` is the AI-SDK tool table (four zod-schema'd defs plus `grep_files`). Name constants live alongside as `AgentFs.TOOL_NAMES`:
 
-| Tool         | Operation                                                                                         | Claude Code parallel |
-| ------------ | ------------------------------------------------------------------------------------------------- | -------------------- |
-| `read_file`  | `{ path }` → `{ content, version }`                                                               | `Read`               |
-| `edit_file`  | `{ path, old_string, new_string, replace_all?, version }` → match-and-replace                     | `Edit`               |
-| `write_file` | `{ path, content, version? }` → full upsert; version-checked or permissive                        | `Write`              |
-| `list_files` | `{}` → `{ files: string[] }` — flat enumeration                                                   | ~`Glob` (simpler)    |
-| `grep_files` | `{ pattern, path_prefix?, case_sensitive? }` → `{ matches, files_scanned }`, mirrors `grep -n -F` | `Grep`               |
+| Tool         | Operation                                                                                                 | Claude Code parallel |
+| ------------ | --------------------------------------------------------------------------------------------------------- | -------------------- |
+| `read_file`  | `{ path }` → `{ content, version }`                                                                       | `Read`               |
+| `edit_file`  | `{ path, old_string, new_string, replace_all?, version }` → match-and-replace                             | `Edit`               |
+| `write_file` | `{ path, content, version? }` → full upsert; version-checked or permissive                                | `Write`              |
+| `list_files` | `{ path?, offset?, limit? }` → `{ path, folders, files, truncated, next_offset? }` — direct children only | ~`Glob` (scoped)     |
+| `grep_files` | `{ pattern, path_prefix?, case_sensitive? }` → `{ matches, files_scanned }`, mirrors `grep -n -F`         | `Grep`               |
 
-`AgentFs.resolveToolCall(fs, toolCall)` dispatches inbound calls. Hosts
-plug it into `Chat.onToolCall`:
+`list_files` is directory discovery, not a repository inventory. It
+defaults to `/`, returns sorted absolute child paths grouped into
+`folders` and `files`, and marks pagination with `truncated` /
+`next_offset`. Keep the tool for VFS / OPFS / memory-backed agents
+that may not have shell search. In a shell-capable real-fs profile,
+prefer explicit command/search tools for broad discovery (`rg --files`,
+`find`, `ls`, `tree`) rather than teaching the model to trust a flat
+index.
+
+`AgentFs.resolveToolCall(fs, toolCall)` dispatches inbound calls
+synchronously against the hydrated VFS map. Use
+`AgentFs.resolveToolCallAsync(fs, toolCall)` on server-bound real-fs
+agents so `list_files` can call the backend's scoped directory reader
+instead of trusting the hydrate index.
+
+Client-resolved VFS hosts plug the sync resolver into `Chat.onToolCall`:
 
 ```ts
 const chat = new Chat({
@@ -110,6 +126,10 @@ const chat = new Chat({
 });
 ```
 
+Server-bound toolsets use the async resolver through `createToolset`, so
+workspace `list_files({ path })` reads the requested directory from disk
+on demand when the backend supports it.
+
 ```ts
 namespace AgentFs {
   interface LiveBinding {
@@ -121,6 +141,7 @@ namespace AgentFs {
 
   interface Backend {
     list(): Promise<string[]>;
+    list_directory?(path: string): Promise<AgentFs.ListEntries>;
     read(path: string): Promise<string | null>;
     write(path: string, content: string): Promise<void>;
     delete(path: string): Promise<void>;

--- a/packages/grida-ai-agent/src/fs/fs.test.ts
+++ b/packages/grida-ai-agent/src/fs/fs.test.ts
@@ -200,6 +200,76 @@ describe("AgentFs — basics", () => {
   });
 });
 
+describe("AgentFs.list_directory", () => {
+  function seed(): AgentFs {
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    fs.write("/canvas.svg", { content: "<svg/>", expected_version: null });
+    fs.write("/notes/brief.md", { content: "brief", expected_version: null });
+    fs.write("/notes/drafts/a.md", { content: "a", expected_version: null });
+    fs.write("/public/slides/index.md", {
+      content: "slides",
+      expected_version: null,
+    });
+    return fs;
+  }
+
+  it("lists root direct children as folders and files", () => {
+    expect(seed().list_directory()).toEqual({
+      path: "/",
+      folders: ["/notes", "/public"],
+      files: ["/canvas.svg"],
+      truncated: false,
+    });
+  });
+
+  it("lists a nested directory without returning descendants as files", () => {
+    expect(seed().list_directory({ path: "/notes" })).toEqual({
+      path: "/notes",
+      folders: ["/notes/drafts"],
+      files: ["/notes/brief.md"],
+      truncated: false,
+    });
+  });
+
+  it("normalizes relative paths from the agent fs root", () => {
+    expect(seed().list_directory({ path: "public/slides/" })).toEqual({
+      path: "/public/slides",
+      folders: [],
+      files: ["/public/slides/index.md"],
+      truncated: false,
+    });
+  });
+
+  it("paginates over sorted folders first, then files", () => {
+    expect(seed().list_directory({ path: "/", limit: 2 })).toEqual({
+      path: "/",
+      folders: ["/notes", "/public"],
+      files: [],
+      truncated: true,
+      next_offset: 2,
+    });
+    expect(seed().list_directory({ path: "/", offset: 2, limit: 2 })).toEqual({
+      path: "/",
+      folders: [],
+      files: ["/canvas.svg"],
+      truncated: false,
+    });
+  });
+
+  it("resolveToolCallAsync falls back to the in-memory directory listing", async () => {
+    const out = await AgentFs.resolveToolCallAsync(seed(), {
+      tool_name: AgentFs.TOOL_NAMES.list_files,
+      input: { path: "/public", limit: 1 },
+    });
+    expect(out).toEqual({
+      path: "/public",
+      folders: ["/public/slides"],
+      files: [],
+      truncated: false,
+    });
+  });
+});
+
 describe("AgentFs — mounted (live binding)", () => {
   it("reads through the binding and tracks its version", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());

--- a/packages/grida-ai-agent/src/fs/index.ts
+++ b/packages/grida-ai-agent/src/fs/index.ts
@@ -46,6 +46,11 @@ type FileEntry = {
   version: number;
 };
 
+type DirectoryEntries = {
+  folders: string[];
+  files: string[];
+};
+
 const PATH_DESCRIPTION =
   "Absolute path in the agent filesystem, starting with `/`. " +
   "Examples: `/canvas.svg`, `/notes/draft.md`.";
@@ -59,6 +64,88 @@ const PATH_DESCRIPTION =
  * list reads safely.
  */
 const HYDRATE_READ_CONCURRENCY = 24;
+const LIST_DIRECTORY_DEFAULT_LIMIT = 200;
+const LIST_DIRECTORY_MAX_LIMIT = 1000;
+
+function normalizeDirectoryPath(path: string | undefined): string {
+  const raw = path?.trim();
+  if (!raw || raw === "." || raw === "./" || raw === "*") return "/";
+  const rooted = raw.startsWith("/") ? raw : `/${raw}`;
+  const collapsed = rooted.replace(/\/+/g, "/");
+  if (collapsed === "/") return "/";
+  return collapsed.replace(/\/+$/, "");
+}
+
+function normalizeListOffset(offset: number | undefined): number {
+  if (offset === undefined || !Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.trunc(offset));
+}
+
+function normalizeListLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return LIST_DIRECTORY_DEFAULT_LIMIT;
+  }
+  return Math.max(1, Math.min(Math.trunc(limit), LIST_DIRECTORY_MAX_LIMIT));
+}
+
+function collectDirectoryEntries(
+  paths: Iterable<string>,
+  path: string
+): DirectoryEntries {
+  const prefix = path === "/" ? "/" : `${path}/`;
+  const folders = new Set<string>();
+  const files = new Set<string>();
+
+  for (const filePath of paths) {
+    if (!filePath.startsWith(prefix)) continue;
+    const rest = filePath.slice(prefix.length);
+    if (rest.length === 0) continue;
+    const slash = rest.indexOf("/");
+    if (slash === -1) {
+      files.add(filePath);
+    } else {
+      folders.add(`${prefix}${rest.slice(0, slash)}`);
+    }
+  }
+
+  return {
+    folders: [...folders].sort(),
+    files: [...files].sort(),
+  };
+}
+
+function mergeDirectoryEntries(
+  a: DirectoryEntries,
+  b: DirectoryEntries
+): DirectoryEntries {
+  return {
+    folders: [...new Set([...a.folders, ...b.folders])].sort(),
+    files: [...new Set([...a.files, ...b.files])].sort(),
+  };
+}
+
+function pageDirectoryEntries(
+  path: string,
+  entries: DirectoryEntries,
+  args: AgentFs.ListArgs
+): AgentFs.ListResult {
+  const offset = normalizeListOffset(args.offset);
+  const limit = normalizeListLimit(args.limit);
+  const ordered: Array<{ type: "folder" | "file"; path: string }> = [
+    ...entries.folders.map((p) => ({ type: "folder" as const, path: p })),
+    ...entries.files.map((p) => ({ type: "file" as const, path: p })),
+  ];
+  const page = ordered.slice(offset, offset + limit);
+  const truncated = offset + limit < ordered.length;
+
+  return {
+    path,
+    folders: page.filter((e) => e.type === "folder").map((e) => e.path),
+    files: page.filter((e) => e.type === "file").map((e) => e.path),
+    truncated,
+    ...(truncated ? { next_offset: offset + limit } : {}),
+  };
+}
 
 /**
  * `Promise.allSettled`-shaped map with a fixed in-flight width. Results are
@@ -351,6 +438,44 @@ export class AgentFs {
     // Keys are disjoint by construction (`mount()` drops any shadowing
     // pure-file entry; `write()` to a mounted path goes through the binding).
     return [...this.bindings.keys(), ...this.files.keys()];
+  }
+
+  /**
+   * List direct children under a directory path. Unlike `list()`, this is the
+   * model-facing discovery shape: scoped, paginated, and explicit about
+   * truncation so the agent never mistakes an index cap for a full inventory.
+   */
+  list_directory(args: AgentFs.ListArgs = {}): AgentFs.ListResult {
+    const path = normalizeDirectoryPath(args.path);
+    return pageDirectoryEntries(
+      path,
+      collectDirectoryEntries(this.list(), path),
+      args
+    );
+  }
+
+  /**
+   * Fresh directory listing for server-bound real filesystem backends. Falls
+   * back to the hydrated VFS map when the backend cannot list directories
+   * directly. In-memory writes/mounts are merged before pagination so a
+   * just-written file remains discoverable even inside the debounce window.
+   */
+  async list_directory_fresh(
+    args: AgentFs.ListArgs = {}
+  ): Promise<AgentFs.ListResult> {
+    const path = normalizeDirectoryPath(args.path);
+    let entries = collectDirectoryEntries(this.list(), path);
+    if (this.backend.list_directory) {
+      try {
+        entries = mergeDirectoryEntries(
+          entries,
+          await this.backend.list_directory(path)
+        );
+      } catch (err) {
+        console.warn(`[agent-fs] backend.list_directory(${path}) failed:`, err);
+      }
+    }
+    return pageDirectoryEntries(path, entries, args);
   }
 
   exists(path: string): boolean {
@@ -767,6 +892,13 @@ export namespace AgentFs {
     /** Enumerate every persisted path. Order undefined. */
     list(): Promise<string[]>;
 
+    /**
+     * List direct child folders/files under `path`, if the backend can do
+     * scoped directory reads without hydrating the whole tree. `path` is already
+     * normalized in the agent filesystem's path space.
+     */
+    list_directory?(path: string): Promise<ListEntries>;
+
     /** Read the bytes at `path`, or `null` if no such file. */
     read(path: string): Promise<string | null>;
 
@@ -921,6 +1053,33 @@ export namespace AgentFs {
     | { ok: true }
     | { ok: false; reason: DeleteFailureReason; message: string };
 
+  export type ListArgs = {
+    /**
+     * Directory path rooted in the agent filesystem. Defaults to `/`. Relative
+     * inputs are tolerated by resolving them from `/`.
+     */
+    path?: string;
+    /** Zero-based offset over the sorted direct-child entry list. */
+    offset?: number;
+    /** Page size, host-capped. Defaults to 200, max 1000. */
+    limit?: number;
+  };
+
+  export type ListResult = {
+    /** Normalized directory path that was listed. */
+    path: string;
+    /** Sorted absolute paths of direct child folders in this page. */
+    folders: string[];
+    /** Sorted absolute paths of direct child files in this page. */
+    files: string[];
+    /** True when more direct children remain after this page. */
+    truncated: boolean;
+    /** Pass as `offset` to fetch the next page. Present only when truncated. */
+    next_offset?: number;
+  };
+
+  export type ListEntries = DirectoryEntries;
+
   export type GrepArgs = {
     /** Literal substring to match. Empty pattern → empty result. */
     pattern: string;
@@ -1043,13 +1202,49 @@ export namespace AgentFs {
 
     [TOOL_NAMES.list_files]: tool({
       description:
-        "Enumerate every known file in the agent filesystem. Returns " +
-        "sorted absolute paths (e.g. `/canvas.svg`, `/notes/draft.md`).",
-      inputSchema: z.object({}),
+        "List direct child folders and files under a directory in the agent " +
+        "filesystem. Defaults to `/`. This is scoped directory discovery, " +
+        "not a recursive whole-workspace inventory; use grep_files for " +
+        "content search.",
+      inputSchema: z.object({
+        path: z
+          .string()
+          .optional()
+          .describe(
+            "Directory path rooted in the agent filesystem. Examples: `/`, `/notes`, `/public/slides-templates`. Omit for `/`."
+          ),
+        offset: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe("Zero-based pagination offset. Omit for the first page."),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(LIST_DIRECTORY_MAX_LIMIT)
+          .optional()
+          .describe(
+            `Maximum direct-child entries to return. Defaults to ${LIST_DIRECTORY_DEFAULT_LIMIT}.`
+          ),
+      }),
       outputSchema: z.object({
+        path: z.string().describe("Normalized directory path that was listed."),
+        folders: z
+          .array(z.string())
+          .describe("Sorted absolute paths of direct child folders."),
         files: z
           .array(z.string())
-          .describe("Sorted absolute paths of every known file."),
+          .describe("Sorted absolute paths of direct child files."),
+        truncated: z
+          .boolean()
+          .describe("True when more direct children remain after this page."),
+        next_offset: z
+          .number()
+          .int()
+          .optional()
+          .describe("Pass as offset to fetch the next page."),
       }),
     }),
 
@@ -1165,6 +1360,11 @@ export namespace AgentFs {
     version: number;
   };
   type WriteFileInput = { path: string; content: string; version?: number };
+  type ListFilesInput = {
+    path?: string;
+    offset?: number;
+    limit?: number;
+  };
   type GrepFilesInput = {
     pattern: string;
     path_prefix?: string;
@@ -1190,7 +1390,9 @@ export namespace AgentFs {
         return r;
       }
       case TOOL_NAMES.list_files: {
-        return { files: [...fs.list()].sort() };
+        const { path, offset, limit } = (toolCall.input ??
+          {}) as ListFilesInput;
+        return fs.list_directory({ path, offset, limit });
       }
       case TOOL_NAMES.grep_files: {
         const { pattern, path_prefix, case_sensitive } =
@@ -1214,6 +1416,18 @@ export namespace AgentFs {
       default:
         return undefined;
     }
+  }
+
+  export async function resolveToolCallAsync(
+    fs: AgentFs,
+    toolCall: { tool_name: string; input: unknown; dynamic?: boolean }
+  ): Promise<unknown> {
+    if (toolCall.dynamic) return undefined;
+    if (toolCall.tool_name === TOOL_NAMES.list_files) {
+      const { path, offset, limit } = (toolCall.input ?? {}) as ListFilesInput;
+      return await fs.list_directory_fresh({ path, offset, limit });
+    }
+    return resolveToolCall(fs, toolCall);
   }
 
   // -------------------------------------------------------------------------

--- a/packages/grida-ai-agent/src/index.ts
+++ b/packages/grida-ai-agent/src/index.ts
@@ -88,6 +88,7 @@ export type {
   ChatPartRow,
   ChatMessageWithParts,
   MessageUsage,
+  AssistantTurnAccounting,
   PermissionRule,
   ForkSessionOptions,
   RewindResult,

--- a/packages/grida-ai-agent/src/prompts.ts
+++ b/packages/grida-ai-agent/src/prompts.ts
@@ -50,11 +50,14 @@ seen.
 You operate on the user's workspace via a virtual filesystem. The
 consumer mounts what you can see; paths outside the mount will be
 rejected. If a request is ambiguous about which file to act on, ask,
-or call ${fs.list_files} first.
+or call ${fs.list_files} on the relevant directory first.
 
 Filesystem tools:
 
-- ${fs.list_files}: {} → { files: string[] }. Enumerate every file.
+- ${fs.list_files}: { path?, offset?, limit? } → { path, folders, files,
+  truncated, next_offset? }. List direct children of a directory only.
+  Defaults to \`/\`; this is not recursive and not a whole-workspace
+  inventory.
 - ${fs.read_file}: { path } → { content, version }.
 - ${fs.edit_file}: { path, old_string, new_string, replace_all?, version }.
   Match-and-replace. The default write path.
@@ -78,6 +81,9 @@ Rules:
    output. Include enough surrounding context to be unique; on
    reason="ambiguous" you'll get the count — add more context and retry.
 5. Multiple unrelated edits → multiple ${fs.edit_file} calls.
+6. Treat ${fs.list_files} results as one directory page. If \`truncated\`
+   is true, call it again with \`next_offset\`; use ${fs.grep_files} or
+   command/search tools for broad searches.
 </filesystem>
 
 <planning>

--- a/packages/grida-ai-agent/src/runtime/index.ts
+++ b/packages/grida-ai-agent/src/runtime/index.ts
@@ -1123,14 +1123,16 @@ export class AgentRuntime {
             on_step_usage: (usage) => {
               const delta = messageUsageFromStepUsage(usage);
               accumulateUsage(runUsage, delta);
-              void sessionsStore.updateUsage(sessionId, {
-                prompt_tokens: delta.input,
-                completion_tokens: delta.output,
-                reasoning_tokens: delta.reasoning,
-                cache_read: delta.cache_read,
-                cache_write: delta.cache_write,
-                total_tokens: usageTokenTotal(delta),
-              });
+              void sessionsStore
+                .updateUsage(sessionId, {
+                  prompt_tokens: delta.input,
+                  completion_tokens: delta.output,
+                  reasoning_tokens: delta.reasoning,
+                  cache_read: delta.cache_read,
+                  cache_write: delta.cache_write,
+                  total_tokens: usageTokenTotal(delta),
+                })
+                .catch(() => undefined);
             },
           },
           // GRIDA-SEC-004 — `secrets_root` rides the bindings deps down to the
@@ -1487,12 +1489,14 @@ export class AgentRuntime {
  */
 function messageUsageFromStepUsage(u: AgentStepUsage): MessageUsage {
   const cacheRead = u.cached_input_tokens ?? 0;
-  const input = Math.max(0, (u.input_tokens ?? 0) - cacheRead);
+  const cacheWrite = u.cache_write_tokens ?? 0;
+  const input = Math.max(0, (u.input_tokens ?? 0) - cacheRead - cacheWrite);
   return {
     input,
     output: u.output_tokens ?? 0,
     reasoning: u.reasoning_tokens ?? 0,
     cache_read: cacheRead,
+    cache_write: cacheWrite,
   };
 }
 

--- a/packages/grida-ai-agent/src/runtime/index.ts
+++ b/packages/grida-ai-agent/src/runtime/index.ts
@@ -37,6 +37,7 @@ import { createRecorderConsumer } from "../session/recorder";
 import { titler } from "../session/titler";
 import type { SessionsStore } from "../session/store";
 import type { ChatModel, MessageUsage } from "../session/rows";
+import { usageTokenTotal } from "../session/cost";
 import {
   DEFAULT_COMPACTION_CONFIG,
   compactSession,
@@ -1097,6 +1098,11 @@ export class AgentRuntime {
         // assistant message — recomputeRollups (rewind/fork/compaction)
         // sums per-message usage.
         const runUsage: MessageUsage = {};
+        const turnModel: ChatModel = {
+          provider_id: provider.provider_id,
+          tier,
+          model_id: modelId,
+        };
 
         const response = await runAgentFn(
           provider,
@@ -1115,11 +1121,15 @@ export class AgentRuntime {
             skill_cache: ctx.skill_cache,
             project_instructions: ctx.project_instructions,
             on_step_usage: (usage) => {
-              accumulateUsage(runUsage, usage);
+              const delta = messageUsageFromStepUsage(usage);
+              accumulateUsage(runUsage, delta);
               void sessionsStore.updateUsage(sessionId, {
-                prompt_tokens: usage.input_tokens,
-                completion_tokens: usage.output_tokens,
-                total_tokens: usage.total_tokens,
+                prompt_tokens: delta.input,
+                completion_tokens: delta.output,
+                reasoning_tokens: delta.reasoning,
+                cache_read: delta.cache_read,
+                cache_write: delta.cache_write,
+                total_tokens: usageTokenTotal(delta),
               });
             },
           },
@@ -1134,17 +1144,23 @@ export class AgentRuntime {
         // Drain the recorder BEFORE stamping usage. The recorder creates the
         // assistant row on a fire-and-forget write_chain fed by each pushed
         // frame; `pumpResponseIntoRegistry` returning only means the frames
-        // were enqueued, not that the row was written. `setLatestAssistantUsage`
-        // addresses "the latest assistant row", so stamping before the write
-        // settles races onto the wrong row (or none). The recorder's terminal
-        // flush (its `on_end`) awaits its write_chain + finalizes, so awaiting
-        // it here makes the row exist deterministically. Detach so the later
+        // were enqueued, not that the row was written. Usage/accounting stamps
+        // "the latest assistant row", so stamping before the write settles
+        // races onto the wrong row (or none). The recorder's terminal flush
+        // (its `on_end`) awaits its write_chain + finalizes, so awaiting it
+        // here makes the row exist deterministically. Detach so the later
         // `streams.finish` won't re-fire `on_end` on it.
         detachRecorder();
         await recorder.on_end("finish");
         if (hasUsage(runUsage)) {
           await sessionsStore
-            .setLatestAssistantUsage(sessionId, runUsage)
+            .setLatestAssistantAccounting(sessionId, {
+              model: turnModel,
+              usage: runUsage,
+            })
+            .catch(() => undefined);
+          await sessionsStore
+            .recomputeRollups(sessionId)
             .catch(() => undefined);
         }
         streams.finish(sessionId, "finish");
@@ -1469,13 +1485,23 @@ export class AgentRuntime {
  * RFC cache-normalization rule, `inputTokens` already includes cache
  * reads, so subtract them out before recording `input`.
  */
-function accumulateUsage(acc: MessageUsage, u: AgentStepUsage): void {
+function messageUsageFromStepUsage(u: AgentStepUsage): MessageUsage {
   const cacheRead = u.cached_input_tokens ?? 0;
   const input = Math.max(0, (u.input_tokens ?? 0) - cacheRead);
-  acc.input = (acc.input ?? 0) + input;
-  acc.output = (acc.output ?? 0) + (u.output_tokens ?? 0);
-  acc.reasoning = (acc.reasoning ?? 0) + (u.reasoning_tokens ?? 0);
-  acc.cache_read = (acc.cache_read ?? 0) + cacheRead;
+  return {
+    input,
+    output: u.output_tokens ?? 0,
+    reasoning: u.reasoning_tokens ?? 0,
+    cache_read: cacheRead,
+  };
+}
+
+function accumulateUsage(acc: MessageUsage, u: MessageUsage): void {
+  acc.input = (acc.input ?? 0) + (u.input ?? 0);
+  acc.output = (acc.output ?? 0) + (u.output ?? 0);
+  acc.reasoning = (acc.reasoning ?? 0) + (u.reasoning ?? 0);
+  acc.cache_read = (acc.cache_read ?? 0) + (u.cache_read ?? 0);
+  acc.cache_write = (acc.cache_write ?? 0) + (u.cache_write ?? 0);
 }
 
 function hasUsage(u: MessageUsage): boolean {

--- a/packages/grida-ai-agent/src/runtime/run-agent.ts
+++ b/packages/grida-ai-agent/src/runtime/run-agent.ts
@@ -111,7 +111,7 @@ export type AgentRunRequest = {
 /**
  * Subset of AI SDK `LanguageModelUsage` we use for persistence. The
  * SDK's `LanguageModelUsage` has many optional fields; we project the
- * three we keep on `chat_sessions.{prompt,completion,total}_tokens`.
+ * fields we keep on assistant-message usage metadata and session rollups.
  */
 export type AgentStepUsage = {
   input_tokens?: number;
@@ -252,11 +252,8 @@ export async function runAgent(
     },
     abortSignal: req.signal,
     // Stream the turn's usage as message metadata so the LIVE assistant
-    // message the renderer holds carries it — the context meter reads
-    // `metadata.usage` off `useChat` messages, and nothing rehydrates from
-    // the DB after a normal turn. Mirrors the canvas route; shape matches
-    // what `setLatestAssistantUsage` writes to the row so live and
-    // post-reload agree.
+    // message the renderer holds carries it. The DB row is stamped after
+    // recorder flush with this usage plus the runtime-resolved model.
     messageMetadata: ({ part }) =>
       part.type === "finish"
         ? { usage: toMessageUsage(part.totalUsage) }

--- a/packages/grida-ai-agent/src/runtime/run-agent.ts
+++ b/packages/grida-ai-agent/src/runtime/run-agent.ts
@@ -119,6 +119,7 @@ export type AgentStepUsage = {
   total_tokens?: number;
   reasoning_tokens?: number;
   cached_input_tokens?: number;
+  cache_write_tokens?: number;
 };
 
 /**
@@ -134,6 +135,11 @@ type SdkStepUsage = {
   totalTokens?: number;
   reasoningTokens?: number;
   cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  inputTokenDetails?: {
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
 };
 
 /**
@@ -143,12 +149,16 @@ type SdkStepUsage = {
  * cache reads, so subtract them so `input` + `cache_read` don't double-count.
  */
 function toMessageUsage(u: SdkStepUsage): MessageUsage {
-  const cacheRead = u.cachedInputTokens ?? 0;
+  const cacheRead =
+    u.cachedInputTokens ?? u.inputTokenDetails?.cacheReadTokens ?? 0;
+  const cacheWrite =
+    u.cacheCreationInputTokens ?? u.inputTokenDetails?.cacheWriteTokens ?? 0;
   return {
-    input: Math.max(0, (u.inputTokens ?? 0) - cacheRead),
+    input: Math.max(0, (u.inputTokens ?? 0) - cacheRead - cacheWrite),
     output: u.outputTokens ?? 0,
     reasoning: u.reasoningTokens ?? 0,
     cache_read: cacheRead,
+    cache_write: cacheWrite,
   };
 }
 
@@ -274,7 +284,11 @@ export async function runAgent(
                 output_tokens: u.outputTokens,
                 total_tokens: u.totalTokens,
                 reasoning_tokens: u.reasoningTokens,
-                cached_input_tokens: u.cachedInputTokens,
+                cached_input_tokens:
+                  u.cachedInputTokens ?? u.inputTokenDetails?.cacheReadTokens,
+                cache_write_tokens:
+                  u.cacheCreationInputTokens ??
+                  u.inputTokenDetails?.cacheWriteTokens,
               });
             }
           } catch {

--- a/packages/grida-ai-agent/src/runtime/runtime.test.ts
+++ b/packages/grida-ai-agent/src/runtime/runtime.test.ts
@@ -238,10 +238,10 @@ describe("agent workspace bindings", () => {
                   finishReason: { unified: "stop", raw: "stop" },
                   usage: {
                     inputTokens: {
-                      total: 7,
+                      total: 11,
                       noCache: 7,
-                      cacheRead: undefined,
-                      cacheWrite: undefined,
+                      cacheRead: 2,
+                      cacheWrite: 2,
                     },
                     outputTokens: { total: 3, text: 3, reasoning: undefined },
                   },
@@ -279,13 +279,18 @@ describe("agent workspace bindings", () => {
     expect(usages.length).toBeGreaterThan(0);
     const last = usages.at(-1)!;
     // Pre-fix, the bare cast left these undefined (camelCase keys never read).
-    expect(last.input_tokens).toBe(7);
+    expect(last.input_tokens).toBe(11);
     expect(last.output_tokens).toBe(3);
+    expect(last.cached_input_tokens).toBe(2);
+    expect(last.cache_write_tokens).toBe(2);
 
     // 2) The stream carries usage as message metadata (live context-meter
-    //    path) — `input` is cache-normalized: 7 input − 0 cache_read = 7.
+    //    path) — `input` is cache-normalized:
+    //    11 input − 2 cache_read − 2 cache_write = 7.
     expect(body).toContain('"usage"');
     expect(body).toMatch(/"input":7/);
     expect(body).toMatch(/"output":3/);
+    expect(body).toMatch(/"cache_read":2/);
+    expect(body).toMatch(/"cache_write":2/);
   });
 });

--- a/packages/grida-ai-agent/src/runtime/runtime.test.ts
+++ b/packages/grida-ai-agent/src/runtime/runtime.test.ts
@@ -40,13 +40,49 @@ describe("agent workspace bindings", () => {
     );
 
     expect(bindings).not.toBeNull();
-    const output = AgentFs.resolveToolCall(bindings!.fs, {
+    const output = await AgentFs.resolveToolCallAsync(bindings!.fs, {
       tool_name: AgentFs.TOOL_NAMES.list_files,
       input: {},
     });
 
     expect(output).toEqual({
-      files: ["/canvas.svg", "/notes/brief.md"],
+      path: "/",
+      folders: ["/notes"],
+      files: ["/canvas.svg"],
+      truncated: false,
+    });
+  });
+
+  it("list_files reads a requested workspace directory from disk on demand", async () => {
+    await fixture.write_workspace_file("canvas.svg", "<svg/>");
+
+    const bindings = await createWorkspaceAgentBindings(
+      {
+        workspace_root: fixture.workspace_root,
+      },
+      { workspace_registry: fixture.registry }
+    );
+
+    expect(bindings).not.toBeNull();
+
+    // Written after createWorkspaceAgentBindings hydrates AgentFs. A flat
+    // hydrated index cannot see this path; the workspace backend's scoped
+    // directory read can.
+    await fixture.write_workspace_file(
+      "public/slides-templates/README.md",
+      "slides"
+    );
+
+    const output = await AgentFs.resolveToolCallAsync(bindings!.fs, {
+      tool_name: AgentFs.TOOL_NAMES.list_files,
+      input: { path: "/public/slides-templates" },
+    });
+
+    expect(output).toEqual({
+      path: "/public/slides-templates",
+      folders: [],
+      files: ["/public/slides-templates/README.md"],
+      truncated: false,
     });
   });
 

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
@@ -532,6 +532,50 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
     return out;
   }
 
+  async list_directory(pathname: string): Promise<AgentFs.ListEntries> {
+    try {
+      const { scope, rel } = this.scopeFor(pathname);
+      const entries = await workspaceFs.readDir(scope, rel);
+      const workspaceRooted = scope === this.workspace;
+      const folders: string[] = [];
+      const files: string[] = [];
+
+      for (const entry of entries) {
+        if (entry.kind === "directory") {
+          if (isIgnoredScanDir(entry.name)) continue;
+          folders.push(
+            workspaceRooted
+              ? `/${entry.rel_path.replace(/\\/g, "/")}`
+              : path.join(scope.root, entry.rel_path)
+          );
+          continue;
+        }
+        if (entry.kind === "file" || entry.kind === "symlink") {
+          if (isIgnoredScanFile(entry.name)) continue;
+          files.push(
+            workspaceRooted
+              ? `/${entry.rel_path.replace(/\\/g, "/")}`
+              : path.join(scope.root, entry.rel_path)
+          );
+        }
+      }
+
+      return {
+        folders: folders.sort(),
+        files: files.sort(),
+      };
+    } catch (err) {
+      if (
+        isNotFound(err) ||
+        isWorkspaceFsCode(err, "not-a-directory") ||
+        isWorkspaceFsCode(err, "not-a-file")
+      ) {
+        return { folders: [], files: [] };
+      }
+      throw err;
+    }
+  }
+
   async read(path: string): Promise<string | null> {
     try {
       const { scope, rel } = this.scopeFor(path);

--- a/packages/grida-ai-agent/src/session/cost.test.ts
+++ b/packages/grida-ai-agent/src/session/cost.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { costUsdFromMessageUsage, usageTokenTotal } from "./cost";
+
+describe("session cost accounting", () => {
+  it("sums all persisted usage buckets into the rollup token total", () => {
+    expect(
+      usageTokenTotal({
+        input: 2,
+        output: 3,
+        reasoning: 5,
+        cache_read: 7,
+        cache_write: 11,
+      })
+    ).toBe(28);
+  });
+
+  it("uses the catalog card, including cache and reasoning rates", () => {
+    const cost = costUsdFromMessageUsage(
+      {
+        provider_id: "openrouter",
+        model_id: "anthropic/claude-sonnet-5",
+      },
+      {
+        input: 2_000,
+        cache_read: 8_000,
+        cache_write: 1_000,
+        output: 1_000,
+        reasoning: 500,
+      }
+    );
+
+    expect(cost).toBeCloseTo(
+      (2_000 * 3 + 8_000 * 0.3 + 1_000 * 3.75 + 1_000 * 15 + 500 * 15) /
+        1_000_000
+    );
+  });
+
+  it("returns undefined when no catalog price card is available", () => {
+    expect(
+      costUsdFromMessageUsage(
+        { provider_id: "ollama", model_id: "acme/local-model" },
+        { input: 1, output: 1 }
+      )
+    ).toBeUndefined();
+  });
+});

--- a/packages/grida-ai-agent/src/session/cost.ts
+++ b/packages/grida-ai-agent/src/session/cost.ts
@@ -1,0 +1,37 @@
+import { models, TIER_MODEL_IDS } from "@grida/ai-models";
+import type { ChatModel, MessageUsage } from "./rows";
+
+export function usageTokenTotal(usage: MessageUsage): number {
+  return (
+    (usage.input ?? 0) +
+    (usage.output ?? 0) +
+    (usage.reasoning ?? 0) +
+    (usage.cache_read ?? 0) +
+    (usage.cache_write ?? 0)
+  );
+}
+
+export function costUsdFromMessageUsage(
+  model: ChatModel | undefined,
+  usage: MessageUsage
+): number | undefined {
+  const modelId =
+    model?.model_id ?? (model?.tier ? TIER_MODEL_IDS[model.tier] : undefined);
+  if (!modelId) return undefined;
+  const spec = models.text.modelSpecById(modelId);
+  if (!spec) return undefined;
+  const rates = spec.cost;
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const reasoning = usage.reasoning ?? 0;
+  const cacheRead = usage.cache_read ?? 0;
+  const cacheWrite = usage.cache_write ?? 0;
+  return (
+    (input * rates.input +
+      output * rates.output +
+      reasoning * rates.output +
+      cacheRead * (rates.cacheRead ?? rates.input) +
+      cacheWrite * (rates.cacheWrite ?? rates.input)) /
+    1_000_000
+  );
+}

--- a/packages/grida-ai-agent/src/session/rows.ts
+++ b/packages/grida-ai-agent/src/session/rows.ts
@@ -57,8 +57,8 @@ export type ChatSessionRow = {
   cache_read: number;
   cache_write: number;
   total_tokens: number;
-  /** Derived from visible assistant-message `{ model, usage }`; not
-   * authoritative billing state. */
+  /** Derived from assistant-message `{ model, usage }`, including turns hidden
+   * by rewind or compaction; not authoritative billing state. */
   cost_usd: number;
   created_at: number;
   updated_at: number;

--- a/packages/grida-ai-agent/src/session/rows.ts
+++ b/packages/grida-ai-agent/src/session/rows.ts
@@ -57,6 +57,8 @@ export type ChatSessionRow = {
   cache_read: number;
   cache_write: number;
   total_tokens: number;
+  /** Derived from visible assistant-message `{ model, usage }`; not
+   * authoritative billing state. */
   cost_usd: number;
   created_at: number;
   updated_at: number;
@@ -92,7 +94,8 @@ export type ChatMessageWithParts = ChatMessageRow & { parts: ChatPartRow[] };
 /**
  * Per-turn token usage (RFC `session / context-window-tracking`).
  * Stored under an assistant message's `metadata.usage`; summed into the
- * session-row rollups. All five buckets count toward the context window.
+ * session-row rollups for usage and cost. This is provider accounting data,
+ * not the UI's visible-transcript context estimate.
  */
 export type MessageUsage = {
   /** User + system tokens this step consumed (cache excluded). */
@@ -105,6 +108,14 @@ export type MessageUsage = {
   cache_read?: number;
   /** Tokens written to the provider's prompt cache. */
   cache_write?: number;
+};
+
+export type AssistantTurnAccounting = {
+  /** Model that produced this assistant turn. Required for accurate cost when
+   * a session switches models between turns. */
+  model?: ChatModel;
+  /** Provider-reported token usage for this assistant turn. */
+  usage?: MessageUsage;
 };
 
 export type SessionListFilter = {

--- a/packages/grida-ai-agent/src/session/smoke.live.ts
+++ b/packages/grida-ai-agent/src/session/smoke.live.ts
@@ -236,9 +236,8 @@ async function main(): Promise<void> {
   if (!session || session.total_tokens <= 0) {
     fail(`[smoke] session totalTokens not positive: ${session?.total_tokens}`);
   }
-  // Cost is intentionally not asserted: BYOK pays the upstream provider
-  // directly; pricing-aware cost rollup lives in the editor's hosted
-  // route, not in the agent host recorder. `cost_usd` stays at 0 for BYOK.
+  // Cost is intentionally not asserted: model ids and pricing cards vary
+  // across BYOK/endpoint smoke runs, while usage is always required.
 
   // ── Open the DB directly to prove the file is inspectable ───────────
   const dbPath = path.join(userDataPath, "sessions.db");

--- a/packages/grida-ai-agent/src/session/store.test.ts
+++ b/packages/grida-ai-agent/src/session/store.test.ts
@@ -358,26 +358,43 @@ describe("SessionsStore messages + parts", () => {
     await store.updateUsage(s.id, {
       prompt_tokens: 10,
       completion_tokens: 5,
-      total_tokens: 15,
+      reasoning_tokens: 1,
+      cache_read: 3,
+      cache_write: 2,
+      total_tokens: 21,
     });
     await store.updateUsage(s.id, {
       prompt_tokens: 2,
       completion_tokens: 1,
-      total_tokens: 3,
+      reasoning_tokens: 4,
+      cache_read: 5,
+      cache_write: 6,
+      total_tokens: 18,
     });
     let row = await store.get(s.id);
     expect(row!.prompt_tokens).toBe(12);
     expect(row!.completion_tokens).toBe(6);
-    expect(row!.total_tokens).toBe(18);
+    expect(row!.reasoning_tokens).toBe(5);
+    expect(row!.cache_read).toBe(8);
+    expect(row!.cache_write).toBe(8);
+    expect(row!.total_tokens).toBe(39);
+    expect(row!.cost_usd).toBe(0);
 
     await store.setUsage(s.id, {
       prompt_tokens: 100,
       completion_tokens: 50,
+      reasoning_tokens: 10,
+      cache_read: 8,
+      cache_write: 2,
       total_tokens: 150,
     });
     row = await store.get(s.id);
     expect(row!.prompt_tokens).toBe(100);
+    expect(row!.reasoning_tokens).toBe(10);
+    expect(row!.cache_read).toBe(8);
+    expect(row!.cache_write).toBe(2);
     expect(row!.total_tokens).toBe(150);
+    expect(row!.cost_usd).toBe(0);
   });
 
   it("listMessages returns messages in insertion order with their parts", async () => {
@@ -572,17 +589,31 @@ describe("SessionsStore rollups", () => {
     const s = await store.create({ agent: "grida" });
     await store.appendMessage(s.id, { role: "user" });
     const a1 = await store.appendMessage(s.id, { role: "assistant" });
-    await store.setMessageUsage(a1.id, {
-      input: 100,
-      output: 20,
-      reasoning: 5,
-      cache_read: 10,
-      cache_write: 2,
+    await store.setMessageAccounting(a1.id, {
+      model: {
+        provider_id: "openrouter",
+        tier: "pro",
+        model_id: "anthropic/claude-sonnet-5",
+      },
+      usage: {
+        input: 100,
+        output: 20,
+        reasoning: 5,
+        cache_read: 10,
+        cache_write: 2,
+      },
     });
     await delay(2);
     await store.appendMessage(s.id, { role: "user" });
     const a2 = await store.appendMessage(s.id, { role: "assistant" });
-    await store.setMessageUsage(a2.id, { input: 50, output: 10 });
+    await store.setMessageAccounting(a2.id, {
+      model: {
+        provider_id: "openrouter",
+        tier: "mini",
+        model_id: "openai/gpt-5.4-mini",
+      },
+      usage: { input: 50, output: 10 },
+    });
 
     await store.recomputeRollups(s.id);
     const row = await store.get(s.id);
@@ -592,6 +623,20 @@ describe("SessionsStore rollups", () => {
     expect(row!.cache_read).toBe(10);
     expect(row!.cache_write).toBe(2);
     expect(row!.total_tokens).toBe(150 + 30 + 5 + 10 + 2);
+    expect(row!.cost_usd).toBeCloseTo(
+      (100 * 3 +
+        20 * 15 +
+        5 * 15 +
+        10 * 0.3 +
+        2 * 3.75 +
+        50 * 0.75 +
+        10 * 4.5) /
+        1_000_000
+    );
+    const dbRow = opened.sqlite
+      .prepare("SELECT cost_usd FROM chat_sessions WHERE id = ?")
+      .get(s.id) as { cost_usd: number };
+    expect(dbRow.cost_usd).toBe(0);
   });
 
   it("rewind excludes hidden assistant usage from the rollup", async () => {
@@ -609,6 +654,37 @@ describe("SessionsStore rollups", () => {
     // Rewinding to u1 hides a1, u2, a2 → only nothing-visible-assistant remains.
     await store.rewind(s.id, u1.id);
     expect((await store.get(s.id))!.total_tokens).toBe(0);
+  });
+
+  it("cost includes charged assistant turns hidden by rewind", async () => {
+    const s = await store.create({ agent: "grida" });
+    const u1 = await store.appendMessage(s.id, { role: "user" });
+    const a1 = await store.appendMessage(s.id, { role: "assistant" });
+    await store.setMessageAccounting(a1.id, {
+      model: {
+        provider_id: "openrouter",
+        tier: "mini",
+        model_id: "openai/gpt-5.4-mini",
+      },
+      usage: { input: 100, output: 10 },
+    });
+    await delay(2);
+    await store.appendMessage(s.id, { role: "user" });
+    const a2 = await store.appendMessage(s.id, { role: "assistant" });
+    await store.setMessageAccounting(a2.id, {
+      model: {
+        provider_id: "openrouter",
+        tier: "mini",
+        model_id: "openai/gpt-5.4-mini",
+      },
+      usage: { input: 50, output: 5 },
+    });
+
+    await store.recomputeRollups(s.id);
+    await store.rewind(s.id, u1.id);
+    const row = await store.get(s.id);
+    expect(row!.total_tokens).toBe(0);
+    expect(row!.cost_usd).toBeCloseTo((150 * 0.75 + 15 * 4.5) / 1_000_000);
   });
 
   it("recomputeRollups counts from the compaction boundary (summarized head excluded)", async () => {

--- a/packages/grida-ai-agent/src/session/store.test.ts
+++ b/packages/grida-ai-agent/src/session/store.test.ts
@@ -386,14 +386,14 @@ describe("SessionsStore messages + parts", () => {
       reasoning_tokens: 10,
       cache_read: 8,
       cache_write: 2,
-      total_tokens: 150,
+      total_tokens: 170,
     });
     row = await store.get(s.id);
     expect(row!.prompt_tokens).toBe(100);
     expect(row!.reasoning_tokens).toBe(10);
     expect(row!.cache_read).toBe(8);
     expect(row!.cache_write).toBe(2);
-    expect(row!.total_tokens).toBe(150);
+    expect(row!.total_tokens).toBe(170);
     expect(row!.cost_usd).toBe(0);
   });
 
@@ -637,6 +637,35 @@ describe("SessionsStore rollups", () => {
       .prepare("SELECT cost_usd FROM chat_sessions WHERE id = ?")
       .get(s.id) as { cost_usd: number };
     expect(dbRow.cost_usd).toBe(0);
+
+    const listed = await store.list({ agent: "grida" });
+    expect(listed.items.find((item) => item.id === s.id)!.cost_usd).toBeCloseTo(
+      row!.cost_usd
+    );
+  });
+
+  it("setMessageAccounting ignores undefined fields when merging metadata", async () => {
+    const s = await store.create({ agent: "grida" });
+    const a = await store.appendMessage(s.id, { role: "assistant" });
+    const model = {
+      provider_id: "openrouter",
+      tier: "mini",
+      model_id: "openai/gpt-5.4-mini",
+    } as const;
+
+    await store.setMessageAccounting(a.id, {
+      model,
+      usage: { input: 10, output: 2 },
+    });
+    await store.setMessageAccounting(a.id, {
+      model: undefined,
+      usage: { input: 12, output: 3 },
+    });
+
+    expect((await store.getMessage(a.id))!.metadata).toMatchObject({
+      model,
+      usage: { input: 12, output: 3 },
+    });
   });
 
   it("rewind excludes hidden assistant usage from the rollup", async () => {

--- a/packages/grida-ai-agent/src/session/store.ts
+++ b/packages/grida-ai-agent/src/session/store.ts
@@ -39,6 +39,7 @@ import { compactionBoundary } from "./boundary";
 // re-exported at the bottom of this module so consumers get one import
 // path for both the CRUD surface and the row shapes it emits.
 import type {
+  AssistantTurnAccounting,
   ForkSessionOptions,
   ChatMessageRow,
   ChatModel,
@@ -51,6 +52,7 @@ import type {
   SessionListFilter,
   SessionListPage,
 } from "./rows";
+import { costUsdFromMessageUsage, usageTokenTotal } from "./cost";
 
 export type AppendMessageInput = {
   id?: string;
@@ -77,8 +79,10 @@ export type UpsertPartInput = {
 export type UpdateUsageDelta = {
   prompt_tokens?: number;
   completion_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read?: number;
+  cache_write?: number;
   total_tokens?: number;
-  cost_usd?: number;
 };
 
 const DEFAULT_LIMIT = 50;
@@ -139,7 +143,7 @@ export class SessionsStore {
       .from(chatSessions)
       .where(eq(chatSessions.id, id))
       .limit(1);
-    return rows[0] ? rowToSession(rows[0]) : null;
+    return rows[0] ? await this.rowToSessionWithDerivedCost(rows[0]) : null;
   }
 
   /**
@@ -202,7 +206,9 @@ export class SessionsStore {
       .orderBy(desc(chatSessions.updated_at), desc(chatSessions.id))
       .limit(limit + 1);
     const rows = where ? await query.where(where) : await query;
-    const items = rows.slice(0, limit).map(rowToSession);
+    const items = await Promise.all(
+      rows.slice(0, limit).map((row) => this.rowToSessionWithDerivedCost(row))
+    );
     const last = rows[limit - 1];
     const nextCursor =
       rows.length > limit && last
@@ -306,11 +312,17 @@ export class SessionsStore {
     if (delta.completion_tokens !== undefined) {
       parts.completion_tokens = sql`${chatSessions.completion_tokens} + ${delta.completion_tokens}`;
     }
+    if (delta.reasoning_tokens !== undefined) {
+      parts.reasoning_tokens = sql`${chatSessions.reasoning_tokens} + ${delta.reasoning_tokens}`;
+    }
+    if (delta.cache_read !== undefined) {
+      parts.cache_read = sql`${chatSessions.cache_read} + ${delta.cache_read}`;
+    }
+    if (delta.cache_write !== undefined) {
+      parts.cache_write = sql`${chatSessions.cache_write} + ${delta.cache_write}`;
+    }
     if (delta.total_tokens !== undefined) {
       parts.total_tokens = sql`${chatSessions.total_tokens} + ${delta.total_tokens}`;
-    }
-    if (delta.cost_usd !== undefined) {
-      parts.cost_usd = sql`${chatSessions.cost_usd} + ${delta.cost_usd}`;
     }
     await this.db
       .update(chatSessions)
@@ -331,9 +343,12 @@ export class SessionsStore {
     if (usage.completion_tokens !== undefined) {
       parts.completion_tokens = usage.completion_tokens;
     }
+    if (usage.reasoning_tokens !== undefined)
+      parts.reasoning_tokens = usage.reasoning_tokens;
+    if (usage.cache_read !== undefined) parts.cache_read = usage.cache_read;
+    if (usage.cache_write !== undefined) parts.cache_write = usage.cache_write;
     if (usage.total_tokens !== undefined)
       parts.total_tokens = usage.total_tokens;
-    if (usage.cost_usd !== undefined) parts.cost_usd = usage.cost_usd;
     await this.db
       .update(chatSessions)
       .set(parts)
@@ -612,7 +627,7 @@ export class SessionsStore {
    * Fire a queued message: clear `metadata.queued_at` so it becomes a normal
    * visible user message (RFC `queue / the run-state machine`). No-op if the
    * row is gone or was not queued. Merges metadata so sibling keys survive
-   * (mirrors {@link setMessageUsage}).
+   * (mirrors {@link setMessageAccounting}).
    */
   async dequeueMessage(messageId: string): Promise<void> {
     const existing = await this.getMessage(messageId);
@@ -666,9 +681,16 @@ export class SessionsStore {
    * existing metadata so a `model` / `agent` key set elsewhere survives.
    */
   async setMessageUsage(messageId: string, usage: MessageUsage): Promise<void> {
+    await this.setMessageAccounting(messageId, { usage });
+  }
+
+  async setMessageAccounting(
+    messageId: string,
+    accounting: AssistantTurnAccounting
+  ): Promise<void> {
     const existing = await this.getMessage(messageId);
     if (!existing) return;
-    const metadata = { ...existing.metadata, usage };
+    const metadata = { ...existing.metadata, ...accounting };
     await this.db
       .update(chatMessages)
       .set({ metadata_json: JSON.stringify(metadata), updated_at: Date.now() })
@@ -685,6 +707,13 @@ export class SessionsStore {
     sessionId: string,
     usage: MessageUsage
   ): Promise<void> {
+    await this.setLatestAssistantAccounting(sessionId, { usage });
+  }
+
+  async setLatestAssistantAccounting(
+    sessionId: string,
+    accounting: AssistantTurnAccounting
+  ): Promise<void> {
     const rows = await this.db
       .select({ id: chatMessages.id })
       .from(chatMessages)
@@ -696,7 +725,7 @@ export class SessionsStore {
       )
       .orderBy(desc(chatMessages.created_at), desc(chatMessages.id))
       .limit(1);
-    if (rows[0]) await this.setMessageUsage(rows[0].id, usage);
+    if (rows[0]) await this.setMessageAccounting(rows[0].id, accounting);
   }
 
   /**
@@ -810,17 +839,49 @@ export class SessionsStore {
     await this.recomputeRollups(sessionId);
   }
 
-  /**
-   * Recompute the session-row token rollups to reflect what the MODEL sees.
-   * Called after a rewind/compaction/fork changes the live view.
-   *
-   * A compaction does not hide the summarized head, so a naive "sum every
-   * visible assistant" would over-count the turns that are no longer in the
-   * model's context. Instead, sum assistant `metadata.usage` from the latest
-   * compaction boundary onward (the verbatim tail + the summary's own token
-   * cost); rewind-hidden rows are already excluded by `listVisibleMessages`.
-   */
-  async recomputeRollups(sessionId: string): Promise<void> {
+  private async rowToSessionWithDerivedCost(
+    row: ChatSessionDbRow
+  ): Promise<ChatSessionRow> {
+    const session = rowToSession(row);
+    return {
+      ...session,
+      // `chat_sessions.cost_usd` is a legacy persisted column. Public session
+      // rows expose cumulative cost as derived data from every assistant turn's
+      // model+usage. Unlike context rollups, spend does not disappear after a
+      // rewind or compaction.
+      cost_usd: await this.sessionCostUsd(row.id),
+    };
+  }
+
+  private async sessionCostUsd(sessionId: string): Promise<number> {
+    const rows = await this.db
+      .select({ metadata_json: chatMessages.metadata_json })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.session_id, sessionId),
+          eq(chatMessages.role, "assistant")
+        )
+      );
+    let costUsd = 0;
+    for (const row of rows) {
+      const meta = parseJsonOr(row.metadata_json, {}) as
+        | ({ usage?: MessageUsage } & Partial<AssistantTurnAccounting>)
+        | undefined;
+      if (!meta?.usage) continue;
+      costUsd += costUsdFromMessageUsage(meta.model, meta.usage) ?? 0;
+    }
+    return costUsd;
+  }
+
+  private async visibleUsageRollup(sessionId: string): Promise<{
+    promptTokens: number;
+    completionTokens: number;
+    reasoningTokens: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+  }> {
     const visible = await this.listVisibleMessages(sessionId);
     const boundary = compactionBoundary(visible);
     // Auto: count from the verbatim tail. Manual (no tail): count from the
@@ -841,7 +902,10 @@ export class SessionsStore {
     for (let i = from; i < visible.length; i += 1) {
       const m = visible[i];
       if (m.role !== "assistant") continue;
-      const u = (m.metadata as { usage?: MessageUsage } | undefined)?.usage;
+      const meta = m.metadata as
+        | ({ usage?: MessageUsage } & Partial<AssistantTurnAccounting>)
+        | undefined;
+      const u = meta?.usage;
       if (!u) continue;
       promptTokens += u.input ?? 0;
       completionTokens += u.output ?? 0;
@@ -849,21 +913,48 @@ export class SessionsStore {
       cacheRead += u.cache_read ?? 0;
       cacheWrite += u.cache_write ?? 0;
     }
-    const totalTokens =
-      promptTokens +
-      completionTokens +
-      reasoningTokens +
-      cacheRead +
-      cacheWrite;
+    const totalTokens = usageTokenTotal({
+      input: promptTokens,
+      output: completionTokens,
+      reasoning: reasoningTokens,
+      cache_read: cacheRead,
+      cache_write: cacheWrite,
+    });
+    return {
+      promptTokens,
+      completionTokens,
+      reasoningTokens,
+      cacheRead,
+      cacheWrite,
+      totalTokens,
+    };
+  }
+
+  /**
+   * Recompute the session-row token rollups to reflect what the MODEL sees.
+   * Called after a rewind/compaction/fork changes the live view.
+   *
+   * A compaction does not hide the summarized head, so a naive "sum every
+   * visible assistant" would over-count the turns that are no longer in the
+   * model's context. Instead, sum assistant `metadata.usage` from the latest
+   * compaction boundary onward (the verbatim tail + the summary's own token
+   * cost); rewind-hidden rows are already excluded by `listVisibleMessages`.
+   *
+   * Cost is deliberately not persisted. Public session rows derive cumulative
+   * spend from every assistant turn's `{ model, usage }` and the current model
+   * catalog, independent of the current context-window boundary.
+   */
+  async recomputeRollups(sessionId: string): Promise<void> {
+    const rollup = await this.visibleUsageRollup(sessionId);
     await this.db
       .update(chatSessions)
       .set({
-        prompt_tokens: promptTokens,
-        completion_tokens: completionTokens,
-        reasoning_tokens: reasoningTokens,
-        cache_read: cacheRead,
-        cache_write: cacheWrite,
-        total_tokens: totalTokens,
+        prompt_tokens: rollup.promptTokens,
+        completion_tokens: rollup.completionTokens,
+        reasoning_tokens: rollup.reasoningTokens,
+        cache_read: rollup.cacheRead,
+        cache_write: rollup.cacheWrite,
+        total_tokens: rollup.totalTokens,
         updated_at: Date.now(),
       })
       .where(eq(chatSessions.id, sessionId));

--- a/packages/grida-ai-agent/src/session/store.ts
+++ b/packages/grida-ai-agent/src/session/store.ts
@@ -206,9 +206,12 @@ export class SessionsStore {
       .orderBy(desc(chatSessions.updated_at), desc(chatSessions.id))
       .limit(limit + 1);
     const rows = where ? await query.where(where) : await query;
-    const items = await Promise.all(
-      rows.slice(0, limit).map((row) => this.rowToSessionWithDerivedCost(row))
-    );
+    const pageRows = rows.slice(0, limit);
+    const costs = await this.sessionCostsUsd(pageRows.map((row) => row.id));
+    const items = pageRows.map((row) => ({
+      ...rowToSession(row),
+      cost_usd: costs.get(row.id) ?? 0,
+    }));
     const last = rows[limit - 1];
     const nextCursor =
       rows.length > limit && last
@@ -690,7 +693,10 @@ export class SessionsStore {
   ): Promise<void> {
     const existing = await this.getMessage(messageId);
     if (!existing) return;
-    const metadata = { ...existing.metadata, ...accounting };
+    const next: Partial<AssistantTurnAccounting> = {};
+    if (accounting.model !== undefined) next.model = accounting.model;
+    if (accounting.usage !== undefined) next.usage = accounting.usage;
+    const metadata = { ...existing.metadata, ...next };
     await this.db
       .update(chatMessages)
       .set({ metadata_json: JSON.stringify(metadata), updated_at: Date.now() })
@@ -854,24 +860,38 @@ export class SessionsStore {
   }
 
   private async sessionCostUsd(sessionId: string): Promise<number> {
+    return (await this.sessionCostsUsd([sessionId])).get(sessionId) ?? 0;
+  }
+
+  private async sessionCostsUsd(
+    sessionIds: readonly string[]
+  ): Promise<Map<string, number>> {
+    if (sessionIds.length === 0) return new Map();
     const rows = await this.db
-      .select({ metadata_json: chatMessages.metadata_json })
+      .select({
+        session_id: chatMessages.session_id,
+        metadata_json: chatMessages.metadata_json,
+      })
       .from(chatMessages)
       .where(
         and(
-          eq(chatMessages.session_id, sessionId),
+          inArray(chatMessages.session_id, [...sessionIds]),
           eq(chatMessages.role, "assistant")
         )
       );
-    let costUsd = 0;
+    const costs = new Map<string, number>();
     for (const row of rows) {
       const meta = parseJsonOr(row.metadata_json, {}) as
         | ({ usage?: MessageUsage } & Partial<AssistantTurnAccounting>)
         | undefined;
       if (!meta?.usage) continue;
-      costUsd += costUsdFromMessageUsage(meta.model, meta.usage) ?? 0;
+      costs.set(
+        row.session_id,
+        (costs.get(row.session_id) ?? 0) +
+          (costUsdFromMessageUsage(meta.model, meta.usage) ?? 0)
+      );
     }
-    return costUsd;
+    return costs;
   }
 
   private async visibleUsageRollup(sessionId: string): Promise<{

--- a/packages/grida-ai-agent/src/tools/index.ts
+++ b/packages/grida-ai-agent/src/tools/index.ts
@@ -181,7 +181,7 @@ export function createToolset(caps: ToolsetCapabilities = {}) {
   const todosBinding = caps.todos;
   const fsTools = fsBinding
     ? wrapWithResolver(AgentFs.tools, (name, input) =>
-        AgentFs.resolveToolCall(fsBinding, {
+        AgentFs.resolveToolCallAsync(fsBinding, {
           tool_name: name as AgentFs.ToolName,
           input,
         })


### PR DESCRIPTION
## Summary

- change `list_files` from a whole-workspace inventory into scoped, paginated directory discovery, with fresh real-fs directory reads for workspace-backed agents
- update agent/tool docs and prompts to describe when the structured list tool is useful, especially VFS vs real filesystem hosts
- make the desktop context meter use visible-transcript context estimates instead of cumulative provider turn usage
- derive cumulative session cost from per-assistant-turn `{ model, usage }` and model catalog pricing without persisting cost as authoritative DB state

## Review notes

- `chat_sessions.cost_usd` remains for schema compatibility, but public session rows now derive cost at read time. Cost includes charged turns hidden by rewind or excluded from the live context by compaction.
- Prompt cache enablement is intentionally not included here; follow-up is tracked in #966.
- Security review: touched `workspace-agent-bindings.ts` under GRIDA-SEC-004; the new directory read still goes through the existing scope resolver and workspace fs containment, and adjacent boundary tests pass.

## Verification

- `pnpm --filter @grida/agent exec vitest run src/session/cost.test.ts src/session/store.test.ts src/fs/fs.test.ts src/runtime/runtime.test.ts src/http/routes/agent.test.ts src/__public-api__.test.ts`
- `pnpm --filter @grida/agent typecheck`
- `pnpm --filter editor exec vitest run lib/agent-chat/context-usage.test.ts`
- `pnpm --filter editor typecheck`
- `pnpm --filter @grida/agent exec vitest run src/runtime/workspace-agent-bindings.test.ts src/runtime/command-backend.test.ts src/session/store.test.ts`
