### PR TITLE
fix(desktop): polish workspace interactions

### DIFF
--- a/editor/app/editor.css
+++ b/editor/app/editor.css
@@ -21,3 +21,14 @@ textarea,
 select {
   -webkit-app-region: no-drag;
 }
+
+/*
+ * Chromium does not clip app-region boxes to a scrollport. Scrolling
+ * descendants must not publish native rectangles of their own. Controls in
+ * ordinary content remain covered by the body's no-drag region; title-bar
+ * controls mirror their visible intersections into stationary exclusions.
+ * Upstream: https://issues.chromium.org/issues/40857813
+ */
+.desktop-native-drag-scroll-viewport * {
+  -webkit-app-region: initial;
+}

--- a/editor/scaffolds/desktop/shared/chat-session-picker.tsx
+++ b/editor/scaffolds/desktop/shared/chat-session-picker.tsx
@@ -171,20 +171,22 @@ export function ChatSessionPicker({
             align="start"
             className="max-h-(--radix-popover-content-available-height) w-64 overflow-x-hidden overflow-y-auto p-1"
           >
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8 w-full justify-start rounded-sm px-2 text-sm font-normal"
-              onClick={() => {
-                setListOpen(false);
-                onSelect(null);
-              }}
-            >
-              <MessageSquarePlusIcon className="size-3.5" />
-              New chat
-            </Button>
-            {session.sessions.length > 0 && (
+            {!hideNewChat && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 w-full justify-start rounded-sm px-2 text-sm font-normal"
+                onClick={() => {
+                  setListOpen(false);
+                  onSelect(null);
+                }}
+              >
+                <MessageSquarePlusIcon className="size-3.5" />
+                New chat
+              </Button>
+            )}
+            {!hideNewChat && session.sessions.length > 0 && (
               <Separator className="-mx-1 my-1 w-auto" />
             )}
             {session.sessions.slice(0, 20).map((s) => (

--- a/editor/scaffolds/desktop/shared/chat-session-picker.tsx
+++ b/editor/scaffolds/desktop/shared/chat-session-picker.tsx
@@ -44,6 +44,12 @@ import {
 } from "@app/ui/components/dropdown-menu";
 import { Button } from "@app/ui/components/button";
 import { Input } from "@app/ui/components/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@app/ui/components/popover";
+import { Separator } from "@app/ui/components/separator";
 import { cn } from "@app/ui/lib/utils";
 import type { UseChatSessionResult } from "@/lib/agent-chat";
 
@@ -143,8 +149,13 @@ export function ChatSessionPicker({
         )}
       >
         {icon}
-        <DropdownMenu open={listOpen} onOpenChange={setListOpen} modal={false}>
-          <DropdownMenuTrigger asChild>
+        {/* The history surface contains an independent actions menu in every
+            row. It must be a Popover rather than another Menu root: an outer
+            menuitem refocuses itself during pointer travel and dismisses the
+            row menu before the pointer reaches it.
+            (see test/desktop-chat-session-row-actions.md) */}
+        <Popover open={listOpen} onOpenChange={setListOpen}>
+          <PopoverTrigger asChild>
             <Button
               type="button"
               variant="ghost"
@@ -155,32 +166,65 @@ export function ChatSessionPicker({
             >
               <ListIcon className="size-3.5" />
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-64">
-            <DropdownMenuItem onSelect={() => onSelect(null)}>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className="max-h-(--radix-popover-content-available-height) w-64 overflow-x-hidden overflow-y-auto p-1"
+          >
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-full justify-start rounded-sm px-2 text-sm font-normal"
+              onClick={() => {
+                setListOpen(false);
+                onSelect(null);
+              }}
+            >
               <MessageSquarePlusIcon className="size-3.5" />
               New chat
-            </DropdownMenuItem>
-            {session.sessions.length > 0 && <DropdownMenuSeparator />}
+            </Button>
+            {session.sessions.length > 0 && (
+              <Separator className="-mx-1 my-1 w-auto" />
+            )}
             {session.sessions.slice(0, 20).map((s) => (
-              <DropdownMenuItem
+              <div
                 key={s.id}
-                onSelect={() => onSelect(s.id)}
                 className={cn(
-                  "flex items-center gap-2",
+                  "flex items-center rounded-sm pr-1",
                   s.id === session.current_id && "bg-accent"
                 )}
               >
-                <span className="flex-1 truncate">{s.title}</span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "h-8 min-w-0 flex-1 justify-start rounded-sm px-2 text-sm font-normal",
+                    s.id === session.current_id &&
+                      "bg-accent hover:bg-accent focus-visible:bg-accent"
+                  )}
+                  onClick={() => {
+                    setListOpen(false);
+                    onSelect(s.id);
+                  }}
+                >
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    {s.title}
+                  </span>
+                </Button>
                 <SessionActionsMenu
                   session={s}
                   onRename={openRename}
-                  onDelete={setDeleteTargetId}
+                  onDelete={(id) => {
+                    setListOpen(false);
+                    setDeleteTargetId(id);
+                  }}
                 />
-              </DropdownMenuItem>
+              </div>
             ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          </PopoverContent>
+        </Popover>
         {renameTargetId !== null ? (
           <Input
             value={draft}
@@ -299,16 +343,6 @@ function SessionActionsMenu({
           aria-label="Chat actions"
           title="Chat actions"
           className="shrink-0"
-          // This trigger sits inside a selectable row (DropdownMenuItem).
-          // Radix's menu item synthesizes a click on the row at pointer-up
-          // when it never saw the matching pointer-down (`!isPointerDownRef`,
-          // see @radix-ui/react-menu MenuItem). Stopping only pointer-down +
-          // click leaves that pointer-up path open, so opening this menu also
-          // selects the row — switching sessions and closing the list out from
-          // under the just-opened menu. Stop all three.
-          onPointerDown={(e) => e.stopPropagation()}
-          onPointerUp={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
         >
           <EllipsisVerticalIcon className="size-3.5" />
         </Button>

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -804,7 +804,7 @@ function AgentPaneContent({
             className="gap-4 px-3 py-4"
             scrollClassName={cn(
               styles.chatScroll,
-              "scroll-fade-y scroll-fade-4"
+              "desktop-native-drag-scroll-viewport scroll-fade-y scroll-fade-4"
             )}
           >
             {/* Empty state intentionally omitted — the chat starts blank

--- a/editor/scaffolds/desktop/workbench/editor-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -28,6 +29,7 @@ import { EditorPaneDesignSearch } from "./editor-pane-design-search";
 import { EditorPaneStart } from "./editor-pane-start";
 import { EditorTabPreview } from "./editor-tab-preview";
 import { isVirtualTab, type DesignSearchSession } from "./design-search-tab";
+import { TabNativeDragRegion } from "./tab-native-drag-region";
 import { TabPreviewController } from "./tab-preview-controller";
 import type { WorkspaceCanvasCreation } from "./workspace-canvas-creation";
 import { useWorkspaceChanges } from "./workspace-changes";
@@ -278,6 +280,7 @@ function EditorTitleBar({
   onFileTrashed?: (relPath: string) => void;
 }) {
   const railRef = useRef<HTMLDivElement | null>(null);
+  const nativeDragExclusionLayerRef = useRef<HTMLDivElement | null>(null);
   const [previewController] = useState(() => new TabPreviewController());
   const [thumbnailCache] = useState(() => new WorkspaceTabThumbnail.Cache());
   const [previewRevision, setPreviewRevision] = useState(0);
@@ -325,6 +328,16 @@ function EditorTitleBar({
     }
   });
 
+  useLayoutEffect(() => {
+    const rail = railRef.current;
+    const exclusionLayer = nativeDragExclusionLayerRef.current;
+    if (!rail || !exclusionLayer) return;
+
+    const controller = new TabNativeDragRegion.Controller(rail, exclusionLayer);
+    controller.connect();
+    return () => controller.dispose();
+  }, [showStart, tabs]);
+
   return (
     <div
       className="desktop-drag-area relative flex h-11 shrink-0 items-center"
@@ -341,7 +354,7 @@ function EditorTitleBar({
         ref={railRef}
         role="tablist"
         aria-label="Open editors"
-        className="desktop-no-drag scroll-fade-x scroll-fade-3 no-scrollbar flex h-full min-w-0 flex-1 items-center gap-1 overflow-x-auto overscroll-x-contain pl-1.5 pr-2 scroll-pl-1.5 scroll-pr-2"
+        className="desktop-native-drag-scroll-viewport scroll-fade-x scroll-fade-3 no-scrollbar flex h-full min-w-0 flex-1 items-center gap-1 overflow-x-auto overscroll-x-contain pl-1.5 pr-2 scroll-pl-1.5 scroll-pr-2"
         onPointerLeave={(event) =>
           previewController.railLeave(event.pointerType)
         }
@@ -379,12 +392,34 @@ function EditorTitleBar({
             />
           );
         })}
-        {/* Keep unused title-bar space draggable without turning the gaps
-            between scrollable tabs back into Electron drag regions. */}
-        <div
-          role="presentation"
-          className="desktop-drag-area h-full min-w-0 flex-1"
-        />
+        {/* The parent title bar owns dragging; region-free tab descendants
+            leave this unused space and the inter-tab gaps draggable. */}
+        <div role="presentation" className="h-full min-w-0 flex-1" />
+      </div>
+      {/* Chromium does not clip native app-region boxes to scrollports. Keep
+          moving tab descendants region-free and mirror only their visible
+          rectangles here. This layer is stationary and pointer-transparent.
+          (see test/desktop-workbench-scrolled-tab-drag-region.md) */}
+      <div
+        ref={nativeDragExclusionLayerRef}
+        className="pointer-events-none absolute inset-0"
+        aria-hidden
+      >
+        {showStart && (
+          <div
+            data-tab-native-drag-region-exclusion="start"
+            className="desktop-no-drag absolute"
+            style={{ display: "none" }}
+          />
+        )}
+        {tabs.map((relPath) => (
+          <div
+            key={relPath}
+            data-tab-native-drag-region-exclusion={relPath}
+            className="desktop-no-drag absolute"
+            style={{ display: "none" }}
+          />
+        ))}
       </div>
       <EditorTabPreview
         controller={previewController}
@@ -411,7 +446,8 @@ function StartTabItem() {
       role="tab"
       tabIndex={0}
       aria-selected
-      className="desktop-no-drag flex h-6 shrink-0 select-none items-center rounded-md bg-muted px-2 text-xs text-foreground shadow-xs outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+      data-tab-native-drag-region-target="start"
+      className="flex h-6 shrink-0 select-none items-center rounded-md bg-muted px-2 text-xs text-foreground shadow-xs outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
     >
       Quick Start
     </div>
@@ -488,6 +524,7 @@ function TabItem({
       role="tab"
       tabIndex={0}
       aria-selected={active}
+      data-tab-native-drag-region-target={relPath}
       title={virtual ? name : undefined}
       onPointerEnter={(event) => {
         if (!virtual) {
@@ -521,7 +558,7 @@ function TabItem({
         }
       }}
       className={cn(
-        "desktop-no-drag group flex h-6 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs outline-none transition-colors",
+        "group flex h-6 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs outline-none transition-colors",
         active
           ? "bg-muted text-foreground shadow-xs"
           : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -538,7 +575,7 @@ function TabItem({
           onClose();
         }}
         className={cn(
-          "desktop-no-drag ml-1 grid size-4 place-items-center rounded text-muted-foreground hover:bg-muted hover:text-foreground",
+          "ml-1 grid size-4 place-items-center rounded text-muted-foreground hover:bg-muted hover:text-foreground",
           active || dirty ? "opacity-100" : "opacity-0 group-hover:opacity-100"
         )}
         aria-label={dirty ? `Close ${name} (unsaved)` : `Close ${name}`}

--- a/editor/scaffolds/desktop/workbench/editor-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane.tsx
@@ -14,13 +14,8 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  ImagesIcon,
-  PanelRightCloseIcon,
-  PanelRightOpenIcon,
-  XIcon,
-} from "lucide-react";
-import { Button } from "@app/ui/components/button";
+import { ImagesIcon, PanelRightIcon, XIcon } from "lucide-react";
+import { Toggle } from "@app/ui/components/toggle";
 import { cn } from "@app/ui/lib/utils";
 import { getDesktopBridge, type Workspace } from "@/lib/desktop/bridge";
 import { DESKTOP_WINDOW_CONTROLS_RIGHT_INSET } from "@/scaffolds/desktop/chrome/title-bar";
@@ -464,18 +459,22 @@ export function WorkspaceExplorerToggleButton({
   className?: string;
 }) {
   return (
-    <Button
+    <Toggle
       type="button"
-      variant="ghost"
-      size="icon-sm"
-      className={cn("desktop-no-drag shrink-0", className)}
-      onClick={onToggle}
+      size="sm"
+      pressed={open}
+      className={cn(
+        "desktop-no-drag size-7 min-w-7 shrink-0 p-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className
+      )}
+      onPressedChange={onToggle}
       aria-label={open ? "Hide file tree pane" : "Show file tree pane"}
-      aria-pressed={open}
       title={open ? "Hide file tree pane (⌘B)" : "Show file tree pane (⌘B)"}
     >
-      {open ? <PanelRightCloseIcon /> : <PanelRightOpenIcon />}
-    </Button>
+      <PanelRightIcon
+        className={cn(!open && "fill-muted text-muted-foreground")}
+      />
+    </Toggle>
   );
 }
 

--- a/editor/scaffolds/desktop/workbench/tab-native-drag-region.test.ts
+++ b/editor/scaffolds/desktop/workbench/tab-native-drag-region.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TabNativeDragRegion } from "./tab-native-drag-region";
+
+type TestRect = Readonly<{
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}>;
+
+function element({
+  attribute,
+  rect,
+  display = "",
+}: {
+  attribute?: readonly [string, string];
+  rect: TestRect;
+  display?: string;
+}): HTMLElement {
+  const attributes = new Map(attribute ? [attribute] : []);
+  return {
+    style: { display },
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    getBoundingClientRect: () => rect,
+  } as unknown as HTMLElement;
+}
+
+function container(rect: TestRect, children: readonly HTMLElement[]) {
+  const addEventListener = vi.fn<HTMLElement["addEventListener"]>();
+  const removeEventListener = vi.fn<HTMLElement["removeEventListener"]>();
+  return {
+    element: {
+      style: {},
+      getBoundingClientRect: () => rect,
+      querySelectorAll: () => children,
+      addEventListener,
+      removeEventListener,
+    } as unknown as HTMLElement,
+    addEventListener,
+    removeEventListener,
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("TabNativeDragRegion.intersection", () => {
+  const viewport = { left: 100, top: 0, right: 500, bottom: 44 };
+
+  it("keeps a fully visible tab rectangle", () => {
+    expect(
+      TabNativeDragRegion.intersection(
+        { left: 160, top: 10, right: 280, bottom: 34 },
+        viewport
+      )
+    ).toEqual({
+      left: 160,
+      top: 10,
+      right: 280,
+      bottom: 34,
+      width: 120,
+      height: 24,
+    });
+  });
+
+  it("clips a partially scrolled tab to the viewport", () => {
+    expect(
+      TabNativeDragRegion.intersection(
+        { left: 40, top: 10, right: 180, bottom: 34 },
+        viewport
+      )
+    ).toEqual({
+      left: 100,
+      top: 10,
+      right: 180,
+      bottom: 34,
+      width: 80,
+      height: 24,
+    });
+  });
+
+  it("rejects an offscreen tab rectangle", () => {
+    expect(
+      TabNativeDragRegion.intersection(
+        { left: -100, top: 10, right: 80, bottom: 34 },
+        viewport
+      )
+    ).toBeNull();
+  });
+});
+
+describe("TabNativeDragRegion.Controller", () => {
+  it("mirrors clipped targets in layer coordinates and clears stale overlays", () => {
+    const targetA = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "a"],
+      rect: { left: 40, top: 10, right: 180, bottom: 34 },
+    });
+    const targetB = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "b"],
+      rect: { left: -100, top: 10, right: 80, bottom: 34 },
+    });
+    const targetC = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "c"],
+      rect: { left: 460, top: 10, right: 560, bottom: 34 },
+    });
+    const exclusionA = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "a"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "none",
+    });
+    const exclusionB = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "b"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "block",
+    });
+    const exclusionC = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "c"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "none",
+    });
+    const viewport = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      targetA,
+      targetB,
+      targetC,
+    ]);
+    const layer = container({ left: 80, top: 0, right: 520, bottom: 44 }, [
+      exclusionA,
+      exclusionB,
+      exclusionC,
+    ]);
+
+    new TabNativeDragRegion.Controller(
+      viewport.element,
+      layer.element
+    ).reconcile();
+
+    expect({
+      display: exclusionA.style.display,
+      left: exclusionA.style.left,
+      top: exclusionA.style.top,
+      width: exclusionA.style.width,
+      height: exclusionA.style.height,
+    }).toEqual({
+      display: "block",
+      left: "20px",
+      top: "10px",
+      width: "80px",
+      height: "24px",
+    });
+    expect(exclusionB.style.display).toBe("none");
+    expect({
+      display: exclusionC.style.display,
+      left: exclusionC.style.left,
+      width: exclusionC.style.width,
+    }).toEqual({
+      display: "block",
+      left: "380px",
+      width: "40px",
+    });
+  });
+
+  it("owns observation and scroll-listener cleanup", () => {
+    const target = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "a"],
+      rect: { left: 120, top: 10, right: 180, bottom: 34 },
+    });
+    const exclusion = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "a"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "none",
+    });
+    const viewport = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      target,
+    ]);
+    const layer = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      exclusion,
+    ]);
+    const observe = vi.fn<ResizeObserver["observe"]>();
+    const disconnect = vi.fn<ResizeObserver["disconnect"]>();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe = observe;
+        disconnect = disconnect;
+      }
+    );
+    const controller = new TabNativeDragRegion.Controller(
+      viewport.element,
+      layer.element
+    );
+
+    controller.connect();
+    controller.connect();
+    controller.dispose();
+
+    expect(observe.mock.calls.map(([observed]) => observed)).toEqual([
+      viewport.element,
+      target,
+    ]);
+    expect(viewport.addEventListener).toHaveBeenCalledOnce();
+    expect(viewport.addEventListener).toHaveBeenCalledWith(
+      "scroll",
+      controller.reconcile,
+      { passive: true }
+    );
+    expect(viewport.removeEventListener).toHaveBeenCalledWith(
+      "scroll",
+      controller.reconcile
+    );
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/editor/scaffolds/desktop/workbench/tab-native-drag-region.ts
+++ b/editor/scaffolds/desktop/workbench/tab-native-drag-region.ts
@@ -1,0 +1,147 @@
+type Rect = Readonly<{
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}>;
+
+type VisibleRect = Rect &
+  Readonly<{
+    width: number;
+    height: number;
+  }>;
+
+/**
+ * Native `no-drag` rectangles for tabs inside the horizontally scrolling
+ * editor rail.
+ *
+ * Chromium does not clip `-webkit-app-region` boxes to an ancestor's
+ * scrollport. The moving tab nodes therefore carry no app-region declaration.
+ * This controller mirrors only their visible intersections onto stationary,
+ * pointer-transparent exclusion rectangles outside the scroller.
+ */
+export namespace TabNativeDragRegion {
+  export const TARGET_ATTRIBUTE = "data-tab-native-drag-region-target";
+  export const EXCLUSION_ATTRIBUTE = "data-tab-native-drag-region-exclusion";
+
+  export function intersection(
+    target: Rect,
+    viewport: Rect
+  ): VisibleRect | null {
+    const left = Math.max(target.left, viewport.left);
+    const top = Math.max(target.top, viewport.top);
+    const right = Math.min(target.right, viewport.right);
+    const bottom = Math.min(target.bottom, viewport.bottom);
+    if (right <= left || bottom <= top) return null;
+    return {
+      left,
+      top,
+      right,
+      bottom,
+      width: right - left,
+      height: bottom - top,
+    };
+  }
+
+  export class Controller {
+    private resizeObserver: ResizeObserver | null = null;
+
+    constructor(
+      private readonly viewport: HTMLElement,
+      private readonly exclusionLayer: HTMLElement
+    ) {}
+
+    connect(): void {
+      if (this.resizeObserver) return;
+
+      this.resizeObserver = new ResizeObserver(this.reconcile);
+      this.resizeObserver.observe(this.viewport);
+      for (const target of this.targets()) {
+        this.resizeObserver.observe(target);
+      }
+      this.viewport.addEventListener("scroll", this.reconcile, {
+        passive: true,
+      });
+      this.reconcile();
+    }
+
+    dispose(): void {
+      this.viewport.removeEventListener("scroll", this.reconcile);
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = null;
+    }
+
+    readonly reconcile = (): void => {
+      const exclusions = this.exclusions();
+      const visibleExclusions = new Map<HTMLElement, VisibleRect>();
+      const viewportRect = this.viewport.getBoundingClientRect();
+      const layerRect = this.exclusionLayer.getBoundingClientRect();
+
+      // Finish all layout reads before writing overlay styles. This runs on
+      // every horizontal scroll event and must not force a layout per tab.
+      for (const target of this.targets()) {
+        const id = target.getAttribute(TARGET_ATTRIBUTE);
+        if (id === null) continue;
+        const exclusion = exclusions.get(id);
+        if (!exclusion) continue;
+
+        const visible = intersection(
+          target.getBoundingClientRect(),
+          viewportRect
+        );
+        if (visible) visibleExclusions.set(exclusion, visible);
+      }
+
+      for (const exclusion of exclusions.values()) {
+        const visible = visibleExclusions.get(exclusion);
+        if (!visible) {
+          if (exclusion.style.display !== "none") {
+            exclusion.style.display = "none";
+          }
+          continue;
+        }
+
+        this.setStyle(exclusion, {
+          display: "block",
+          left: `${visible.left - layerRect.left}px`,
+          top: `${visible.top - layerRect.top}px`,
+          width: `${visible.width}px`,
+          height: `${visible.height}px`,
+        });
+      }
+    };
+
+    private targets(): NodeListOf<HTMLElement> {
+      return this.viewport.querySelectorAll<HTMLElement>(
+        `[${TARGET_ATTRIBUTE}]`
+      );
+    }
+
+    private exclusions(): Map<string, HTMLElement> {
+      const exclusions = new Map<string, HTMLElement>();
+      for (const element of this.exclusionLayer.querySelectorAll<HTMLElement>(
+        `[${EXCLUSION_ATTRIBUTE}]`
+      )) {
+        const id = element.getAttribute(EXCLUSION_ATTRIBUTE);
+        if (id !== null) exclusions.set(id, element);
+      }
+      return exclusions;
+    }
+
+    private setStyle(
+      element: HTMLElement,
+      style: Readonly<
+        Pick<
+          CSSStyleDeclaration,
+          "display" | "left" | "top" | "width" | "height"
+        >
+      >
+    ): void {
+      for (const property of Object.keys(style) as Array<keyof typeof style>) {
+        if (element.style[property] !== style[property]) {
+          element.style[property] = style[property];
+        }
+      }
+    }
+  }
+}

