### PR TITLE
fix(ai): canvas/svg design agent never billed — snake_case providerOptions.grida key

### DIFF
--- a/editor/app/(canvas)/canvas/tools/ai/generate.ts
+++ b/editor/app/(canvas)/canvas/tools/ai/generate.ts
@@ -12,7 +12,11 @@ import {
 } from "ai";
 import { createStreamableValue } from "@ai-sdk/rsc";
 import { request_schema, type StreamingResponse } from "./schema";
-import { grida, model as tieredModel } from "@/lib/ai/server";
+import {
+  grida,
+  model as tieredModel,
+  gridaProviderOptions,
+} from "@/lib/ai/server";
 import assert from "assert";
 
 export type UserAttachment = {
@@ -106,9 +110,10 @@ export async function generate({
   (async () => {
     const { partialOutputStream } = streamText({
       model,
-      providerOptions: {
-        grida: { organizationId, feature: "canvas/generate" },
-      },
+      providerOptions: gridaProviderOptions({
+        organizationId,
+        feature: "canvas/generate",
+      }),
       ...model_config,
       system,
       ...(message

--- a/editor/app/(canvas)/canvas/tools/ai/generate.ts
+++ b/editor/app/(canvas)/canvas/tools/ai/generate.ts
@@ -110,10 +110,17 @@ export async function generate({
   (async () => {
     const { partialOutputStream } = streamText({
       model,
-      providerOptions: gridaProviderOptions({
-        organizationId,
-        feature: "canvas/generate",
-      }),
+      // `organizationId` is optional only for the dev-tool harness (see the
+      // param doc); the real /canvas path always threads a verified id. When
+      // present, build the payload type-safely; when the harness omits it,
+      // preserve the documented behavior — the seam throws MissingOrgIdError.
+      providerOptions:
+        organizationId === undefined
+          ? { grida: { feature: "canvas/generate" } }
+          : gridaProviderOptions({
+              organizationId,
+              feature: "canvas/generate",
+            }),
       ...model_config,
       system,
       ...(message

--- a/editor/grida-canvas-hosted/ai/agent/server-agent.ts
+++ b/editor/grida-canvas-hosted/ai/agent/server-agent.ts
@@ -6,7 +6,7 @@ import {
 } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { canvas_use } from "../tools/canvas-use";
-import { model } from "@/lib/ai/server";
+import { model, gridaProviderOptions } from "@/lib/ai/server";
 
 const tools = {
   [canvas_use.tools_spec.name_platform_sys_tool_ai_fetch_preflight]:
@@ -78,10 +78,10 @@ export const canvasDesignAgent = new ToolLoopAgent<
     ...settings,
     providerOptions: {
       ...settings.providerOptions,
-      grida: {
-        organization_id: options.organization_id,
+      ...gridaProviderOptions({
+        organizationId: options.organization_id,
         feature: options.feature ?? "canvas/agent/chat",
-      },
+      }),
       openai: {
         ...settings.providerOptions?.openai,
         reasoningEffort: "medium",

--- a/editor/lib/ai/actions/forms-schema.ts
+++ b/editor/lib/ai/actions/forms-schema.ts
@@ -13,7 +13,12 @@
 import { generateObject } from "ai";
 import { z } from "zod/v3";
 import { supported_field_types } from "@/k/supported_field_types";
-import { model, withAiAuth, type ActionResult } from "@/lib/ai/server";
+import {
+  model,
+  withAiAuth,
+  gridaProviderOptions,
+  type ActionResult,
+} from "@/lib/ai/server";
 import type { FormInputType } from "@/grida-forms-hosted/types";
 
 /**
@@ -82,9 +87,10 @@ export async function generateFormFieldSchema(
     async (organizationId) => {
       const { object } = await generateObject({
         model: model("nano"),
-        providerOptions: {
-          grida: { organizationId, feature: "forms/schema/generate" },
-        },
+        providerOptions: gridaProviderOptions({
+          organizationId,
+          feature: "forms/schema/generate",
+        }),
         schema: formFieldSchema,
         system:
           "Generate a form field definition based on the user's description. " +

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -328,6 +328,47 @@ type GridaProviderOptions = {
   awaitIngest?: boolean;
 };
 
+/**
+ * The call-site (producer) contract for a billed seam call.
+ *
+ * `providerOptions` in the AI SDK is an OPEN `Record<string, Record<string,
+ * JSONValue>>`, so a hand-written `{ grida: {...} }` literal type-checks with
+ * ANY keys — which is exactly how a snake_cased `organization_id` shipped past
+ * `tsc` and failed only at runtime in {@link extractContext}. This is the typed
+ * producer contract: `organizationId` and `feature` — the two fields the
+ * middleware requires — are MANDATORY, so a missing or misspelled key is a
+ * compile error at the call site, not a runtime `MissingOrgIdError`.
+ *
+ * Deliberately stricter than the internal (read-side) {@link GridaProviderOptions},
+ * which stays all-optional because the middleware reads it defensively. Strict
+ * in what we produce, lenient in what we accept.
+ *
+ * Always build the payload with {@link gridaProviderOptions}; never hand-write
+ * the `grida` provider-options object.
+ */
+export type GridaCallProviderOptions = {
+  organizationId: number;
+  feature: string;
+  transactionId?: string;
+  costMills?: number;
+  awaitIngest?: boolean;
+};
+
+/**
+ * Build the `{ grida }` provider-options payload the billing middleware reads.
+ *
+ * Use at EVERY billed call site instead of a bare `{ grida: {...} }` literal:
+ * the typed parameter turns a misspelled/snake_cased/omitted `organizationId`
+ * into a compile error. Generic in the argument so the returned literal keeps
+ * its exact shape (no phantom optional `| undefined`) and stays assignable to
+ * the AI SDK `providerOptions` slot.
+ */
+export function gridaProviderOptions<T extends GridaCallProviderOptions>(
+  options: T
+): { grida: T } {
+  return { grida: options };
+}
+
 type ExtractedContext = GridaCallContext & { costMills?: number };
 
 function readGridaOptions(


### PR DESCRIPTION
## Symptom

Paid users (with credits) sending a message from the **web** canvas/svg design
agent — `/svg/examples/default` and `/canvas` — get:

```
AI SDK call missing providerOptions.grida.organizationId (model=openai/gpt-5.4-mini).
Pass { providerOptions: { grida: { organizationId, feature } } } to the SDK call.
```

Not a credits problem: the error is thrown by the billing-seam middleware
**before** any gate/entitlement check runs, so credits are never consulted.
Every call from this agent fails.

## Etiology

1. **Presentation** — `MissingOrgIdError` at send, for every user of the canvas
   design agent, regardless of balance.
2. **Proximate cause** — the agent's `prepareCall` injected
   `providerOptions.grida.`**`organization_id`** (snake_case), but the middleware
   reads `providerOptions.grida.`**`organizationId`** (camelCase). So
   `organizationId` was always `undefined` → `extractContext` throws. The error
   *fires* in the middleware; it *lives* at the injection site.
3. **API contract (misleading)** — `providerOptions` is the AI SDK's **open**
   `Record<string, Record<string, JSONValue>>`. `GridaProviderOptions` (the shape
   the middleware reads) is a **private, unexported** type consumed via an
   unchecked `raw as GridaProviderOptions` cast. There is no nominal link between
   producer and consumer, so any developer hand-writing a `grida: {…}` literal —
   the documented pattern — can re-trigger the bug at a different call site.
4. **Systemic** — ~5 call sites each hand-write an untyped `grida` literal; the
   consumer casts. The snake_case key is one instance of an **unenforced
   contract**, not a lone typo.

## Why `tsc` did not catch it

- `providerOptions`'s type is an open record — `{ organization_id: number }` and
  `{ organizationId: number }` are *both* valid `Record<string, JSONValue>`.
- The consumer reads it back with `raw as GridaProviderOptions` — a type
  **assertion**, which suppresses checking rather than performing it.
- `GridaProviderOptions` was not exported and had all-optional fields, so no call
  site could be checked against it even in principle.

There was no point in the pipeline where the compiler saw producer and consumer
agree on a shape. The only guard was the runtime `typeof` check that throws —
i.e. the symptom itself.

## The fix (fundamental, not the one-liner)

Close the producer→consumer type hole with a typed contract + builder in the seam
(`editor/lib/ai/server.ts`):

```ts
export type GridaCallProviderOptions = {
  organizationId: number;   // required
  feature: string;          // required
  transactionId?: string;
  costMills?: number;
  awaitIngest?: boolean;
};

export function gridaProviderOptions<T extends GridaCallProviderOptions>(
  options: T
): { grida: T } {
  return { grida: options };
}
```

- `organizationId`/`feature` are **required**, so a missing or misspelled key is a
  **compile error** at the call site — not a runtime `MissingOrgIdError`.
- Generic in the argument so the returned literal keeps its exact shape (no
  phantom optional `| undefined`) and stays assignable to the `providerOptions`
  slot.
- Deliberately stricter than the internal read-side `GridaProviderOptions`, which
  stays all-optional (the middleware reads defensively). *Strict in what we
  produce, lenient in what we accept.*

Migrated the billed call sites to the builder: the canvas design agent (the fix),
`forms/schema`, and `canvas/generate`. The strict builder immediately **surfaced a
second latent instance at compile time** — `canvas/generate`'s `organizationId` is
`number | undefined` (an intentional dev-tool-harness affordance, per its param
doc). That path is now explicit: the type-safe builder when a verified id is
present (the real `/canvas` path), and the documented `MissingOrgIdError` seam
behavior when the harness omits it.

## Verification

Type-level proof (`tsc --strict`, passing — every `@ts-expect-error` is a real
error or tsc fails on an unused directive):

- OLD pattern `grida: { organization_id: 1 }` under an open `providerOptions`
  compiles with **no error** → reproduces *why it shipped*.
- NEW builder with correct keys compiles **and** stays assignable to
  `providerOptions`.
- `organization_id` (the bug), an omitted org id, and `number | undefined` are all
  now **compile errors**.

`oxfmt` + `oxlint` clean. The authoritative gate is the CI `editor#typecheck`
step (stricter than Next's build, which ignores TS errors) — it caught
`canvas/generate`'s optional org (handled above), confirming the builder works on
the real tree, not just in isolation.

**Coverage:** the regression guard is the type system itself — the cheapest
coverage available for this class. The builder makes "wrong/missing key" a compile
error at every migrated site.

## Scope / follow-up

`editor/scaffolds/playground-forms/actions.ts` passes
`organizationId: number | undefined` into the seam — a **latent instance of the
same class** (undefined org would also throw at runtime). Left unchanged here to
avoid altering playground behavior; migrating it to `gridaProviderOptions` surfaces
the `undefined` as a compile error and needs an owner decision on the no-org case.
Flagged as a separate task.
