### PR TITLE
Update AI model catalogue for GPT-5.6 and Claude Fable 5

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,4 +1,7 @@
 ---
+title: Models & Pricing
+description: Compare Grida AI model tiers, context windows, token prices, and image generation costs.
+keywords: [AI models, AI pricing, GPT-5.6, Claude Fable 5, Grida AI]
 slug: pricing
 format: md
 ---
@@ -28,14 +31,15 @@ Models are organized into **tiers** based on capability and cost:
 
 ### Current Models
 
-| Tier   | Model                                         | Context | Max Output | Input (per 1M) | Output (per 1M) |
-| ------ | --------------------------------------------- | ------- | ---------- | -------------- | --------------- |
-| `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)          | 400K    | 128K       | $0.20          | $1.25           |
-| `mini` | GPT-5.4 Mini (`openai/gpt-5.4-mini`)          | 400K    | 128K       | $0.75          | $4.50           |
-| `pro`  | Claude Sonnet 5 (`anthropic/claude-sonnet-5`) | 1M      | 128K       | $3.00          | $15.00          |
-| `max`  | Claude Opus 4.8 (`anthropic/claude-opus-4.8`) | 1M      | 128K       | $5.00          | $25.00          |
+| Tier   | Model                                  | Context | Max Output | Input (per 1M) | Output (per 1M) |
+| ------ | -------------------------------------- | ------- | ---------- | -------------- | --------------- |
+| `nano` | GPT-5.4 Nano (`openai/gpt-5.4-nano`)   | 400K    | 128K       | $0.20          | $1.25           |
+| `mini` | GPT-5.6 Luna (`openai/gpt-5.6-luna`)   | 1.05M   | 128K       | $1.00          | $6.00           |
+| `pro`  | GPT-5.6 Terra (`openai/gpt-5.6-terra`) | 1.05M   | 128K       | $2.50          | $15.00          |
+| `max`  | GPT-5.6 Sol (`openai/gpt-5.6-sol`)     | 1.05M   | 128K       | $5.00          | $30.00          |
 
 All tier models support **multimodal** inputs (text + images).
+Claude Fable 5 and Claude Opus 4.8 remain active, non-tiered catalogue models.
 
 ### Cache Pricing
 
@@ -44,8 +48,8 @@ All tiers support prompt caching, which reduces cost for repeated context:
 | Tier   | Cache Read (per 1M) | Cache Write (per 1M) |
 | ------ | ------------------- | -------------------- |
 | `nano` | $0.02               | —                    |
-| `mini` | $0.075              | —                    |
-| `pro`  | $0.30               | $3.75                |
+| `mini` | $0.10               | $1.25                |
+| `pro`  | $0.25               | $3.125               |
 | `max`  | $0.50               | $6.25                |
 
 ### All Models
@@ -58,12 +62,22 @@ Per 1M tokens.
 | GPT-5.4 Mini (`openai/gpt-5.4-mini`)                         | $0.75  | —           | $0.075     | $4.50   |
 | Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Fable 5 (`anthropic/claude-fable-5`)                  | $10.00 | $12.50      | $1.00      | $50.00  |
 | Claude Opus 4.8 (`anthropic/claude-opus-4.8`)                | $5.00  | $6.25       | $0.50      | $25.00  |
 | Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
-| GPT-5.5 (`openai/gpt-5.5`)                                   | $5.00  | —           | $0.50      | $30.00  |
+| GPT-5.6 Sol (`openai/gpt-5.6-sol`)                           | $5.00  | $6.25       | $0.50      | $30.00  |
+| GPT-5.6 Terra (`openai/gpt-5.6-terra`)                       | $2.50  | $3.125      | $0.25      | $15.00  |
+| GPT-5.6 Luna (`openai/gpt-5.6-luna`)                         | $1.00  | $1.25       | $0.10      | $6.00   |
+| GPT-5.5 (`openai/gpt-5.5`) _(legacy)_                        | $5.00  | —           | $0.50      | $30.00  |
 | GPT-5.5 Pro (`openai/gpt-5.5-pro`)                           | $30.00 | —           | —          | $180.00 |
 | Gemini 3.5 Flash (`google/gemini-3.5-flash`)                 | $1.50  | —           | $0.15      | $9.00   |
 | Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`)     | $2.00  | —           | $0.20      | $12.00  |
