### PR TITLE
docs: entry-doc accuracy pass (post-split audit)

### DIFF
--- a/.agents/skills/docs-wg/SKILL.md
+++ b/.agents/skills/docs-wg/SKILL.md
@@ -69,7 +69,7 @@ study established; research that surveys how the domain is understood.
   by being correct and findable, not long.
 - **Domain-first.** It studies the _problem_, not Grida's solution to it.
 
-> **The dedicated upstream-survey subtree is `docs/wg/research/**`**, and
+> **The dedicated upstream-survey subtree is the engine repo's `docs/wg/research/**`** (github.com/gridaco/nothing), and
 it has its own stricter rules (pure survey, Grida absent from the body).
 When writing there, use [`research`](https://github.com/gridaco/nothing/blob/main/.agents/skills/research/SKILL.md) — it governs
 > that subtree specifically. This skill governs the broader WG surface.

--- a/.agents/skills/grounding/scripts/docsearch.py
+++ b/.agents/skills/grounding/scripts/docsearch.py
@@ -19,7 +19,7 @@ COMMANDS
                              counts + drift (defined-unused / used-undefined).
   find  [filters] [SUBDIR…]  Docs whose frontmatter matches ALL filters.
                              Optional SUBDIR args scope the scan (relative
-                             to docs root, e.g. `wg/feat-svg reference`).
+                             to docs root, e.g. `wg/feat-fig reference`).
   show  PATH                 Parsed frontmatter for one file (path is
                              relative to cwd or docs root).
 

--- a/.github/scripts/split-probe-allow.txt
+++ b/.github/scripts/split-probe-allow.txt
@@ -11,3 +11,5 @@ AGENTS.md	the engine pointer paragraph — repo URL sits on the adjacent line
 fixtures/test-grida/	frozen snapshot — mirrors engine canon; edits happen upstream (see fixtures/README.md)
 fixtures/text-editor/	frozen snapshot — byte-parity with engine canon; v1.json is test-consumed
 supabase/drafts/20251214_grida_canvas_document_model.sql	draft provenance comment citing the engine schema file as of authoring
+packages/dotcanvas/CHANGELOG.md	changelog — historical record (decay, not a lie); cites the spec path as of each release
+packages/grida-format/src/grida/	flatc tombstone — generated output, byte-parity forbids edits; schema-comment refs fixed upstream in the engine repo

--- a/.github/scripts/split-probe.sh
+++ b/.github/scripts/split-probe.sh
@@ -32,6 +32,10 @@ TOKENS=(
   'model-v2/'
   'grida_wpt'
   'cargo (build|test|check|clippy|fmt|run)'
+  # moved docs/wg clusters (feat-svg guarded against the staying feat-svg-editor)
+  'docs/wg/(canvas|format|research)'
+  'docs/wg/feat-(2d|crdt|css|fontgen|hash-nch|history|icu-uct|image-filters|layout|masks|painting|paragraph|resources|schema|text-editing|tray|vector-network)'
+  'docs/wg/feat-svg(/|[^-])'
 )
 
 # Trees that are historical/generated/deprecated by declaration — decay, not lies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ We use supabase for database, auth, and storage.
 - /supabase
   - ~~/functions~~ - we are not using supabase edge functions.
   - /migrations - applied migration sqls.