--- a/test/desktop-chat-session-row-actions.md
+++ b/test/desktop-chat-session-row-actions.md
@@ -1,0 +1,47 @@
+---
+id: TC-DESKTOP-CHAT-002
+title: Chat history row actions remain interactive
+module: desktop
+area: chat
+tags: [chat, history, menu, pointer, delete]
+status: verified
+severity: medium
+date: 2026-07-24
+updated: 2026-07-24
+automatable: true
+covered_by: []
+---
+
+## Behavior
+
+Each saved chat row has its own actions menu inside the larger chat-history
+popover. Moving the pointer from a row's overflow button, across the intervening
+row or overlay gap, and into the portaled actions menu must not dismiss either
+surface or select the history row. The actions menu stays open and every action
+remains clickable without switching conversations.
+
+## Steps
+
+1. Open a workspace with at least two saved chat sessions.
+2. Open the chat-history menu.
+3. Activate a non-current row's overflow button.
+   - Expected: the Rename, Copy session ID, and Delete actions appear while the
+     chat-history menu remains open.
+4. Move the pointer over each action without clicking.
+   - Expected: the actions menu remains visible and the active chat does not
+     change.
+5. Click Delete.
+   - Expected: the actions menu closes and the Delete chat confirmation dialog
+     opens for that row. The row is not selected and no chat is deleted before
+     confirmation.
+
+## Notes
+
+- 2026-07-24: An instantaneous locator hover passed while a 30-step pointer
+  path reproduced the dismissal. The history surface was a Radix menu whose
+  `menuitem` contained a second independent menu root; pointer travel refocused
+  the outer item and dismissed the inner menu.
+- 2026-07-24: Verified in local Grida Desktop with 30-step pointer movement
+  from the overflow trigger through the gap to Rename. A second stepped move
+  followed by mouse down/up on Delete opened the confirmation dialog without
+  deleting data.

