### PR TITLE
feat(library): content-addressed identity — sha256 lands (#929, increment 1)

### DIFF
--- a/database/database-generated.types.ts
+++ b/database/database-generated.types.ts
@@ -2446,6 +2446,7 @@ export type Database = {
           public_domain: boolean
           score: number | null
           search_tsv: unknown
+          sha256: string | null
           sys_annotations: string[]
           title: string | null
           transparency: boolean
@@ -2485,6 +2486,7 @@ export type Database = {
           public_domain?: boolean
           score?: number | null
           search_tsv?: unknown
+          sha256?: string | null
           sys_annotations?: string[]
           title?: string | null
           transparency: boolean
@@ -2524,6 +2526,7 @@ export type Database = {
           public_domain?: boolean
           score?: number | null
           search_tsv?: unknown
+          sha256?: string | null
           sys_annotations?: string[]
           title?: string | null
           transparency?: boolean
@@ -2616,6 +2619,7 @@ export type Database = {
           public_domain: boolean
           score: number | null
           search_tsv: unknown
+          sha256: string | null
           sys_annotations: string[]
           title: string | null
           transparency: boolean
@@ -2669,6 +2673,7 @@ export type Database = {
           public_domain: boolean
           score: number | null
           search_tsv: unknown
+          sha256: string | null
           sys_annotations: string[]
           title: string | null
           transparency: boolean
@@ -2717,6 +2722,7 @@ export type Database = {
           public_domain: boolean
           score: number | null
           search_tsv: unknown
+          sha256: string | null
           sys_annotations: string[]
           title: string | null
           transparency: boolean

--- a/docs/wg/platform/index.md
+++ b/docs/wg/platform/index.md
@@ -14,6 +14,6 @@ Working group documents for Grida platform and infrastructure topics.
 
 - [Billing](./billing) — subscriptions, AI credit, Stripe ↔ Metronome sync.
 - [Grida Gateway (GG)](./hosted-ai) — the first-party metered, no-BYOK AI gateway: scoped-token federation → org-credit spend; the desktop's no-key AI path.
-- [Grida Library](./library) — curated open visual-asset corpus and its retrieval model (similarity & semantic search).
+- [Grida Library](./library) — curated open visual-asset corpus, content-addressed identity & ingestion, and its retrieval model (similarity & semantic search).
 - [Multi-tenant Custom Domains on Vercel](./multi-tenant-custom-domain-vercel)
 - [Universal Docs Routing](./universal-docs-routing)

--- a/docs/wg/platform/library.md
+++ b/docs/wg/platform/library.md
@@ -6,6 +6,7 @@ tags:
   - library
   - ai
   - platform
+  - resources
 format: md
 ---
 
@@ -21,7 +22,8 @@ format: md
 This is an evolving RFC. It states what the Library **is** and **why** it is
 shaped that way, in domain terms — not how any one implementation realizes it.
 It is the canonical entry point for understanding the Library; it is not a plan
-and not a record of changes.
+and not a record of changes. The key words **MUST**, **MUST NOT**, **SHOULD**,
+and **MAY** are used as in RFC 2119.
 
 **Non-goals.** A general-purpose asset DAM, user-uploaded private libraries,
 rights management beyond licensing metadata, or a recommendation feed. The
@@ -50,9 +52,11 @@ background").
 
 - **Asset** — a single licensed visual object in the corpus, with its image and
   its metadata.
+- **Identity** — an asset's durable **catalog identity** and its
+  content-derived **address** (a hash of its stored bytes). Specified in §3.
 - **Description** — a meaningful, prose account of what an asset depicts and
   evokes. Distinct from the title or tags; it may be authored or **generated**
-  (see §6).
+  (see §7).
 - **Representation** — a learned, fixed-dimensional vector placing an asset in a
   shared semantic space so that proximity approximates relatedness. An asset has
   a **visual representation** and may have a **textual representation**.
@@ -62,11 +66,225 @@ background").
   description."
 - **Modality** — the kind of a representation or query: visual or textual.
 
-## 3. The retrieval model
+## 3. Identity and ingestion
+
+The corpus is fed by multiple independent producers — curation tooling,
+automation, in-product generation — that share no state, no transaction, and
+no common code path. When identity is minted by the act of writing (an
+identifier assigned at insert time, a randomly named location), the same bytes
+ingested twice become two assets silently, and no producer can ask _"do you
+already have this?"_. Content addressing inverts this: identity derives from
+the **bytes**, so it is producer-independent and reproducible, ingestion is
+idempotent by construction, and producers share a coordination key without
+coordinating.
+
+### 3.1 Two identities, deliberately
+
+Every asset carries two identifiers, and the distinction is load-bearing:
+
+- **Catalog identity** — a surrogate identifier assigned once, stable for the
+  asset's lifetime. All references (collections, representations, links) point
+  to it.
+- **Content address** — the SHA-256 of the asset's **currently stored bytes**,
+  encoded as 64 lowercase hexadecimal characters. A function of the bytes, and
+  only of the bytes.
+
+The catalog identity survives anything that happens to the bytes; the address
+tracks them. If stored bytes are ever transformed (§3.6), the address re-keys
+and every reference keeps working. This split makes format canonicalization,
+backfill, and identity adoption **order-independent** of one another. The
+address is deliberately _not_ the catalog's primary reference.
+
+### 3.2 The address
+
+- Every newly registered asset **MUST** carry its content address, computed by
+  the producer over the exact bytes submitted, before registration. A
+  registration without an address **MUST** be rejected.
+- The address **MUST** be unique across the corpus. Registering bytes whose
+  address already exists **MUST** resolve to the existing asset — no new
+  entry, no new blob, no new enrichment.
+- On a duplicate hit the existing asset's facts stand (**first-writer-wins**).
+  Metadata corrections are a deliberate curation act on the existing asset;
+  re-submission **MUST NOT** be used as a correction channel.
+- **Self-verification invariant**: re-hashing an asset's stored bytes **MUST**
+  equal its recorded address, so the corpus is auditable with no trusted
+  index. A mismatch is a defect — quarantined and reported, never silently
+  re-keyed. Continuous audit belongs naturally to enrichment, which already
+  streams every asset's bytes.
+
+_Rejected alternatives_: prefixed address values (`sha256:<hex>` — the field
+carrying the address names its algorithm, so a future algorithm is a sibling
+field and a migration; a prefix buys nothing); faster non-universal hashes (a
+dependency in every producer runtime, where SHA-256 is universally built in);
+non-cryptographic hashes (collision posture wrong for an _identity_ key).
+
+### 3.3 Storage location
+
+- A newly stored asset's location **SHOULD** be its address stem, flat, with an
+  informative extension: `<address>.<ext>`. The extension derives from the
+  media type via a single pinned mapping; it is informative only and **never
+  identity-bearing**.
+- Consumers **MUST** treat locations as opaque — identity never derives from
+  location; location merely _advertises_ identity. Published asset URLs are
+  permanent: once public, a location is never rewritten or reused.
+
+This is **SHOULD**, not MUST, by honest necessity: a byte store cannot enforce
+naming, and correctness already lives in address uniqueness (§3.2). The
+convention buys self-describing placement — an object named by its own hash
+can be verified in place — and a store a human can audit at a glance.
+
+### 3.4 Ingestion contract
+
+The order of operations is fixed: **hash** the exact bytes → optionally
+**pre-check** whether the address is known (on a hit, adopt the existing asset
+and stop with zero writes) → **store** the blob at the conventional location
+(an "already exists" outcome is a _success signal_, not an error) →
+**register** the asset with its address (a duplicate-address outcome resolves
+to the existing asset). Every step is idempotent, so a crash anywhere is
+healed by retrying the whole sequence; a failure between store and register
+leaves an inert, unregistered blob, collected by a reconciliation sweep that
+compares the store against the catalog.
+
+Producers **MUST** compute the address themselves, register through the
+sanctioned write surface, and adopt the canonical asset a registration
+returns. Producers **MUST NOT** mint identities any other way, overwrite
+existing blobs, or delete from the store. **Enrichment never mints identity**:
+representations, derived visual attributes, and curation operate on the
+catalog identity of assets that already exist.
+
+Corpus writes are restricted to a small circle of trusted operators, so
+addresses are producer-asserted; the self-verification invariant plus
+continuous audit bounds what a defective producer can do, and a duplicate
+address can never create a second asset regardless of producer behavior.
+
+### 3.5 Regimes and adoption
+
+Content addressing was adopted on **2026-07-19** over a live corpus, which
+therefore permanently carries two regimes:
+
+- **Legacy** (pre-adoption): identity was storage-assigned at write time;
+  locations are a curated folder taxonomy or generator-minted random names;
+  the address is absent until backfilled.
+- **Content-addressed** (adoption →): the address is mandatory (§3.2); the
+  location follows §3.3.
+
+Both are queryable facts, not guesswork: an asset without an address predates
+backfill; a location containing folder separators, or whose stem differs from
+the address, is a legacy placement. **Legacy locations are permanent** —
+published URLs are load-bearing — so backfill assigns addresses without
+relocating bytes. After full backfill every asset has an address; only
+content-addressed-regime assets also satisfy the location convention, and that
+is acceptable forever.
+
+Adoption path: address optional → mandatory for new assets → corpus backfill
+(stored bytes must be re-read and hashed; store-layer metadata offers no
+substitute for a true byte hash) → surfaced duplicates collapsed by hand
+(expected rare) → address mandatory corpus-wide.
+
+| date       | convention change                                                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-07-19 | Content addressing adopted: address **MUST** for new assets; flat address-stem locations **SHOULD**; efficient formats (WebP) **SHOULD**. Legacy corpus enters backfill. |
+| (before)   | Identity storage-assigned at write time; locations curated-taxonomy or generator-minted random names.                                                                    |
+
+### 3.6 Canonical format posture
+
+Producers **SHOULD** prefer efficient delivery formats at creation time — WebP
+for raster imagery. The identity layer itself does **not** canonicalize: the
+address is the hash of the bytes _as stored_. Lossy re-encoding is not
+byte-deterministic across encoders and versions, so canonicalization
+distributed across producers would defeat deduplication — determinism demands
+**exactly one canonicalizer**, placed _before_ registration. That is a
+recognized evolution of this spec, not part of it: a **staged/final** shape in
+which raw submissions land in a transient staging zone and a single
+canonicalizer converts, addresses, places, and registers — collapsing
+format-variant duplicates at the identity level. Its admission requirement is
+a story for synchronous producers that need a published location at submission
+time; if adopted, addresses re-key per asset while catalog identity persists
+(§3.1). Until then, format-variant duplicates (the same picture as PNG and
+WebP) are accepted as distinct identities; the retrieval model (§4) surfaces
+them for discovery.
+
+### 3.7 Topology
+
+The Library spans two homes. The **data plane** — the registry (catalog), the
+byte store, and the product retrieval surfaces — lives with the platform
+([gridaco/grida](https://github.com/gridaco/grida)), because whoever owns the
+database owns the schema and its single migration timeline. The **content
+operations** — curation and batch producers, and the enrichment worker — live
+in the library operations repo
+([gridaco/library](https://github.com/gridaco/library)), the corpus's home as
+a content factory. Producers and the worker form the trusted write circle
+(§3.4); every consumer surface is read-only.
+
+```mermaid
+flowchart LR
+    subgraph producers ["Producers — trusted write circle"]
+        IP["In-product generation<br/>(platform)"]
+        CT["Curation & batch tooling<br/>(library ops repo)"]
+    end
+
+    subgraph plane ["Data plane (platform)"]
+        BS["Byte store<br/>blobs at &lt;address&gt;.&lt;ext&gt;"]
+        RG["Registry<br/>catalog identity + address + metadata"]
+        EQ["Ingest events"]
+    end
+
+    subgraph enrich ["Enrichment (library ops repo)"]
+        WK["Worker<br/>audit · representations · derived attributes"]
+    end
+
+    subgraph consumers ["Consumers — read-only"]
+        UI["Gallery browse & search"]
+        AG["Agents (RAG)"]
+    end
+
+    IP -- "hash · store · register" --> BS
+    CT -- "hash · store · register" --> BS
+    IP --> RG
+    CT --> RG
+    RG -- "genuine registrations only" --> EQ
+    EQ --> WK
+    WK -- "fetch bytes" --> BS
+    WK -- "verify · enrich" --> RG
+    RG --> UI
+    RG --> AG
+```
+
+The ingestion steps (§3.4) and the enrichment lane, end to end:
+
+```mermaid
+sequenceDiagram
+    participant P as Producer
+    participant R as Registry
+    participant S as Byte store
+    participant W as Enrichment worker
+
+    P->>P: hash bytes → address
+    opt pre-check
+        P->>R: is address known?
+        R-->>P: known → adopt existing asset, stop (zero writes)
+    end
+    P->>S: store blob at the conventional location (§3.3)
+    Note over S: "already exists" = success signal
+    P->>R: register (address, metadata)
+    alt address already registered
+        R-->>P: existing asset (first-writer-wins)
+    else genuine registration
+        R-->>P: new asset (catalog identity)
+        R->>W: ingest event (dedup emits nothing)
+        W->>S: fetch bytes
+        W->>W: re-hash, compare to address
+        Note over W: mismatch → quarantine, never silent re-key
+        W->>R: representations + derived attributes
+        Note over R: asset now serves similarity & search (§4)
+    end
+```
+
+## 4. The retrieval model
 
 Retrieval is the heart of the Library, and it rests on one principle.
 
-### 3.1 The modality-matching principle
+### 4.1 The modality-matching principle
 
 Visual and textual representations, even when trained into a single shared
 space, do not occupy the same region of it — there is a measurable **modality
@@ -86,7 +304,7 @@ Two consequences follow, and they shape the entire design:
    query) matches against visual representations; search (text query) matches,
    wherever possible, against textual representations.
 
-### 3.2 Similarity — visual ↔ visual
+### 4.2 Similarity — visual ↔ visual
 
 The query is an existing asset; the result is other assets that **look**
 related. This is matched same-modality: the query asset's visual representation
@@ -94,7 +312,7 @@ is compared against the visual representations of the corpus, ranked by
 proximity. Every asset has a visual representation, so similarity covers the
 entire corpus.
 
-### 3.3 Search — text ↔ text, with a visual floor
+### 4.3 Search — text ↔ text, with a visual floor
 
 The query is free text. A library of visual assets receives two intents that
 look identical as strings but resolve differently:
@@ -111,7 +329,7 @@ meaningful. A meaningful description verbalizes both what an asset depicts _and_
 what it evokes, so a same-modality text-to-text match captures appearance and
 concept together, without crossing the modality gap.
 
-Because the textual representation is **optional** (§4), search must degrade
+Because the textual representation is **optional** (§5), search must degrade
 gracefully:
 
 - Assets with a textual representation are matched same-modality against the
@@ -126,7 +344,7 @@ distributions, and averaging them is a calibration error that degrades both.
 Where both are surfaced, they are composed as ordered tiers (matched results
 first, cross-modal coverage after), or selected explicitly — never summed.
 
-### 3.4 Invariants
+### 4.4 Invariants
 
 - **Every asset has a visual representation.** It is the floor for both
   similarity and search.
@@ -138,7 +356,7 @@ first, cross-modal coverage after), or selected explicitly — never summed.
   mixing a proximity measure with an index built for a different one yields
   silently wrong rankings.
 
-## 4. Why the textual representation is optional
+## 5. Why the textual representation is optional
 
 Not every asset is described. Description is an enrichment, applied over time
 and unevenly across the corpus; ingestion of a new asset must never block on it.
@@ -147,7 +365,7 @@ fabricate empty descriptions that pollute search. So the model admits assets
 that carry image only, and search is defined to remain correct — merely less
 precise for those assets — until a description arrives.
 
-## 5. Use cases
+## 6. Use cases
 
 The same retrieval surface serves two consumers with different query shapes:
 
@@ -163,7 +381,7 @@ A single search contract serving both is a deliberate design goal: the agent and
 the gallery query the same corpus by the same model, differing only in the text
 they submit.
 
-## 6. Description as verbalization
+## 7. Description as verbalization
 
 A description is what makes the strong (same-modality) search path possible for
 an asset, so the corpus is enriched by a **verbalization** process: examining an
@@ -172,16 +390,16 @@ bridge across the modality gap — it converts visual content into text that a
 text query can match directly, and it can express concept and intent that a
 purely visual representation does not encode.
 
-Verbalization is asynchronous and best-effort by design (§4). Its output feeds
+Verbalization is asynchronous and best-effort by design (§5). Its output feeds
 the textual representation; until it runs for a given asset, that asset is
 served by the visual floor alone.
 
-## 7. Design alternatives considered
+## 8. Design alternatives considered
 
 - **One fused image-and-text representation per asset.** Rejected: it serves
   every query modality through a representation matched to none, and it couples
   ingestion to description. Separate per-modality representations dominate it on
-  both retrieval modes (§3.1).
+  both retrieval modes (§4.1).
 - **Text-only representation (verbalize everything, never embed pixels).**
   Rejected as the sole model: similarity is inherently visual, and a description
   is a lossy summary that discards fine visual detail. A visual representation
@@ -192,7 +410,7 @@ served by the visual floor alone.
   **always semantic**; it trades guaranteed exact-keyword ordering (acceptable
   for a discovery surface) for meaning-based recall.
 
-## 8. Open questions
+## 9. Open questions
 
 As an evolving RFC, the following are deliberately unsettled:
 
@@ -209,3 +427,12 @@ As an evolving RFC, the following are deliberately unsettled:
   the old, then switch retrieval once coverage is complete — is understood; the
   invariants that make such a transition seamless for live retrieval deserve
   their own treatment.
+- **Event provenance.** First-writer-wins (§3.2) drops a duplicate submission's
+  own generation facts (its prompt, its generator). Does a per-event log
+  deserve to exist alongside the per-asset entry?
+- **Algorithm succession.** A successor hash algorithm is a sibling field by
+  construction (§3.2), but the choreography of switching the uniqueness
+  guarantee between algorithms over a live corpus is not yet specified.
+- **Staged/final admission.** The synchronous-producer story (§3.6) — serve a
+  provisional location and re-key, or make submission asynchronous — is
+  unresolved, and is the gate on canonical-format identity.

--- a/editor/lib/ai/actions/image-generate.ts
+++ b/editor/lib/ai/actions/image-generate.ts
@@ -12,10 +12,9 @@ import {
   type GenerateImageResult,
   type ImageModel,
 } from "ai";
-import { v4 } from "uuid";
-import mime from "mime-types";
 import imageSize from "image-size";
 import { service_role } from "@/lib/supabase/server";
+import { LibraryCAS } from "@/lib/library/cas";
 import ai from "@/lib/ai";
 import { computeImageCostMills } from "@/lib/ai/image-cost";
 import {
@@ -129,10 +128,10 @@ async function uploadGeneratedToLibrary({
   const client = service_role.library;
   const { mediaType, uint8Array } = file;
 
-  const ext = mime.extension(mediaType);
-  const name = v4();
-  const folder = "generated";
-  const path = `${folder}/${name}${ext ? `.${ext}` : ""}`;
+  // #929 content addressing: identity = sha256 of the bytes; storage path =
+  // the flat CAS location `<sha256>.<ext>` (docs/wg/platform/library.md §3).
+  const sha256 = LibraryCAS.sha256Hex(uint8Array);
+  const path = LibraryCAS.path(sha256, mediaType);
 
   const { data: uploaded, error: upload_err } = await client.storage
     .from("library")
@@ -140,15 +139,36 @@ async function uploadGeneratedToLibrary({
       contentType: mediaType,
     });
 
-  if (upload_err) throw new Error(upload_err.message);
+  // Same bytes → same CAS path: "already exists" means the blob is already
+  // stored (a prior run or another producer) — success signal, not an error.
+  if (upload_err && !LibraryCAS.isDuplicateError(upload_err)) {
+    throw new Error(upload_err.message);
+  }
+
+  // Storage object id: fresh upload → from the response; duplicate upload →
+  // the row usually exists too (adopted below via 23505), but an orphan blob
+  // from a crashed prior attempt needs its id recovered to register.
+  let storage_id = uploaded?.id;
+  if (!storage_id) {
+    const { data: info, error: info_err } = await client.storage
+      .from("library")
+      .info(path);
+    if (info_err || !info?.id) {
+      throw new Error(
+        info_err?.message ?? `library: cannot resolve storage id for ${path}`
+      );
+    }
+    storage_id = info.id;
+  }
 
   const { data: object, error: object_err } = await client
     .from("object")
     .insert({
-      id: uploaded.id,
+      id: storage_id,
       bytes: uint8Array.length,
       category: "generated",
-      path: uploaded.path,
+      path,
+      sha256,
       mimetype: mediaType,
       generator: request.model,
       prompt: request.prompt,
@@ -159,7 +179,26 @@ async function uploadGeneratedToLibrary({
     .select()
     .single();
 
-  if (object_err) throw new Error(object_err.message);
+  if (object_err) {
+    // unique_violation: the same bytes are already registered (sha256 — or
+    // the id/path of the already-registered blob). First-writer-wins
+    // (WG §3.2): adopt the canonical row; this generation's prompt and
+    // generator are dropped by design.
+    if (object_err.code === "23505") {
+      const { data: existing, error: existing_err } = await client
+        .from("object")
+        .select()
+        .eq("sha256", sha256)
+        .single();
+      if (!existing_err && existing) {
+        const publicUrl = client.storage
+          .from("library")
+          .getPublicUrl(existing.path).data.publicUrl;
+        return { object: existing, publicUrl };
+      }
+    }
+    throw new Error(object_err.message);
+  }
 
   const publicUrl = client.storage.from("library").getPublicUrl(object.path)
     .data.publicUrl;

--- a/editor/lib/library/cas.test.ts
+++ b/editor/lib/library/cas.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { LibraryCAS } from "./cas";
+
+describe("LibraryCAS", () => {
+  // Cross-language contract vectors — the sibling-repo producer (Python,
+  // hashlib) asserts these same pairs. If these move, the contract broke.
+  it("sha256Hex matches the pinned cross-language vectors", () => {
+    expect(LibraryCAS.sha256Hex(new Uint8Array(0))).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+    expect(LibraryCAS.sha256Hex(new TextEncoder().encode("abc"))).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+  });
+
+  it("pins image/jpeg to 'jpg' (mime-types would say 'jpeg')", () => {
+    expect(LibraryCAS.ext("image/jpeg")).toBe("jpg");
+    expect(LibraryCAS.ext("image/png")).toBe("png");
+    expect(LibraryCAS.ext("image/svg+xml")).toBe("svg");
+  });
+
+  it("builds flat CAS paths", () => {
+    const h = LibraryCAS.sha256Hex(new TextEncoder().encode("abc"));
+    expect(LibraryCAS.path(h, "image/jpeg")).toBe(`${h}.jpg`);
+    expect(LibraryCAS.path(h, "application/x-unknown-blob")).toBe(h);
+    expect(LibraryCAS.path(h, "image/png")).not.toContain("/");
+  });
+
+  it("discriminates duplicate-upload errors across storage-api shapes", () => {
+    expect(LibraryCAS.isDuplicateError({ statusCode: "409" })).toBe(true);
+    expect(LibraryCAS.isDuplicateError({ status: 409 })).toBe(true);
+    expect(LibraryCAS.isDuplicateError({ error: "Duplicate" })).toBe(true);
+    expect(
+      LibraryCAS.isDuplicateError({ message: "The resource already exists" })
+    ).toBe(true);
+    expect(
+      LibraryCAS.isDuplicateError({ status: 400, message: "Payload too large" })
+    ).toBe(false);
+  });
+});

--- a/editor/lib/library/cas.ts
+++ b/editor/lib/library/cas.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import mime from "mime-types";
+
+/**
+ * Library content addressing — #929.
+ *
+ * Identity contract (docs/wg/platform/library.md §3): a library object's
+ * content address is the SHA-256 of its stored bytes, lowercase hex, and the
+ * storage location for new objects is the flat CAS path `<sha256>.<ext>`.
+ * Producers compute the address over the exact bytes they upload; the
+ * extension is informative only and never identity-bearing.
+ */
+export namespace LibraryCAS {
+  /** SHA-256 of the exact bytes, as 64 lowercase hex characters. */
+  export function sha256Hex(bytes: Uint8Array): string {
+    return createHash("sha256").update(bytes).digest("hex");
+  }
+
+  /**
+   * Pinned mimetype → extension map. Pinned (rather than delegated to a
+   * library) so every producer, in every language, derives the same CAS path
+   * for the same media type — e.g. `mime-types` (npm) says "jpeg" while
+   * Python's `mimetypes` says ".jpg". The sibling-repo producer mirrors this
+   * table verbatim.
+   */
+  const EXT: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "image/svg+xml": "svg",
+    "image/avif": "avif",
+  };
+
+  /** Informative extension for a media type; pinned map first, `mime-types` fallback. */
+  export function ext(mimetype: string): string | null {
+    return EXT[mimetype] ?? mime.extension(mimetype) ?? null;
+  }
+
+  /** Flat CAS storage path: `<sha256>.<ext>` (bare `<sha256>` when the type has no extension). */
+  export function path(sha256: string, mimetype: string): string {
+    const e = ext(mimetype);
+    return e ? `${sha256}.${e}` : sha256;
+  }
+
+  /**
+   * True when a storage upload failed because the object already exists —
+   * which, at a CAS path, means the same bytes are already stored: a success
+   * signal, not an error. Tolerant of both storage-api error shapes (current
+   * HTTP 409 / `statusCode: "409"` / "Duplicate", and the historic HTTP 400
+   * with a 409 body code).
+   */
+  export function isDuplicateError(error: {
+    message?: string;
+    status?: number;
+    statusCode?: string | number;
+    error?: string;
+  }): boolean {
+    return (
+      String(error.statusCode) === "409" ||
+      error.status === 409 ||
+      error.error === "Duplicate" ||
+      /already exists|duplicate/i.test(error.message ?? "")
+    );
+  }
+}

--- a/editor/lib/library/index.ts
+++ b/editor/lib/library/index.ts
@@ -28,6 +28,8 @@ export namespace Library {
     prompt: string | null;
     public_domain: boolean;
     score: number | null;
+    /** Content address: sha256 of the stored bytes, lowercase hex. NULL = legacy (pre-backfill) rows (#929). */
+    sha256: string | null;
     title: string | null;
     transparency: boolean;
     updated_at: string;

--- a/supabase/migrations/20260719104152_library_sha256_identity.sql
+++ b/supabase/migrations/20260719104152_library_sha256_identity.sql
@@ -1,0 +1,43 @@
+-- #929 — content-addressed library, increment 1: sha256 identity lands.
+-- Spec: docs/wg/platform/library.md §3 "Identity and ingestion".
+--
+-- Adds the content address column to grida_library.object:
+--   - sha256 of the stored bytes, lowercase hex (64). Nullable = legacy regime
+--     (pre-backfill) only; new rows MUST carry it (INSERT guard below).
+--   - Partial unique index gives synchronous dedup for hashed rows while the
+--     legacy corpus is still NULL.
+--   - The guard is a BEFORE INSERT trigger, NOT a `CHECK ... NOT VALID`:
+--     a NOT VALID check would still fire on UPDATEs of legacy rows, breaking
+--     the worker's derived-metadata writes and curation edits. INSERT-only
+--     enforcement = "NOT NULL for new rows" with legacy rows editable.
+--     Replaced by a real SET NOT NULL after the corpus backfill.
+
+ALTER TABLE grida_library.object
+  ADD COLUMN sha256 TEXT
+  CONSTRAINT object_sha256_format_chk CHECK (sha256 ~ '^[0-9a-f]{64}$');
+
+COMMENT ON COLUMN grida_library.object.sha256 IS
+  'Content address: SHA-256 of the currently stored bytes, lowercase hex. NULL = legacy (pre-backfill) regime. See docs/wg/platform/library.md §3.';
+
+CREATE UNIQUE INDEX object_sha256_key
+  ON grida_library.object (sha256)
+  WHERE sha256 IS NOT NULL;
+
+CREATE FUNCTION grida_library.fn_object_require_sha256()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.sha256 IS NULL THEN
+    RAISE EXCEPTION 'grida_library.object: sha256 is required for new objects (content addressing, #929)'
+      USING ERRCODE = '23502';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER object_require_sha256
+  BEFORE INSERT ON grida_library.object
+  FOR EACH ROW
+  EXECUTE FUNCTION grida_library.fn_object_require_sha256();

--- a/supabase/schemas/grida_library.sql
+++ b/supabase/schemas/grida_library.sql
@@ -105,6 +105,11 @@ CREATE POLICY "public_read" ON grida_library.category FOR SELECT TO public USING
 CREATE TABLE grida_library.object (
   id UUID PRIMARY KEY REFERENCES storage.objects(id) ON DELETE CASCADE,
   path TEXT NOT NULL UNIQUE,
+  -- Content address: SHA-256 of the currently stored bytes, lowercase hex (#929;
+  -- docs/wg/platform/library.md §3). NULL = legacy (pre-backfill) regime only —
+  -- new rows are forced to carry it by the object_require_sha256 trigger below.
+  -- Flips to NOT NULL once the legacy corpus is backfilled.
+  sha256 TEXT CONSTRAINT object_sha256_format_chk CHECK (sha256 ~ '^[0-9a-f]{64}$'),
   path_tokens TEXT[] GENERATED ALWAYS AS (string_to_array(path, '/'::text)) STORED,
   title TEXT,
   alt TEXT,
@@ -144,6 +149,34 @@ CREATE TABLE grida_library.object (
 ALTER TABLE grida_library.object ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "public_read" ON grida_library.object FOR SELECT TO public USING (true);
 CREATE TRIGGER enqueue_object_embedding_on_insert AFTER INSERT ON grida_library.object FOR EACH ROW EXECUTE FUNCTION enqueue_object_embedding_job();
+
+-- Content-address dedup: unique over hashed rows only (legacy rows stay NULL
+-- until backfill). Same bytes registered twice → unique_violation, producer
+-- resolves the existing row.
+CREATE UNIQUE INDEX object_sha256_key ON grida_library.object (sha256) WHERE sha256 IS NOT NULL;
+
+-- INSERT-only guard: new objects MUST carry their content address. Deliberately
+-- a trigger and not a CHECK ... NOT VALID — a NOT VALID check still fires on
+-- UPDATEs of legacy rows (worker metadata writes, curation edits). Replaced by
+-- SET NOT NULL after backfill.
+CREATE FUNCTION grida_library.fn_object_require_sha256()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.sha256 IS NULL THEN
+    RAISE EXCEPTION 'grida_library.object: sha256 is required for new objects (content addressing, #929)'
+      USING ERRCODE = '23502';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER object_require_sha256
+  BEFORE INSERT ON grida_library.object
+  FOR EACH ROW
+  EXECUTE FUNCTION grida_library.fn_object_require_sha256();
 
 ---------------------------------------------------------------------
 -- [Text Search support] --

--- a/supabase/tests/grida_library_gemini_search_test.sql
+++ b/supabase/tests/grida_library_gemini_search_test.sql
@@ -54,11 +54,13 @@ INSERT INTO storage.objects (id, bucket_id, name) VALUES
   ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'testgembucket', 'testgem/b.png'),
   ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'testgembucket', 'testgem/c.png');
 
+-- sha256: required for new rows since the #929 content-addressing guard
+-- (synthetic, distinct — dedup is not under test here).
 INSERT INTO grida_library.object
-  (id, path, category, mimetype, width, height, bytes, transparency) VALUES
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'testgem/a.png', 'testgem', 'image/png', 1, 1, 1, false),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'testgem/b.png', 'testgem', 'image/png', 1, 1, 1, false),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'testgem/c.png', 'testgem', 'image/png', 1, 1, 1, false);
+  (id, path, category, mimetype, width, height, bytes, transparency, sha256) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'testgem/a.png', 'testgem', 'image/png', 1, 1, 1, false, repeat('a1', 32)),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'testgem/b.png', 'testgem', 'image/png', 1, 1, 1, false, repeat('b2', 32)),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'testgem/c.png', 'testgem', 'image/png', 1, 1, 1, false, repeat('c3', 32));
 
 -- Synthetic 1536-d unit vectors:
 --   e1     = [1,0,0,...]

--- a/supabase/tests/grida_library_sha256_test.sql
+++ b/supabase/tests/grida_library_sha256_test.sql
@@ -1,0 +1,105 @@
+BEGIN;
+SELECT plan(13);
+
+-- ===================================================================
+-- grida_library content addressing (#929, increment 1)
+--
+-- Pins the sha256 identity contract on grida_library.object:
+--   - column shape + lowercase-hex CHECK
+--   - partial unique index (dedup over hashed rows; legacy NULLs coexist)
+--   - INSERT-only guard trigger: new rows MUST carry sha256, while legacy
+--     (NULL-sha256) rows remain UPDATE-able — the regression this file
+--     exists to pin (a CHECK ... NOT VALID would break legacy updates).
+-- Spec: docs/wg/platform/library.md §3.
+-- ===================================================================
+
+-- ── shape ──────────────────────────────────────────────────────────
+SELECT has_column('grida_library', 'object', 'sha256', 'object.sha256 exists');
+SELECT col_type_is('grida_library', 'object', 'sha256', 'text', 'sha256 is text');
+SELECT ok(
+  pg_get_indexdef('grida_library.object_sha256_key'::regclass)
+    ~* 'create unique index .*\(sha256\).* where \(sha256 is not null\)',
+  'object_sha256_key is a partial unique index over non-NULL sha256'
+);
+SELECT has_trigger('grida_library', 'object', 'object_require_sha256', 'INSERT guard trigger exists');
+SELECT has_function('grida_library', 'fn_object_require_sha256', '{}'::name[], 'guard function exists');
+
+-- ── fixtures (self-contained; rolled back) ─────────────────────────
+INSERT INTO grida_library.category (id, name) VALUES ('testsha', 'Test');
+
+-- Self-contained bucket: the (newer) storage.prefixes trigger FK-references
+-- storage.buckets, so the bucket must exist. Don't depend on seed data.
+INSERT INTO storage.buckets (id, name) VALUES ('testshabucket', 'testshabucket')
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO storage.objects (id, bucket_id, name) VALUES
+  ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'testshabucket', 'o1.png'),
+  ('dddddddd-dddd-dddd-dddd-dddddddddd02', 'testshabucket', 'o2.png'),
+  ('dddddddd-dddd-dddd-dddd-dddddddddd03', 'testshabucket', 'o3.png');
+
+-- ── guard: new rows must carry sha256 ──────────────────────────────
+SELECT throws_ok(
+  $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency)
+     VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'o1.png', 'testsha', 'image/png', 1, 1, 1, false) $$,
+  '23502', NULL,
+  'INSERT without sha256 is rejected by the guard'
+);
+
+-- ── CHECK: lowercase hex, 64 chars ─────────────────────────────────
+SELECT throws_ok(
+  $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency, sha256)
+     VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'o1.png', 'testsha', 'image/png', 1, 1, 1, false, 'not-a-hash') $$,
+  '23514', NULL,
+  'non-hex sha256 violates the format CHECK'
+);
+SELECT throws_ok(
+  format(
+    $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency, sha256)
+       VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'o1.png', 'testsha', 'image/png', 1, 1, 1, false, %L) $$,
+    repeat('A1', 32)
+  ),
+  '23514', NULL,
+  'UPPERCASE hex violates the format CHECK (lowercase is canonical)'
+);
+
+-- ── happy path + dedup ─────────────────────────────────────────────
+SELECT lives_ok(
+  format(
+    $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency, sha256)
+       VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'o1.png', 'testsha', 'image/png', 1, 1, 1, false, %L) $$,
+    repeat('d4', 32)
+  ),
+  'hashed INSERT succeeds'
+);
+SELECT throws_ok(
+  format(
+    $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency, sha256)
+       VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd02', 'o2.png', 'testsha', 'image/png', 1, 1, 1, false, %L) $$,
+    repeat('d4', 32)
+  ),
+  '23505', NULL,
+  'same sha256 twice → unique_violation (synchronous dedup)'
+);
+
+-- ── legacy regime: NULL-sha256 rows coexist and stay editable ──────
+SELECT lives_ok(
+  format(
+    $$ INSERT INTO grida_library.object (id, path, category, mimetype, width, height, bytes, transparency, sha256)
+       VALUES ('dddddddd-dddd-dddd-dddd-dddddddddd02', 'o2.png', 'testsha', 'image/png', 1, 1, 1, false, %L) $$,
+    repeat('e5', 32)
+  ),
+  'second object with a distinct sha256 inserts'
+);
+SELECT lives_ok(
+  $$ UPDATE grida_library.object SET sha256 = NULL
+     WHERE id IN ('dddddddd-dddd-dddd-dddd-dddddddddd01', 'dddddddd-dddd-dddd-dddd-dddddddddd02') $$,
+  'guard is INSERT-only: rows can be updated to NULL sha256 (legacy simulation), and two NULL rows coexist under the partial index'
+);
+SELECT lives_ok(
+  $$ UPDATE grida_library.object SET title = 'legacy row, still editable', colors = '{#aabbcc}'
+     WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddd01' $$,
+  'legacy (NULL-sha256) rows remain UPDATE-able — worker metadata writes and curation are unaffected'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## What

Increment 1 of #929: **library object identity becomes content-derived.** Producers MUST compute the sha256 of the bytes they upload; the schema enforces it for new rows; new storage paths are the flat CAS location `<sha256>.<ext>`.

The full spec (identity model, MUST/SHOULD contracts, the two-regime corpus with a dated convention history, topology diagrams) is added to [`docs/wg/platform/library.md` §3 — Identity and ingestion](https://github.com/gridaco/grida/blob/feat/library-sha256-identity/docs/wg/platform/library.md).

## DB

- `grida_library.object.sha256 TEXT` + lowercase-hex CHECK + **partial UNIQUE** (`WHERE sha256 IS NOT NULL`) — synchronous dedup for hashed rows while the legacy corpus is still NULL.
- **BEFORE INSERT guard trigger**: new rows without a hash are rejected (`23502`). Deliberately *not* `CHECK … NOT VALID` — that fires on UPDATEs of legacy rows and would break the embedding worker's metadata writes and curation edits. Real `SET NOT NULL` comes after backfill.
- pgTAP: new `grida_library_sha256_test.sql` (13 assertions incl. the legacy-rows-stay-editable regression); gemini-test fixtures gain hashes.

## Editor (the only in-repo producer)

- New `LibraryCAS` namespace: `sha256Hex`, **pinned** mime→ext map (npm `mime-types` says `jpeg`, Python says `jpg` — the map is the cross-producer contract), flat CAS path, tolerant duplicate-error discriminator. Unit-tested with pinned cross-language vectors (mirrored in the sibling-repo port).
- `uploadGeneratedToLibrary`: hash → CAS path → 409-tolerant upload → `info()` id-recovery for orphan blobs → insert with sha256 → `23505` dedup branch adopts the canonical row (first-writer-wins per WG §3.2 — a dedup hit drops this generation's prompt/generator by design).
- Types regen + `Library.Object` mirror.

## ⚠️ Deploy order (owner)

**Apply the migration to prod BEFORE merging.** Vercel deploys the editor on merge; if it deploys first, the insert references a column prod doesn't have and AI-generation library upload fails.

```sh
git fetch && git checkout feat/library-sha256-identity
supabase db push   # applies 20260719104152_library_sha256_identity
```

Sibling repo: **gridaco/library#2** ports `g/src/upload.py` — hash + CAS path + pre-check by sha256 **or legacy path** (re-runs refresh metadata instead of minting duplicates), drops `x-upsert`, replaces the `list(search=)` id-hack with `info()`. Do not run it against prod until this migration is applied.

## Verification

- `supabase db reset` + `supabase test db`: **166 pgTAP assertions green** (10 files).
- `turbo typecheck`: 39/39. `vitest` cas: 4/4. `just fmt` + oxlint clean.
- Live local probe: identical bytes ingested twice → duplicate upload tolerated → `23505` branch → **same row adopted, exactly one pgmq embedding job**.
- `upload.py` dry-run (local): fresh insert, crash-orphan heal, and re-run→metadata-refresh all green; row lands with **path stem == sha256** (self-verification invariant).

## Pre-flight findings (recorded for later increments)

- Read-only prod probe: corpus is **11,588 objects**; ≤**43 exact-duplicate candidates** by (bytes,w,h,mime) — manual collapse at backfill time is viable.
- Local storage `x-upsert` **preserves** `storage.objects.id` — the feared cascade-delete hazard does not materialize; x-upsert is dropped by contract, not by hazard.
- The `~/.library/factory` corpus filenames are **truncated sha256** (first 16 hex) — same algorithm, compatible in spirit.

## Out of scope (roadmap in #929)

Worker dual-mode verify → lockdown + ingest RPC → scoped `library_service` role → backfill + manual dup collapse + `SET NOT NULL` flip → (maybe) staged/final canonicalization.

refs #929
