### PR TITLE
docs(billing): list required Stripe webhook event classes for hosted deploys

### DIFF
--- a/docs/contributing/billing.md
+++ b/docs/contributing/billing.md
@@ -93,6 +93,18 @@ stripe listen --forward-to localhost:3000/webhooks/stripe
 
 Copy the printed `whsec_…` into `STRIPE_WEBHOOK_SECRET`. Per-`stripe listen` session — restart resets it.
 
+**Hosted / self-host deployments.** `stripe listen` forwards _every_ event to your machine, so local dev needs no event list. A real Stripe webhook endpoint delivers only the event types you enable — so when you deploy, create an endpoint (Stripe Dashboard → Developers → Webhooks) at `https://<your-domain>/webhooks/stripe`, copy its signing secret into `STRIPE_WEBHOOK_SECRET`, and subscribe every event class below. All of them feed the billing projector or the AI-credit flow, so enable the full set.
+
+| Class            | Events                                                                                            | Drives                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Checkout**     | `checkout.session.completed`                                                                      | AI-credit top-up + auto-reload enablement   |
+| **Customer**     | `customer.created`, `customer.updated`                                                            | Stripe-customer ↔ org binding               |
+| **Subscription** | `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted` | plan state + auto-reload teardown on cancel |
+| **Invoice**      | `invoice.payment_succeeded`, `invoice.payment_failed`                                             | subscription renew / dunning state          |
+| **Disputes**     | `charge.dispute.created`, `charge.dispute.updated`, `charge.dispute.closed`                       | chargeback handling                         |
+
+The Metronome endpoint (step 8) is the same in production — the same `/webhooks/metronome` path on your own domain, with its signing secret in `METRONOME_WEBHOOK_SECRET`.
+
 ### 7. Metronome webhooks (cloudflared tunnel)
 
 The Stripe CLI can forward to localhost; Metronome can't — it requires a public HTTPS endpoint. Use a Cloudflare named tunnel configured **locally** to forward `/webhooks/*` only. Nothing about the tunnel is git-tracked — the config lives in your `~/.cloudflared/` directory and the hostname is one of yours.


### PR DESCRIPTION
## What

Adds a short table to the billing contributor guide (§6, Stripe webhooks) enumerating the Stripe webhook **event classes** a hosted / self-host deployment must subscribe its `/webhooks/stripe` endpoint to.

## Why

Local setup uses `stripe listen --forward-to`, which forwards *every* event — so the guide never stated which events a real, hosted webhook endpoint needs. A hosted endpoint only delivers the event types you explicitly enable, leaving this undocumented for anyone deploying (self-hosters included — billing is EE/self-host territory).

## Notes

- The list is **derived from the code that consumes each type** — the Stripe projector (`public.fn_billing_apply_stripe_event`) and the `/webhooks/stripe` route — so it's authoritative rather than a Dashboard snapshot.
- Async-checkout events (`checkout.session.async_payment_*`) are intentionally **omitted**: the handler doesn't process them yet, so documenting them would promise a path that doesn't work. Wiring those is a separate code change.
- Docs-only; `format: md` page, no MDX.