--- a/test/desktop-workbench-scrolled-chat-drag-region.md
+++ b/test/desktop-workbench-scrolled-chat-drag-region.md
@@ -1,0 +1,39 @@
+---
+id: TC-DESKTOP-WORKBENCH-006
+title: Scrolled chat controls do not block native window dragging
+module: desktop
+area: workbench
+tags: [desktop, title-bar, chat, scroll, window-drag]
+status: untested
+severity: medium
+date: 2026-07-24
+updated: 2026-07-24
+automatable: false
+covered_by: []
+---
+
+## Behavior
+
+Interactive controls inside the vertically scrolling chat remain ordinary
+content controls and do not publish native window regions. Scrolling a message
+action toolbar behind the chat viewport must not leave ghost `no-drag`
+rectangles over the left title bar.
+
+## Steps
+
+1. Open a Desktop workspace with enough chat history to scroll vertically.
+2. Before scrolling, drag the native window from empty space in the left title
+   bar to the right of the workspace-name button.
+   - Expected: the OS window moves.
+3. Scroll the conversation until a message and its action buttons move above
+   the visible chat viewport.
+4. Drag again from the same title-bar point.
+   - Expected: the OS window still moves.
+5. Hover a visible message and use a non-destructive action such as Copy.
+   - Expected: the action remains interactive and the window does not move.
+
+## Notes
+
+- Companion regression for #994. Chromium does not clip native app-region
+  rectangles to scrollports, so this requires a real OS window drag rather than
+  renderer pointer events.

