### PR TITLE
chore(desktop): prepare 0.0.9 release

### DIFF
--- a/.agents/skills/desktop/SKILL.md
+++ b/.agents/skills/desktop/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: desktop
 description: >-
-  Pure Electron work for Grida Desktop: BrowserWindow, preload,
+  Grida Desktop Electron shell and release-impact work: BrowserWindow, preload,
   `window.grida`, menus, protocol/deep links, file associations, Forge,
   path-scoped bridge security, Electron-only UI bugs, and CDP / Playwright
   verification. Use for `desktop/`, `editor/app/desktop/**`,
   `editor/scaffolds/desktop/**`, `editor/lib/desktop/**`, `/desktop/*` CSP,
-  and GRIDA-SEC-004. For the daemon/agent-tenant packages, sessions, tools, providers, or
-  `packages/grida-daemon/**` / `packages/grida-ai-agent/**`, use `agent-system`.
+  GRIDA-SEC-004, and deciding whether linked-package or hosted-renderer changes
+  require a native Desktop version bump or coordinated release. For implementing
+  daemon/agent-tenant core behavior, use `agent-system` as well.
 ---
 
 # Grida Desktop - Electron Shell
@@ -39,11 +40,14 @@ sessions, workspaces, providers, tool execution, HTTP routes, and tests in
   Electron" issues.
 - Verifying the desktop app through CDP / Playwright.
 - Touching CSP or proxy behavior for `/desktop/*`.
+- Auditing whether linked-package or hosted Desktop renderer changes require a
+  native version bump or coordinated release.
 
-Skip this skill when the change is core agent behavior that can be tested
-without Electron. Use `agent-system` for `packages/grida-daemon/**` / `packages/grida-ai-agent/**`,
-daemon HTTP routes, sessions, files/workspaces, providers, tools, runtime,
-skills, and BYOK/secrets.
+Use `agent-system` to implement core agent behavior that can be tested without
+Electron: `packages/grida-daemon/**`, `packages/grida-ai-agent/**`, daemon HTTP
+routes, sessions, files/workspaces, providers, tools, runtime, skills, and
+BYOK/secrets. Also use this skill when auditing whether that work changes the
+packaged Desktop payload or its compatibility with the hosted renderer.
 
 ---
 
@@ -241,6 +245,78 @@ When changing the bridge or navigation rules, review `SECURITY.md` and the
 4. Per-launch bridge credentials held in the preload closure, never exposed on
    `window.grida`.
 5. No bridge method may exfiltrate secrets or run arbitrary local code.
+
+---
+
+## Release impact and versioning
+
+Production Desktop has two independently shipped halves: the renderer loaded
+from `https://grida.co/desktop/*`, and the native app containing Electron plus
+the bundled daemon/agent sidecar. A change can require a Desktop release
+without touching `desktop/src/**`.
+
+At the start and before handoff, compare the branch with the latest published
+stable Desktop release:
+
+```bash
+LATEST_DESKTOP_TAG="$(
+  gh release list \
+    --repo gridaco/grida \
+    --exclude-drafts \
+    --exclude-pre-releases \
+    --limit 1 \
+    --json tagName \
+    --jq '.[0].tagName'
+)"
+if [ -z "$LATEST_DESKTOP_TAG" ]; then
+  echo "No published stable Desktop release found" >&2
+  exit 1
+fi
+git fetch origin "refs/tags/${LATEST_DESKTOP_TAG}:refs/tags/${LATEST_DESKTOP_TAG}"
+DESKTOP_RELEASE_PATHS=(
+  desktop
+  skills
+  packages/grida-ai-agent
+  packages/grida-daemon
+  packages/grida-ai-models
+  packages/grida-desktop-bridge
+  packages/grida-home
+  editor/app/desktop
+  editor/scaffolds/desktop
+  editor/lib/agent-chat
+  editor/lib/desktop
+  editor/proxy.ts
+)
+git diff --name-status "$LATEST_DESKTOP_TAG" -- "${DESKTOP_RELEASE_PATHS[@]}"
+git status --short -- "${DESKTOP_RELEASE_PATHS[@]}"
+
+CURRENT_DESKTOP_VERSION="$(node -p 'require("./desktop/package.json").version')"
+# Only `release not found` confirms this version is unused. Any other error
+# blocks the audit; do not reinterpret auth, network, or API failures.
+gh release view "v${CURRENT_DESKTOP_VERSION}" \
+  --repo gridaco/grida \
+  --json tagName,isDraft,isPrerelease,targetCommitish,url
+```
+
+Decide from the shipped boundary, not the directory name:
+
+- A change to `desktop/**`, `skills/**`, or a linked package in the command
+  changes the native payload. Bump `desktop/package.json` before publishing a
+  new native build when its current `v<version>` is already published, including
+  as a prerelease. The release assembler deliberately refuses to modify any
+  published release.
+- A renderer-only change needs no native version bump when it remains
+  compatible with the latest published sidecar.
+- A renderer change that sends a new model id, provider id, protocol field,
+  route, or bridge call that the published sidecar rejects is release-coupled.
+  Compare the validation code at the published tag and bump the Desktop
+  version, but block the incompatible hosted behavior until affected clients
+  are required to run that compatible version. Publishing or auto-update
+  notification alone does not update installed clients.
+
+When the scoped diff is non-empty, record one line in the PR description or
+handoff: `Desktop release impact: none`, `Desktop release impact: version bump
+included`, or `Desktop release impact: follow-up release required`.
 
 ---
 

