### PR TITLE
ci(sanitize): engine-split forbidden-token probe (P1/P4) + last departed-path fixes

### DIFF
--- a/.agents/skills/naming/cases.md
+++ b/.agents/skills/naming/cases.md
@@ -22,7 +22,6 @@ short-published-name pattern — see the next table.
 | `packages/grida-canvas-io-figma` | `@grida/io-figma`    |
 | `packages/grida-canvas-tailwind` | `@grida/tailwindcss` |
 | `packages/grida-cmath`           | `@grida/cmath`       |
-| `packages/grida-reftest`         | `@grida/reftest`     |
 | `packages/react-p-queue`         | `react-p-queue`      |
 
 ## Route group charter (`editor/app/(*)/`)

--- a/.github/scripts/split-probe-allow.txt
+++ b/.github/scripts/split-probe-allow.txt
@@ -1,0 +1,13 @@
+# Earned exceptions to the engine-split forbidden-token probe.
+# Format: <tracked path><TAB><reason>. P4 fails if a grant stops matching.
+.agents/skills/docs-wg/SKILL.md	doctrine: names `crates/` as the anti-pattern authors must search for
+.agents/skills/io-grida/SKILL.md	truthful negative: states these files are NOT in this repo (tombstone doc)
+.agents/skills/links/SKILL.md	link doctrine: cites the departed path as its worked anti-example
+.agents/skills/naming/SKILL.md	cross-repo naming rationale names the engine crate inline (pointer paragraph)
+.agents/skills/naming/cases.md	crate-alignment doctrine referencing engine crates (pointer paragraph)
+.agents/skills/sdk-design/SKILL.md	scope gate names engine crates as governed surfaces (with repo attribution)
+.agents/skills/sdk-seam/SKILL.md	boundary archetype example (a crate + the binary that links it)
+AGENTS.md	the engine pointer paragraph — repo URL sits on the adjacent line
+fixtures/test-grida/	frozen snapshot — mirrors engine canon; edits happen upstream (see fixtures/README.md)
+fixtures/text-editor/	frozen snapshot — byte-parity with engine canon; v1.json is test-consumed
+supabase/drafts/20251214_grida_canvas_document_model.sql	draft provenance comment citing the engine schema file as of authoring