-  - /schema - human friendly organized schema sqls.
+  - /schemas - human friendly organized schema sqls.
 
 - To run supabase locally, follow the instructions in the [supabase docs](https://supabase.com/docs/guides/local-development).
 - To suggest a new feature, use `supabase migration new <feature-name>`.
@@ -175,13 +175,13 @@ To run test, build, and dev, use below commands.
 just fmt
 
 # run tests
-turbo test
+pnpm turbo test
 
 # run tests for packages
-turbo test --filter='./packages/*'
+pnpm turbo test --filter='./packages/*'
 
 # build packages (required for typecheck for its dependants)
-turbo build --filter='./packages/*'
+pnpm turbo build --filter='./packages/*'
 
 # build packages in watch mode
 pnpm dev:packages
@@ -190,13 +190,13 @@ pnpm dev:packages
 pnpm lint
 
 # run build (all, not recommended)
-turbo build
+pnpm turbo build
 
 # run dev
-turbo dev
+pnpm turbo dev
 
 # run typecheck (always run)
-turbo typecheck # fallback when build fails due to network issues (nextjs package might fail due to font fetching issues)
+pnpm turbo typecheck # fallback when build fails due to network issues (nextjs package might fail due to font fetching issues)
 ```
 
 > **Important for agents:** Formatting and linting run automatically on commit via lefthook pre-commit hooks (`oxfmt`, `oxlint`). You can also run `just fmt` manually. `oxfmt` is enforced in CI — PRs will fail format checks if code is not formatted. (Rust tooling lives with the engine repo.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,24 +33,6 @@ brew install just
 brew install typos-cli
 ```
 
-## The Rust engine
-
-The Rust rendering engine (canvas WASM) is developed in
-[gridaco/nothing](https://github.com/gridaco/nothing). This repo does not
-contain Rust code and needs no Rust toolchain — the editor consumes the
-published `@grida/canvas-wasm` package from npm. To contribute to the engine
-itself, see that repository.
-
-### Where work gets filed
-
-- **[gridaco/nothing](https://github.com/gridaco/nothing)**: engine rendering,
-  the node/document model, `.grida` format/schema, engine text/SVG/HTML import,
-  reftests and engine perf, `@grida/canvas-wasm` publishing, engine WG specs.
-- **This repo**: the editor/product, desktop, forms/database, the SVG editor
-  (TS), platform/billing, and everything user-facing.
-- When unsure: file where the fix would land. Cross-repo references are always
-  full `gridaco/<repo>#N` form — never bare `#N`.
-
 Then, install the dependencies and run the development server:
 
 ```bash
@@ -93,6 +75,24 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 ### Signing in locally
 
 After `supabase db reset --local` runs, `supabase/seed.sql` creates three test users you can sign in as via the `/sign-in` route. The default for normal flows is **`insider@grida.co` / `password`** (owner of the `local` org). See [`supabase/seed.md`](./supabase/seed.md) for the other personas (`alice@acme.com` for multi-tenant testing, `random@example.com` for no-org access checks). All three share the password `password`.
+
+## The Rust engine
+
+The Rust rendering engine (canvas WASM) is developed in
+[gridaco/nothing](https://github.com/gridaco/nothing). This repo does not
+contain Rust code and needs no Rust toolchain — the editor consumes the
+published `@grida/canvas-wasm` package from npm. To contribute to the engine
+itself, see that repository.
+
+### Where work gets filed
+
+- **[gridaco/nothing](https://github.com/gridaco/nothing)**: engine rendering,
+  the node/document model, `.grida` format/schema, engine text/SVG/HTML import,
+  reftests and engine perf, `@grida/canvas-wasm` publishing, engine WG specs.
+- **This repo**: the editor/product, desktop, forms/database, the SVG editor
+  (TS), platform/billing, and everything user-facing.
+- When unsure: file where the fix would land. Cross-repo references are always
+  full `gridaco/<repo>#N` form — never bare `#N`.
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,11 +95,13 @@ as public.
    when the signing secret is missing in production.
 4. **Replay protection** — receivers dedup on event id and reject
    events older than 5 minutes (where applicable).
-5. **Tunnel path filter at the edge** —
-   [editor/scripts/billing/tunnel.sh](editor/scripts/billing/tunnel.sh)
-   configures cloudflared to forward only `/webhooks/*` and reject
-   everything else with 404. Defense-in-depth at the network layer:
-   even if app code drifts, the tunnel cannot expose non-webhook paths.
+5. **Tunnel path filter at the edge** — cloudflared is configured to
+   forward only `/webhooks/*` and reject everything else with 404.
+   Defense-in-depth at the network layer: even if app code drifts, the
+   tunnel cannot expose non-webhook paths. The tunnel config is
+   **deliberately not git-tracked** (it lives in the operator's
+   `~/.cloudflared/`); setup is documented in
+   [docs/contributing/billing.md](docs/contributing/billing.md) §7.
 
 **Files bound by this id.** Run `grep -rn GRIDA-SEC-001 .` to enumerate.
 Today:
@@ -108,7 +110,7 @@ Today:
 - [editor/app/(ingest)/webhooks/stripe/route.ts](<editor/app/(ingest)/webhooks/stripe/route.ts>) — Stripe receiver.
 - [editor/app/(ingest)/webhooks/metronome/route.ts](<editor/app/(ingest)/webhooks/metronome/route.ts>) — Metronome receiver.
 - [editor/proxy.ts](editor/proxy.ts) — path bypass.
-- [editor/scripts/billing/tunnel.sh](editor/scripts/billing/tunnel.sh) — tunnel ingress filter.
+- [docs/contributing/billing.md](docs/contributing/billing.md) — tunnel ingress filter setup (the config itself is untracked by design).
 - [editor/scripts/billing/README.md](editor/scripts/billing/README.md) — dev docs.
 
 **What does NOT belong under `(ingest)/`.** Admin tools, internal RPC,

--- a/editor/grida-canvas/reducers/methods/scale.ts
+++ b/editor/grida-canvas/reducers/methods/scale.ts
@@ -21,7 +21,7 @@ import { css } from "@/grida-canvas-utils/css";
  *
  * Pure math + property rewrite rules live under `schema.parametric_scale` and are unit-tested.
  *
- * Spec: https://grida.co/docs/wg/canvas/parametric-scaling
+ * Spec: https://github.com/gridaco/nothing/blob/main/docs/wg/canvas/parametric-scaling.md
  */
 
 function deepClone<T>(value: T): T {

--- a/editor/grida-canvas/reducers/schema/schema.ts
+++ b/editor/grida-canvas/reducers/schema/schema.ts
@@ -17,7 +17,7 @@ export namespace schema {}
  * - scaling rectangles around an anchor point
  * - scaling geometry-contributing properties (stroke widths, radii, font sizes, effects, vector networks, etc.)
  *
- * Spec: https://grida.co/docs/wg/canvas/parametric-scaling
+ * Spec: https://github.com/gridaco/nothing/blob/main/docs/wg/canvas/parametric-scaling.md
  */
 // oxlint-disable-next-line eslint(no-unused-vars)
 export namespace schema.parametric_scale {

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -6,7 +6,7 @@ Ownership map after the engine split (the Rust engine lives in
 ## Grida-owned (live, evolve here)
 
 - `test-fig/`, `test-figma/` — Figma import fixtures (LFS: `*.fig`, `*.deck`)
-- `test-canvas/`, `test-markdown/`, `text-editor/`… — see below for `text-editor`
+- `test-canvas/`, `test-markdown/` — dotcanvas / markdown fixtures
 
 ## FROZEN SNAPSHOTS — canon lives in the engine repo
 

--- a/fixtures/test-canvas/README.md
+++ b/fixtures/test-canvas/README.md
@@ -1,6 +1,6 @@
 # `test-canvas` fixtures
 
-On-disk [`.canvas`](../../docs/wg/format/canvas.md) bundles — a portable
+On-disk [`.canvas`](https://github.com/gridaco/nothing/blob/main/docs/wg/format/canvas.md) bundles — a portable
 directory of standalone SVG documents plus a `.canvas.json` manifest. Consumed by
 `dotcanvas`. Two bundles cover the two editors: a `slides` deck and a `board`.
 

--- a/packages/dotcanvas/README.md
+++ b/packages/dotcanvas/README.md
@@ -11,7 +11,7 @@ manifest. It is a _container_ format one layer above
 of documents with an order and an optional 2D placement.
 
 Reference page: [grida.co/dotcanvas](https://grida.co/dotcanvas) ·
-Spec: [`docs/wg/format/canvas.md`](https://github.com/gridaco/grida/blob/main/docs/wg/format/canvas.md).
+Spec: [`docs/wg/format/canvas.md`](https://github.com/gridaco/nothing/blob/main/docs/wg/format/canvas.md).
 
 ## Install
 

--- a/packages/dotcanvas/src/canvas.ts
+++ b/packages/dotcanvas/src/canvas.ts
@@ -5,7 +5,7 @@
 // has no filesystem, no clock, no global state — plain functions over plain
 // inputs, so the vitest suite exercises it with zero mocks.
 //
-// Contract reference: docs/wg/format/canvas.md (the `.canvas` Draft-V1 RFD).
+// Contract reference: https://github.com/gridaco/nothing/blob/main/docs/wg/format/canvas.md (the `.canvas` Draft-V1 RFD).
 // The reconcile rule, in one line: the manifest is authoritative for ORDER and
 // PLACEMENT; disk is authoritative for EXISTENCE.
 
@@ -217,7 +217,7 @@ export function isBundlePath(path: string): boolean {
  * format: a URI `src` is a first-class placed reference used as-is — it skips
  * the disk-existence gate in {@link resolve} and is never the target of a local
  * file op. Tested on the RAW `src` (before any path normalization, which would
- * mangle `https://` → `https:/`). See docs/wg/format/canvas.md §9.
+ * mangle `https://` → `https:/`). See the .canvas spec §9 (github.com/gridaco/nothing, docs/wg/format/canvas.md).
  */
 export function isUriSrc(src: string): boolean {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(src);

--- a/packages/dotcanvas/src/index.ts
+++ b/packages/dotcanvas/src/index.ts
@@ -4,5 +4,5 @@
 //   import { dotcanvas } from "dotcanvas";
 //   const canvas = await dotcanvas.read(fs);
 //
-// Contract: docs/wg/format/canvas.md
+// Contract: https://github.com/gridaco/nothing/blob/main/docs/wg/format/canvas.md
 export * as dotcanvas from "./api";

--- a/packages/grida-canvas-cg/lib.ts
+++ b/packages/grida-canvas-cg/lib.ts
@@ -186,7 +186,7 @@ export namespace cg {
    * stroke path. When a preset is present at an endpoint, the renderer
    * uses Butt cap at that endpoint and draws the marker geometry instead.
    *
-   * @see docs/wg/feat-2d/curve-decoration.md
+   * @see https://github.com/gridaco/nothing/blob/main/docs/wg/feat-2d/curve-decoration.md
    */
   export type StrokeMarkerPreset =
     | "none"

--- a/packages/grida-text-editor/README.md
+++ b/packages/grida-text-editor/README.md
@@ -216,9 +216,9 @@ TS ecosystem.
 
 ## References
 
-- WG manifesto: [`docs/wg/feat-text-editing/index.md`](../../docs/wg/feat-text-editing/index.md)
-- Attributed text spec: [`docs/wg/feat-text-editing/attributed-text.md`](../../docs/wg/feat-text-editing/attributed-text.md)
-- Performance roadmap: [`docs/wg/feat-text-editing/impl-performance.md`](../../docs/wg/feat-text-editing/impl-performance.md)
+- WG manifesto: [`docs/wg/feat-text-editing/index.md`](https://github.com/gridaco/nothing/blob/main/docs/wg/feat-text-editing/index.md)
+- Attributed text spec: [`docs/wg/feat-text-editing/attributed-text.md`](https://github.com/gridaco/nothing/blob/main/docs/wg/feat-text-editing/attributed-text.md)
+- Performance roadmap: [`docs/wg/feat-text-editing/impl-performance.md`](https://github.com/gridaco/nothing/blob/main/docs/wg/feat-text-editing/impl-performance.md)
 - Reference Rust impl: [the engine's `text_edit`](https://github.com/gridaco/nothing/tree/main/crates/grida/src/text_edit) (~11.7k LoC; the bulk is `attributed_text/` for V2)
 - Reference Rust example: [`wd_text_editor.rs`](https://github.com/gridaco/nothing/blob/main/crates/grida_dev/examples/wd_text_editor.rs)
 - Main editor's current integration: [`editor/grida-canvas-react/viewport/ui/surface-text-editor.tsx`](../../editor/grida-canvas-react/viewport/ui/surface-text-editor.tsx)


### PR DESCRIPTION
Follow-up to #988/#989 — a fresh-eyes audit of entry documents (README/AGENTS/CONTRIBUTING/SECURITY/fixtures) against the actual tree, plus a mechanical link-resolution pass over both repos' entry docs.

- **SECURITY.md (GRIDA-SEC-001)**: the `tunnel.sh` references pointed at a file that has **never existed in git** — the tunnel config is deliberately untracked (`~/.cloudflared`). Both references now point at the real setup doc (`docs/contributing/billing.md` §7) and state the untracked-by-design fact. Control description unchanged; only the reference is corrected.
- **AGENTS.md**: `/schemas` (dir name), `pnpm turbo …` (bare `turbo` fails on a clean setup).
- **fixtures/README.md**: `text-editor/` de-duplicated to frozen-only.
- **CONTRIBUTING.md**: the engine section no longer interrupts the First→Then setup flow.

The nothing-side counterpart pass (15 findings, incl. a broken PUBLISHING flow and inverted format-contract statements) is already on its `main` (`90cc63a4`). Doc-only; split-probe + fmt clean.