### PR TITLE
fix(ai): bill the canvas/svg design agent — snake_case grida key in @grida/agent (#975 follow-up)

### DIFF
--- a/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.ts
@@ -25,7 +25,7 @@
  */
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { verifyGgToken } from "@/lib/auth/gg-token";
-import { grida } from "@/lib/ai/server";
+import { grida, gridaProviderOptions } from "@/lib/ai/server";
 import {
   decodeRequest,
   encodeCompletion,
@@ -64,13 +64,11 @@ export async function POST(request: Request) {
     const model = grida.languageModel(req.model) as LanguageModelV3;
     const callOptions = {
       ...decoded.callOptions,
-      providerOptions: {
-        grida: {
-          organizationId: claims.org,
-          feature: "v1/ai/chat",
-          awaitIngest: false,
-        },
-      },
+      providerOptions: gridaProviderOptions({
+        organizationId: claims.org,
+        feature: "v1/ai/chat",
+        awaitIngest: false,
+      }),
     };
 
     if (!decoded.stream) {

--- a/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/images/generations/route.ts
@@ -21,7 +21,7 @@ import type { ImageGenerateResult } from "@grida/agent";
 import { verifyGgToken } from "@/lib/auth/gg-token";
 import ai from "@/lib/ai";
 import { computeImageCostMills } from "@/lib/ai/image-cost";
-import { methods } from "@/lib/ai/server";
+import { methods, gridaProviderOptions } from "@/lib/ai/server";
 import {
   fromUnknownError,
   modelNotFound,
@@ -102,11 +102,11 @@ export async function POST(request: Request) {
       aspectRatio: req.aspect_ratio as `${number}:${number}` | undefined,
       seed: req.seed ?? undefined,
       providerOptions: {
-        grida: {
+        ...gridaProviderOptions({
           organizationId: claims.org,
           feature: "v1/ai/images",
           costMills,
-        },
+        }),
         ...(originProvider && quality ? { [originProvider]: { quality } } : {}),
       },
     });

--- a/editor/lib/ai/actions/chat.ts
+++ b/editor/lib/ai/actions/chat.ts
@@ -10,6 +10,7 @@ import {
   model,
   costMillsFromTokenUsage,
   costUsdFromTokenUsage,
+  gridaProviderOptions,
   withAiAuth,
   type AiActionResult,
   type ProviderUsage,
@@ -126,12 +127,10 @@ export async function runChat(input: RunChatInput): Promise<RunChatResponse> {
       const { text, usage } = await generateText({
         model: languageModel,
         messages,
-        providerOptions: {
-          grida: {
-            organizationId: orgId,
-            feature: "ai/chat",
-          },
-        },
+        providerOptions: gridaProviderOptions({
+          organizationId: orgId,
+          feature: "ai/chat",
+        }),
       });
 
       const providerUsage = toProviderUsage(usage);

--- a/editor/lib/ai/actions/image-generate.ts
+++ b/editor/lib/ai/actions/image-generate.ts
@@ -18,7 +18,12 @@ import imageSize from "image-size";
 import { service_role } from "@/lib/supabase/server";
 import ai from "@/lib/ai";
 import { computeImageCostMills } from "@/lib/ai/image-cost";
-import { methods, withAiAuth, type AiActionResult } from "@/lib/ai/server";
+import {
+  methods,
+  withAiAuth,
+  gridaProviderOptions,
+  type AiActionResult,
+} from "@/lib/ai/server";
 
 export type GenerateAiImageInput = {
   prompt: string;
@@ -188,12 +193,10 @@ async function generateImageWithSize({
     size,
     aspectRatio: aspect_ratio,
     n: 1,
-    providerOptions: {
-      grida: {
-        organizationId,
-        feature: "ai/image/generate",
-        costMills,
-      },
-    },
+    providerOptions: gridaProviderOptions({
+      organizationId,
+      feature: "ai/image/generate",
+      costMills,
+    }),
   });
 }

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -37,7 +37,10 @@ import type {
   ImageModel,
 } from "ai";
 import { embed, experimental_generateVideo, wrapProvider } from "ai";
-import { models as ai_models } from "@grida/ai-models";
+import {
+  models as ai_models,
+  type GridaCallProviderOptions,
+} from "@grida/ai-models";
 import type { VideoGenerateRequest, VideoGenerateResult } from "@grida/agent";
 import Replicate from "replicate";
 import OpenAI from "openai";
@@ -161,6 +164,14 @@ export { BillingMetronomeError };
 // into `./models`. Only the boolean crosses out — never the key.
 export { isByokActive };
 export type { ModelTier };
+
+// The producer contract for `providerOptions.grida` lives in `@grida/ai-models`
+// — the one package both this seam and the framework-free `@grida/agent` share
+// — so every billed call site (editor OR package) is compiled against ONE key
+// definition. Re-exported here so editor call sites keep importing it from the
+// seam; `extractContext` (below) reads the same shape via `GridaProviderOptions`.
+export { gridaProviderOptions } from "@grida/ai-models";
+export type { GridaCallProviderOptions };
 
 // ===========================================================================
 // Core seam — gate → run → ingest
@@ -313,61 +324,14 @@ export function costMillsFromTokenUsage(
 // Vercel AI SDK adapter — `grida` provider
 // ===========================================================================
 
-type GridaProviderOptions = {
-  organizationId?: number;
-  feature?: string;
-  transactionId?: string;
-  /**
-   * Explicit cost in mills — used by the image-model middleware since
-   * AI SDK image gen doesn't expose token usage. The route handler
-   * computes cost from request params (n, size, quality) against the
-   * cost card and threads it through.
-   */
-  costMills?: number;
-  /** See {@link GridaCallContext.awaitIngest}. */
-  awaitIngest?: boolean;
-};
-
-/**
- * The call-site (producer) contract for a billed seam call.
- *
- * `providerOptions` in the AI SDK is an OPEN `Record<string, Record<string,
- * JSONValue>>`, so a hand-written `{ grida: {...} }` literal type-checks with
- * ANY keys — which is exactly how a snake_cased `organization_id` shipped past
- * `tsc` and failed only at runtime in {@link extractContext}. This is the typed
- * producer contract: `organizationId` and `feature` — the two fields the
- * middleware requires — are MANDATORY, so a missing or misspelled key is a
- * compile error at the call site, not a runtime `MissingOrgIdError`.
- *
- * Deliberately stricter than the internal (read-side) {@link GridaProviderOptions},
- * which stays all-optional because the middleware reads it defensively. Strict
- * in what we produce, lenient in what we accept.
- *
- * Always build the payload with {@link gridaProviderOptions}; never hand-write
- * the `grida` provider-options object.
- */
-export type GridaCallProviderOptions = {
-  organizationId: number;
-  feature: string;
-  transactionId?: string;
-  costMills?: number;
-  awaitIngest?: boolean;
-};
-
-/**
- * Build the `{ grida }` provider-options payload the billing middleware reads.
- *
- * Use at EVERY billed call site instead of a bare `{ grida: {...} }` literal:
- * the typed parameter turns a misspelled/snake_cased/omitted `organizationId`
- * into a compile error. Generic in the argument so the returned literal keeps
- * its exact shape (no phantom optional `| undefined`) and stays assignable to
- * the AI SDK `providerOptions` slot.
- */
-export function gridaProviderOptions<T extends GridaCallProviderOptions>(
-  options: T
-): { grida: T } {
-  return { grida: options };
-}
+// Read-side view: what the billing middleware defensively reads back off
+// `providerOptions.grida`. DERIVED from the producer contract so the field
+// NAMES have a single definition — rename `organizationId` in
+// `GridaCallProviderOptions` and both the builder (produce side) and
+// `extractContext` (read side) stop compiling in lockstep, which is exactly the
+// producer↔consumer link whose absence let a snake_cased key ship. All-optional
+// because the middleware validates presence/shape at runtime (see extractContext).
+type GridaProviderOptions = Partial<GridaCallProviderOptions>;
 
 type ExtractedContext = GridaCallContext & { costMills?: number };
 

--- a/packages/grida-ai-agent/src/agent/grida-attribution.test.ts
+++ b/packages/grida-ai-agent/src/agent/grida-attribution.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { gridaAttribution } from "./index";
+
+/**
+ * Regression guard for the billing seam's `grida` provider-options key.
+ *
+ * The bug: `prepareCall` hand-wrote `grida: { organization_id }` (snake_case),
+ * but the seam middleware reads `organizationId` (camelCase), so EVERY hosted
+ * design-agent call threw `MissingOrgIdError` before the credit check —
+ * tier-independent, and unbilled (the throw precedes the gate). The compile-time
+ * guard is the shared typed builder; this pins the runtime key mapping so a
+ * future refactor that drops the builder can't silently regress it.
+ */
+describe("gridaAttribution", () => {
+  it("emits the camelCase `organizationId` key the billing seam reads", () => {
+    const out = gridaAttribution({ organization_id: 42, feature: "svg/agent" });
+    expect(out).toEqual({
+      grida: { organizationId: 42, feature: "svg/agent" },
+    });
+    // The exact defect: never the snake_cased key the middleware ignores.
+    expect(out.grida).not.toHaveProperty("organization_id");
+  });
+
+  it("defaults the feature tag when the caller omits it", () => {
+    const out = gridaAttribution({ organization_id: 7 });
+    expect(out).toEqual({
+      grida: { organizationId: 7, feature: "agent/chat" },
+    });
+  });
+
+  it("threads transaction_id → transactionId only when present", () => {
+    expect(
+      gridaAttribution({ organization_id: 7, transaction_id: "tx_1" })
+    ).toEqual({
+      grida: {
+        organizationId: 7,
+        feature: "agent/chat",
+        transactionId: "tx_1",
+      },
+    });
+    // Absent → no stray `transactionId: undefined` on the wire.
+    expect(gridaAttribution({ organization_id: 7 }).grida).not.toHaveProperty(
+      "transactionId"
+    );
+  });
+
+  it("omits the `grida` key entirely on the BYOK path (no org id)", () => {
+    // Desktop/BYOK runs a bare provider with no billing middleware — there is
+    // nothing to attribute, and emitting `grida: { organizationId: undefined }`
+    // would trip the seam's runtime gate on the hosted path.
+    const out = gridaAttribution({ feature: "byok/local" });
+    expect(out).toEqual({});
+    expect(out).not.toHaveProperty("grida");
+  });
+});

--- a/packages/grida-ai-agent/src/agent/index.ts
+++ b/packages/grida-ai-agent/src/agent/index.ts
@@ -45,6 +45,10 @@ import {
 import { renderSkillIndex } from "../skills/skill-tool";
 import { AgentVision } from "../vision";
 import { AgentGen } from "../gen";
+import {
+  gridaProviderOptions,
+  type GridaCallProviderOptions,
+} from "@grida/ai-models";
 import type {
   SkillBodyCache,
   SkillBodyLoader,
@@ -180,11 +184,7 @@ export function createAgent(opts: CreateAgentOptions) {
         model: opts.model_factory(tier, options.model_id),
         providerOptions: {
           ...settings.providerOptions,
-          grida: {
-            organization_id: options.organization_id,
-            feature: options.feature ?? "agent/chat",
-            transaction_id: options.transaction_id,
-          },
+          ...gridaAttribution(options),
           anthropic: {
             ...settings.providerOptions?.anthropic,
             thinking: { type: "adaptive" },
@@ -209,6 +209,39 @@ export function createAgent(opts: CreateAgentOptions) {
       messages: hoistToolResultImages(messages),
     }),
     stopWhen: stepCountIs(8),
+  });
+}
+
+/**
+ * Build the billing seam's `grida` provider-options fragment for a turn.
+ *
+ * Injected via the shared typed builder ({@link gridaProviderOptions}), never a
+ * bare `{ grida: {...} }` literal — a bare literal is how a snake_cased
+ * `organization_id` key once shipped past `tsc` and failed only at runtime with
+ * `MissingOrgIdError`.
+ *
+ * `organization_id` is optional on {@link AgentCallOptions} because the BYOK /
+ * desktop host runs on a bare provider with NO billing middleware — there is no
+ * seam to attribute, so this returns `{}` and no `grida` key is emitted. On the
+ * hosted (billed) path the route always threads a verified id (GRIDA-SEC-003 /
+ * `requireOrganizationId`), so the builder branch always runs there; and if a
+ * billed call ever reached the seam without one, its middleware correctly
+ * throws `MissingOrgIdError` rather than billing a bogus org.
+ *
+ * Exported so the exact key mapping (camelCase, tier-independent) is unit-pinned
+ * without standing up a model — the class of bug this fixes is a wrong key, and
+ * the guard for a wrong key is a test that reads the emitted key.
+ */
+export function gridaAttribution(
+  options: AgentCallOptions
+): { grida: GridaCallProviderOptions } | Record<string, never> {
+  if (options.organization_id === undefined) return {};
+  return gridaProviderOptions({
+    organizationId: options.organization_id,
+    feature: options.feature ?? "agent/chat",
+    ...(options.transaction_id !== undefined
+      ? { transactionId: options.transaction_id }
+      : {}),
   });
 }
 

--- a/packages/grida-ai-models/src/index.ts
+++ b/packages/grida-ai-models/src/index.ts
@@ -7,4 +7,5 @@
 
 export * from "./tiers";
 export * from "./models";
+export * from "./provider-options";
 export { default } from "./models";

--- a/packages/grida-ai-models/src/provider-options.ts
+++ b/packages/grida-ai-models/src/provider-options.ts
@@ -1,0 +1,56 @@
+/**
+ * Producer contract for the billing seam's `grida` provider-options key.
+ *
+ * The Vercel AI SDK's `providerOptions` slot is an OPEN `Record<string,
+ * Record<string, JSONValue>>`, so a hand-written `{ grida: {...} }` literal
+ * type-checks with ANY keys — which is exactly how a snake_cased
+ * `organization_id` shipped past `tsc` and failed only at runtime, when the
+ * billing middleware read `organizationId` (camelCase) and found `undefined`.
+ *
+ * This is the single, typed producer contract shared by EVERY billed call
+ * site: the editor seam (`editor/lib/ai/server.ts`, which re-exports this and
+ * derives its read-side type from it) AND the framework-free `@grida/agent`
+ * package, which cannot import the seam. `organizationId` and `feature` — the
+ * two fields the middleware requires — are MANDATORY, so a missing or
+ * misspelled key is a compile error at the call site, not a runtime
+ * `MissingOrgIdError`. Lives here because `@grida/ai-models` is the one package
+ * both sides already depend on.
+ *
+ * NOTE: this types the org-id KEY; it does NOT verify the org id. Verification
+ * (member-org check) is GRIDA-SEC-003's job and lives upstream in the editor's
+ * `requireOrganizationId`. Strict in what we produce, lenient in what the seam
+ * accepts (the middleware reads defensively).
+ */
+export type GridaCallProviderOptions = {
+  /** Verified organization id. Required. Source: GRIDA-SEC-003 `requireOrganizationId`. */
+  organizationId: number;
+  /** Free-form feature tag — e.g. `"canvas/svg/agent/chat"`. Diagnostics only. */
+  feature: string;
+  /** Optional pre-allocated transaction id (idempotency on retry). */
+  transactionId?: string;
+  /**
+   * Explicit cost in mills — used by the image-model middleware, since AI SDK
+   * image generation doesn't expose token usage.
+   */
+  costMills?: number;
+  /**
+   * Block on the ingest call before returning. Default `false` (fire-and-forget);
+   * set `true` when the caller reads back a debited balance in the same request.
+   */
+  awaitIngest?: boolean;
+};
+
+/**
+ * Build the `{ grida }` provider-options payload the billing middleware reads.
+ *
+ * Use at EVERY billed call site instead of a bare `{ grida: {...} }` literal:
+ * the typed parameter turns a misspelled / snake_cased / omitted
+ * `organizationId` into a compile error. Generic in the argument so the
+ * returned literal keeps its exact shape (no phantom optional `| undefined`)
+ * and stays assignable to the AI SDK `providerOptions` slot.
+ */
+export function gridaProviderOptions<T extends GridaCallProviderOptions>(
+  options: T
+): { grida: T } {
+  return { grida: options };
+}


### PR DESCRIPTION
Follow-up to #975 — which fixed a real instance of this bug but **not the path users actually hit**.

## Symptom

Paid users (with credits) messaging the **web** canvas/svg design agent — `/svg/examples/default`, `/canvas` — get:

```
AI SDK call missing providerOptions.grida.organizationId (model=anthropic/claude-sonnet-5).
Pass { providerOptions: { grida: { organizationId, feature } } } to the SDK call.
```

**Reproduced live on prod** (signed in, $9.97 balance):

| Picker tier | Error |
|---|---|
| Pro (default) | `...missing …organizationId (model=anthropic/claude-sonnet-5)...` |
| Mini | `...missing …organizationId (model=openai/gpt-5.4-mini)...` |

The model name just **tracks the picker** — the failure is tier-independent. Balance stayed **unchanged**, because the throw precedes the credit gate (which is why a paid user still fails).

## Why #975 didn't fix it

#975 corrected `providerOptions.grida.organization_id → organizationId` in the editor call sites and `canvasDesignAgent` — but `canvasDesignAgent` only serves `/private/ai/chat`. The pages above hit **`/private/ai/design/chat`**, which runs `gridaAgent` = `@grida/agent`'s `createAgent`. Its `prepareCall` had the **identical snake_case bug**, and `@grida/agent` is framework-free — it *cannot* import the seam, so #975's builder never reached it.

## Root cause

`packages/grida-ai-agent/src/agent/index.ts` `prepareCall` wrote:

```ts
grida: { organization_id: options.organization_id, feature, transaction_id }
```

…while the seam's `extractContext` reads `g.organizationId` (camelCase). So `organizationId` was always `undefined` → `MissingOrgIdError`, thrown in the middleware **before** `checkGate`/`getEntitlement` and before the model call. The AI-SDK `providerOptions` slot is an open `Record<string, Record<string, JSONValue>>`, so the snake_cased key type-checked and failed only at runtime.

## The fix (fundamental)

Put the typed producer contract where **both** sides already share code — `@grida/ai-models` — so producer and consumer are compiled against **one** `organizationId` definition:

- **`@grida/ai-models`** — new `gridaProviderOptions()` builder + `GridaCallProviderOptions` (`organizationId`/`feature` required).
- **`@grida/agent`** — `prepareCall` builds via `gridaAttribution()` (uses the builder → camelCase; **omits `grida` on the BYOK path**, which runs a bare provider with no middleware). A snake_cased/omitted key is now a **compile error**. + 4-case regression test.
- **editor seam (`server.ts`)** — re-exports the builder (keeps #975's call sites working) and **derives its read-side type** from the canonical one, so a future rename of `organizationId` breaks the producer *and* the reader in lockstep.
- **Migrated the remaining bare `grida: {...}` literals** (`ai/chat`, `ai/image/generate`, `v1/ai/chat/completions`, `v1/ai/images/generations`) to the builder — correct keys today, now compile-locked.

## Verification

- **Live prod repro** (above) — both tiers, balance unchanged.
- `editor` typecheck **41/41**; `@grida/agent` + `@grida/ai-models` typecheck green.
- `gridaAttribution` guard test **4/4** (camelCase key; `grida` omitted with no org; `transactionId` only when present).
- oxfmt + oxlint clean.
- I'll re-run the live browser test once this deploys to confirm the error is gone.

## Security — GRIDA-SEC-003

Reviewed. Org-id **verification** (`requireOrganizationId`) and the seam's **unconditional runtime gate** (`extractContext` throw + `assertOrgId`) are unchanged — this only fixes serialization of the already-verified id. BYOK carve-out preserved (package omits `grida` when there's no org id). The new `@grida/ai-models` file is a serialization contract, not a verification enforcement point, so it's not added to the boundary's file list.

## Follow-up (not in this PR)

`editor/scaffolds/playground-forms/actions.ts` passes `organizationId: number | undefined` — a *different* latent issue (undefined value, not wrong key). Tracked separately.