--- a/.github/scripts/split-probe.sh
+++ b/.github/scripts/split-probe.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# P1 — engine-split forbidden-token probe
+#
+# The Rust engine moved to gridaco/nothing. A reference that reads as current
+# but describes the departed tree is worse than no reference: an absent doc
+# makes you look, a confidently wrong one makes you act. This probe fails when
+# a departed path/toolchain token appears in tracked files as if it were still
+# local to this repo.
+#
+# Deliberate cross-repo POINTERS are exempt: any line that names the engine
+# repo explicitly (github.com/gridaco/nothing) is a pointer, not a lie.
+# Historical records (HISTORY.md, docs/_history, archived trees) are decay,
+# not lies — excluded. Earned exceptions live in split-probe-allow.txt
+# (path<TAB>reason; a trailing "/" grants a directory prefix), asserted
+# non-stale by the P4 half below.
+#
+# Derived from the extraction manifest (the path set that left this repo).
+# ---------------------------------------------------------------------------
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+TOKENS=(
+  'crates/'
+  'format/grida\.fbs'
+  'bin/activate-flatc'
+  'bin/activate-emsdk'
+  'third_party/usvg'
+  'third_party/externals'
+  'packages/grida-reftest'
+  'rust-toolchain\.toml'
+  'model-v2/'
+  'grida_wpt'
+  'cargo (build|test|check|clippy|fmt|run)'
+)
+
+# Trees that are historical/generated/deprecated by declaration — decay, not lies.
+EXCLUDES=(
+  ':!HISTORY.md'
+  ':!docs/_history'
+  ':!docs/@designto-code'
+  ':!docs/cli'
+  ':!apps/docs/build'
+  ':!pnpm-lock.yaml'
+  ':!.ref'
+  ':!.github/scripts/split-probe.sh'
+  ':!.github/scripts/split-probe-allow.txt'
+)
+
+ALLOW_FILE=".github/scripts/split-probe-allow.txt"
+PATTERN="$(IFS='|'; echo "${TOKENS[*]}")"
+
+# grep.threads=1: deterministic, low-memory. git grep exits 0 = hits,
+# 1 = no hits, anything else = the search itself failed — and a failed
+# search MUST fail the probe (a killed grep once produced a false "clean").
+set +e
+RAW=$(git -c grep.threads=1 grep -nIE "$PATTERN" -- . "${EXCLUDES[@]}" 2>&1)
+GREP_EXIT=$?
+set -e
+if [ "$GREP_EXIT" -gt 1 ]; then
+  echo "::error::[P1] git grep failed (exit $GREP_EXIT) — the probe cannot claim clean. Output:"
+  echo "$RAW" | head -5
+  exit 1
+fi
+
+# Exempt pointer lines (explicit engine-repo URL = deliberate cross-repo ref)
+HITS=$(echo "$RAW" | grep -v 'github\.com/gridaco/nothing' | grep -v '^$' || true)
+
+# Apply the allowlist: exact file grants, or directory-prefix grants (trailing /)
+if [ -s "$ALLOW_FILE" ]; then
+  while IFS=$'\t' read -r path _reason; do
+    [ -z "$path" ] && continue
+    case "$path" in \#*) continue ;; esac
+    case "$path" in
+      */) HITS=$(echo "$HITS" | grep -v "^$path" || true) ;;
+      *)  HITS=$(echo "$HITS" | grep -v "^$path:" || true) ;;
+    esac
+  done < "$ALLOW_FILE"
+fi
+
+# ---- P4 half: the allowlist itself must not go stale (fail-open guard) ----
+P4_FAIL=0
+if [ -s "$ALLOW_FILE" ]; then
+  while IFS=$'\t' read -r path _reason; do
+    [ -z "$path" ] && continue
+    case "$path" in \#*) continue ;; esac
+    case "$path" in
+      */)
+        if [ -z "$(git ls-files "$path" | head -1)" ]; then
+          echo "::error::[P4] allowlist grants a directory with no tracked files: $path"
+          P4_FAIL=1
+        elif ! echo "$RAW" | grep -q "^$path"; then
+          echo "::error::[P4] allowlist directory grant no longer matches anything — remove it: $path"
+          P4_FAIL=1
+        fi
+        ;;
+      *)
+        if ! git ls-files --error-unmatch "$path" >/dev/null 2>&1; then
+          echo "::error::[P4] allowlist grants a path that no longer exists: $path"
+          P4_FAIL=1
+        elif ! echo "$RAW" | grep -q "^$path:"; then
+          echo "::error::[P4] allowlist grants a path with no matches — remove the stale grant: $path"
+          P4_FAIL=1
+        fi
+        ;;
+    esac
+  done < "$ALLOW_FILE"
+fi
+
+if [ -n "$HITS" ]; then
+  echo "::error::[P1] departed-engine references found (fix, point at github.com/gridaco/nothing, or add an allowlist grant with a reason):"
+  echo "$HITS" | head -60
+  echo "---"
+  echo "$HITS" | cut -d: -f1 | sort -u | sed 's/^/  /'
+  exit 1
+fi
+
+[ "$P4_FAIL" -ne 0 ] && exit 1
+echo "[split-probe] clean — no departed-engine references outside pointers/allowlist."
+exit 0

--- a/.github/workflows/split-probe.yml
+++ b/.github/workflows/split-probe.yml
@@ -1,0 +1,20 @@
+# Engine-split sanitization probe (P1 forbidden-token + P4 allowlist-freshness).
+# The engine lives in gridaco/nothing; this repo must not accumulate references
+# that describe the departed tree as if it were local. See .github/scripts/split-probe.sh.
+name: split probe
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  probe:
+    name: departed-engine references
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run the probe
+        run: bash .github/scripts/split-probe.sh