--- a/test/desktop-workbench-scrolled-tab-drag-region.md
+++ b/test/desktop-workbench-scrolled-tab-drag-region.md
@@ -1,0 +1,51 @@
+---
+id: TC-DESKTOP-WORKBENCH-005
+title: Scrolled editor tabs do not block native window dragging
+module: desktop
+area: workbench
+tags: [desktop, title-bar, tabs, scroll, window-drag]
+status: untested
+severity: medium
+date: 2026-07-24
+updated: 2026-07-24
+automatable: false
+covered_by:
+  - editor/scaffolds/desktop/workbench/tab-native-drag-region.test.ts
+---
+
+## Behavior
+
+Only the visible portions of interactive editor tabs exclude native window
+dragging. Tabs that are horizontally clipped or fully scrolled out of view must
+not leave ghost hit regions over the neighboring title bars. Visually empty
+title-bar space and the gaps between visible tabs remain draggable at every
+scroll position.
+
+## Steps
+
+1. Open enough files in the Desktop workbench for the editor tab rail to
+   overflow horizontally.
+2. With the rail at its initial scroll position, drag the native window from an
+   empty point in the title bar immediately to the left of the rail.
+   - Expected: the OS window moves.
+3. Scroll the editor tabs fully to the right.
+4. Drag again from the exact same visible title-bar point.
+   - Expected: the OS window still moves.
+5. Drag from the visible portion of a partially clipped tab.
+   - Expected: the window does not move.
+6. Select a visible tab, open and dismiss its context menu, then close a
+   disposable tab with its close button.
+   - Expected: tab selection, context menus, and close actions still work.
+7. Scroll the rail in both directions with the trackpad or mouse, stopping with
+   a tab partially clipped at each edge.
+   - Expected: visible tab portions remain interactive while newly exposed
+     gaps and neighboring title bars remain draggable.
+8. Repeat with the file-tree pane both hidden and visible.
+   - Expected: the left, editor, and right title-bar drag regions behave
+     consistently.
+
+## Notes
+
+- Regression for #994. Renderer pointer events cannot verify this behavior; the
+  pass requires a real OS mouse drag and comparison of the native window
+  position.


### PR DESCRIPTION
## Summary

- keep chat-history row actions interactive by using a popover for the composite history surface and independent dropdown menus for each row
- prevent scrolled editor tabs and chat controls from leaving native `no-drag` hit regions over neighboring title bars
- replace the file-tree panel control with a compact shadcn Toggle and a stable `PanelRight` icon

## Root cause

The chat-history surface nested an independent Radix menu root inside an outer menu item. Radix menus intentionally refocus items during pointer travel, so the outer item reclaimed focus and dismissed the row actions before the pointer could reach them. A Popover is the appropriate container for selectable rows with independent menus.

For title-bar dragging, Chromium does not clip `-webkit-app-region` hit-test boxes to overflow scrollports. Moving descendants therefore continued blocking drag outside their visible bounds. Chat descendants no longer publish native regions, while editor tabs mirror only their visible intersections onto a stationary, pointer-transparent exclusion layer.

## Validation

- `pnpm --filter editor typecheck`
- `pnpm --filter editor test` — 1,110 passed, 4 skipped, 1 todo
- local Grida Desktop interaction checks for chat row actions and native title-bar dragging

Desktop release impact: none

Fixes #994