--- a/.agents/skills/desktop/SKILL.md
+++ b/.agents/skills/desktop/SKILL.md
@@ -255,58 +255,25 @@ from `https://grida.co/desktop/*`, and the native app containing Electron plus
 the bundled daemon/agent sidecar. A change can require a Desktop release
 without touching `desktop/src/**`.
 
-At the start and before handoff, compare the branch with the latest published
-stable Desktop release:
+At the start and before handoff, run the bundled audit from the repository
+root. It reports the release-scoped diff, uncommitted paths, and whether the
+current Desktop version already has a GitHub release:
 
-```bash
-LATEST_DESKTOP_TAG="$(
-  gh release list \
-    --repo gridaco/grida \
-    --exclude-drafts \
-    --exclude-pre-releases \
-    --limit 1 \
-    --json tagName \
-    --jq '.[0].tagName'
-)"
-if [ -z "$LATEST_DESKTOP_TAG" ]; then
-  echo "No published stable Desktop release found" >&2
-  exit 1
-fi
-git fetch origin "refs/tags/${LATEST_DESKTOP_TAG}:refs/tags/${LATEST_DESKTOP_TAG}"
-DESKTOP_RELEASE_PATHS=(
-  desktop
-  skills
-  packages/grida-ai-agent
-  packages/grida-daemon
-  packages/grida-ai-models
-  packages/grida-desktop-bridge
-  packages/grida-home
-  editor/app/desktop
-  editor/scaffolds/desktop
-  editor/lib/agent-chat
-  editor/lib/desktop
-  editor/proxy.ts
-)
-git diff --name-status "$LATEST_DESKTOP_TAG" -- "${DESKTOP_RELEASE_PATHS[@]}"
-git status --short -- "${DESKTOP_RELEASE_PATHS[@]}"
-
-CURRENT_DESKTOP_VERSION="$(node -p 'require("./desktop/package.json").version')"
-# Only `release not found` confirms this version is unused. Any other error
-# blocks the audit; do not reinterpret auth, network, or API failures.
-gh release view "v${CURRENT_DESKTOP_VERSION}" \
-  --repo gridaco/grida \
-  --json tagName,isDraft,isPrerelease,targetCommitish,url
+```sh
+.agents/skills/desktop/scripts/audit-release-impact.sh
 ```
 
 Decide from the shipped boundary, not the directory name:
 
-- A change to `desktop/**`, `skills/**`, or a linked package in the command
-  changes the native payload. Bump `desktop/package.json` before publishing a
-  new native build when its current `v<version>` is already published, including
-  as a prerelease. The release assembler deliberately refuses to modify any
-  published release.
+- A change to `desktop/**`, `skills/**`, or a linked package reported by the
+  audit changes the native payload. Bump `desktop/package.json` before
+  publishing a new native build when its current `v<version>` is already
+  published, including as a prerelease. The release assembler deliberately
+  refuses to modify any published release.
 - A renderer-only change needs no native version bump when it remains
   compatible with the latest published sidecar.
+- A release workflow or assembler change is release-impacting but does not by
+  itself change the native payload; review its version/tag semantics directly.
 - A renderer change that sends a new model id, provider id, protocol field,
   route, or bridge call that the published sidecar rejects is release-coupled.
   Compare the validation code at the published tag and bump the Desktop

--- a/.agents/skills/desktop/scripts/audit-release-impact.sh
+++ b/.agents/skills/desktop/scripts/audit-release-impact.sh
@@ -22,7 +22,7 @@ latest_desktop_tag="$(
     --exclude-pre-releases \
     --limit 1 \
     --json tagName \
-    --jq '.[0].tagName'
+    --jq '.[0].tagName // empty'
 )"
 if [[ -z "$latest_desktop_tag" ]]; then
   echo "No published stable Desktop release found" >&2

--- a/.agents/skills/desktop/scripts/audit-release-impact.sh
+++ b/.agents/skills/desktop/scripts/audit-release-impact.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly REPOSITORY="gridaco/grida"
+readonly CANONICAL_REPOSITORY_URL="https://github.com/gridaco/grida.git"
+
+for command_name in gh git node; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command not found: $command_name" >&2
+    exit 1
+  fi
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+cd "$repository_root"
+
+latest_desktop_tag="$(
+  gh release list \
+    --repo "$REPOSITORY" \
+    --exclude-drafts \
+    --exclude-pre-releases \
+    --limit 1 \
+    --json tagName \
+    --jq '.[0].tagName'
+)"
+if [[ -z "$latest_desktop_tag" ]]; then
+  echo "No published stable Desktop release found" >&2
+  exit 1
+fi
+
+git fetch --quiet "$CANONICAL_REPOSITORY_URL" \
+  "refs/tags/${latest_desktop_tag}"
+baseline_commit="$(git rev-parse --verify 'FETCH_HEAD^{commit}')"
+
+readonly -a release_paths=(
+  .nvmrc
+  .github/release-notes/desktop.md
+  .github/scripts/assemble-desktop-release.mjs
+  .github/scripts/assemble-desktop-release.test.mjs
+  .github/workflows/realease-desktop-app.yml
+  .github/workflows/verify-desktop-package.yml
+  package.json
+  pnpm-lock.yaml
+  pnpm-workspace.yaml
+  turbo.json
+  desktop
+  skills
+  packages/grida-ai-agent
+  packages/grida-daemon
+  packages/grida-ai-models
+  packages/grida-desktop-bridge
+  packages/grida-home
+  editor/app/desktop
+  editor/scaffolds/desktop
+  editor/lib/agent-chat
+  editor/lib/desktop
+  editor/proxy.ts
+)
+
+echo "Latest published stable Desktop release: $latest_desktop_tag"
+echo
+echo "Release-scoped diff:"
+release_diff="$(
+  git diff --name-status "$baseline_commit" -- "${release_paths[@]}"
+)"
+if [[ -n "$release_diff" ]]; then
+  echo "$release_diff"
+else
+  echo "(none)"
+fi
+
+echo
+echo "Uncommitted release-scoped paths:"
+worktree_diff="$(git status --short -- "${release_paths[@]}")"
+if [[ -n "$worktree_diff" ]]; then
+  echo "$worktree_diff"
+else
+  echo "(none)"
+fi
+
+current_desktop_version="$(
+  node -p 'require("./desktop/package.json").version'
+)"
+release_endpoint="repos/${REPOSITORY}/releases/tags/v${current_desktop_version}"
+
+echo
+if release_json="$(
+  gh api "$release_endpoint" \
+    --jq '{tag_name,draft,prerelease,target_commitish,html_url}' 2>&1
+)"; then
+  echo "Current Desktop version release:"
+  echo "$release_json"
+elif [[ "$release_json" == *"(HTTP 404)"* ]]; then
+  upstream_push_access="$(
+    gh api "repos/${REPOSITORY}" --jq '.permissions.push // false'
+  )"
+  if [[ "$upstream_push_access" == "true" ]]; then
+    echo "Current Desktop version release: unused (v${current_desktop_version})"
+  else
+    echo "Current Desktop version release: no published release visible"
+    echo "Draft status: unknown without push access to ${REPOSITORY}"
+  fi
+else
+  echo "$release_json" >&2
+  exit 1
+fi

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],


### PR DESCRIPTION
Follow-up to #981.

## Summary

- bump Grida Desktop from `0.0.8` to `0.0.9` so the bundled GPT-5.6 catalogue and agent changes can ship in a new native release
- move the deterministic release audit into `.agents/skills/desktop/scripts/audit-release-impact.sh`, leaving the Desktop skill focused on invocation and decision rules
- audit the native bundle closure, hosted renderer seam, release machinery, and root build inputs against the latest published stable tag
- require an explicit PR release-impact verdict and an exact current-version release check, including prereleases

## Why

Production Desktop loads its renderer from `grida.co` while bundling the daemon, agent, and model catalogue in the native sidecar. A hosted renderer can therefore become incompatible with an installed sidecar even when no `desktop/src/**` file changes. The new guidance makes that independently shipped seam part of every Desktop release decision.

Desktop release impact: version bump included.

## Validation

- bundled release audit: baseline `v0.0.8`, current `v0.0.9` unused, no uncommitted release-scoped paths
- `bash -n .agents/skills/desktop/scripts/audit-release-impact.sh`
- Desktop tests: 112 passed
- Desktop typecheck
- Desktop skill `quick_validate.py`
- `oxfmt --check` on the skill and Desktop package manifest
- `git diff --check`
- GRIDA-SEC-004 review: enforcement code and boundary tags unchanged