--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -7,7 +7,6 @@
     "sortScripts": true,
   },
   "ignorePatterns": [
-    "third_party/externals/",
     ".ref/",
     ".json5",
     "data/",

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -51,7 +51,6 @@
     "es2024": true,
   },
   "ignorePatterns": [
-    "third_party/externals/",
     ".ref/",
     "data/",
     "bin/",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ contain Rust code and needs no Rust toolchain — the editor consumes the
 published `@grida/canvas-wasm` package from npm. To contribute to the engine
 itself, see that repository.
 
+### Where work gets filed
+
+- **[gridaco/nothing](https://github.com/gridaco/nothing)**: engine rendering,
+  the node/document model, `.grida` format/schema, engine text/SVG/HTML import,
+  reftests and engine perf, `@grida/canvas-wasm` publishing, engine WG specs.
+- **This repo**: the editor/product, desktop, forms/database, the SVG editor
+  (TS), platform/billing, and everything user-facing.
+- When unsure: file where the fix would land. Cross-repo references are always
+  full `gridaco/<repo>#N` form — never bare `#N`.
+
 Then, install the dependencies and run the development server:
 
 ```bash

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -119,7 +119,7 @@ pages, the short version:
 
 - Links **within `/docs`** (relative paths between docs pages) are fine.
 - **Never link outside `/docs` with a relative path** — only `/docs/**`
-  is deployed, so `../../../crates/...` 404s on the site. Use an
+  is deployed, so `../../../editor/...` 404s on the site. Use an
   absolute GitHub URL:
   `https://github.com/gridaco/grida/blob/main/<path>`.
 - Links to **external URLs** (`https://...`) are fine.

--- a/docs/wg/feat-svg-editor/hit-test.md
+++ b/docs/wg/feat-svg-editor/hit-test.md
@@ -286,7 +286,7 @@ complexity in picker.
 ### (W) WASM SVG / CSS renderer
 
 We don't ship our own renderer for this package today. If we did
-(parity with the `crates/grida` canvas), hit-testing comes along
+(parity with the [engine canvas](https://github.com/gridaco/nothing/tree/main/crates/grida)), hit-testing comes along
 naturally because we own every paint decision. Not a v1 or v2 option —
 mentioned for completeness.
 
@@ -454,6 +454,6 @@ reproduced bad versions of them in user code. v2 should reuse them.
 
 - `packages/grida-svg-editor/docs/geometry.md` — how `bounds_of`
   composes CTM. Read before v2. (Lands with the implementation slice.)
-- `crates/grida` — the WASM-rendered canvas; if `@grida/svg-editor`
-  ever ports to a non-DOM backend, hit-testing follows the renderer
-  there too.
+- [the engine canvas](https://github.com/gridaco/nothing/tree/main/crates/grida) —
+  the WASM-rendered canvas; if `@grida/svg-editor` ever ports to a
+  non-DOM backend, hit-testing follows the renderer there too.

--- a/editor/grida-canvas/render-policy-flags.ts
+++ b/editor/grida-canvas/render-policy-flags.ts
@@ -1,7 +1,7 @@
 /**
  * Render-policy bitflags used by the WASM renderer.
  *
- * **Source of truth**: `crates/grida/src/runtime/render_policy.rs`
+ * **Source of truth**: https://github.com/gridaco/nothing/blob/main/crates/grida/src/runtime/render_policy.rs
  *
  * These flags are an ABI boundary between the TypeScript editor runtime and the
  * Rust renderer (via `@grida/canvas-wasm`).

--- a/editor/scaffolds/sidecontrol/controls/icons/stroke-decoration-icons.tsx
+++ b/editor/scaffolds/sidecontrol/controls/icons/stroke-decoration-icons.tsx
@@ -1,7 +1,8 @@
 /**
  * SVG icons for stroke decoration presets.
  *
- * Proportions match the Rust shape spec (crates/grida/src/shape/marker.rs):
+ * Proportions match the Rust shape spec
+ * (https://github.com/gridaco/nothing/blob/main/crates/grida/src/shape/marker.rs):
  * - Arrow lines: right-triangle, arms 45° (depth = size, half_h = size); scaled to fit.
  * - Triangle: depth = s*1.5, half_h = s*0.866, s = size*0.8.
  * - Circle: r = size*0.6, depth = 2r.

--- a/editor/skip-build.sh
+++ b/editor/skip-build.sh
@@ -38,7 +38,6 @@ DEPS=(
   "editor/"
   "database/"             # @app/database
   "packages/"             # most @grida/* deps
-  "crates/grida-canvas-wasm/"  # @grida/canvas-wasm (lives under crates/)
 
   # build orchestration at the repo root
   "/package.json"

--- a/packages/grida-canvas-hud/classes/text-edit/surface.ts
+++ b/packages/grida-canvas-hud/classes/text-edit/surface.ts
@@ -5,7 +5,7 @@
 // content-edit. Both are composited ON the HUD canvas, above the content and
 // the selection box, so the caret is never occluded and the thickness stays
 // constant at any zoom. This mirrors the Skia text-edit overlay
-// (`crates/grida/src/overlay/widgets/text_edit_decoration.rs`).
+// (https://github.com/gridaco/nothing/blob/main/crates/grida/src/overlay/widgets/text_edit_decoration.rs).
 //
 // Anti-goals (what this class is NOT):
 //

--- a/packages/grida-canvas-sdk-render-figma/lib.ts
+++ b/packages/grida-canvas-sdk-render-figma/lib.ts
@@ -11,7 +11,7 @@ import { createCanvas, type Canvas, type types } from "@grida/canvas-wasm";
 /**
  * TODO: remove once @grida/canvas-wasm with Canvas.switchScene /
  * Canvas.loadedSceneIds is published and depended on. The passthroughs
- * already exist on HEAD at crates/grida-canvas-wasm/lib/index.ts but are
+ * already exist in the engine repo's grida-canvas-wasm lib (github.com/gridaco/nothing) but are
  * not in canary.19 or older — we reach into the inner `_scene` field
  * until a newer version ships.
  */

--- a/packages/grida-format/README.md
+++ b/packages/grida-format/README.md
@@ -4,7 +4,7 @@ Generated TypeScript bindings for the Grida FlatBuffers schema.
 
 ## Overview
 
-This package contains **generated-only** TypeScript code produced from [`format/grida.fbs`](../../format/grida.fbs) using the FlatBuffers compiler (`flatc`).
+This package contains **generated-only** TypeScript code produced from [`format/grida.fbs`](https://github.com/gridaco/nothing/blob/main/format/grida.fbs) using the FlatBuffers compiler (`flatc`).
 
 ## Generating Code
 

--- a/packages/grida-text-editor/README.md
+++ b/packages/grida-text-editor/README.md
@@ -22,7 +22,7 @@ implementations.
   backend. SVG backend ships in V1; DOM and canvas backends are future
   work _outside_ the package's responsibility.
 - **Rust-code style** — file names and command vocabulary mirror
-  [`crates/grida/src/text_edit/`](../../crates/grida/src/text_edit/) so
+  [the engine's `text_edit`](https://github.com/gridaco/nothing/tree/main/crates/grida/src/text_edit) so
   cross-referencing the two is friction-free.
 - **Engine-grade testability** — pure layers (session, commands,
   history, boundaries) are unit-tested against a `MockLayoutEngine`
@@ -113,7 +113,7 @@ The package doesn't:
 
 V1 is plaintext only. Run-based attributed text (bold/italic/font-swap
 _within_ one editable text) is out of scope for V1; tracked for V2 by
-mirroring `crates/grida/src/text_edit/attributed_text/`.
+mirroring the engine's `text_edit/attributed_text/`.
 
 ### Block structure
 
@@ -164,7 +164,7 @@ refuses to define them.
 
 ## Naming conventions (Rust-style)
 
-The package mirrors `crates/grida/src/text_edit/` so cross-referencing
+The package mirrors the engine's `text_edit` module so cross-referencing
 is friction-free. Identifiers follow the Rust crate's casing; file
 names use kebab-case (TS norm) so the module tree is greppable across
 both languages while the on-disk filenames remain idiomatic for the
@@ -219,8 +219,8 @@ TS ecosystem.
 - WG manifesto: [`docs/wg/feat-text-editing/index.md`](../../docs/wg/feat-text-editing/index.md)
 - Attributed text spec: [`docs/wg/feat-text-editing/attributed-text.md`](../../docs/wg/feat-text-editing/attributed-text.md)
 - Performance roadmap: [`docs/wg/feat-text-editing/impl-performance.md`](../../docs/wg/feat-text-editing/impl-performance.md)
-- Reference Rust impl: [`crates/grida/src/text_edit/`](../../crates/grida/src/text_edit/) (~11.7k LoC; the bulk is `attributed_text/` for V2)
-- Reference Rust example: [`crates/grida_dev/examples/wd_text_editor.rs`](../../crates/grida_dev/examples/wd_text_editor.rs)
+- Reference Rust impl: [the engine's `text_edit`](https://github.com/gridaco/nothing/tree/main/crates/grida/src/text_edit) (~11.7k LoC; the bulk is `attributed_text/` for V2)
+- Reference Rust example: [`wd_text_editor.rs`](https://github.com/gridaco/nothing/blob/main/crates/grida_dev/examples/wd_text_editor.rs)
 - Main editor's current integration: [`editor/grida-canvas-react/viewport/ui/surface-text-editor.tsx`](../../editor/grida-canvas-react/viewport/ui/surface-text-editor.tsx)
 - Fixtures skill: [`.agents/skills/fixtures/SKILL.md`](../../.agents/skills/fixtures/SKILL.md)
 - Existing SVG text fixtures: `fixtures/test-svg/L0/text-*.svg`

--- a/packages/grida-text-editor/src/boundaries.ts
+++ b/packages/grida-text-editor/src/boundaries.ts
@@ -124,7 +124,7 @@ export function prev_word(text: string, index: number): number {
  * containing `index`. Falls back to a zero-length range if `index` is
  * out of bounds. Used by word-granularity delete/backspace so the
  * operation matches the canonical UAX-29 segment-based behavior of
- * `crates/grida/src/text_edit/` and the shared-fixture suite:
+ * the engine's `text_edit` (github.com/gridaco/nothing) and the shared-fixture suite:
  * a word-delete at "hello |world" (caret = 6, right after the space)
  * removes only the space, yielding "helloworld", not "world".
  */

--- a/packages/grida-text-editor/src/edit-command.ts
+++ b/packages/grida-text-editor/src/edit-command.ts
@@ -1,7 +1,7 @@
 /**
  * Command vocabulary + dispatcher.
  *
- * Mirrors `crates/grida/src/text_edit/`'s `EditingCommand` enum.
+ * Mirrors the engine `text_edit` `EditingCommand` enum (https://github.com/gridaco/nothing/tree/main/crates/grida/src/text_edit).
  * `apply_command` takes a session and a command, mutates the session,
  * and returns an `EditKind` (for history grouping) or `null` when the
  * command was non-mutating (caret/selection only).
@@ -106,7 +106,7 @@ export function apply_command(
     case "move_left": {
       // Selection + arrow WITHOUT extend = collapse to the boundary;
       // the caret does NOT move past it by an extra grapheme. Matches
-      // every native text editor (and `crates/grida/src/text_edit/`).
+      // every native text editor (and the engine's `text_edit`).
       const sel = session.selection;
       if (sel && !cmd.extend) {
         session.moveCaret(sel.start, false);

--- a/packages/grida-text-editor/src/history.ts
+++ b/packages/grida-text-editor/src/history.ts
@@ -1,7 +1,7 @@
 /**
  * Session-internal undo/redo stack with merge-by-EditKind grouping.
  *
- * Mirrors `crates/grida/src/text_edit/history.rs`. Same `EditKind`
+ * Mirrors the engine's `text_edit/history.rs` (https://github.com/gridaco/nothing/blob/main/crates/grida/src/text_edit/history.rs). Same `EditKind`
  * vocabulary, same 2-second merge timeout. Stores snapshots, not
  * diffs — fine at our text lengths.
  *

--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,7 @@ This directory contains structured test case (TC) specifications for behaviors t
 
 ## What does NOT belong here
 
-Core math, algorithmic, or low-level features should be covered by formal unit/integration tests co-located with their source code (`__tests__/`, `*.test.ts`, `cargo test`). Only add entries here when automated testing is impractical or would bloat the test suite unnecessarily.
+Core math, algorithmic, or low-level features should be covered by formal unit/integration tests co-located with their source code (`__tests__/`, `*.test.ts`). Only add entries here when automated testing is impractical or would bloat the test suite unnecessarily.
 
 ## File naming
 


### PR DESCRIPTION
Post-merge follow-up to #988 (the engine split).

## What

**The P1 probe** (`.github/scripts/split-probe.sh`, wired via `split-probe.yml` on push/PR): fails when a departed engine path or toolchain token (`crates/`, `format/grida.fbs`, `bin/activate-*`, `third_party/*`, `packages/grida-reftest`, `model-v2/`, cargo commands, …) appears in tracked files **as if it were still local to this repo**. A reference that reads as current but describes the departed tree is worse than no reference — an absent doc makes you look; a confidently wrong one makes you act.

- Deliberate cross-repo **pointers** are exempt: any line naming `github.com/gridaco/nothing` explicitly.
- Historical records (`HISTORY.md`, `docs/_history`, archived/deprecated trees) are decay, not lies — excluded.
- Earned doctrine exceptions live in `split-probe-allow.txt`, each with a reason.
- **P4 half**: a stale allowlist grant (path deleted, or no longer matching) fails the run too — the allowlist cannot rot silently.

**The fixes** the probe caught on its first run (everything else was already clean):
- dead `third_party/externals/` ignore patterns in `.oxfmtrc.jsonc` / `.oxlintrc.jsonc`
- dead `crates/grida-canvas-wasm/` dep entry in `editor/skip-build.sh`
- departed `@grida/reftest` row in `naming/cases.md`
- `docs/AGENTS.md` linking-rule example updated off the departed path
- absolute engine-repo URLs for the three "source of truth" references: `docs/wg/feat-svg-editor/hit-test.md`, `editor/grida-canvas/render-policy-flags.ts`, `editor/scaffolds/sidecontrol/controls/icons/stroke-decoration-icons.tsx`

**Plus**: `CONTRIBUTING.md` gains the standing filing rule (engine work → [gridaco/nothing](https://github.com/gridaco/nothing); product → here) — the tracker-sweep's permanent deliverable. The nothing-side counterpart is already on its `main`.

## Verification

Probe runs clean on this branch · workflow YAML validated · `fmt`/`lint` green · doc/comment/config-only changes (no runtime surface).