+
+GPT-5.6 prices above are base rates. Requests with more than 272K input
+tokens are billed at 2x input and 1.5x output for the full request.
+
+`GPT-5.5` is deprecated in Grida's catalogue in favor of `GPT-5.6 Sol`;
+this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.
 
 ## Image Generation Models
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -73,8 +73,8 @@ Per 1M tokens.
 | Gemini 3.5 Flash (`google/gemini-3.5-flash`)                 | $1.50  | —           | $0.15      | $9.00   |
 | Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`)     | $2.00  | —           | $0.20      | $12.00  |
 
-GPT-5.6 prices above are base rates. Requests with more than 272K input
-tokens are billed at 2x input and 1.5x output for the full request.
+GPT-5.6 and GPT-5.5 prices above are base rates. Requests with more than 272K
+input tokens are billed at 2x input and 1.5x output for the full request.
 
 `GPT-5.5` is deprecated in Grida's catalogue in favor of `GPT-5.6 Sol`;
 this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.

--- a/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/chat/completions/route.test.ts
@@ -121,6 +121,16 @@ const USAGE: LanguageModelV3Usage = {
   outputTokens: { total: 20, text: 15, reasoning: 5 },
 };
 
+const LONG_CONTEXT_USAGE: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 272_001,
+    noCache: 200_001,
+    cacheRead: 70_000,
+    cacheWrite: 2_000,
+  },
+  outputTokens: { total: 1_000, text: 800, reasoning: 200 },
+};
+
 function clientModel(token: string, modelId = MODEL): LanguageModelV3 {
   const provider = createOpenAICompatible({
     name: "gg",
@@ -212,6 +222,23 @@ describe("POST /api/v1/ai/chat/completions (contract)", () => {
     const [orgArg, millsArg] = mockedIngest.mock.calls[0]!;
     expect(orgArg).toBe(ORG);
     expect(millsArg).toBeCloseTo(costMillsFromTokenUsage(MODEL, USAGE), 10);
+  });
+
+  it("bills GPT-5.6 long-context usage at the literal request-wide rate", async () => {
+    h.generate = {
+      content: [{ type: "text", text: "Done." }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: LONG_CONTEXT_USAGE,
+      warnings: [],
+    };
+    const model = clientModel(await mintedToken(), "openai/gpt-5.6-terra");
+
+    await model.doGenerate({ prompt: PROMPT });
+
+    expect(mockedIngest).toHaveBeenCalledTimes(1);
+    expect(mockedIngest.mock.calls[0]![0]).toBe(ORG);
+    // Terra above 272K: all input buckets ×2, all output ×1.5.
+    expect(mockedIngest.mock.calls[0]![1]).toBeCloseTo(1070.005, 10);
   });
 
   it("stream: tool-call arguments reassemble byte-for-byte; usage arrives; ingest fires", async () => {

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -50,10 +50,24 @@ describe("GET /api/v1/ai/models", () => {
 
     const byId = new Map(body.data.map((entry) => [entry.id, entry]));
     // Tier annotation via the reverse TIER_MODEL_IDS map.
-    expect(byId.get("anthropic/claude-sonnet-5")?.grida).toMatchObject({
-      modality: "text",
-      tier: "pro",
-    });
+    for (const [tier, id] of [
+      ["nano", "openai/gpt-5.4-nano"],
+      ["mini", "openai/gpt-5.6-luna"],
+      ["pro", "openai/gpt-5.6-terra"],
+      ["max", "openai/gpt-5.6-sol"],
+    ] as const) {
+      expect(byId.get(id)?.grida).toMatchObject({ modality: "text", tier });
+    }
+    for (const id of [
+      "anthropic/claude-fable-5",
+      "anthropic/claude-opus-4.8",
+    ]) {
+      expect(byId.get(id)?.grida).toMatchObject({
+        modality: "text",
+        tier: null,
+        deprecated: false,
+      });
+    }
     // Every modality is represented.
     const modalities = new Set(body.data.map((e) => e.grida.modality));
     expect(modalities).toEqual(new Set(["text", "image", "video"]));

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -413,7 +413,17 @@ function CatalogRow({ spec }: { spec: ModelSpec }) {
         <div className="flex items-center gap-2">
           {Logo && <Logo className="size-4 shrink-0" />}
           <div>
-            <div className="font-medium">{spec.label}</div>
+            <div className="flex items-center gap-1.5">
+              <span className="font-medium">{spec.label}</span>
+              {spec.deprecated && (
+                <Badge
+                  variant="outline"
+                  className="h-4 px-1.5 text-[10px] font-normal"
+                >
+                  Deprecated
+                </Badge>
+              )}
+            </div>
             <code className="text-xs text-muted-foreground">{spec.id}</code>
           </div>
         </div>

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -47,6 +47,9 @@ const Logos: Partial<Record<string, FC<{ className?: string }>>> = {
   google: GoogleLogo,
 };
 
+const LONG_CONTEXT_PRICING_NOTE =
+  "For GPT-5.5 and GPT-5.6 Sol, Terra, and Luna, requests above 272K total input tokens use 2× input/cache rates and 1.5× output rates for the full request.";
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function groupByVendor(
@@ -453,7 +456,9 @@ function CatalogSection() {
         <h3 className="text-lg font-semibold tracking-tight mb-1">
           All Models
         </h3>
-        <p className="text-xs text-muted-foreground">Per 1M tokens.</p>
+        <p className="text-xs text-muted-foreground">
+          Base rates per 1M tokens. {LONG_CONTEXT_PRICING_NOTE}
+        </p>
       </div>
       <div className="rounded-lg border overflow-hidden">
         <Table>
@@ -494,7 +499,8 @@ function TextModelsSection() {
       {/* Tier table */}
       <div className="container mx-auto px-4 pb-12">
         <p className="text-xs text-muted-foreground mb-2">
-          Cost columns are USD per 1M tokens.
+          Cost columns are base rates in USD per 1M tokens.{" "}
+          {LONG_CONTEXT_PRICING_NOTE}
         </p>
         <div className="rounded-lg border overflow-hidden">
           <Table>

--- a/editor/lib/ai/__tests__/server.test.ts
+++ b/editor/lib/ai/__tests__/server.test.ts
@@ -110,6 +110,62 @@ describe("costMillsFromTokenUsage", () => {
     expect(mills).toBeCloseTo(8.4);
   });
 
+  // GRIDA-GG: gateway — pin request pricing used by hosted chat metering.
+  it("keeps GPT-5.6 base rates at the 272K input boundary", () => {
+    const mills = costMillsFromTokenUsage("openai/gpt-5.6-terra", {
+      inputTokens: {
+        total: 272_000,
+        noCache: 180_000,
+        cacheRead: 72_000,
+        cacheWrite: 20_000,
+      },
+      outputTokens: { total: 10_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      ((180_000 * 2.5 + 72_000 * 0.25 + 20_000 * 3.125 + 10_000 * 15) /
+        1_000_000) *
+        1000
+    );
+  });
+
+  it("applies GPT-5.6 request-wide rates above 272K input", () => {
+    const mills = costMillsFromTokenUsage("openai/gpt-5.6-terra", {
+      inputTokens: {
+        total: 272_001,
+        noCache: 180_001,
+        cacheRead: 72_000,
+        cacheWrite: 20_000,
+      },
+      outputTokens: { total: 10_000, reasoning: 2_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      (((180_001 * 2.5 + 72_000 * 0.25 + 20_000 * 3.125) * 2 +
+        10_000 * 15 * 1.5) /
+        1_000_000) *
+        1000
+    );
+  });
+
+  it("derives total input from normalized buckets before applying the band", () => {
+    const mills = costMillsFromTokenUsage("openai/gpt-5.6-terra", {
+      inputTokens: {
+        noCache: 180_001,
+        cacheRead: 72_000,
+        cacheWrite: 20_000,
+      },
+      outputTokens: { total: 10_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      (((180_001 * 2.5 + 72_000 * 0.25 + 20_000 * 3.125) * 2 +
+        10_000 * 15 * 1.5) /
+        1_000_000) *
+        1000
+    );
+  });
+
   it("throws on unknown model id", () => {
     expect(() =>
       costMillsFromTokenUsage("acme/totally-fake-model", {

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -278,6 +278,7 @@ function resolveModelSpec(modelId: string): ModelSpec {
  * - cached input tokens charge at `cacheRead` rate (falls back to `input`)
  * - cache writes charge at `cacheWrite` rate (falls back to `input`)
  * - reasoning tokens are priced at the standard output rate
+ * - request-wide long-context multipliers use total input, including caches
  */
 export function costUsdFromTokenUsage(
   modelId: string,
@@ -286,19 +287,28 @@ export function costUsdFromTokenUsage(
   const spec = resolveModelSpec(modelId);
   const input = usage.inputTokens ?? {};
   const output = usage.outputTokens ?? {};
-  const inTotal = input.total ?? 0;
   const inCacheRead = input.cacheRead ?? 0;
   const inCacheWrite = input.cacheWrite ?? 0;
   const inNoCache =
-    input.noCache ?? Math.max(0, inTotal - inCacheRead - inCacheWrite);
+    input.noCache ??
+    Math.max(0, (input.total ?? 0) - inCacheRead - inCacheWrite);
+  const inTotal = input.total ?? inNoCache + inCacheRead + inCacheWrite;
   const outTotal = output.total ?? 0;
 
   const rates = spec.cost;
+  const longContext = rates.longContext;
+  const appliesLongContext =
+    longContext !== undefined && inTotal > longContext.inputTokensAbove;
+  const inputMultiplier = appliesLongContext ? longContext.inputMultiplier : 1;
+  const outputMultiplier = appliesLongContext
+    ? longContext.outputMultiplier
+    : 1;
   return (
-    (inNoCache * rates.input +
+    ((inNoCache * rates.input +
       inCacheRead * (rates.cacheRead ?? rates.input) +
-      inCacheWrite * (rates.cacheWrite ?? rates.input) +
-      outTotal * rates.output) /
+      inCacheWrite * (rates.cacheWrite ?? rates.input)) *
+      inputMultiplier +
+      outTotal * rates.output * outputMultiplier) /
     1_000_000
   );
 }

--- a/editor/scaffolds/desktop/shared/context-meter.tsx
+++ b/editor/scaffolds/desktop/shared/context-meter.tsx
@@ -62,7 +62,8 @@ export function DesktopContextMeter({
   messages: UIMessage[];
   /** Active model id — its resolved spec supplies the context window. */
   modelId: string;
-  /** Session cumulative model cost, already computed from per-turn model usage. */
+  /** Session cumulative base-rate estimate from aggregate per-turn usage.
+   * Request-level pricing bands are not reconstructible from this rollup. */
   costUsd?: number;
   /** Configured endpoint providers (issue #806) — registered local models
    *  resolve their real (often small) windows through these. */
@@ -163,7 +164,7 @@ export function DesktopContextMeter({
         </div>
         {typeof costUsd === "number" && costUsd > 0 ? (
           <div className="flex items-center justify-between border-t px-3 py-2 text-xs">
-            <span className="text-muted-foreground">Cost</span>
+            <span className="text-muted-foreground">Estimated base cost</span>
             <span className="font-mono tabular-nums">
               {formatCostUsd(costUsd)}
             </span>

--- a/editor/scaffolds/desktop/shared/default-model.test.ts
+++ b/editor/scaffolds/desktop/shared/default-model.test.ts
@@ -14,8 +14,8 @@ const knows =
     typeof id === "string" && ids.includes(id);
 
 describe("resolveDefaultModelId — the initial default for a new chat", () => {
-  it("defaults the picker to Claude Sonnet 5", () => {
-    expect(DEFAULT_MODEL_ID).toBe("anthropic/claude-sonnet-5");
+  it("defaults the picker to GPT-5.6 Terra", () => {
+    expect(DEFAULT_MODEL_ID).toBe("openai/gpt-5.6-terra");
   });
 
   it("upgrades the keyless default to the included tier when a GG session is live", () => {

--- a/packages/grida-ai-agent/src/session/cost.test.ts
+++ b/packages/grida-ai-agent/src/session/cost.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { costUsdFromMessageUsage, usageTokenTotal } from "./cost";
+import { baseCostUsdFromMessageUsage, usageTokenTotal } from "./cost";
 
 describe("session cost accounting", () => {
   it("sums all persisted usage buckets into the rollup token total", () => {
@@ -14,8 +14,8 @@ describe("session cost accounting", () => {
     ).toBe(28);
   });
 
-  it("uses the catalog card, including cache and reasoning rates", () => {
-    const cost = costUsdFromMessageUsage(
+  it("uses the base catalog card, including cache and reasoning rates", () => {
+    const cost = baseCostUsdFromMessageUsage(
       {
         provider_id: "openrouter",
         model_id: "anthropic/claude-sonnet-5",
@@ -35,9 +35,30 @@ describe("session cost accounting", () => {
     );
   });
 
+  it("does not apply request-level bands to an aggregate message rollup", () => {
+    const cost = baseCostUsdFromMessageUsage(
+      {
+        provider_id: "openrouter",
+        model_id: "openai/gpt-5.6-terra",
+      },
+      {
+        input: 200_001,
+        cache_read: 70_000,
+        cache_write: 2_000,
+        output: 800,
+        reasoning: 200,
+      }
+    );
+
+    expect(cost).toBeCloseTo(
+      (200_001 * 2.5 + 70_000 * 0.25 + 2_000 * 3.125 + 800 * 15 + 200 * 15) /
+        1_000_000
+    );
+  });
+
   it("returns undefined when no catalog price card is available", () => {
     expect(
-      costUsdFromMessageUsage(
+      baseCostUsdFromMessageUsage(
         { provider_id: "ollama", model_id: "acme/local-model" },
         { input: 1, output: 1 }
       )

--- a/packages/grida-ai-agent/src/session/cost.ts
+++ b/packages/grida-ai-agent/src/session/cost.ts
@@ -11,7 +11,14 @@ export function usageTokenTotal(usage: MessageUsage): number {
   );
 }
 
-export function costUsdFromMessageUsage(
+/**
+ * Estimate an assistant message at base catalogue rates.
+ *
+ * A message can aggregate several provider requests, so request-level pricing
+ * bands cannot be reconstructed from this rollup. Authoritative hosted billing
+ * is computed per request by the Grida Gateway billing seam.
+ */
+export function baseCostUsdFromMessageUsage(
   model: ChatModel | undefined,
   usage: MessageUsage
 ): number | undefined {

--- a/packages/grida-ai-agent/src/session/rows.ts
+++ b/packages/grida-ai-agent/src/session/rows.ts
@@ -57,8 +57,10 @@ export type ChatSessionRow = {
   cache_read: number;
   cache_write: number;
   total_tokens: number;
-  /** Derived from assistant-message `{ model, usage }`, including turns hidden
-   * by rewind or compaction; not authoritative billing state. */
+  /** Base-rate estimate derived from assistant-message `{ model, usage }`,
+   * including turns hidden by rewind or compaction. A message can aggregate
+   * multiple provider requests, so request-level bands are not reconstructible;
+   * this is not authoritative billing state. */
   cost_usd: number;
   created_at: number;
   updated_at: number;

--- a/packages/grida-ai-agent/src/session/store.ts
+++ b/packages/grida-ai-agent/src/session/store.ts
@@ -52,7 +52,7 @@ import type {
   SessionListFilter,
   SessionListPage,
 } from "./rows";
-import { costUsdFromMessageUsage, usageTokenTotal } from "./cost";
+import { baseCostUsdFromMessageUsage, usageTokenTotal } from "./cost";
 
 export type AppendMessageInput = {
   id?: string;
@@ -852,9 +852,10 @@ export class SessionsStore {
     return {
       ...session,
       // `chat_sessions.cost_usd` is a legacy persisted column. Public session
-      // rows expose cumulative cost as derived data from every assistant turn's
-      // model+usage. Unlike context rollups, spend does not disappear after a
-      // rewind or compaction.
+      // rows expose a cumulative base-rate estimate from every assistant
+      // turn's model+usage. Unlike context rollups, the estimate does not
+      // disappear after a rewind or compaction. Request-level bands cannot be
+      // reconstructed because one assistant turn may aggregate model steps.
       cost_usd: await this.sessionCostUsd(row.id),
     };
   }
@@ -888,7 +889,7 @@ export class SessionsStore {
       costs.set(
         row.session_id,
         (costs.get(row.session_id) ?? 0) +
-          (costUsdFromMessageUsage(meta.model, meta.usage) ?? 0)
+          (baseCostUsdFromMessageUsage(meta.model, meta.usage) ?? 0)
       );
     }
     return costs;

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -78,7 +78,8 @@ Each `ModelSpec` contains:
   (explicit on every entry; the agent loop is tool-heavy)
 - `contextWindow`
 - `outputLimit`
-- `cost`
+- `cost` — base token rates plus any provider-published request-wide
+  long-context multiplier
 - `deprecated` — optional Grida catalogue lifecycle marker; this does not
   imply that the upstream provider has retired the model
 

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -43,7 +43,7 @@ import models, { TIER_MODEL_IDS } from "@grida/ai-models";
 
 const proModelId = TIER_MODEL_IDS.pro;
 const proModel = models.text.byTier.pro;
-const spec = models.text.modelSpecById("claude-sonnet-4.6");
+const spec = models.text.modelSpecById("claude-fable-5");
 
 const imageModel = models.image.models["openai/gpt-image-2"];
 const compactImageModel = imageModel && models.image.toCompact(imageModel);
@@ -79,6 +79,8 @@ Each `ModelSpec` contains:
 - `contextWindow`
 - `outputLimit`
 - `cost`
+- `deprecated` — optional Grida catalogue lifecycle marker; this does not
+  imply that the upstream provider has retired the model
 
 Token costs are stored as USD per 1 million tokens.
 

--- a/packages/grida-ai-models/__tests__/modelSpecById.test.ts
+++ b/packages/grida-ai-models/__tests__/modelSpecById.test.ts
@@ -1,10 +1,27 @@
 import models, { TIER_MODEL_IDS } from "..";
 
 describe("models.text.modelSpecById", () => {
-  it("resolves an exact gateway id", () => {
-    const spec = models.text.modelSpecById("anthropic/claude-sonnet-4.6");
-    expect(spec?.id).toBe("anthropic/claude-sonnet-4.6");
-    expect(spec?.label).toBe("Claude Sonnet 4.6");
+  it.each([
+    {
+      id: "openai/gpt-5.6-sol",
+      label: "GPT-5.6 Sol",
+    },
+    {
+      id: "openai/gpt-5.6-terra",
+      label: "GPT-5.6 Terra",
+    },
+    {
+      id: "openai/gpt-5.6-luna",
+      label: "GPT-5.6 Luna",
+    },
+    {
+      id: "anthropic/claude-fable-5",
+      label: "Claude Fable 5",
+    },
+  ])("resolves the exact $id gateway id", ({ id, label }) => {
+    const spec = models.text.modelSpecById(id);
+    expect(spec?.id).toBe(id);
+    expect(spec?.label).toBe(label);
   });
 
   it("resolves a bare provider id", () => {

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -209,12 +209,24 @@ describe("models.text.byTier", () => {
 });
 
 describe("models.text current catalogue", () => {
+  const longContext = {
+    inputTokensAbove: 272_000,
+    inputMultiplier: 2,
+    outputMultiplier: 1.5,
+  } as const;
+
   const newModels = [
     {
       id: "openai/gpt-5.6-sol",
       contextWindow: 1_050_000,
       outputLimit: 128_000,
-      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+      cost: {
+        input: 5,
+        output: 30,
+        cacheRead: 0.5,
+        cacheWrite: 6.25,
+        longContext,
+      },
     },
     {
       id: "openai/gpt-5.6-terra",
@@ -225,13 +237,20 @@ describe("models.text current catalogue", () => {
         output: 15,
         cacheRead: 0.25,
         cacheWrite: 3.125,
+        longContext,
       },
     },
     {
       id: "openai/gpt-5.6-luna",
       contextWindow: 1_050_000,
       outputLimit: 128_000,
-      cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
+      cost: {
+        input: 1,
+        output: 6,
+        cacheRead: 0.1,
+        cacheWrite: 1.25,
+        longContext,
+      },
     },
     {
       id: "anthropic/claude-fable-5",
@@ -246,6 +265,20 @@ describe("models.text current catalogue", () => {
     expect(spec.contextWindow).toBe(expected.contextWindow);
     expect(spec.outputLimit).toBe(expected.outputLimit);
     expect(spec.cost).toEqual(expected.cost);
+  });
+
+  it("keeps the published long-context rule on every affected OpenAI card", () => {
+    for (const id of [
+      "openai/gpt-5.5",
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-terra",
+      "openai/gpt-5.6-luna",
+    ] as const) {
+      expect(models.text.catalog[id].cost.longContext).toEqual(longContext);
+    }
+    expect(
+      models.text.catalog["openai/gpt-5.5-pro"].cost.longContext
+    ).toBeUndefined();
   });
 
   it("keeps catalogue lifecycle markers scoped to the requested models", () => {

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -185,6 +185,15 @@ describe("models.video catalogue invariants", () => {
 });
 
 describe("models.text.byTier", () => {
+  it("pins the accepted capability and cost topology", () => {
+    expect(TIER_MODEL_IDS).toEqual({
+      nano: "openai/gpt-5.4-nano",
+      mini: "openai/gpt-5.6-luna",
+      pro: "openai/gpt-5.6-terra",
+      max: "openai/gpt-5.6-sol",
+    });
+  });
+
   it("exposes a spec for every tier", () => {
     expect(models.text.byTier.nano).toBeDefined();
     expect(models.text.byTier.mini).toBeDefined();
@@ -196,6 +205,60 @@ describe("models.text.byTier", () => {
     for (const tier of ["nano", "mini", "pro", "max"] as const) {
       expect(models.text.byTier[tier].id).toBe(TIER_MODEL_IDS[tier]);
     }
+  });
+});
+
+describe("models.text current catalogue", () => {
+  const newModels = [
+    {
+      id: "openai/gpt-5.6-sol",
+      contextWindow: 1_050_000,
+      outputLimit: 128_000,
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+    },
+    {
+      id: "openai/gpt-5.6-terra",
+      contextWindow: 1_050_000,
+      outputLimit: 128_000,
+      cost: {
+        input: 2.5,
+        output: 15,
+        cacheRead: 0.25,
+        cacheWrite: 3.125,
+      },
+    },
+    {
+      id: "openai/gpt-5.6-luna",
+      contextWindow: 1_050_000,
+      outputLimit: 128_000,
+      cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
+    },
+    {
+      id: "anthropic/claude-fable-5",
+      contextWindow: 1_000_000,
+      outputLimit: 128_000,
+      cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+    },
+  ] as const;
+
+  it.each(newModels)("stores the published $id rate card", (expected) => {
+    const spec = models.text.catalog[expected.id];
+    expect(spec.contextWindow).toBe(expected.contextWindow);
+    expect(spec.outputLimit).toBe(expected.outputLimit);
+    expect(spec.cost).toEqual(expected.cost);
+  });
+
+  it("keeps catalogue lifecycle markers scoped to the requested models", () => {
+    expect(models.text.catalog["openai/gpt-5.5"].deprecated).toBe(true);
+    expect(
+      models.text.catalog["openai/gpt-5.5-pro"].deprecated
+    ).toBeUndefined();
+    expect(
+      models.text.catalog["anthropic/claude-fable-5"].deprecated
+    ).toBeUndefined();
+    expect(
+      models.text.catalog["anthropic/claude-opus-4.8"].deprecated
+    ).toBeUndefined();
   });
 });
 

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -113,8 +113,8 @@ export namespace models {
       /** Cost per 1M tokens in USD. */
       cost: ModelCostPerMillion;
       /**
-       * Legacy/superseded marker. The model is still callable, but a newer
-       * sibling has taken its tier slot; UIs may hide or mark it.
+       * Grida catalogue lifecycle marker. The model is still callable, but
+       * Grida considers it superseded; UIs may hide or mark it.
        */
       deprecated?: boolean;
     }
@@ -176,6 +176,7 @@ export namespace models {
         contextWindow: 1_050_000,
         outputLimit: 128_000,
         cost: { input: 5, output: 30, cacheRead: 0.5 },
+        deprecated: true,
       },
       "openai/gpt-5.5-pro": {
         id: "openai/gpt-5.5-pro",
@@ -186,6 +187,54 @@ export namespace models {
         contextWindow: 1_050_000,
         outputLimit: 128_000,
         cost: { input: 30, output: 180 },
+      },
+      // Base rates. Requests with more than 272K input tokens are billed at
+      // 2x input and 1.5x output for the full request; the catalogue's flat
+      // ModelCostPerMillion shape does not yet represent conditional bands.
+      "openai/gpt-5.6-sol": {
+        id: "openai/gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        multimodal: true,
+        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_050_000,
+        outputLimit: 128_000,
+        cost: {
+          input: 5,
+          output: 30,
+          cacheRead: 0.5,
+          cacheWrite: 6.25,
+        },
+      },
+      "openai/gpt-5.6-terra": {
+        id: "openai/gpt-5.6-terra",
+        label: "GPT-5.6 Terra",
+        multimodal: true,
+        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_050_000,
+        outputLimit: 128_000,
+        cost: {
+          input: 2.5,
+          output: 15,
+          cacheRead: 0.25,
+          cacheWrite: 3.125,
+        },
+      },
+      "openai/gpt-5.6-luna": {
+        id: "openai/gpt-5.6-luna",
+        label: "GPT-5.6 Luna",
+        multimodal: true,
+        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_050_000,
+        outputLimit: 128_000,
+        cost: {
+          input: 1,
+          output: 6,
+          cacheRead: 0.1,
+          cacheWrite: 1.25,
+        },
       },
       // Standard rates stored as canonical (identical to Sonnet 4.6).
       // Anthropic ran an introductory discount ($2 in / $10 out / $0.20
@@ -213,6 +262,17 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
         deprecated: true,
+      },
+      "anthropic/claude-fable-5": {
+        id: "anthropic/claude-fable-5",
+        label: "Claude Fable 5",
+        short_label: "Fable 5",
+        multimodal: true,
+        imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_000_000,
+        outputLimit: 128_000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
       },
       "anthropic/claude-opus-4.8": {
         id: "anthropic/claude-opus-4.8",

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -75,6 +75,15 @@ export namespace models {
       cacheRead?: number;
       /** USD per 1M cached input tokens (write). `undefined` if not supported. */
       cacheWrite?: number;
+      /** Optional request-wide long-context pricing rule. */
+      longContext?: {
+        /** Apply when total input tokens are strictly greater than this value. */
+        inputTokensAbove: number;
+        /** Multiplier for every input bucket, including cache reads and writes. */
+        inputMultiplier: number;
+        /** Multiplier for every output bucket, including reasoning tokens. */
+        outputMultiplier: number;
+      };
     }
 
     /** An exact image media type accepted as model input. */
@@ -146,6 +155,17 @@ export namespace models {
       "image/heif",
     ] as const satisfies readonly ImageInputMime[];
 
+    // OpenAI bills the full request at these multipliers once its total input
+    // exceeds 272K tokens. The same rule is published for GPT-5.5 and every
+    // GPT-5.6 family member.
+    // https://developers.openai.com/api/docs/models/gpt-5.5
+    // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+    const OPENAI_LONG_CONTEXT_PRICING = {
+      inputTokensAbove: 272_000,
+      inputMultiplier: 2,
+      outputMultiplier: 1.5,
+    } as const satisfies NonNullable<ModelCostPerMillion["longContext"]>;
+
     const catalogSpecs = {
       "openai/gpt-5.4-nano": {
         id: "openai/gpt-5.4-nano",
@@ -175,7 +195,12 @@ export namespace models {
         tool_call: true,
         contextWindow: 1_050_000,
         outputLimit: 128_000,
-        cost: { input: 5, output: 30, cacheRead: 0.5 },
+        cost: {
+          input: 5,
+          output: 30,
+          cacheRead: 0.5,
+          longContext: OPENAI_LONG_CONTEXT_PRICING,
+        },
         deprecated: true,
       },
       "openai/gpt-5.5-pro": {
@@ -188,9 +213,8 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 30, output: 180 },
       },
-      // Base rates. Requests with more than 272K input tokens are billed at
-      // 2x input and 1.5x output for the full request; the catalogue's flat
-      // ModelCostPerMillion shape does not yet represent conditional bands.
+      // Base rates; OPENAI_LONG_CONTEXT_PRICING represents the request-wide
+      // band that applies above 272K total input tokens.
       "openai/gpt-5.6-sol": {
         id: "openai/gpt-5.6-sol",
         label: "GPT-5.6 Sol",
@@ -204,6 +228,7 @@ export namespace models {
           output: 30,
           cacheRead: 0.5,
           cacheWrite: 6.25,
+          longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
       "openai/gpt-5.6-terra": {
@@ -219,6 +244,7 @@ export namespace models {
           output: 15,
           cacheRead: 0.25,
           cacheWrite: 3.125,
+          longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
       "openai/gpt-5.6-luna": {
@@ -234,6 +260,7 @@ export namespace models {
           output: 6,
           cacheRead: 0.1,
           cacheWrite: 1.25,
+          longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
       // Standard rates stored as canonical (identical to Sonnet 4.6).

--- a/packages/grida-ai-models/src/tiers.ts
+++ b/packages/grida-ai-models/src/tiers.ts
@@ -37,9 +37,9 @@ export type ModelTier = "nano" | "mini" | "pro" | "max";
  */
 export const TIER_MODEL_IDS = {
   nano: "openai/gpt-5.4-nano",
-  mini: "openai/gpt-5.4-mini",
-  pro: "anthropic/claude-sonnet-5",
-  max: "anthropic/claude-opus-4.8",
+  mini: "openai/gpt-5.6-luna",
+  pro: "openai/gpt-5.6-terra",
+  max: "openai/gpt-5.6-sol",
 } as const satisfies Record<ModelTier, models.text.CatalogId>;
 
 /** Literal union of tier-mapped model ids (values of {@link TIER_MODEL_IDS}). */


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna plus Claude Fable 5 with provider-published capabilities and pricing
- deprecate GPT-5.5 while keeping GPT-5.5 Pro and Claude Opus 4.8 active
- map the catalogue tiers to GPT-5.4 Nano, GPT-5.6 Luna, GPT-5.6 Terra, and GPT-5.6 Sol
- represent OpenAI's strict >272K-input request-wide pricing rule for GPT-5.5 and the GPT-5.6 family, and apply it to hosted metering
- update the public catalogue, pricing documentation, desktop default assertion, model lookup coverage, hosted-model metadata assertions, and long-context price disclosures

Provider references:
- [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5)
- [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- [GPT-5.6 Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
- [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
- [Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview)

## User impact

Grida's model catalogue and tier-derived defaults now expose the accepted GPT-5.6 topology. Claude Fable 5 and Claude Opus 4.8 remain selectable as active, non-tiered catalogue models.

Hosted GPT-5.5 and GPT-5.6 requests above 272K total input tokens now debit the provider's request-wide 2x input/cache and 1.5x output rates. Exactly 272K remains at the published base rate.

Desktop session cost is explicitly labeled **Estimated base cost**: assistant-message usage can aggregate multiple provider requests, so nonlinear request bands cannot safely be reconstructed there. Authoritative hosted billing remains per request in the server seam.

## Etiology

- **Presentation:** valid long-context hosted requests were metered below provider cost.
- **Proximate cause:** the billing seam multiplied usage by a flat model card.
- **API contract:** the catalogue could not represent the provider's conditional request-wide rate.
- **Systemic fix:** the rule is stored once on every affected catalogue card and applied at the single per-request metering seam, with strict boundary, cached-input, missing-total, and gateway-ingest regressions.

## Security review

- **GRIDA-SEC-003:** verified organization resolution, unconditional entitlement gating, BYOK behavior, and the single provider seam are unchanged. Pricing is selected only after provider usage is returned.
- **GRIDA-SEC-006 / GRIDA-GG:** scoped-token minting, HS256/audience pinning, expiry, fail-closed secrets, exclusive `verifyGgToken` authentication, memory-only custody, and rate limiting are unchanged. The gateway contract test still uses a genuinely minted token and now asserts the literal premium debit.
- AI-seam audit: 2,081 files scanned, 0 violations.
- Added-line review found no credentials, internal identifiers/URLs, or machine-specific paths.

## Validation

- `pnpm --filter @grida/ai-models build`
- `pnpm --filter @grida/ai-models test` — 54 passed
- `pnpm --filter @grida/ai-models typecheck`
- targeted `@grida/agent` session tests — 62 passed
- `pnpm --filter @grida/agent typecheck`
- targeted editor billing/gateway tests — 24 passed
- `pnpm --filter editor typecheck`
- `pnpm --filter editor audit:ai-seam`
- `oxfmt --check`
- `oxlint` — 0 errors (4 pre-existing repository TODO warnings)
- `git diff --check`
