### PR TITLE
fix(desktop): tolerate release visibility lag

### DIFF
--- a/.github/scripts/assemble-desktop-release.mjs
+++ b/.github/scripts/assemble-desktop-release.mjs
@@ -272,7 +272,14 @@ function wait(delayMs) {
 
 async function confirmDraftIdentity(
   client,
-  { expectedId, retryDelaysMs, tag, target, waitForRetry = wait }
+  {
+    expectedId,
+    phase = "while assembling",
+    retryDelaysMs,
+    tag,
+    target,
+    waitForRetry = wait,
+  }
 ) {
   for (let attempt = 0; ; attempt += 1) {
     const selected = DesktopRelease.selectDraft(
@@ -283,7 +290,7 @@ async function confirmDraftIdentity(
     if (selected) {
       if (selected.id !== expectedId) {
         throw new Error(
-          `Release identity changed while assembling ${tag}: expected ${expectedId}, found ${selected.id}`
+          `Release identity changed ${phase} ${tag}: expected ${expectedId}, found ${selected.id}`
         );
       }
       return selected;
@@ -292,7 +299,7 @@ async function confirmDraftIdentity(
     const delayMs = retryDelaysMs[attempt];
     if (delayMs === undefined) {
       throw new Error(
-        `Release ${expectedId} did not become visible while assembling ${tag} after ${attempt + 1} checks`
+        `Release ${expectedId} did not become visible ${phase} ${tag} after ${attempt + 1} checks`
       );
     }
     if (!Number.isFinite(delayMs) || delayMs < 0) {
@@ -354,7 +361,6 @@ export async function assembleDesktopRelease(options, client) {
     tag,
     target
   );
-  const created = !release;
   if (!release) {
     release = await client.createDraft({
       tag,
@@ -364,28 +370,17 @@ export async function assembleDesktopRelease(options, client) {
     });
   }
 
-  if (created) {
-    // GitHub's list endpoint can briefly lag behind createDraft(). Retry only
-    // that absent state; conflicting, duplicate, published, immutable, and
-    // wrong-target releases still fail immediately through selectDraft().
-    await confirmDraftIdentity(client, {
-      expectedId: release.id,
-      retryDelaysMs:
-        draftVisibility.retryDelaysMs ?? githubReleaseVisibilityRetryDelaysMs,
-      tag,
-      target,
-      waitForRetry: draftVisibility.wait,
-    });
-  } else {
-    const selected = DesktopRelease.selectDraft(
-      await client.listReleases(),
-      tag,
-      target
-    );
-    if (!selected || selected.id !== release.id) {
-      throw new Error(`Release identity changed while assembling ${tag}`);
-    }
-  }
+  // GitHub's list endpoint can briefly omit a release around mutations.
+  // Retry only that absent state; conflicting, duplicate, published,
+  // immutable, and wrong-target releases still fail immediately.
+  await confirmDraftIdentity(client, {
+    expectedId: release.id,
+    retryDelaysMs:
+      draftVisibility.retryDelaysMs ?? githubReleaseVisibilityRetryDelaysMs,
+    tag,
+    target,
+    waitForRetry: draftVisibility.wait,
+  });
 
   release = await client.updateDraft(release.id, {
     tag,
@@ -453,14 +448,15 @@ export async function assembleDesktopRelease(options, client) {
     throw new Error(`Remote release metadata verification failed for ${tag}`);
   }
 
-  const finalSelection = DesktopRelease.selectDraft(
-    await client.listReleases(),
+  await confirmDraftIdentity(client, {
+    expectedId: release.id,
+    phase: "after assembling",
+    retryDelaysMs:
+      draftVisibility.retryDelaysMs ?? githubReleaseVisibilityRetryDelaysMs,
     tag,
-    target
-  );
-  if (!finalSelection || finalSelection.id !== release.id) {
-    throw new Error(`Release identity changed after assembling ${tag}`);
-  }
+    target,
+    waitForRetry: draftVisibility.wait,
+  });
   return finalRelease;
 }
 

--- a/.github/scripts/assemble-desktop-release.mjs
+++ b/.github/scripts/assemble-desktop-release.mjs
@@ -10,6 +10,9 @@ const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 const githubApiVersion = "2022-11-28";
 const githubRequestTimeoutMs = 30_000;
 const githubUploadTimeoutMs = 300_000;
+const githubReleaseVisibilityRetryDelaysMs = Object.freeze([
+  500, 1_000, 2_000, 4_000, 8_000,
+]);
 
 export const DesktopRelease = Object.freeze({
   expectedAssetNames(version) {
@@ -263,6 +266,45 @@ async function sha256(filePath) {
   return `sha256:${hash.digest("hex")}`;
 }
 
+function wait(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function confirmDraftIdentity(
+  client,
+  { expectedId, retryDelaysMs, tag, target, waitForRetry = wait }
+) {
+  for (let attempt = 0; ; attempt += 1) {
+    const selected = DesktopRelease.selectDraft(
+      await client.listReleases(),
+      tag,
+      target
+    );
+    if (selected) {
+      if (selected.id !== expectedId) {
+        throw new Error(
+          `Release identity changed while assembling ${tag}: expected ${expectedId}, found ${selected.id}`
+        );
+      }
+      return selected;
+    }
+
+    const delayMs = retryDelaysMs[attempt];
+    if (delayMs === undefined) {
+      throw new Error(
+        `Release ${expectedId} did not become visible while assembling ${tag} after ${attempt + 1} checks`
+      );
+    }
+    if (!Number.isFinite(delayMs) || delayMs < 0) {
+      throw new Error("Release visibility retry delays must be non-negative");
+    }
+    console.log(
+      `Waiting ${delayMs}ms for GitHub to list ${tag} release ${expectedId}`
+    );
+    await waitForRetry(delayMs);
+  }
+}
+
 export async function collectReleaseAssets(directory, expectedNames) {
   const assets = new Map();
   for (const filePath of await walkFiles(directory)) {
@@ -292,7 +334,14 @@ export async function collectReleaseAssets(directory, expectedNames) {
 }
 
 export async function assembleDesktopRelease(options, client) {
-  const { assetsDirectory, notes, prerelease, target, version } = options;
+  const {
+    assetsDirectory,
+    draftVisibility = {},
+    notes,
+    prerelease,
+    target,
+    version,
+  } = options;
   const tag = `v${version}`;
   const expectedNames = DesktopRelease.expectedAssetNames(version);
   const localAssets = await collectReleaseAssets(
@@ -305,6 +354,7 @@ export async function assembleDesktopRelease(options, client) {
     tag,
     target
   );
+  const created = !release;
   if (!release) {
     release = await client.createDraft({
       tag,
@@ -314,15 +364,27 @@ export async function assembleDesktopRelease(options, client) {
     });
   }
 
-  // Re-read after creation. This catches any competing publisher instead of
-  // silently splitting the release across multiple draft IDs.
-  const selected = DesktopRelease.selectDraft(
-    await client.listReleases(),
-    tag,
-    target
-  );
-  if (!selected || selected.id !== release.id) {
-    throw new Error(`Release identity changed while assembling ${tag}`);
+  if (created) {
+    // GitHub's list endpoint can briefly lag behind createDraft(). Retry only
+    // that absent state; conflicting, duplicate, published, immutable, and
+    // wrong-target releases still fail immediately through selectDraft().
+    await confirmDraftIdentity(client, {
+      expectedId: release.id,
+      retryDelaysMs:
+        draftVisibility.retryDelaysMs ?? githubReleaseVisibilityRetryDelaysMs,
+      tag,
+      target,
+      waitForRetry: draftVisibility.wait,
+    });
+  } else {
+    const selected = DesktopRelease.selectDraft(
+      await client.listReleases(),
+      tag,
+      target
+    );
+    if (!selected || selected.id !== release.id) {
+      throw new Error(`Release identity changed while assembling ${tag}`);
+    }
   }
 
   release = await client.updateDraft(release.id, {

--- a/.github/scripts/assemble-desktop-release.test.mjs
+++ b/.github/scripts/assemble-desktop-release.test.mjs
@@ -168,16 +168,14 @@ test("assembles one complete draft after delayed list visibility", async () => {
     await writeReleaseAssets(directory);
 
     const uploads = [];
-    let visibilityMisses = 1;
+    const waits = [];
+    let listCount = 0;
+    let visible = false;
     const client = {
       release: undefined,
       async listReleases() {
-        if (!this.release) return [];
-        if (visibilityMisses > 0) {
-          visibilityMisses -= 1;
-          return [];
-        }
-        return [this.release];
+        listCount += 1;
+        return this.release && visible ? [this.release] : [];
       },
       async createDraft({ tag, target, notes, prerelease }) {
         this.release = {
@@ -233,14 +231,18 @@ test("assembles one complete draft after delayed list visibility", async () => {
         ...assemblyOptions,
         assetsDirectory: directory,
         draftVisibility: {
-          retryDelaysMs: [0],
-          wait: async () => {},
+          retryDelaysMs: [25],
+          wait: async (delayMs) => {
+            waits.push(delayMs);
+            visible = true;
+          },
         },
       },
       client
     );
     assert.equal(release.id, 42);
-    assert.equal(visibilityMisses, 0);
+    assert.equal(listCount, 4);
+    assert.deepEqual(waits, [25]);
     assert.deepEqual(uploads, Array(11).fill(42));
   } finally {
     await rm(directory, { force: true, recursive: true });
@@ -388,6 +390,7 @@ test("fails when a created draft never becomes list-visible", async () => {
     await writeReleaseAssets(directory);
     const created = createRelease({ id: 42 });
     let listCount = 0;
+    const waits = [];
     const client = {
       async listReleases() {
         listCount += 1;
@@ -405,7 +408,7 @@ test("fails when a created draft never becomes list-visible", async () => {
           assetsDirectory: directory,
           draftVisibility: {
             retryDelaysMs: [0, 0],
-            wait: async () => {},
+            wait: async (delayMs) => waits.push(delayMs),
           },
         },
         client
@@ -413,6 +416,71 @@ test("fails when a created draft never becomes list-visible", async () => {
       /Release 42 did not become visible while assembling v0\.0\.8 after 3 checks/
     );
     assert.equal(listCount, 4);
+    assert.deepEqual(waits, [0, 0]);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects duplicate drafts discovered after asset uploads", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "desktop-release-"));
+  try {
+    await writeReleaseAssets(directory);
+    const release = createRelease({ id: 42 });
+    const competitor = createRelease({ id: 43 });
+    let listCount = 0;
+    let uploadCount = 0;
+    const client = {
+      async listReleases() {
+        listCount += 1;
+        if (listCount === 1) return [];
+        if (listCount === 2) return [release];
+        return [release, competitor];
+      },
+      async createDraft() {
+        return release;
+      },
+      async updateDraft(releaseId) {
+        assert.equal(releaseId, release.id);
+        return release;
+      },
+      async deleteAsset() {
+        assert.fail("a new release must not delete assets");
+      },
+      async uploadAsset(existingRelease, asset) {
+        uploadCount += 1;
+        const uploaded = {
+          digest: asset.digest,
+          id: uploadCount,
+          name: asset.name,
+          size: asset.size,
+          state: "uploaded",
+        };
+        existingRelease.assets.push(uploaded);
+        return uploaded;
+      },
+      async getRelease(releaseId) {
+        assert.equal(releaseId, release.id);
+        return release;
+      },
+    };
+
+    await assert.rejects(
+      assembleDesktopRelease(
+        {
+          ...assemblyOptions,
+          assetsDirectory: directory,
+          draftVisibility: {
+            retryDelaysMs: [0],
+            wait: async () => assert.fail("duplicates must not retry"),
+          },
+        },
+        client
+      ),
+      /Refusing ambiguous v0\.0\.8: found 2 releases \(42, 43\)/
+    );
+    assert.equal(uploadCount, 11);
+    assert.equal(listCount, 3);
   } finally {
     await rm(directory, { force: true, recursive: true });
   }

--- a/.github/scripts/assemble-desktop-release.test.mjs
+++ b/.github/scripts/assemble-desktop-release.test.mjs
@@ -162,16 +162,22 @@ test("refuses incomplete local artifacts", async () => {
   }
 });
 
-test("assembles one complete draft through one numeric release ID", async () => {
+test("assembles one complete draft after delayed list visibility", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "desktop-release-"));
   try {
     await writeReleaseAssets(directory);
 
     const uploads = [];
+    let visibilityMisses = 1;
     const client = {
       release: undefined,
       async listReleases() {
-        return this.release ? [this.release] : [];
+        if (!this.release) return [];
+        if (visibilityMisses > 0) {
+          visibilityMisses -= 1;
+          return [];
+        }
+        return [this.release];
       },
       async createDraft({ tag, target, notes, prerelease }) {
         this.release = {
@@ -226,10 +232,15 @@ test("assembles one complete draft through one numeric release ID", async () => 
       {
         ...assemblyOptions,
         assetsDirectory: directory,
+        draftVisibility: {
+          retryDelaysMs: [0],
+          wait: async () => {},
+        },
       },
       client
     );
     assert.equal(release.id, 42);
+    assert.equal(visibilityMisses, 0);
     assert.deepEqual(uploads, Array(11).fill(42));
   } finally {
     await rm(directory, { force: true, recursive: true });
@@ -316,11 +327,92 @@ test("rejects a release identity change after draft creation", async () => {
 
     await assert.rejects(
       assembleDesktopRelease(
-        { ...assemblyOptions, assetsDirectory: directory },
+        {
+          ...assemblyOptions,
+          assetsDirectory: directory,
+          draftVisibility: {
+            retryDelaysMs: [0],
+            wait: async () => assert.fail("a conflicting ID must not retry"),
+          },
+        },
         client
       ),
-      /Release identity changed while assembling v0\.0\.8/
+      /Release identity changed while assembling v0\.0\.8: expected 42, found 43/
     );
+    assert.equal(listCount, 2);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects duplicate drafts immediately after creation", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "desktop-release-"));
+  try {
+    await writeReleaseAssets(directory);
+    const created = createRelease({ id: 42 });
+    const competitor = createRelease({ id: 43 });
+    let listCount = 0;
+    const client = {
+      async listReleases() {
+        listCount += 1;
+        return listCount === 1 ? [] : [created, competitor];
+      },
+      async createDraft() {
+        return created;
+      },
+    };
+
+    await assert.rejects(
+      assembleDesktopRelease(
+        {
+          ...assemblyOptions,
+          assetsDirectory: directory,
+          draftVisibility: {
+            retryDelaysMs: [0],
+            wait: async () => assert.fail("duplicate drafts must not retry"),
+          },
+        },
+        client
+      ),
+      /Refusing ambiguous v0\.0\.8: found 2 releases \(42, 43\)/
+    );
+    assert.equal(listCount, 2);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("fails when a created draft never becomes list-visible", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "desktop-release-"));
+  try {
+    await writeReleaseAssets(directory);
+    const created = createRelease({ id: 42 });
+    let listCount = 0;
+    const client = {
+      async listReleases() {
+        listCount += 1;
+        return [];
+      },
+      async createDraft() {
+        return created;
+      },
+    };
+
+    await assert.rejects(
+      assembleDesktopRelease(
+        {
+          ...assemblyOptions,
+          assetsDirectory: directory,
+          draftVisibility: {
+            retryDelaysMs: [0, 0],
+            wait: async () => {},
+          },
+        },
+        client
+      ),
+      /Release 42 did not become visible while assembling v0\.0\.8 after 3 checks/
+    );
+    assert.equal(listCount, 4);
   } finally {
     await rm(directory, { force: true, recursive: true });
   }


### PR DESCRIPTION
## What changed

- Retry bounded release-list visibility checks when the expected numeric draft ID is temporarily absent.
- Continue failing immediately for a different ID, duplicate drafts, published or immutable releases, and target mismatches.
- Cover delayed visibility, bounded exhaustion, immediate conflicts, and duplicates discovered after uploads.

## Etiology

The v0.0.9001 smoke run created one draft successfully, but the immediately following release-list read did not yet include it. The assembler treated absence as a competing identity and failed before upload. The defect was in the API contract assumption: a successful create response is immediately authoritative, while collection visibility is eventually consistent.

## Validation

- Synthetic v0.0.9002 run passed all four platform builders and the single assembler job: https://github.com/gridaco/grida/actions/runs/29336085017
- Exactly one draft was created with all 11 expected uploaded assets, nonzero sizes, SHA-256 digests, and the correct target SHA.
- 14 assembler tests
- 112 Desktop tests
- Desktop typecheck
- oxlint, oxfmt, actionlint, and diff check