### PR TITLE
Polish desktop agent UX and file editing semantics

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/docs/wg/ai/agent/scratch.md
+++ b/docs/wg/ai/agent/scratch.md
@@ -134,9 +134,11 @@ pre-authorized middle.
 ### S5 — Scratch is not the workspace
 
 Writing to scratch MUST NOT be treated as editing the user's project. The
-contracts that govern workspace edits — read-before-edit, the freshness token an
-edit requires — do not apply to scratch. Perceiving or producing a scratch file
-is not reading-to-edit a user file, and MUST NOT satisfy those obligations.
+authority, review, and preservation safeguards that govern workspace mutation
+do not apply to scratch. Perceiving or producing a scratch file grants no
+authority over a workspace file. The edit operation's own current-content match
+still applies wherever that operation is used; it is intrinsic conflict
+detection, not a workspace-authorization rule.
 
 ## Lifecycle
 
@@ -173,8 +175,8 @@ A conforming implementation MUST:
 - Make scratch the default destination for tools that produce files (S3).
 - Let the agent read, move, copy, and perceive within scratch without
   per-operation approval, while keeping scratch inside sandbox containment (S4).
-- Keep scratch writes outside the workspace-edit contracts (read-before-edit /
-  freshness) (S5).
+- Keep scratch writes outside workspace mutation authority and review
+  safeguards, while retaining each operation's intrinsic validation (S5).
 
 ## What this guide does not specify
 

--- a/docs/wg/ai/agent/tools.md
+++ b/docs/wg/ai/agent/tools.md
@@ -106,6 +106,37 @@ profile that intentionally relies on shell/search commands for
 discovery should document that product choice in its binding instead
 of shipping a misleading whole-index list tool.
 
+### Filesystem mutation invariant
+
+`edit` is a conditional mutation over the file's **current content**. During
+each invocation, the tool reads the current text and applies the replacement
+only when the supplied old text identifies the requested location. A missing
+match or an ambiguous match is a conflict result; the tool MUST leave the file
+unchanged.
+
+A prior `read` is often how an agent obtains exact edit context, but it is
+guidance, not authorization. Conformance MUST NOT depend on a session-local
+ledger recording that the agent read the path earlier. Such a ledger loses its
+meaning when a run pauses, resumes, or moves between workers. In particular, an
+agent MAY edit a file it just successfully wrote without reading the same bytes
+back first.
+
+An implementation SHOULD close the gap between validation and publication with
+an atomic or conditional backend write when its storage layer supports one. If
+it cannot, it MUST still read current content during the invocation and
+serialize its own same-path mutations; it must not claim cross-process
+atomicity.
+
+`write` remains the locked full-file operation: it creates or overwrites the
+path. It is intentionally different from `edit` and SHOULD be used only when
+replacing the complete content is the caller's intent.
+
+An implementation MAY impose a bounded text-file size. If it does, the same
+bound MUST govern successful reads, writes, and edits, and an oversized
+operation MUST return an explicit typed size failure rather than masquerading
+as a missing file. This preserves the guarantee that a successful write remains
+eligible for a later edit, including after the runtime is reconstructed.
+
 **Common extensions seen on top of the lock.** A code-shaped agent
 typically ships additional tools beyond the lock. Names are not
 standardized, but a recurring catalog includes:

--- a/docs/wg/ai/agent/vision.md
+++ b/docs/wg/ai/agent/vision.md
@@ -81,9 +81,10 @@ the read tool needs — perceiving a source is a read, not a new privilege. It
 adds no write or network surface. (A future rendering path, below, adds a
 render capability; bitmap perception does not.)
 
-Perception is **not** a `read` for the read-before-edit contract. Seeing an
-image is not reading text you intend to change; it must not satisfy the
-freshness token an edit requires.
+Perception grants no write authority and supplies no textual edit context.
+Seeing an image is not observing the exact text a match-and-replace edit needs.
+The edit operation independently validates its supplied context against current
+text; perception neither satisfies nor bypasses that check.
 
 ## The input matrix
 

--- a/docs/wg/ai/grida/tools-fundamentals.md
+++ b/docs/wg/ai/grida/tools-fundamentals.md
@@ -75,7 +75,9 @@ Returns the file's current text content. Read is how the agent understands an
 existing file and obtains exact edit context; it is not an authorization event.
 The tool exposes no session-local freshness token to the model. Grida bounds
 model-readable and model-mutable text files at 1 MiB of UTF-8; larger files
-return `too_large`.
+return `too_large`. A storage read failure returns `io_error`, never
+`not_found`, so the agent cannot mistake an inaccessible existing file for a
+safe path to recreate.
 
 ### `edit_file`
 

--- a/docs/wg/ai/grida/tools-fundamentals.md
+++ b/docs/wg/ai/grida/tools-fundamentals.md
@@ -36,8 +36,8 @@ tool](#adding-a-new-fundamental-tool)).
 | RFC id        | Grida id                   | Notes                                                                                                                                                           |
 | ------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `read`        | `read_file`                | Same shape; Grida's name is more specific.                                                                                                                      |
-| `write`       | `write_file`               | Same shape; Grida adds an optional `version` for stale-check.                                                                                                   |
-| `edit`        | `edit_file`                | Same shape; Grida adds a strict ambiguity rule on multi-match.                                                                                                  |
+| `write`       | `write_file`               | Same full-file upsert shape; creates or overwrites.                                                                                                             |
+| `edit`        | `edit_file`                | Same current-content replacement shape; Grida adds a strict ambiguity rule on multi-match.                                                                      |
 | `glob`        | `list_files`               | Grida binding uses a path-scoped directory-listing shape; VFS hosts should provide it, real-fs hosts may omit it when command/search tools are stronger.        |
 | `grep`        | `grep_files`               | Same shape; literal substring search (regex is not shipped).                                                                                                    |
 | `bash`        | `run_command`              | Honest name — Grida's host does not always launch a shell.                                                                                                      |
@@ -55,12 +55,12 @@ Grida's filesystem tools are storage-agnostic by signature. The same
 `read_file({ path })` call works against any backend; what differs is
 **the adapter under the fs, not the schema the model sees**.
 
-| Backend         | Where                   | Use case                                                                          |
-| --------------- | ----------------------- | --------------------------------------------------------------------------------- |
-| `MemoryBackend` | in-process map          | Tests, scratch documents, ad-hoc agent runs.                                      |
-| `OpfsBackend`   | OPFS in the browser     | Web environment (per [`agent/environments / web`](../agent/environments.md#web)). |
-| `NodeFsBackend` | real disk via `node:fs` | Desktop / computer environment, scoped by the workspace root and OS sandbox.      |
-| (future) remote | remote document store   | Multi-tenant cloud product surfaces.                                              |
+| Backend category    | Where                 | Use case                                                                          |
+| ------------------- | --------------------- | --------------------------------------------------------------------------------- |
+| In-process storage  | application memory    | Tests, scratch documents, ad-hoc agent runs.                                      |
+| Browser storage     | browser origin        | Web environment (per [`agent/environments / web`](../agent/environments.md#web)). |
+| Host-scoped storage | local host filesystem | Opened Desktop/agent workspaces under the host's containment policy.              |
+| Remote storage      | service boundary      | Multi-tenant cloud product surfaces.                                              |
 
 A path can be **bound** to live state (an editor, a doc model) or
 **pure** in-memory storage (notes, scratch). Both shapes share the API.
@@ -71,27 +71,40 @@ Items where Grida's binding deviates from or extends the RFC shape.
 
 ### `read_file`
 
-Returns content + a freshness token. The token is mandatory for
-subsequent edits — `edit_file` and `write_file` (with `version`)
-check it for staleness. Same shape as the RFC's `read` plus the
-explicit freshness token.
+Returns the file's current text content. Read is how the agent understands an
+existing file and obtains exact edit context; it is not an authorization event.
+The tool exposes no session-local freshness token to the model. Grida bounds
+model-readable and model-mutable text files at 1 MiB of UTF-8; larger files
+return `too_large`.
 
 ### `edit_file`
 
 Match-and-replace edit. The default write path — cheap, safe, must
 locate the change.
 
+Each invocation loads current content and finds `old_string`. Where the storage
+layer supports an optimistic publication precondition, a detected concurrent
+change produces `stale` without clobbering the newer bytes. This narrows the
+validation-to-publication gap; it is not a claim of cross-process atomicity. A
+prior `read_file` is useful but not required: content from a successful
+`write_file` is already valid edit context, including after a pause or resumed
+run.
+
 Matching: literal substring first, then a whitespace-normalized
 fallback. Ambiguous matches reject unless `replace_all: true`. The
-strategy is conservative on purpose — closer to Claude Code's `Edit`
-than to fuzzing diff matchers.
+strategy is conservative on purpose: it tolerates whitespace drift, not semantic
+or broadly fuzzy matches.
 
 ### `write_file`
 
-Full-file upsert. `version` optional: include it (from the last read)
-for an explicit wholesale rewrite with staleness safety; omit it for a
-permissive write that bypasses the freshness check (use for
-fresh-start writes).
+Full-file upsert. It creates a missing path or replaces all content at an
+existing path. The model-facing shape has no version argument: choosing this
+tool is the explicit intent to perform a last-writer-wins wholesale write.
+Targeted changes belong in `edit_file`.
+
+Success means the full write has completed before the result returns.
+Content above the shared 1 MiB text bound is rejected with `too_large`, so every
+successful write can still be read and edited after a resumed run.
 
 ### `list_files`
 
@@ -120,8 +133,8 @@ Contract:
 - The result lists only the direct children of `path`, grouped into
   folders and files.
 - The result is sorted, paginated, and explicit about truncation.
-- `list_files` discovers names only. It does not search file content,
-  and it does not count as `read_file`.
+- `list_files` discovers names only. It does not return file content or provide
+  textual edit context.
 - For filename-pattern search, use a separate glob / find-path tool
   rather than overloading this directory-listing result.
 
@@ -146,9 +159,9 @@ Implementation guidance:
 Literal substring search across every known file. Returns one entry
 per matching line with a 1-indexed line number and the full line
 text. Mirrors `grep -n -F` (case-sensitive, fixed-string by default;
-pass `case_sensitive: false` for `-i`). Does NOT count as a
-`read_file` — search is for finding things, not for claiming you've
-read them.
+pass `case_sensitive: false` for `-i`). A result may provide enough
+text for a unique edit, but the agent should read the file when it
+needs broader context.
 
 Roadmap:
 
@@ -303,11 +316,10 @@ next thing to ship.
 
 ## What lives where
 
-- `packages/grida-agent-tools/src/fs/` — filesystem fundamentals
-  ([README](https://github.com/gridaco/grida/blob/main/packages/grida-agent-tools/src/fs/README.md))
-- `packages/grida-agent-tools/src/todos/` — planning fundamentals
-  ([README](https://github.com/gridaco/grida/blob/main/packages/grida-agent-tools/src/todos/README.md))
-- `packages/grida-agent-tools/src/tool-search/` — _not yet created; see proposal above_
+- `packages/grida-ai-agent/src/fs/` — filesystem fundamentals
+  ([README](https://github.com/gridaco/grida/blob/main/packages/grida-ai-agent/src/fs/README.md))
+- `packages/grida-ai-agent/src/todos/` — planning fundamentals
+- `packages/grida-ai-agent/src/tool-search/` — _not yet created; see proposal above_
 - `editor/grida-canvas-hosted/ai/tools/` — canvas tools; see
   [`tools-canvas.md`](./tools-canvas.md) for the catalog.
 
@@ -322,7 +334,7 @@ Process:
 
 1. Confirm the RFC carries the shape — if not, propose it to
    [`../agent/tools.md`](../agent/tools.md) first.
-2. Drop the implementation in `packages/grida-agent-tools/src/<name>/`
+2. Drop the implementation in `packages/grida-ai-agent/src/<name>/`
    with its own README, class, AI-SDK tool schema, and pure-logic tests.
 3. Add a row to the naming map above and a per-tool section below it.
 4. If it's vfs-only (only needed because we lack command execution),

--- a/editor/app/(canvas)/svg/_ai/binding-svg.ts
+++ b/editor/app/(canvas)/svg/_ai/binding-svg.ts
@@ -10,10 +10,9 @@ import { formatSvg } from "./format-svg";
  *   `read_file` — stable, line-oriented, perfect for `edit_file`'s
  *   match-and-replace.
  * - `load()` accepts any valid SVG; the editor handles re-formatting.
- * - `getVersion()` returns `content_version` so UI-state emissions
- *   (selection, scope, mode, tool) don't strand AI writes as stale —
- *   a click between the agent's read and write must not invalidate
- *   the write.
+ * - `getVersion()` returns `content_version` for host-side change events
+ *   and direct conditional writes. Model-facing edits validate their
+ *   supplied text against the binding's current serialized content.
  * - `subscribe()` wires the editor's emit channel to the fs for
  *   auto-flush to the backend. The fs dedups by content, so it's fine
  *   that this fires on every emission.

--- a/editor/app/(canvas)/svg/_ai/tool-call-item.tsx
+++ b/editor/app/(canvas)/svg/_ai/tool-call-item.tsx
@@ -180,8 +180,6 @@ function rejectionLabel(rej: EditOrWriteFailure): {
       return { label: "Canvas changed — will retry", tone: "warn" };
     case "parse_error":
       return { label: "Invalid SVG — will retry", tone: "warn" };
-    case "not_read":
-      return { label: "Read first — will retry", tone: "warn" };
     case "not_found":
       return { label: "Snippet not found — will retry", tone: "warn" };
     case "ambiguous":
@@ -193,6 +191,8 @@ function rejectionLabel(rej: EditOrWriteFailure): {
       };
     case "no_op":
       return { label: "No change", tone: "warn" };
+    case "too_large":
+      return { label: "Canvas too large for text tools", tone: "warn" };
     default:
       return { label: "Edit rejected", tone: "warn" };
   }

--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -689,15 +689,15 @@ function WelcomeSurface() {
                             ? `Ask Grida to design something in ${target.name}…`
                             : presetPlaceholder
                     }
-                    toolbar={
-                      <>
-                        <PresetChip value={preset} onChange={setPreset} />
-                        <DesktopModelPicker
-                          value={modelId}
-                          onValueChange={setModelId}
-                          endpoints={endpoints}
-                        />
-                      </>
+                    toolbarStart={
+                      <PresetChip value={preset} onChange={setPreset} />
+                    }
+                    toolbarEnd={
+                      <DesktopModelPicker
+                        value={modelId}
+                        onValueChange={setModelId}
+                        endpoints={endpoints}
+                      />
                     }
                   />
                   {/* Kept inside the composer so a submit error is visible even when

--- a/editor/lib/agent-chat/context-usage.test.ts
+++ b/editor/lib/agent-chat/context-usage.test.ts
@@ -108,6 +108,77 @@ describe("estimateContextBreakdown", () => {
       other: 3,
     });
   });
+
+  it("does not count persisted inline image bytes as prompt text", () => {
+    const image = {
+      ok: true,
+      path: "/scratch/image.png",
+      mime: "image/png",
+      width: 1024,
+      height: 1024,
+      bytes: 3_000_000,
+    };
+    const withoutUiBytes = estimateContextBreakdown([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-generate_image",
+            input: { prompt: "A poster" },
+            output: image,
+          },
+          {
+            type: "tool-view_image",
+            input: { path: image.path },
+            output: image,
+          },
+        ],
+      },
+    ]);
+    const withUiBytes = estimateContextBreakdown([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-generate_image",
+            input: { prompt: "A poster" },
+            output: { ...image, data: "A".repeat(4_000_000) },
+          },
+          {
+            type: "tool-view_image",
+            input: { path: image.path },
+            output: { ...image, data: "A".repeat(4_000_000) },
+          },
+        ],
+      },
+    ]);
+
+    expect(withUiBytes).toEqual(withoutUiBytes);
+    expect(withUiBytes.tools).toBeLessThan(100);
+  });
+
+  it("still counts ordinary text stored in a data field", () => {
+    const withoutData = estimateContextBreakdown([
+      {
+        role: "assistant",
+        parts: [{ type: "tool-example", input: {}, output: {} }],
+      },
+    ]);
+    const withData = estimateContextBreakdown([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-example",
+            input: {},
+            output: { data: "x".repeat(40) },
+          },
+        ],
+      },
+    ]);
+
+    expect(withData.tools).toBeGreaterThan(withoutData.tools);
+  });
 });
 
 describe("computeContextUsage", () => {

--- a/editor/lib/agent-chat/context-usage.ts
+++ b/editor/lib/agent-chat/context-usage.ts
@@ -12,7 +12,9 @@
  * runtime will send next: hidden system prompt, skill blocks, tool schemas,
  * provider framing, and server-side compaction state all live outside this
  * UI message list. Until the runtime exposes a prompt-token preflight value,
- * the honest client-side value is chars/4 over the visible message parts.
+ * the honest client-side value is chars/4 over the visible message parts'
+ * model-facing text. Persisted inline media bytes are UI payloads, not prompt
+ * text, and MUST NOT be serialized into this estimate.
  *
  * Provider-reported `metadata.usage` is still surfaced separately as
  * last-turn usage. That number is useful for cost/debugging, but it is not
@@ -108,13 +110,42 @@ function estimatePartTokens(part: PartLike): number {
   return 0;
 }
 
+/**
+ * Serialize the model-facing textual portion of a structured part.
+ *
+ * Image tools persist base64 `data` so the transcript can render their result,
+ * but the runtime's tool `toModelOutput` either lowers that result to a short
+ * descriptor or sends it as provider-native media. Counting the durable base64
+ * as prompt text can turn one image into millions of fake tokens.
+ */
 function safeStringify(value: unknown): string {
   if (typeof value === "string") return value;
   try {
-    return JSON.stringify(value) ?? "";
+    return (
+      JSON.stringify(value, (_key, nested) => {
+        if (!isInlineMediaPayload(nested)) return nested;
+        const { data: _mediaBytes, ...modelFacingMetadata } = nested;
+        return modelFacingMetadata;
+      }) ?? ""
+    );
   } catch {
     return "";
   }
+}
+
+function isInlineMediaPayload(
+  value: unknown
+): value is Record<string, unknown> & { data: string } {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const mime = record.mime ?? record.mediaType;
+  return (
+    typeof record.data === "string" &&
+    typeof mime === "string" &&
+    /^(image|audio|video)\//.test(mime)
+  );
 }
 
 /** The latest assistant message's stamped usage, or `undefined` until the

--- a/editor/scaffolds/desktop/ai-sidebar/agent-fs-binding.ts
+++ b/editor/scaffolds/desktop/ai-sidebar/agent-fs-binding.ts
@@ -9,9 +9,9 @@
  *               match-and-replace `edit_file`)
  *   load      → editor accepts any valid SVG; re-formatting is the
  *               editor's concern
- *   getVersion → `state.content_version` so UI-state emissions
- *               (selection, scope, mode, tool) don't strand the
- *               agent's writes as stale between read and edit
+ *   getVersion → `state.content_version` for host-side change events
+ *               and direct conditional writes; model-facing edits
+ *               validate their text against current content
  *   subscribe  → wires editor emissions into the fs's auto-flush
  *
  * The owning `AgentFs` (built once per file window in

--- a/editor/scaffolds/desktop/ai-sidebar/chat.tsx
+++ b/editor/scaffolds/desktop/ai-sidebar/chat.tsx
@@ -658,17 +658,17 @@ export function AISidebarChat({
           }
           providerFileMimes={providerFileMimes}
           operableFiles={isWorkspace}
-          toolbar={
+          toolbarEnd={
             <>
-              <DesktopModelPicker
-                value={modelId}
-                onValueChange={setModelId}
-                endpoints={endpoints}
-              />
               <DesktopContextMeter
                 messages={messages}
                 modelId={modelId}
                 costUsd={activeSession?.cost_usd}
+                endpoints={endpoints}
+              />
+              <DesktopModelPicker
+                value={modelId}
+                onValueChange={setModelId}
                 endpoints={endpoints}
               />
             </>

--- a/editor/scaffolds/desktop/shared/agent-composer-input.tsx
+++ b/editor/scaffolds/desktop/shared/agent-composer-input.tsx
@@ -525,7 +525,7 @@ function AgentComposerInner({
   return (
     <div
       className={cn(
-        "relative rounded-lg border bg-accent transition-colors [&_button:focus-visible]:ring-0!",
+        "relative rounded-lg border bg-accent transition-colors [&_button:focus-visible]:ring-1! [&_button:focus-visible]:ring-inset",
         className
       )}
     >

--- a/editor/scaffolds/desktop/shared/agent-composer-input.tsx
+++ b/editor/scaffolds/desktop/shared/agent-composer-input.tsx
@@ -7,9 +7,9 @@
  * (workspace file references), plus light rich text.
  *
  * Headless-ish: the caller supplies the `catalog` (commands + mentions)
- * and a `toolbar` (e.g. the model picker), and receives the lowered
- * prompt text on submit. The composer owns trigger state + editing; this
- * component owns the surrounding frame + send/stop affordances.
+ * and optional start/end toolbar content, and receives the lowered prompt
+ * text on submit. The composer owns trigger state + editing; this component
+ * owns the surrounding frame + send/stop affordances.
  *
  * Lowering: the prompt is `message.meta.text` plus an explicit list of
  * any referenced file paths (from `@`-mentions / file-ref parts) so the
@@ -148,8 +148,10 @@ export type AgentComposerInputProps = {
    * Hosts that give an empty submission its own action should describe it here.
    */
   emptySubmitLabel?: string;
-  /** Left-aligned footer content (e.g. the model picker). */
-  toolbar?: ReactNode;
+  /** Footer content grouped with the attachment button. */
+  toolbarStart?: ReactNode;
+  /** Footer content right-aligned before the submit/stop button. */
+  toolbarEnd?: ReactNode;
   className?: string;
 };
 
@@ -195,7 +197,8 @@ function AgentComposerInner({
   scratchReservation = ScratchSeedBudget.NONE,
   allowEmptySubmit = false,
   emptySubmitLabel,
-  toolbar,
+  toolbarStart,
+  toolbarEnd,
   className,
 }: Omit<AgentComposerInputProps, "catalog">) {
   // The image-block gate must match the queue controller's enqueue decision,
@@ -585,19 +588,22 @@ function AgentComposerInner({
             </DropdownMenu>
           </div>
         )}
-        {/* The toolbar (pickers + context meter) rides a shrinkable,
-            clipping track; the submit button sits outside it as shrink-0,
-            so as the composer narrows the pickers truncate first and the
-            most-important submit control is never culled. */}
+        {/* Start/end tools share a shrinkable, clipping track. `ml-auto`
+            creates the space-between split while the submit button stays
+            outside as shrink-0, so pickers truncate before the terminal
+            action is ever culled. */}
         <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
-          {toolbar}
+          {toolbarStart}
+          <div className="ml-auto flex min-w-0 items-center gap-0.5 overflow-hidden">
+            {toolbarEnd}
+          </div>
         </div>
         <div className="shrink-0">
           {isStreaming ? (
             <Button
               type="button"
-              size="icon-sm"
-              className="rounded-full"
+              size="icon-xs"
+              className="size-7 rounded-full"
               onClick={onStop}
               aria-label="Stop"
             >
@@ -606,8 +612,8 @@ function AgentComposerInner({
           ) : (
             <Button
               type="button"
-              size="icon-sm"
-              className="rounded-full"
+              size="icon-xs"
+              className="size-7 rounded-full"
               onClick={submit}
               disabled={isEncodingFiles}
               aria-label={

--- a/editor/scaffolds/desktop/shared/agent-composer-input.tsx
+++ b/editor/scaffolds/desktop/shared/agent-composer-input.tsx
@@ -525,7 +525,7 @@ function AgentComposerInner({
   return (
     <div
       className={cn(
-        "relative rounded-lg border bg-accent transition-colors",
+        "relative rounded-lg border bg-accent transition-colors [&_button:focus-visible]:ring-0!",
         className
       )}
     >

--- a/editor/scaffolds/desktop/shared/chat-session-picker.tsx
+++ b/editor/scaffolds/desktop/shared/chat-session-picker.tsx
@@ -17,12 +17,13 @@
 
 import { useRef, useState } from "react";
 import {
+  CircleIcon,
   CopyIcon,
   EllipsisVerticalIcon,
   ListIcon,
-  MessageSquarePlusIcon,
   PencilIcon,
   PlusIcon,
+  SquarePenIcon,
   Trash2Icon,
 } from "lucide-react";
 import {
@@ -182,7 +183,7 @@ export function ChatSessionPicker({
                   onSelect(null);
                 }}
               >
-                <MessageSquarePlusIcon className="size-3.5" />
+                <SquarePenIcon className="size-3.5" />
                 New chat
               </Button>
             )}
@@ -193,7 +194,7 @@ export function ChatSessionPicker({
               <div
                 key={s.id}
                 className={cn(
-                  "flex items-center rounded-sm pr-1",
+                  "group relative flex items-center rounded-sm hover:bg-accent has-[:focus-visible]:bg-accent has-data-[state=open]:bg-accent",
                   s.id === session.current_id && "bg-accent"
                 )}
               >
@@ -202,7 +203,7 @@ export function ChatSessionPicker({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "h-8 min-w-0 flex-1 justify-start rounded-sm px-2 text-sm font-normal",
+                    "h-8 min-w-0 flex-1 justify-start rounded-sm px-2 text-sm font-normal group-hover:pr-8 group-has-[:focus-visible]:pr-8 group-has-data-[state=open]:pr-8",
                     s.id === session.current_id &&
                       "bg-accent hover:bg-accent focus-visible:bg-accent"
                   )}
@@ -211,12 +212,16 @@ export function ChatSessionPicker({
                     onSelect(s.id);
                   }}
                 >
+                  <span className="flex size-2 shrink-0 items-center justify-center">
+                    <CircleIcon className="size-1.5 fill-current text-muted-foreground/50" />
+                  </span>
                   <span className="min-w-0 flex-1 truncate text-left">
                     {s.title}
                   </span>
                 </Button>
                 <SessionActionsMenu
                   session={s}
+                  triggerClassName="pointer-events-none absolute top-1/2 right-1 z-10 -translate-y-1/2 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 data-[state=open]:pointer-events-auto data-[state=open]:opacity-100"
                   onRename={openRename}
                   onDelete={(id) => {
                     setListOpen(false);
@@ -328,10 +333,12 @@ export function ChatSessionPicker({
  */
 function SessionActionsMenu({
   session: s,
+  triggerClassName,
   onRename,
   onDelete,
 }: {
   session: SessionRow;
+  triggerClassName?: string;
   onRename: (s: SessionRow) => void;
   onDelete: (id: string) => void;
 }) {
@@ -344,7 +351,7 @@ function SessionActionsMenu({
           size="icon-xs"
           aria-label="Chat actions"
           title="Chat actions"
-          className="shrink-0"
+          className={cn("shrink-0", triggerClassName)}
         >
           <EllipsisVerticalIcon className="size-3.5" />
         </Button>

--- a/editor/scaffolds/desktop/shared/context-meter.tsx
+++ b/editor/scaffolds/desktop/shared/context-meter.tsx
@@ -120,7 +120,14 @@ export function DesktopContextMeter({
               </Button>
             </PopoverTrigger>
           </TooltipTrigger>
-          <TooltipContent>Context {pct}</TooltipContent>
+          <TooltipContent className="text-center text-nowrap">
+            <div className="text-background/70">Context window:</div>
+            <div className="text-background/70">{pct} full</div>
+            <div className="mt-0.5">
+              {compact.format(usedTokens)} / {compact.format(maxTokens)} tokens
+              used
+            </div>
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
 

--- a/editor/scaffolds/desktop/shared/mode-picker.tsx
+++ b/editor/scaffolds/desktop/shared/mode-picker.tsx
@@ -24,11 +24,29 @@ import {
   asAgentMode,
   type AgentMode,
 } from "@grida/agent";
+import { HandIcon, ShieldCheckIcon, type LucideIcon } from "lucide-react";
 import type { ChatSessionRow } from "@/lib/desktop/bridge";
 
-const MODE_LABELS: Record<AgentMode, string> = {
-  "accept-edits": "Accept Edits",
-  auto: "Auto",
+const MODE_OPTIONS: Record<
+  AgentMode,
+  {
+    label: string;
+    description: string;
+    icon: LucideIcon;
+  }
+> = {
+  "accept-edits": {
+    label: "Accept Edits",
+    description:
+      "Reads and edits files automatically; asks before commands that may make changes.",
+    icon: HandIcon,
+  },
+  auto: {
+    label: "Auto",
+    description:
+      "Runs all commands without asking; workspace access remains sandboxed.",
+    icon: ShieldCheckIcon,
+  },
 };
 
 export function DesktopModePicker({
@@ -48,14 +66,36 @@ export function DesktopModePicker({
         className="min-w-0 px-2 text-xs [&>svg]:hidden [&_[data-slot=select-value]]:block [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate"
         aria-label="Mode"
       >
-        <PromptInputSelectValue placeholder="Mode" />
+        <PromptInputSelectValue>
+          {MODE_OPTIONS[value].label}
+        </PromptInputSelectValue>
       </PromptInputSelectTrigger>
-      <PromptInputSelectContent>
-        {AGENT_MODES.map((m) => (
-          <PromptInputSelectItem key={m} value={m} className="text-xs">
-            {MODE_LABELS[m]}
-          </PromptInputSelectItem>
-        ))}
+      <PromptInputSelectContent className="w-80 max-w-[calc(100vw-1rem)]">
+        <div className="px-2 py-1.5 text-xs text-muted-foreground">
+          How should agent actions be approved?
+        </div>
+        {AGENT_MODES.map((mode) => {
+          const option = MODE_OPTIONS[mode];
+          const Icon = option.icon;
+          return (
+            <PromptInputSelectItem
+              key={mode}
+              value={mode}
+              textValue={option.label}
+              className="items-start py-2.5 [&>span:last-child]:items-start"
+            >
+              <Icon className="mt-0.5 size-4" />
+              <span className="min-w-0">
+                <span className="block text-sm font-medium text-foreground">
+                  {option.label}
+                </span>
+                <span className="mt-0.5 block text-xs leading-snug whitespace-normal text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+            </PromptInputSelectItem>
+          );
+        })}
       </PromptInputSelectContent>
     </PromptInputSelect>
   );

--- a/editor/scaffolds/desktop/shared/mode-picker.tsx
+++ b/editor/scaffolds/desktop/shared/mode-picker.tsx
@@ -45,7 +45,7 @@ export function DesktopModePicker({
     >
       <PromptInputSelectTrigger
         size="sm"
-        className="min-w-0 gap-1 px-2 text-xs [&>svg]:transition-colors hover:[&>svg]:text-foreground aria-expanded:[&>svg]:text-foreground [&_[data-slot=select-value]]:block [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate"
+        className="min-w-0 px-2 text-xs [&>svg]:hidden [&_[data-slot=select-value]]:block [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate"
         aria-label="Mode"
       >
         <PromptInputSelectValue placeholder="Mode" />

--- a/editor/scaffolds/desktop/workbench/agent-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/agent-pane.tsx
@@ -905,18 +905,20 @@ function AgentPaneContent({
           onStop={stop}
           providerFileMimes={providerFileMimes}
           scratchReservation={scratchReservation}
-          toolbar={
+          toolbarStart={
+            <DesktopModePicker value={mode} onValueChange={setMode} />
+          }
+          toolbarEnd={
             <>
-              <DesktopModePicker value={mode} onValueChange={setMode} />
-              <DesktopModelPicker
-                value={modelId}
-                onValueChange={setModelId}
-                endpoints={endpoints}
-              />
               <DesktopContextMeter
                 messages={messages}
                 modelId={modelId}
                 costUsd={activeSession?.cost_usd}
+                endpoints={endpoints}
+              />
+              <DesktopModelPicker
+                value={modelId}
+                onValueChange={setModelId}
                 endpoints={endpoints}
               />
             </>

--- a/editor/scaffolds/desktop/workbench/editor-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane.tsx
@@ -387,13 +387,15 @@ function EditorTitleBar({
             />
           );
         })}
-        {/* The parent title bar owns dragging; region-free tab descendants
-            leave this unused space and the inter-tab gaps draggable. */}
+        {/* The parent title bar owns dragging. The stationary exclusions below
+            cover the occupied tab run (including inter-tab gaps); this genuinely
+            unused trailing space remains draggable. */}
         <div role="presentation" className="h-full min-w-0 flex-1" />
       </div>
       {/* Chromium does not clip native app-region boxes to scrollports. Keep
-          moving tab descendants region-free and mirror only their visible
-          rectangles here. This layer is stationary and pointer-transparent.
+          moving tab descendants region-free and mirror their visible interaction
+          run (tabs plus following gaps) here. This layer is stationary and
+          pointer-transparent.
           (see test/desktop-workbench-scrolled-tab-drag-region.md) */}
       <div
         ref={nativeDragExclusionLayerRef}

--- a/editor/scaffolds/desktop/workbench/editor-pane.tsx
+++ b/editor/scaffolds/desktop/workbench/editor-pane.tsx
@@ -442,7 +442,7 @@ function StartTabItem() {
       tabIndex={0}
       aria-selected
       data-tab-native-drag-region-target="start"
-      className="flex h-6 shrink-0 select-none items-center rounded-md bg-muted px-2 text-xs text-foreground shadow-xs outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+      className="flex h-7 shrink-0 select-none items-center rounded-md bg-muted px-2 text-xs text-foreground shadow-xs outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
     >
       Quick Start
     </div>
@@ -557,7 +557,7 @@ function TabItem({
         }
       }}
       className={cn(
-        "group flex h-6 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs outline-none transition-colors",
+        "group flex h-7 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs outline-none transition-colors",
         active
           ? "bg-muted text-foreground shadow-xs"
           : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",

--- a/editor/scaffolds/desktop/workbench/tab-native-drag-region.test.ts
+++ b/editor/scaffolds/desktop/workbench/tab-native-drag-region.test.ts
@@ -8,6 +8,25 @@ type TestRect = Readonly<{
   bottom: number;
 }>;
 
+function domRect(rect: TestRect): TestRect {
+  // DOMRect geometry fields are inherited accessors, not own enumerable fields.
+  // Keep the mock faithful so spreading one cannot silently drop coordinates.
+  return Object.create({
+    get left() {
+      return rect.left;
+    },
+    get top() {
+      return rect.top;
+    },
+    get right() {
+      return rect.right;
+    },
+    get bottom() {
+      return rect.bottom;
+    },
+  }) as TestRect;
+}
+
 function element({
   attribute,
   rect,
@@ -18,10 +37,11 @@ function element({
   display?: string;
 }): HTMLElement {
   const attributes = new Map(attribute ? [attribute] : []);
+  const bounds = domRect(rect);
   return {
     style: { display },
     getAttribute: (name: string) => attributes.get(name) ?? null,
-    getBoundingClientRect: () => rect,
+    getBoundingClientRect: () => bounds,
   } as unknown as HTMLElement;
 }
 
@@ -89,18 +109,27 @@ describe("TabNativeDragRegion.intersection", () => {
 });
 
 describe("TabNativeDragRegion.Controller", () => {
-  it("mirrors clipped targets in layer coordinates and clears stale overlays", () => {
+  it("mirrors clipped tabs and their following gaps while clearing stale overlays", () => {
+    const targetOffscreen = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "offscreen"],
+      rect: { left: -100, top: 8, right: 36, bottom: 36 },
+    });
     const targetA = element({
       attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "a"],
-      rect: { left: 40, top: 10, right: 180, bottom: 34 },
+      rect: { left: 40, top: 8, right: 180, bottom: 36 },
     });
     const targetB = element({
       attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "b"],
-      rect: { left: -100, top: 10, right: 80, bottom: 34 },
+      rect: { left: 184, top: 8, right: 300, bottom: 36 },
     });
     const targetC = element({
       attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "c"],
-      rect: { left: 460, top: 10, right: 560, bottom: 34 },
+      rect: { left: 304, top: 8, right: 560, bottom: 36 },
+    });
+    const exclusionOffscreen = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "offscreen"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "block",
     });
     const exclusionA = element({
       attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "a"],
@@ -110,7 +139,7 @@ describe("TabNativeDragRegion.Controller", () => {
     const exclusionB = element({
       attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "b"],
       rect: { left: 0, top: 0, right: 0, bottom: 0 },
-      display: "block",
+      display: "none",
     });
     const exclusionC = element({
       attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "c"],
@@ -118,11 +147,13 @@ describe("TabNativeDragRegion.Controller", () => {
       display: "none",
     });
     const viewport = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      targetOffscreen,
       targetA,
       targetB,
       targetC,
     ]);
     const layer = container({ left: 80, top: 0, right: 520, bottom: 44 }, [
+      exclusionOffscreen,
       exclusionA,
       exclusionB,
       exclusionC,
@@ -142,19 +173,63 @@ describe("TabNativeDragRegion.Controller", () => {
     }).toEqual({
       display: "block",
       left: "20px",
-      top: "10px",
-      width: "80px",
-      height: "24px",
+      top: "8px",
+      width: "84px",
+      height: "28px",
     });
-    expect(exclusionB.style.display).toBe("none");
+    expect({
+      display: exclusionB.style.display,
+      left: exclusionB.style.left,
+      width: exclusionB.style.width,
+    }).toEqual({
+      display: "block",
+      left: "104px",
+      width: "120px",
+    });
     expect({
       display: exclusionC.style.display,
       left: exclusionC.style.left,
       width: exclusionC.style.width,
     }).toEqual({
       display: "block",
-      left: "380px",
-      width: "40px",
+      left: "224px",
+      width: "196px",
+    });
+    expect(exclusionOffscreen.style.display).toBe("none");
+  });
+
+  it("leaves space after the final tab in the native drag region", () => {
+    const target = element({
+      attribute: [TabNativeDragRegion.TARGET_ATTRIBUTE, "final"],
+      rect: { left: 160, top: 8, right: 280, bottom: 36 },
+    });
+    const exclusion = element({
+      attribute: [TabNativeDragRegion.EXCLUSION_ATTRIBUTE, "final"],
+      rect: { left: 0, top: 0, right: 0, bottom: 0 },
+      display: "none",
+    });
+    const viewport = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      target,
+    ]);
+    const layer = container({ left: 100, top: 0, right: 500, bottom: 44 }, [
+      exclusion,
+    ]);
+
+    new TabNativeDragRegion.Controller(
+      viewport.element,
+      layer.element
+    ).reconcile();
+
+    expect({
+      display: exclusion.style.display,
+      left: exclusion.style.left,
+      width: exclusion.style.width,
+      height: exclusion.style.height,
+    }).toEqual({
+      display: "block",
+      left: "60px",
+      width: "120px",
+      height: "28px",
     });
   });
 

--- a/editor/scaffolds/desktop/workbench/tab-native-drag-region.ts
+++ b/editor/scaffolds/desktop/workbench/tab-native-drag-region.ts
@@ -17,8 +17,11 @@ type VisibleRect = Rect &
  *
  * Chromium does not clip `-webkit-app-region` boxes to an ancestor's
  * scrollport. The moving tab nodes therefore carry no app-region declaration.
- * This controller mirrors only their visible intersections onto stationary,
- * pointer-transparent exclusion rectangles outside the scroller.
+ * This controller mirrors their visible intersections onto stationary,
+ * pointer-transparent exclusion rectangles outside the scroller. Each
+ * exclusion extends through the gap before the next tab so wheel input reaches
+ * the scroll viewport there; the final exclusion stops at the final tab so
+ * genuinely unused title-bar space remains draggable.
  */
 export namespace TabNativeDragRegion {
   export const TARGET_ATTRIBUTE = "data-tab-native-drag-region-target";
@@ -76,19 +79,30 @@ export namespace TabNativeDragRegion {
       const visibleExclusions = new Map<HTMLElement, VisibleRect>();
       const viewportRect = this.viewport.getBoundingClientRect();
       const layerRect = this.exclusionLayer.getBoundingClientRect();
+      const targets = Array.from(this.targets(), (target) => ({
+        target,
+        rect: target.getBoundingClientRect(),
+      }));
 
       // Finish all layout reads before writing overlay styles. This runs on
       // every horizontal scroll event and must not force a layout per tab.
-      for (const target of this.targets()) {
+      for (const [index, { target, rect }] of targets.entries()) {
         const id = target.getAttribute(TARGET_ATTRIBUTE);
         if (id === null) continue;
         const exclusion = exclusions.get(id);
         if (!exclusion) continue;
 
-        const visible = intersection(
-          target.getBoundingClientRect(),
-          viewportRect
-        );
+        const next = targets[index + 1];
+        const exclusionRect =
+          next && next.rect.left > rect.right
+            ? {
+                left: rect.left,
+                top: rect.top,
+                right: next.rect.left,
+                bottom: rect.bottom,
+              }
+            : rect;
+        const visible = intersection(exclusionRect, viewportRect);
         if (visible) visibleExclusions.set(exclusion, visible);
       }
 

--- a/editor/scaffolds/desktop/workbench/tab-preview-controller.test.ts
+++ b/editor/scaffolds/desktop/workbench/tab-preview-controller.test.ts
@@ -25,7 +25,7 @@ describe("TabPreviewController", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it("opens a cold pointer target after 500 ms with a stable external-store snapshot", () => {
+  it("opens a cold pointer target after 50 ms with a stable external-store snapshot", () => {
     const controller = new TabPreviewController();
     const tab = anchor("a");
     const closed = controller.getSnapshot();

--- a/editor/scaffolds/desktop/workbench/tab-preview-controller.ts
+++ b/editor/scaffolds/desktop/workbench/tab-preview-controller.ts
@@ -12,7 +12,7 @@
  * flashing the shared viewport closed.
  */
 
-export const TAB_PREVIEW_OPEN_DELAY_MS = 500;
+export const TAB_PREVIEW_OPEN_DELAY_MS = 50;
 export const TAB_PREVIEW_CLOSE_DELAY_MS = 100;
 
 export type TabPreviewTarget = {

--- a/packages/grida-ai-agent/src/agent/prompts.test.ts
+++ b/packages/grida-ai-agent/src/agent/prompts.test.ts
@@ -10,6 +10,20 @@ describe("composeSystemPrompt", () => {
     expect(prompt).toContain("<filesystem>");
   });
 
+  it("teaches current-content edits without a prior-read authorization rule", () => {
+    const prompt = composeSystemPrompt({});
+
+    expect(prompt).toMatch(
+      /checks `old_string` against the file's current\s+content/
+    );
+    expect(prompt).toMatch(
+      /Do not re-read content you just successfully\s+wrote/
+    );
+    expect(prompt).not.toContain("before your first edit");
+    expect(prompt).not.toContain("most recent `version`");
+    expect(prompt).toContain('reason="too_large"');
+  });
+
   it("injects raw eager skill blocks only when provided", () => {
     const base = composeSystemPrompt({});
     const withBlock = composeSystemPrompt({

--- a/packages/grida-ai-agent/src/fs/README.md
+++ b/packages/grida-ai-agent/src/fs/README.md
@@ -36,12 +36,14 @@ share the API:
 
 - **Bound files.** `fs.mount(path, binding)` ties a path to an
   `AgentFs.LiveBinding` — anything with `serialize()` / `load()` / `getVersion()`.
-  Reads and writes go through the binding; freshness comes from
-  `binding.getVersion()`. The backend persists serialized snapshots; on
-  `hydrate()` we feed them back via `binding.load(...)`.
+  Reads and writes go through the binding. Its host-owned version remains an
+  internal concurrency/event primitive for direct callers; it is not exposed to
+  the model. The backend persists serialized snapshots; on `hydrate()` we feed
+  them back via `binding.load(...)`.
 - **Pure files.** Anything not mounted. Stored as `{content, version}`
-  in memory; version starts at 0 and bumps per write. Persisted by the
-  same backend.
+  in memory; the version starts at 0 and bumps per in-process mutation. It is
+  internal bookkeeping, not durable across reconstructed `AgentFs` instances
+  and never model authorization. Content is persisted by the same backend.
 
 The fs **never inspects bytes**. Formatting, parsing, schema validation
 are the binding's concern.
@@ -69,13 +71,24 @@ class AgentFs {
   list_directory_fresh(args?: AgentFs.ListArgs): Promise<AgentFs.ListResult>;
   exists(path: string): boolean;
   read(path: string): AgentFs.ReadResult | null;
-  write(
+  read_fresh(path: string): Promise<AgentFs.ReadResult | null>;
+  write(path: string, args: AgentFs.WriteArgs): AgentFs.WriteResult;
+  write_fresh(
     path: string,
-    content: string,
-    expected_version: number | null
-  ): AgentFs.WriteResult;
-  edit(path: string, args: AgentFs.EditArgs): AgentFs.EditResult;
+    args: AgentFs.WriteArgs
+  ): Promise<AgentFs.WriteResult>;
+  edit(
+    path: string,
+    args: AgentFs.EditArgs,
+    options?: AgentFs.EditOptions
+  ): AgentFs.EditResult;
+  edit_fresh(
+    path: string,
+    args: AgentFs.EditArgs,
+    options?: AgentFs.EditOptions
+  ): Promise<AgentFs.EditResult>;
   grep(args: AgentFs.GrepArgs): AgentFs.GrepResult;
+  grep_fresh(args: AgentFs.GrepArgs): Promise<AgentFs.GrepResult>;
   delete(path: string): AgentFs.DeleteResult; // pure files only
 }
 ```
@@ -88,9 +101,9 @@ All types (`AgentFs.Backend`, `AgentFs.LiveBinding`, `AgentFs.ReadResult`, the r
 
 | Tool         | Operation                                                                                                 | Claude Code parallel |
 | ------------ | --------------------------------------------------------------------------------------------------------- | -------------------- |
-| `read_file`  | `{ path }` → `{ content, version }`                                                                       | `Read`               |
-| `edit_file`  | `{ path, old_string, new_string, replace_all?, version }` → match-and-replace                             | `Edit`               |
-| `write_file` | `{ path, content, version? }` → full upsert; version-checked or permissive                                | `Write`              |
+| `read_file`  | `{ path }` → `{ content }`                                                                                | `Read`               |
+| `edit_file`  | `{ path, old_string, new_string, replace_all? }` → current-content match-and-replace                      | `Edit`               |
+| `write_file` | `{ path, content }` → full-file upsert                                                                    | `Write`              |
 | `list_files` | `{ path?, offset?, limit? }` → `{ path, folders, files, truncated, next_offset? }` — direct children only | ~`Glob` (scoped)     |
 | `grep_files` | `{ pattern, path_prefix?, case_sensitive? }` → `{ matches, files_scanned }`, mirrors `grep -n -F`         | `Grep`               |
 
@@ -103,11 +116,13 @@ prefer explicit command/search tools for broad discovery (`rg --files`,
 `find`, `ls`, `tree`) rather than teaching the model to trust a flat
 index.
 
-`AgentFs.resolveToolCall(fs, toolCall)` dispatches inbound calls
-synchronously against the hydrated VFS map. Use
-`AgentFs.resolveToolCallAsync(fs, toolCall)` on server-bound real-fs
-agents so `list_files` can call the backend's scoped directory reader
-instead of trusting the hydrate index.
+`AgentFs.resolveToolCall(fs, toolCall)` dispatches inbound calls synchronously
+against live bindings or the hydrated VFS map. Use
+`AgentFs.resolveToolCallAsync(fs, toolCall)` on server-bound real-fs agents. It
+reads current backend content for every `read_file` / `edit_file`, awaits
+mutation persistence, uses optimistic conflict detection for edits when the
+backend exposes a paired revision primitive, and uses scoped directory/search
+operations instead of trusting the hydrate index.
 
 Client-resolved VFS hosts plug the sync resolver into `Chat.onToolCall`:
 
@@ -126,9 +141,11 @@ const chat = new Chat({
 });
 ```
 
-Server-bound toolsets use the async resolver through `createToolset`, so
-workspace `list_files({ path })` reads the requested directory from disk
-on demand when the backend supports it.
+Server-bound toolsets use the async resolver through `createToolset`.
+`read_file`, `edit_file`, `write_file`, and `run_command` share
+`AgentFs.runExclusive`, a FIFO that preserves registration order when AI SDK
+executes tool calls concurrently. A successful server `write_file` is therefore
+persisted before a later edit, read, or command starts.
 
 ```ts
 namespace AgentFs {
@@ -143,7 +160,16 @@ namespace AgentFs {
     list(): Promise<string[]>;
     list_directory?(path: string): Promise<AgentFs.ListEntries>;
     read(path: string): Promise<string | null>;
+    // Implement both revision methods, or neither.
+    readWithRevision?(
+      path: string
+    ): Promise<AgentFs.BackendReadWithRevisionResult | null>;
     write(path: string, content: string): Promise<void>;
+    writeIfRevision?(
+      path: string,
+      content: string,
+      revision: string
+    ): Promise<AgentFs.BackendWriteIfRevisionResult>;
     delete(path: string): Promise<void>;
   }
 }
@@ -151,55 +177,74 @@ namespace AgentFs {
 
 ## Safety contract
 
-Every mutating op enforces these invariants:
+The model-facing contract has no prior-read ledger and no ephemeral version
+tokens. `edit_file` establishes its own precondition by loading current content
+during the invocation and locating `old_string`. A successful `write_file`
+therefore provides a valid baseline for an immediate edit; pausing or
+reconstructing the runtime does not create an artificial read requirement.
+All three model-facing text tools share a 1 MiB UTF-8 bound. An oversized read,
+write, or edit returns `too_large`; a write never reports success for content
+that a reconstructed fs cannot edit.
 
-| Precondition                                         | Failure       | Recovery                       |
-| ---------------------------------------------------- | ------------- | ------------------------------ |
-| `edit_file`: agent hasn't read this path yet         | `not_read`    | Read first                     |
-| `edit_file` / version-checked `write`: stale version | `stale`       | Re-read, integrate, retry      |
-| `edit_file`: `old_string` not in current content     | `not_found`   | Re-read, copy snippet verbatim |
-| `edit_file`: matched N > 1, no `replace_all`         | `ambiguous`   | Add context to disambiguate    |
-| `edit_file`: `old_string === new_string`             | `no_op`       | Pick a real change             |
-| `binding.load(content)` throws                       | `parse_error` | Model fixes the content        |
-| `write` with version on a missing path               | `not_found`   | Pass `version: null` to create |
+| Condition                                                | Failure                   | Recovery                                  |
+| -------------------------------------------------------- | ------------------------- | ----------------------------------------- |
+| `edit_file`: path is absent                              | `not_found`               | Create it or choose the correct path      |
+| `edit_file`: `old_string` is absent from current content | `not_found`               | Read current content, reconcile, retry    |
+| `edit_file`: matched N > 1 without `replace_all`         | `ambiguous`               | Add surrounding context                   |
+| `edit_file`: backend revision conflict detected          | `stale`                   | Re-read current content, reconcile, retry |
+| `edit_file`: `old_string === new_string`                 | `no_op`                   | Pick a real change                        |
+| text content exceeds the shared 1 MiB UTF-8 bound        | `too_large`               | Use shell/streaming or split the artifact |
+| `binding.load(content)` throws                           | `parse_error`             | Fix the content                           |
+| backend read/write rejects                               | `io_error`                | Resolve storage failure, then retry       |
+| host mutation policy rejects the path                    | `protected` / `read_only` | Use an authorized surface                 |
 
-`write(path, content, null)` is **permissive** — bypasses `not_read` and
-`stale` entirely. Use only when the agent is genuinely starting fresh.
-The host's prompt should discourage casual use.
+`write_file` is a deliberate last-writer-wins full-file upsert. It creates or
+overwrites; targeted existing-file changes belong in `edit_file`. The internal
+`AgentFs.write({ expected_version })` API remains for host/live-binding callers,
+but that numeric version is not part of the model tool.
 
 ## Match-and-replace (`edit_file`)
 
-Conservative on purpose — closer to Claude Code's `Edit` than to aider's
-diff fuzzing:
+Conservative on purpose — the supplied text is the proof that the mutation
+still applies:
 
-1. **Literal substring match.** Wins almost always when the agent copies
-   the snippet from `read()`.
-2. **Whitespace-normalized fallback.** Runs of whitespace collapse to a
+1. **Operation-time content.** The synchronous resolver uses the current live
+   binding/cache; the server resolver rereads the backend for the invocation.
+2. **Literal substring match.** Wins almost always when the agent copies the
+   snippet from `read_file` or from content it just wrote.
+3. **Whitespace-normalized fallback.** Runs of whitespace collapse to a
    single space on both sides; indices map back to the original. Forgives
    doubled spaces between attributes and minor newline drift; does **not**
    enable attribute-order rewriting or semantic matching.
-3. **Ambiguity rejection.** N > 1 matches without `replace_all` → reject
+4. **Ambiguity rejection.** N > 1 matches without `replace_all` → reject
    with `reason: "ambiguous"` + the occurrence count.
+5. **Optimistic publication when available.** The workspace backend pairs the
+   read with an opaque content revision and rejects a detected conflict. This
+   reduces the read-to-publish race; it does not claim a cross-process lock.
 
 Implementation: `findMatches()` in `internal/match.ts` (not part of the public surface — call `AgentFs.edit()` instead).
 
 ## Backends
 
-| Backend                                    | Where it runs | Use                                          |
-| ------------------------------------------ | ------------- | -------------------------------------------- |
-| `AgentFs.MemoryBackend`                    | anywhere      | Tests, SSR, fallback when no persistence     |
-| `OpfsBackend` (subpath `/backends/opfs`)   | browser only  | The `/svg` demo and future canvas surfaces   |
-| `NodeFsBackend` (subpath `/backends/node`) | Node          | Unit tests and agent host workspace bindings |
+| Backend                                    | Where it runs | Use                                        |
+| ------------------------------------------ | ------------- | ------------------------------------------ |
+| `AgentFs.MemoryBackend`                    | anywhere      | Tests, SSR, fallback when no persistence   |
+| `OpfsBackend` (subpath `/backends/opfs`)   | browser only  | The `/svg` demo and future canvas surfaces |
+| `NodeFsBackend` (subpath `/backends/node`) | Node          | Standalone disk-backed tools and tests     |
+| `WorkspaceAgentFsBackend`                  | Node host     | Opened agent workspaces                    |
 
-All three implement `AgentFs.Backend`. `OpfsBackend` and `NodeFsBackend` live behind subpath imports so a bare `import "@grida/agent/fs"` doesn't pull `window.navigator.storage` or `node:fs`.
+Each implements `AgentFs.Backend`. `OpfsBackend` and `NodeFsBackend` live behind subpath imports so a bare `import "@grida/agent/fs"` doesn't pull `window.navigator.storage` or `node:fs`.
 
 ```ts
 import { OpfsBackend } from "@grida/agent/fs/backends/opfs"; // browser
 import { NodeFsBackend } from "@grida/agent/fs/backends/node"; // server / tests
 ```
 
-Backends are pure I/O — no caching, no debouncing, no version tracking.
-The fs layer owns those.
+Backends are pure I/O — no caching or debouncing. A backend MAY expose the
+`readWithRevision` / `writeIfRevision` pair for optimistic publication.
+`WorkspaceAgentFsBackend` maps that opaque revision to the daemon's mtime
+precondition and atomic replace; memory/OPFS fall back to an immediate read and
+awaited write inside the in-process FIFO.
 
 ## Single-file demos
 
@@ -230,9 +275,13 @@ pnpm --filter @grida/agent test
 ## What this module deliberately is not
 
 - **A general-purpose VFS layer.** No symlinks, no permissions, no mtime,
-  no streaming. The agent surface is the only consumer.
-- **A locking primitive.** Single-tab, single-process. Backends don't
-  implement file locks; concurrent writers on the same path will race.
+  no streaming. The agent surface is the only consumer; text tools are capped
+  at 1 MiB UTF-8.
+- **A cross-process lock.** Server-bound operations and commands serialize
+  within one `AgentFs`. The workspace backend additionally performs best-effort
+  optimistic conflict detection between edit validation and publication, but
+  independent processes are not globally locked and full-file `write_file`
+  remains last-writer-wins.
 - **An IR / format module.** Bytes are opaque to the fs. SVG pretty-
   printing happens in the binding; markdown linting (if added) would
   too.

--- a/packages/grida-ai-agent/src/fs/fs.test.ts
+++ b/packages/grida-ai-agent/src/fs/fs.test.ts
@@ -500,6 +500,44 @@ describe("AgentFs — server-bound current-content edits", () => {
     expect(await backend.read("/notes.md")).toBe("human changed");
   });
 
+  it("reports backend read failures without treating the file as missing", async () => {
+    let failRead = false;
+    const backend: AgentFs.Backend = {
+      async list() {
+        return ["/notes.md"];
+      },
+      async read() {
+        return "persisted";
+      },
+      async readWithRevision() {
+        if (failRead) throw new Error("temporary read failure");
+        return { content: "persisted", revision: "1" };
+      },
+      async write() {},
+      async writeIfRevision(_path, _content, revision) {
+        return { ok: true, revision };
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+    failRead = true;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await AgentFs.resolveToolCallAsync(fs, {
+      tool_name: "read_file",
+      input: { path: "/notes.md" },
+    });
+
+    warn.mockRestore();
+    expect(result).toMatchObject({ ok: false, reason: "io_error" });
+    expect(fs.read("/notes.md")).toMatchObject({ content: "persisted" });
+    const readSchema = AgentFs.tools.read_file.outputSchema as {
+      safeParse(value: unknown): { success: boolean };
+    };
+    expect(readSchema.safeParse(result).success).toBe(true);
+  });
+
   it("serializes concurrent compatible edits on one path", async () => {
     const backend = new AgentFs.MemoryBackend();
     await backend.write("/notes.md", "alpha beta");

--- a/packages/grida-ai-agent/src/fs/fs.test.ts
+++ b/packages/grida-ai-agent/src/fs/fs.test.ts
@@ -154,6 +154,25 @@ describe("MemoryBackend", () => {
 // ---------------------------------------------------------------------------
 
 describe("AgentFs — basics", () => {
+  it("requires backend revision reads and writes to be implemented together", () => {
+    const backend: AgentFs.Backend = {
+      async list() {
+        return [];
+      },
+      async read() {
+        return null;
+      },
+      async readWithRevision() {
+        return null;
+      },
+      async write() {},
+      async delete() {},
+    };
+    expect(() => new AgentFs(backend)).toThrow(
+      /readWithRevision and writeIfRevision together/
+    );
+  });
+
   it("starts empty and lists nothing", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     expect(fs.list()).toEqual([]);
@@ -331,9 +350,7 @@ describe("AgentFs — mounted (live binding)", () => {
 });
 
 describe("AgentFs.edit", () => {
-  it("requires a prior read on the path (not_read)", async () => {
-    // Seed the backend so hydrate brings in a file without any agent read.
-    // A direct `fs.write()` would count as a read, so we use hydrate here.
+  it("edits a hydrated file without a prior read when context matches", async () => {
     const backend = new AgentFs.MemoryBackend();
     await backend.write("/notes.md", "alpha beta");
     const fs = new AgentFs(backend);
@@ -341,21 +358,17 @@ describe("AgentFs.edit", () => {
     const r = fs.edit("/notes.md", {
       old_string: "alpha",
       new_string: "ALPHA",
-      expected_version: 0,
     });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.reason).toBe("not_read");
+    expect(r.ok).toBe(true);
+    expect(fs.read("/notes.md")?.content).toBe("ALPHA beta");
   });
 
   it("applies a unique match and advances the version", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     fs.write("/notes.md", { content: "alpha beta", expected_version: null });
-    const { version } = fs.read("/notes.md")!;
     const r = fs.edit("/notes.md", {
       old_string: "alpha",
       new_string: "ALPHA",
-      expected_version: version,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -366,11 +379,9 @@ describe("AgentFs.edit", () => {
   it("refuses an ambiguous match without replace_all", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     fs.write("/notes.md", { content: "x x x", expected_version: null });
-    const { version } = fs.read("/notes.md")!;
     const r = fs.edit("/notes.md", {
       old_string: "x",
       new_string: "Y",
-      expected_version: version,
     });
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -381,12 +392,10 @@ describe("AgentFs.edit", () => {
   it("applies all matches when replace_all is true", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     fs.write("/notes.md", { content: "x x x", expected_version: null });
-    const { version } = fs.read("/notes.md")!;
     const r = fs.edit("/notes.md", {
       old_string: "x",
       new_string: "Y",
       replace_all: true,
-      expected_version: version,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -397,11 +406,9 @@ describe("AgentFs.edit", () => {
   it("rejects no-op edits", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     fs.write("/notes.md", { content: "alpha", expected_version: null });
-    const { version } = fs.read("/notes.md")!;
     const r = fs.edit("/notes.md", {
       old_string: "alpha",
       new_string: "alpha",
-      expected_version: version,
     });
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -411,11 +418,9 @@ describe("AgentFs.edit", () => {
   it("returns not_found when snippet is absent", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     fs.write("/notes.md", { content: "alpha", expected_version: null });
-    const { version } = fs.read("/notes.md")!;
     const r = fs.edit("/notes.md", {
       old_string: "gamma",
       new_string: "GAMMA",
-      expected_version: version,
     });
     expect(r.ok).toBe(false);
     if (r.ok) return;
@@ -426,15 +431,451 @@ describe("AgentFs.edit", () => {
     const fs = new AgentFs(new AgentFs.MemoryBackend());
     const b = makeBinding('<svg><rect fill="red"/></svg>');
     fs.mount("/canvas.svg", b);
-    const { version } = fs.read("/canvas.svg")!;
     const r = fs.edit("/canvas.svg", {
       old_string: 'fill="red"',
       new_string: 'fill="blue"',
-      expected_version: version,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(b.current()).toContain('fill="blue"');
+  });
+});
+
+describe("AgentFs — server-bound current-content edits", () => {
+  it("writes, reconstructs the fs, then edits without an authorization read", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    const first = new AgentFs(backend);
+    expect(
+      await AgentFs.resolveToolCallAsync(first, {
+        tool_name: "write_file",
+        input: { path: "/new.md", content: "alpha beta" },
+      })
+    ).toEqual({ ok: true });
+    expect(await backend.read("/new.md")).toBe("alpha beta");
+
+    const resumed = new AgentFs(backend);
+    await resumed.hydrate();
+    expect(
+      await AgentFs.resolveToolCallAsync(resumed, {
+        tool_name: "edit_file",
+        input: {
+          path: "/new.md",
+          old_string: "alpha",
+          new_string: "ALPHA",
+        },
+      })
+    ).toEqual({ ok: true, occurrences: 1 });
+    expect(await backend.read("/new.md")).toBe("ALPHA beta");
+  });
+
+  it("validates against backend content changed after hydration", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    await backend.write("/notes.md", "alpha beta");
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+
+    await backend.write("/notes.md", "human alpha beta");
+    expect(
+      await AgentFs.resolveToolCallAsync(fs, {
+        tool_name: "read_file",
+        input: { path: "/notes.md" },
+      })
+    ).toEqual({ content: "human alpha beta" });
+    const staleContext = await fs.edit_fresh("/notes.md", {
+      old_string: "alpha beta",
+      new_string: "agent",
+    });
+    expect(staleContext.ok).toBe(true);
+    expect(await backend.read("/notes.md")).toBe("human agent");
+
+    await backend.write("/notes.md", "human changed");
+    const missingContext = await fs.edit_fresh("/notes.md", {
+      old_string: "agent",
+      new_string: "AGENT",
+    });
+    expect(missingContext).toMatchObject({
+      ok: false,
+      reason: "not_found",
+    });
+    expect(await backend.read("/notes.md")).toBe("human changed");
+  });
+
+  it("serializes concurrent compatible edits on one path", async () => {
+    const backend = new AgentFs.MemoryBackend();
+    await backend.write("/notes.md", "alpha beta");
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+
+    const [first, second] = await Promise.all([
+      fs.edit_fresh("/notes.md", {
+        old_string: "alpha",
+        new_string: "ALPHA",
+      }),
+      fs.edit_fresh("/notes.md", {
+        old_string: "beta",
+        new_string: "BETA",
+      }),
+    ]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(await backend.read("/notes.md")).toBe("ALPHA BETA");
+  });
+
+  it("does not let an older in-flight flush overwrite a fresh write", async () => {
+    let disk: string | null = null;
+    let writes = 0;
+    let startFirst!: () => void;
+    let releaseFirst!: () => void;
+    let finishFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      startFirst = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstFinished = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const backend: AgentFs.Backend = {
+      async list() {
+        return [];
+      },
+      async read() {
+        return disk;
+      },
+      async write(_path, content) {
+        writes += 1;
+        if (writes === 1) {
+          startFirst();
+          await firstGate;
+          disk = content;
+          finishFirst();
+          return;
+        }
+        disk = content;
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend, { flush_debounce_ms: 0 });
+    fs.write("/notes.md", { content: "old", expected_version: null });
+    await firstStarted;
+
+    const fresh = fs.write_fresh("/notes.md", {
+      content: "new",
+      expected_version: null,
+    });
+    setTimeout(releaseFirst, 0);
+
+    expect(await fresh).toMatchObject({ ok: true });
+    await firstFinished;
+    expect(disk).toBe("new");
+    expect(fs.read("/notes.md")?.content).toBe("new");
+    fs.dispose();
+  });
+
+  it("does not replace dirty cache with old disk bytes after a failed flush", async () => {
+    let disk = "base";
+    let failNextWrite = true;
+    const backend: AgentFs.Backend = {
+      async list() {
+        return ["/notes.md"];
+      },
+      async read() {
+        return disk;
+      },
+      async write(_path, content) {
+        if (failNextWrite) {
+          failNextWrite = false;
+          throw new Error("temporary storage failure");
+        }
+        disk = content;
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend, { flush_debounce_ms: 10_000 });
+    await fs.hydrate();
+    fs.write("/notes.md", { content: "new", expected_version: null });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(await fs.read_fresh("/notes.md")).toMatchObject({ content: "new" });
+    expect(disk).toBe("base");
+
+    await fs.flush();
+    warn.mockRestore();
+    expect(disk).toBe("new");
+    expect(fs.read("/notes.md")?.content).toBe("new");
+    fs.dispose();
+  });
+
+  it("does not edit old disk bytes after a pending local flush fails", async () => {
+    let disk = "base alpha";
+    let failNextWrite = true;
+    const backend: AgentFs.Backend = {
+      async list() {
+        return ["/notes.md"];
+      },
+      async read() {
+        return disk;
+      },
+      async write(_path, content) {
+        if (failNextWrite) {
+          failNextWrite = false;
+          throw new Error("temporary storage failure");
+        }
+        disk = content;
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend, { flush_debounce_ms: 10_000 });
+    await fs.hydrate();
+    fs.write("/notes.md", {
+      content: "local alpha",
+      expected_version: null,
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(
+      await fs.edit_fresh("/notes.md", {
+        old_string: "base",
+        new_string: "edited",
+      })
+    ).toMatchObject({ ok: false, reason: "io_error" });
+    warn.mockRestore();
+    expect(disk).toBe("base alpha");
+    expect(fs.read("/notes.md")?.content).toBe("local alpha");
+    fs.dispose();
+  });
+
+  it("does not publish when the backend revision changes during the edit", async () => {
+    let content = "alpha beta";
+    let revision = "1";
+    const backend: AgentFs.Backend = {
+      async list() {
+        return ["/notes.md"];
+      },
+      async read() {
+        return content;
+      },
+      async readWithRevision() {
+        return { content, revision };
+      },
+      async write(_path, next) {
+        content = next;
+      },
+      async writeIfRevision(_path, _next, expected) {
+        content = "human alpha beta";
+        revision = "2";
+        expect(expected).toBe("1");
+        return { ok: false, reason: "stale" };
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend);
+    await fs.hydrate();
+
+    expect(
+      await fs.edit_fresh("/notes.md", {
+        old_string: "alpha",
+        new_string: "ALPHA",
+      })
+    ).toMatchObject({ ok: false, reason: "stale" });
+    expect(content).toBe("human alpha beta");
+    expect(fs.read("/notes.md")?.content).toBe("alpha beta");
+  });
+
+  it("reports persistence failures instead of returning success", async () => {
+    const backend: AgentFs.Backend = {
+      async list() {
+        return [];
+      },
+      async read() {
+        return null;
+      },
+      async write() {
+        throw new Error("disk full");
+      },
+      async delete() {},
+    };
+    const fs = new AgentFs(backend);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await fs.write_fresh("/notes.md", {
+      content: "hello",
+      expected_version: null,
+    });
+    warn.mockRestore();
+    expect(result).toMatchObject({ ok: false, reason: "io_error" });
+    expect(fs.read("/notes.md")).toBeNull();
+  });
+});
+
+describe("AgentFs — model tool contract", () => {
+  it("does not expose ephemeral versions in schemas or results", async () => {
+    const readSchema = AgentFs.tools.read_file.outputSchema as {
+      safeParse(value: unknown): {
+        success: boolean;
+        data?: Record<string, unknown>;
+      };
+    };
+    const editSchema = AgentFs.tools.edit_file.inputSchema as {
+      safeParse(value: unknown): {
+        success: boolean;
+        data?: Record<string, unknown>;
+      };
+    };
+    const writeSchema = AgentFs.tools.write_file.inputSchema as {
+      safeParse(value: unknown): {
+        success: boolean;
+        data?: Record<string, unknown>;
+      };
+    };
+
+    expect(readSchema.safeParse({ content: "x" }).success).toBe(true);
+    const parsedRead = readSchema.safeParse({ content: "x", version: 7 });
+    expect(parsedRead.success).toBe(true);
+    expect(parsedRead.data).not.toHaveProperty("version");
+    expect(
+      editSchema.safeParse({
+        path: "/x",
+        old_string: "a",
+        new_string: "b",
+        version: 7,
+      }).data
+    ).not.toHaveProperty("version");
+    expect(
+      writeSchema.safeParse({
+        path: "/x",
+        content: "b",
+        version: 7,
+      }).data
+    ).not.toHaveProperty("version");
+
+    const fs = new AgentFs(new AgentFs.MemoryBackend());
+    expect(
+      AgentFs.resolveToolCall(fs, {
+        tool_name: "write_file",
+        input: { path: "/x", content: "a" },
+      })
+    ).toEqual({ ok: true });
+    expect(
+      AgentFs.resolveToolCall(fs, {
+        tool_name: "read_file",
+        input: { path: "/x" },
+      })
+    ).toEqual({ content: "a" });
+    expect(
+      AgentFs.resolveToolCall(fs, {
+        tool_name: "edit_file",
+        input: {
+          path: "/x",
+          old_string: "a",
+          new_string: "b",
+        },
+      })
+    ).toEqual({ ok: true, occurrences: 1 });
+    const editFailure = AgentFs.resolveToolCall(fs, {
+      tool_name: "edit_file",
+      input: {
+        path: "/x",
+        old_string: "missing",
+        new_string: "c",
+      },
+    });
+    expect(editFailure).toMatchObject({ ok: false, reason: "not_found" });
+    expect(editFailure).not.toHaveProperty("version");
+    expect(editFailure).not.toHaveProperty("current_version");
+
+    const asyncFs = new AgentFs(new AgentFs.MemoryBackend());
+    const asyncWrite = await AgentFs.resolveToolCallAsync(asyncFs, {
+      tool_name: "write_file",
+      input: { path: "/async", content: "a" },
+    });
+    expect(asyncWrite).toEqual({ ok: true });
+    expect(asyncWrite).not.toHaveProperty("version");
+    const asyncEdit = await AgentFs.resolveToolCallAsync(asyncFs, {
+      tool_name: "edit_file",
+      input: {
+        path: "/async",
+        old_string: "a",
+        new_string: "b",
+      },
+    });
+    expect(asyncEdit).toEqual({ ok: true, occurrences: 1 });
+    expect(asyncEdit).not.toHaveProperty("version");
+  });
+
+  it("returns too_large consistently for model text beyond the shared bound", async () => {
+    const oversized = "x".repeat(AgentFs.MAX_TEXT_FILE_BYTES + 1);
+    const backend = new AgentFs.MemoryBackend();
+    const fs = new AgentFs(backend);
+
+    expect(
+      AgentFs.resolveToolCall(fs, {
+        tool_name: "write_file",
+        input: { path: "/large.txt", content: oversized },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+    expect(
+      AgentFs.resolveToolCall(fs, {
+        tool_name: "write_file",
+        input: {
+          path: "/large-unicode.txt",
+          content: "😀".repeat(AgentFs.MAX_TEXT_FILE_BYTES / 4 + 1),
+        },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+    expect(await backend.read("/large.txt")).toBeNull();
+
+    const directLarge = "x".repeat(AgentFs.MAX_TEXT_FILE_BYTES) + "a";
+    expect(
+      fs.write("/direct-large.txt", {
+        content: directLarge,
+        expected_version: null,
+      })
+    ).toMatchObject({ ok: true });
+    expect(
+      fs.edit("/direct-large.txt", {
+        old_string: "a",
+        new_string: "b",
+      })
+    ).toMatchObject({ ok: true });
+    await fs.flush();
+    expect((await backend.read("/direct-large.txt"))?.endsWith("b")).toBe(true);
+
+    await backend.write("/large.txt", oversized);
+    const resumed = new AgentFs(backend);
+    await resumed.hydrate();
+    expect(
+      await AgentFs.resolveToolCallAsync(resumed, {
+        tool_name: "read_file",
+        input: { path: "/large.txt" },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+    expect(
+      await AgentFs.resolveToolCallAsync(resumed, {
+        tool_name: "edit_file",
+        input: {
+          path: "/large.txt",
+          old_string: "x",
+          new_string: "y",
+        },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+
+    const bounded = "x".repeat(AgentFs.MAX_TEXT_FILE_BYTES - 1) + "a";
+    await backend.write("/bounded.txt", bounded);
+    const boundedFs = new AgentFs(backend);
+    await boundedFs.hydrate();
+    expect(
+      await AgentFs.resolveToolCallAsync(boundedFs, {
+        tool_name: "edit_file",
+        input: {
+          path: "/bounded.txt",
+          old_string: "a",
+          new_string: "aa",
+        },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+    expect(await backend.read("/bounded.txt")).toBe(bounded);
   });
 });
 
@@ -505,13 +946,7 @@ describe("AgentFs.grep", () => {
     expect(r.matches[0].line).toBe(2);
   });
 
-  it("does NOT count as a read — subsequent edit still requires read_file", () => {
-    const fs = new AgentFs(new AgentFs.MemoryBackend());
-    const backend = new AgentFs.MemoryBackend();
-    void backend; // unused
-    fs.write("/notes.md", { content: "hello", expected_version: null });
-    // simulate fresh session by hand: a write counts as a read, so use a fresh fs hydrated from backend.
-    // Easier: assert via a second fs that loaded without a read.
+  it("finds edit context without creating a separate authorization state", () => {
     const b2Backend = new AgentFs.MemoryBackend();
     return (async () => {
       await b2Backend.write("/notes.md", "hello");
@@ -519,15 +954,12 @@ describe("AgentFs.grep", () => {
       await fs2.hydrate();
       const r = fs2.grep({ pattern: "hello" });
       expect(r.matches.length).toBe(1);
-      // Now editing should still fail with not_read because grep didn't set last_read.
       const e = fs2.edit("/notes.md", {
         old_string: "hello",
         new_string: "hi",
-        expected_version: 0,
       });
-      expect(e.ok).toBe(false);
-      if (e.ok) return;
-      expect(e.reason).toBe("not_read");
+      expect(e.ok).toBe(true);
+      expect(fs2.read("/notes.md")?.content).toBe("hi");
     })();
   });
 });
@@ -753,7 +1185,6 @@ describe("AgentFs.watch", () => {
     const r = fs.edit("/notes.md", {
       old_string: "world",
       new_string: "there",
-      expected_version: start!.version,
     });
     expect(r.ok).toBe(true);
     expect(listener).toHaveBeenCalledTimes(1);

--- a/packages/grida-ai-agent/src/fs/index.ts
+++ b/packages/grida-ai-agent/src/fs/index.ts
@@ -66,6 +66,47 @@ const PATH_DESCRIPTION =
 const HYDRATE_READ_CONCURRENCY = 24;
 const LIST_DIRECTORY_DEFAULT_LIMIT = 200;
 const LIST_DIRECTORY_MAX_LIMIT = 1000;
+const MODEL_TEXT_FILE_MAX_BYTES = 1_048_576;
+
+function utf8ByteLength(content: string): number {
+  let bytes = 0;
+  for (let i = 0; i < content.length; i++) {
+    const code = content.charCodeAt(i);
+    if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x7ff) {
+      bytes += 2;
+    } else if (
+      code >= 0xd800 &&
+      code <= 0xdbff &&
+      i + 1 < content.length &&
+      content.charCodeAt(i + 1) >= 0xdc00 &&
+      content.charCodeAt(i + 1) <= 0xdfff
+    ) {
+      bytes += 4;
+      i += 1;
+    } else {
+      // Three bytes covers BMP code points and TextEncoder's U+FFFD
+      // replacement for an unpaired surrogate.
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function textSizeFailure(
+  path: string,
+  content: string,
+  maxBytes: number
+): { ok: false; reason: "too_large"; message: string } | null {
+  const bytes = utf8ByteLength(content);
+  if (bytes <= maxBytes) return null;
+  return {
+    ok: false,
+    reason: "too_large",
+    message: `File at ${path} is ${bytes} UTF-8 bytes; the text file limit is ${maxBytes} bytes.`,
+  };
+}
 
 function normalizeDirectoryPath(path: string | undefined): string {
   const raw = path?.trim();
@@ -201,16 +242,17 @@ async function mapSettledBounded<T, R>(
  *  - **Mirrors real fs ops.** `read` / `write` / `edit` / `delete` /
  *    `list` / `exists`, with a `mount` hook for paths backed by live
  *    state.
- *  - **Safety contract.** Read-before-write + version freshness checks
- *    on every mutating op, so the agent can't silently overwrite human
- *    edits or its own stale view.
+ *  - **Safety contract.** Match-and-replace edits validate their context
+ *    against the file's current content when the operation executes. A
+ *    session-local "read" record is never treated as write authority.
  *
  * Two file shapes share the API:
  *
  *  - **Bound files.** `mount(path, binding)` ties a path to an
  *    `AgentFs.LiveBinding`. `read` and `write` go through the binding;
- *    `getVersion()` is the freshness token. The backend persists a
- *    serialized snapshot; on `hydrate()` we load it via `binding.load()`.
+ *    `getVersion()` is an internal host freshness token, not a model-facing
+ *    credential. The backend persists a serialized snapshot; on `hydrate()`
+ *    we load it via `binding.load()`.
  *
  *  - **Pure files.** Anything not mounted. Stored in memory as
  *    `{content, version}` (version starts at 0, bumps per write). Useful
@@ -226,15 +268,25 @@ export class AgentFs {
   private readonly bindings = new Map<string, AgentFs.LiveBinding>();
   private readonly binding_unsubs = new Map<string, () => void>();
   private readonly files = new Map<string, FileEntry>();
-  /** Paths the agent has called `read()` on this session. */
-  private readonly last_read = new Map<string, number>();
   /** Last content sent to the backend per path. Avoids redundant writes. */
   private readonly last_flushed = new Map<string, string>();
   private readonly flush_queue = new Set<string>();
   private flush_timer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Debounced flushes may already be awaiting backend I/O when another
+   * operation asks to flush. Join them instead of starting a second writer:
+   * otherwise an older write can finish after a newer server-bound mutation.
+   */
+  private flush_tail: Promise<boolean> = Promise.resolve(true);
   private disposed = false;
   private hydrate_promise: Promise<void> | null = null;
   private readonly watchers = new Set<AgentFs.Listener>();
+  /**
+   * Server-bound filesystem operations and commands share this FIFO. AI SDK
+   * tool calls may execute concurrently; registration order must still
+   * preserve a write → edit → command sequence against one workspace.
+   */
+  private operation_tail: Promise<void> = Promise.resolve();
 
   private readonly write_guard?: AgentFs.Options["write_guard"];
 
@@ -242,6 +294,13 @@ export class AgentFs {
     private readonly backend: AgentFs.Backend,
     opts: AgentFs.Options = {}
   ) {
+    const readsRevisions = typeof backend.readWithRevision === "function";
+    const writesRevisions = typeof backend.writeIfRevision === "function";
+    if (readsRevisions !== writesRevisions) {
+      throw new Error(
+        "AgentFs backend revision support must provide readWithRevision and writeIfRevision together."
+      );
+    }
     this.flush_debounce_ms = opts.flush_debounce_ms ?? 500;
     this.write_guard = opts.write_guard;
   }
@@ -291,7 +350,6 @@ export class AgentFs {
     this.bindings.delete(path);
     // Clear per-path bookkeeping so repeated mount/unmount cycles don't
     // grow the maps unboundedly.
-    this.last_read.delete(path);
     this.last_flushed.delete(path);
   }
 
@@ -483,6 +541,21 @@ export class AgentFs {
   }
 
   /**
+   * Serialize a server-bound filesystem or command operation with the other
+   * operations registered on this fs. The action is enqueued synchronously,
+   * before its first await, so concurrent AI-SDK tool executions retain call
+   * order. Rejections never poison later operations.
+   */
+  runExclusive<T>(action: () => Promise<T>): Promise<T> {
+    const result = this.operation_tail.then(action, action);
+    this.operation_tail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  /**
    * Read the content + current version. Returns `null` for unknown paths
    * (call `hydrate()` first if the file might only exist in the backend).
    */
@@ -490,39 +563,62 @@ export class AgentFs {
     const binding = this.bindings.get(path);
     if (binding) {
       const version = binding.getVersion();
-      this.last_read.set(path, version);
       return { content: binding.serialize(), version };
     }
     const entry = this.files.get(path);
     if (!entry) return null;
-    this.last_read.set(path, entry.version);
     return { content: entry.content, version: entry.version };
   }
 
   /**
-   * Read through to the backend when a path was deliberately left out of the
-   * hydrate index. This is the server-bound path for lazy resources such as a
-   * dropped directory reference: the tree is not walked at session start, but
-   * an explicit `read_file` still resolves the requested descendant.
-   *
-   * A successful backend read is cached with version `0` for the rest of this
-   * fs instance and counts as the required read-before-edit observation. The
-   * host's mutation guard still decides whether that path is editable.
+   * Read the backend's current content rather than trusting the hydrate cache.
+   * This is the server-bound path for both ordinary workspace files and lazy
+   * resources such as a dropped directory reference. A pending local flush
+   * completes first, then the returned bytes refresh the local cache.
    */
   async read_fresh(path: string): Promise<AgentFs.ReadResult | null> {
-    const cached = this.read(path);
-    if (cached !== null) return cached;
+    return this.runExclusive(() => this.readFreshUnlocked(path));
+  }
+
+  private async readFreshUnlocked(
+    path: string
+  ): Promise<AgentFs.ReadResult | null> {
+    if (this.bindings.has(path)) return this.read(path);
+    // A failed forced flush leaves the newer local snapshot dirty. Do not
+    // replace it with older backend bytes; the queued retry still owns
+    // persistence of that mutation.
+    if (!(await this.flushPending())) return this.read(path);
+
     let content: string | null;
     try {
-      content = await this.backend.read(path);
+      if (this.backend.readWithRevision) {
+        const versioned = await this.backend.readWithRevision(path);
+        content = versioned?.content ?? null;
+      } else {
+        content = await this.backend.read(path);
+      }
     } catch (err) {
+      if (err instanceof AgentFs.TextFileTooLargeError) throw err;
       console.warn(`[agent-fs] backend.read(${path}) failed:`, err);
       return null;
     }
-    if (content === null) return null;
-    const entry = { content, version: 0 };
+    if (content === null) {
+      this.files.delete(path);
+      this.last_flushed.delete(path);
+      return null;
+    }
+
+    const previous = this.files.get(path);
+    const entry = {
+      content,
+      version:
+        previous === undefined
+          ? 0
+          : previous.content === content
+            ? previous.version
+            : previous.version + 1,
+    };
     this.files.set(path, entry);
-    this.last_read.set(path, entry.version);
     this.last_flushed.set(path, content);
     return entry;
   }
@@ -535,8 +631,9 @@ export class AgentFs {
    * (see `../vision`) resolves against; `AgentFs` satisfies
    * `AgentVision.ByteReader` by exposing exactly this method.
    *
-   * NOT counted as a `read()` for the freshness/edit contract — perceiving
-   * pixels is not the same as reading text you intend to edit.
+   * Perception grants no write authority and provides no textual context for
+   * an edit. `edit_file` independently validates its supplied text against the
+   * current file content.
    */
   async readBytes(path: string): Promise<Uint8Array | null> {
     return (await this.backend.readBytes?.(path)) ?? null;
@@ -584,17 +681,97 @@ export class AgentFs {
   }
 
   /**
-   * Match-and-replace edit. Requires the file to exist and the agent to
-   * have read it this session (`not_read` otherwise). Standard staleness
-   * check via `expected_version`.
+   * Persist a server-bound full-file write before reporting success. The
+   * model-facing `write_file` is an explicit upsert, so it passes
+   * `expected_version: null`; the internal numeric-version path remains for
+   * live/client hosts that call {@link write} directly.
+   */
+  async write_fresh(
+    path: string,
+    args: AgentFs.WriteArgs
+  ): Promise<AgentFs.WriteResult> {
+    return this.runExclusive(async () => {
+      const guarded = this.mutationFailure(path, "write");
+      if (guarded) return guarded;
+
+      // Drain any older debounced snapshot before publishing the newer full
+      // write. `flushPending` also joins a flush whose backend write is already
+      // in flight.
+      if (!(await this.flushPending())) {
+        return {
+          ok: false,
+          reason: "io_error",
+          message: `The backing store rejected a pending write before writing ${path}.`,
+        };
+      }
+
+      if (this.bindings.has(path)) {
+        const result = this.write(path, args);
+        if (result.ok && !(await this.flushPending())) {
+          return {
+            ok: false,
+            reason: "io_error",
+            message: `The backing store rejected the write to ${path}.`,
+          };
+        }
+        return result;
+      }
+
+      if (args.expected_version !== null) {
+        await this.readFreshUnlocked(path);
+        const current = this.lookup(path);
+        if (current === null) {
+          return {
+            ok: false,
+            reason: "not_found",
+            message: `No file at ${path}. Pass expected_version=null to create it.`,
+          };
+        }
+        if (current.version !== args.expected_version) {
+          return {
+            ok: false,
+            reason: "stale",
+            message: `File at ${path} changed since you last read it. Re-read and retry.`,
+            current_version: current.version,
+          };
+        }
+      }
+
+      try {
+        await this.backend.write(path, args.content);
+      } catch (err) {
+        if (err instanceof AgentFs.TextFileTooLargeError) {
+          return {
+            ok: false,
+            reason: "too_large",
+            message: err.message,
+          };
+        }
+        console.warn(`[agent-fs] backend.write(${path}) failed:`, err);
+        return {
+          ok: false,
+          reason: "io_error",
+          message: `The backing store rejected the write to ${path}.`,
+        };
+      }
+      return this.acceptPersisted(path, args.content);
+    });
+  }
+
+  /**
+   * Match-and-replace edit against the content that is current when this
+   * method executes. No prior-read ledger or model-supplied version is
+   * consulted: the supplied `old_string` is the edit's precondition.
    *
    * Matching: literal first, then whitespace-normalized — see
    * `findMatches`. Ambiguous matches reject with `reason: "ambiguous"`
    * unless `replace_all` is set.
    */
-  edit(path: string, args: AgentFs.EditArgs): AgentFs.EditResult {
-    const { old_string, new_string, replace_all, expected_version } = args;
-
+  edit(
+    path: string,
+    args: AgentFs.EditArgs,
+    options: AgentFs.EditOptions = {}
+  ): AgentFs.EditResult {
     const guarded = this.mutationFailure(path, "edit");
     if (guarded) return guarded;
     const entry = this.lookup(path);
@@ -605,21 +782,146 @@ export class AgentFs {
         message: `No file at ${path}.`,
       };
     }
-    if (!this.last_read.has(path)) {
-      return {
-        ok: false,
-        reason: "not_read",
-        message: `Call read_file(${path}) before editing.`,
-      };
+
+    const derived = this.deriveEdit(
+      path,
+      entry.content,
+      args,
+      options.max_bytes
+    );
+    if (!derived.ok) return derived;
+
+    const committed = this.commit(path, derived.content);
+    if (!committed.ok) return committed;
+    return { ...committed, occurrences: derived.occurrences };
+  }
+
+  /**
+   * Server-bound edit: read current bytes and an opaque backend revision,
+   * derive the replacement from those bytes, then conditionally publish. A
+   * backend without revision support still reads immediately before an
+   * awaited write; the shared operation FIFO prevents in-process tool races.
+   */
+  async edit_fresh(
+    path: string,
+    args: AgentFs.EditArgs,
+    options: AgentFs.EditOptions = {}
+  ): Promise<AgentFs.EditResult> {
+    return this.runExclusive(async () => {
+      const guarded = this.mutationFailure(path, "edit");
+      if (guarded) return guarded;
+
+      if (this.bindings.has(path)) {
+        const result = this.edit(path, args, options);
+        if (result.ok && !(await this.flushPending())) {
+          return {
+            ok: false,
+            reason: "io_error",
+            message: `The backing store rejected the edit to ${path}.`,
+          };
+        }
+        return result;
+      }
+
+      if (!(await this.flushPending())) {
+        return {
+          ok: false,
+          reason: "io_error",
+          message: `The backing store rejected a pending write before editing ${path}.`,
+        };
+      }
+      let current: { content: string; revision?: string } | null;
+      try {
+        current = this.backend.readWithRevision
+          ? await this.backend.readWithRevision(path)
+          : null;
+        if (current === null && !this.backend.readWithRevision) {
+          const content = await this.backend.read(path);
+          current = content === null ? null : { content, revision: undefined };
+        }
+      } catch (err) {
+        if (err instanceof AgentFs.TextFileTooLargeError) {
+          return {
+            ok: false,
+            reason: "too_large",
+            message: err.message,
+          };
+        }
+        console.warn(`[agent-fs] backend.read(${path}) failed:`, err);
+        return {
+          ok: false,
+          reason: "io_error",
+          message: `The backing store rejected the read of ${path}.`,
+        };
+      }
+      if (current === null) {
+        this.files.delete(path);
+        this.last_flushed.delete(path);
+        return {
+          ok: false,
+          reason: "not_found",
+          message: `No file at ${path}.`,
+        };
+      }
+
+      const derived = this.deriveEdit(
+        path,
+        current.content,
+        args,
+        options.max_bytes
+      );
+      if (!derived.ok) return derived;
+
+      try {
+        if (current.revision !== undefined && this.backend.writeIfRevision) {
+          const published = await this.backend.writeIfRevision(
+            path,
+            derived.content,
+            current.revision
+          );
+          if (!published.ok) {
+            return {
+              ok: false,
+              reason: "stale",
+              message: `File at ${path} changed while the edit was being applied. Retry against its current content.`,
+            };
+          }
+        } else {
+          await this.backend.write(path, derived.content);
+        }
+      } catch (err) {
+        if (err instanceof AgentFs.TextFileTooLargeError) {
+          return {
+            ok: false,
+            reason: "too_large",
+            message: err.message,
+          };
+        }
+        console.warn(`[agent-fs] backend.write(${path}) failed:`, err);
+        return {
+          ok: false,
+          reason: "io_error",
+          message: `The backing store rejected the edit to ${path}.`,
+        };
+      }
+
+      const committed = this.acceptPersisted(path, derived.content);
+      return { ...committed, occurrences: derived.occurrences };
+    });
+  }
+
+  private deriveEdit(
+    path: string,
+    content: string,
+    args: AgentFs.EditArgs,
+    maxBytes?: number
+  ): { ok: true; content: string; occurrences: number } | AgentFs.EditFailure {
+    if (maxBytes !== undefined) {
+      const oversizedCurrent = textSizeFailure(path, content, maxBytes);
+      if (oversizedCurrent) return oversizedCurrent;
     }
-    if (entry.version !== expected_version) {
-      return {
-        ok: false,
-        reason: "stale",
-        message: `File at ${path} changed since you last read it.`,
-        current_version: entry.version,
-      };
-    }
+
+    const { old_string, new_string, replace_all } = args;
     if (old_string.length === 0) {
       return {
         ok: false,
@@ -635,12 +937,12 @@ export class AgentFs {
       };
     }
 
-    const ranges = findMatches(entry.content, old_string);
+    const ranges = findMatches(content, old_string);
     if (ranges.length === 0) {
       return {
         ok: false,
         reason: "not_found",
-        message: `\`old_string\` not found in ${path}. Re-read with read_file and copy the snippet verbatim.`,
+        message: `\`old_string\` not found in the current content of ${path}. Read the file for updated context and retry.`,
       };
     }
     if (ranges.length > 1 && !replace_all) {
@@ -651,11 +953,16 @@ export class AgentFs {
         occurrences: ranges.length,
       };
     }
-    const next = applyReplacements(entry.content, ranges, new_string);
-
-    const committed = this.commit(path, next);
-    if (!committed.ok) return committed;
-    return { ...committed, occurrences: ranges.length };
+    const nextContent = applyReplacements(content, ranges, new_string);
+    if (maxBytes !== undefined) {
+      const oversizedNext = textSizeFailure(path, nextContent, maxBytes);
+      if (oversizedNext) return oversizedNext;
+    }
+    return {
+      ok: true,
+      content: nextContent,
+      occurrences: ranges.length,
+    };
   }
 
   /**
@@ -667,9 +974,8 @@ export class AgentFs {
    * the same formatted bytes `read()` would return). Empty pattern → empty
    * result. Scope can be narrowed with `path_prefix`.
    *
-   * Side-effect-free: does NOT mark `last_read`, so a subsequent `edit_file`
-   * still has to read the file first. Search is for finding things, not
-   * for claiming you've read them.
+   * Side-effect-free. Search results identify locations but may not contain
+   * enough context to author a unique match-and-replace edit.
    */
   grep(args: AgentFs.GrepArgs): AgentFs.GrepResult {
     const matches: AgentFs.GrepMatch[] = [];
@@ -762,7 +1068,6 @@ export class AgentFs {
       };
     }
     this.files.delete(path);
-    this.last_read.delete(path);
     this.last_flushed.delete(path);
     void this.backend.delete(path).catch((err) => {
       console.warn(`[agent-fs] backend.delete(${path}) failed:`, err);
@@ -822,19 +1127,35 @@ export class AgentFs {
         return parseError(err);
       }
       const v = binding.getVersion();
-      this.last_read.set(path, v);
       this.queueFlush(path);
       this.emit({ type: "write", path, version: v });
       return { ok: true, version: v };
     }
+    const result = this.acceptContent(path, content, false);
+    this.queueFlush(path);
+    return result;
+  }
+
+  /**
+   * Accept content already persisted by a server-bound operation into the
+   * local cache and event stream without scheduling a redundant backend write.
+   */
+  private acceptPersisted(path: string, content: string): AgentFs.WriteSuccess {
+    return this.acceptContent(path, content, true);
+  }
+
+  private acceptContent(
+    path: string,
+    content: string,
+    persisted: boolean
+  ): AgentFs.WriteSuccess {
     const existing = this.files.get(path);
     const next: FileEntry = {
       content,
       version: (existing?.version ?? 0) + 1,
     };
     this.files.set(path, next);
-    this.last_read.set(path, next.version);
-    this.queueFlush(path);
+    if (persisted) this.last_flushed.set(path, content);
     this.emit({ type: "write", path, version: next.version });
     return { ok: true, version: next.version };
   }
@@ -850,7 +1171,13 @@ export class AgentFs {
     if (this.flush_timer) clearTimeout(this.flush_timer);
     this.flush_timer = setTimeout(() => {
       this.flush_timer = null;
-      void this.runFlush();
+      // Background persistence participates in the same FIFO as server-bound
+      // tools and commands. It must not overtake, or be overtaken by, a fresh
+      // operation against the same workspace.
+      void this.runExclusive(() => this.flush()).catch(() => {
+        // `runFlush` already logged and re-queued the failed path. The timer is
+        // best-effort; explicit readers/commands receive the rejection.
+      });
     }, this.flush_debounce_ms);
   }
 
@@ -863,18 +1190,35 @@ export class AgentFs {
    * Idempotent and a no-op when nothing is dirty.
    */
   async flush(): Promise<void> {
+    if (!(await this.flushPending())) {
+      throw new Error("One or more agent filesystem writes failed to persist.");
+    }
+  }
+
+  /**
+   * Cancel the debounce timer, join any backend write already in flight, then
+   * drain the paths queued after it. The boolean is false only when this batch
+   * still could not be persisted (the path is re-queued for a later retry).
+   */
+  private async flushPending(): Promise<boolean> {
     if (this.flush_timer) {
       clearTimeout(this.flush_timer);
       this.flush_timer = null;
     }
-    await this.runFlush();
+    const result = this.flush_tail.then(
+      () => this.runFlush(),
+      () => this.runFlush()
+    );
+    this.flush_tail = result;
+    return result;
   }
 
-  private async runFlush(): Promise<void> {
+  private async runFlush(): Promise<boolean> {
+    let persisted = true;
     const targets = [...this.flush_queue];
     this.flush_queue.clear();
     for (const path of targets) {
-      if (this.disposed) return;
+      if (this.disposed) return persisted;
       const entry = this.lookup(path);
       if (entry === null) continue;
       if (this.last_flushed.get(path) === entry.content) continue;
@@ -882,6 +1226,7 @@ export class AgentFs {
         await this.backend.write(path, entry.content);
         if (!this.disposed) this.last_flushed.set(path, entry.content);
       } catch (err) {
+        persisted = false;
         console.warn(`[agent-fs] backend.write(${path}) failed:`, err);
         // Re-queue on transient failure so eventual persistence still
         // holds; otherwise a single failed flush would silently drop
@@ -889,6 +1234,7 @@ export class AgentFs {
         if (!this.disposed) this.queueFlush(path);
       }
     }
+    return persisted;
   }
 }
 
@@ -912,6 +1258,23 @@ function parseError(err: unknown): AgentFs.WriteFailure {
 // ---------------------------------------------------------------------------
 
 export namespace AgentFs {
+  /** Shared UTF-8 bound for model-readable and model-mutable text files. */
+  export const MAX_TEXT_FILE_BYTES = MODEL_TEXT_FILE_MAX_BYTES;
+
+  /** Backend signal for an existing text file outside the shared bound. */
+  export class TextFileTooLargeError extends Error {
+    readonly name = "TextFileTooLargeError";
+
+    constructor(
+      readonly path: string,
+      readonly byte_length: number
+    ) {
+      super(
+        `File at ${path} is ${byte_length} UTF-8 bytes; the text file limit is ${MAX_TEXT_FILE_BYTES} bytes.`
+      );
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Bindings & backend contracts
   // -------------------------------------------------------------------------
@@ -925,8 +1288,9 @@ export namespace AgentFs {
    *
    * **Version is monotonic and host-owned.** `getVersion()` must change
    * (typically increment) on every host-visible mutation — AI write, human
-   * gesture, undo, external sync. The fs uses it as a freshness token
-   * (`expected_version` matches → safe to write; mismatch → stale).
+   * gesture, undo, external sync. Direct host callers may use it as the
+   * `expected_version` for a whole-file write. Model-facing tools do not see
+   * or return it.
    *
    * **`subscribe` is optional** but recommended for live-bound paths. Without
    * it, the fs only knows about its own writes — it can't auto-flush changes
@@ -943,9 +1307,9 @@ export namespace AgentFs {
     load(content: string): void;
 
     /**
-     * Monotonic freshness token. Must reflect every host-visible change
-     * (not just writes through the fs). The fs uses it to detect
-     * concurrent edits between the agent's read and write.
+     * Monotonic host revision. Must reflect every host-visible change
+     * (not just writes through the fs). Direct callers use it for conditional
+     * full-file writes; model-facing edits use current-content matching.
      */
     getVersion(): number;
 
@@ -964,8 +1328,9 @@ export namespace AgentFs {
    * `/` as separator regardless of host OS — backends translate to their
    * native layout (subdirectories on disk, directory handles on OPFS, …).
    *
-   * Backends are pure I/O — no caching, no debouncing, no version
-   * tracking. The fs layer owns those.
+   * Backends are pure I/O — no caching or debouncing. A real filesystem MAY
+   * expose the paired opaque-revision methods so an edit can detect competing
+   * writes near publication time.
    *
    * Errors should be **thrown**, not swallowed. The fs handles them
    * (typically by logging + falling back to in-memory state).
@@ -993,6 +1358,15 @@ export namespace AgentFs {
     read(path: string): Promise<string | null>;
 
     /**
+     * Read current text plus an opaque backend revision. Paired with
+     * {@link writeIfRevision}; implementations MUST provide both methods or
+     * neither.
+     */
+    readWithRevision?(
+      path: string
+    ): Promise<BackendReadWithRevisionResult | null>;
+
+    /**
      * Read the RAW bytes at `path` (no text decode), or `null` if no such
      * file. Optional: a backend that has no byte view (or stores only text)
      * MAY omit it, in which case byte-level consumers (e.g. `view_image`,
@@ -1007,9 +1381,30 @@ export namespace AgentFs {
      */
     write(path: string, content: string): Promise<void>;
 
+    /**
+     * Attempt an optimistic publish against `revision`. A stale result means a
+     * competing change was detected and the backend MUST leave the file
+     * unchanged. Success does not imply a cross-process lock unless the backend
+     * itself provides one.
+     */
+    writeIfRevision?(
+      path: string,
+      content: string,
+      revision: string
+    ): Promise<BackendWriteIfRevisionResult>;
+
     /** Remove the file at `path`. No-op when the file doesn't exist. */
     delete(path: string): Promise<void>;
   }
+
+  export type BackendReadWithRevisionResult = {
+    content: string;
+    revision: string;
+  };
+
+  export type BackendWriteIfRevisionResult =
+    | { ok: true; revision: string }
+    | { ok: false; reason: "stale" };
 
   // -------------------------------------------------------------------------
   // Mutation events
@@ -1065,10 +1460,15 @@ export namespace AgentFs {
   // derived from these tuples, so they can't drift.
   // -------------------------------------------------------------------------
 
+  export const READ_FAILURE_REASONS = ["not_found", "too_large"] as const;
+  export type ReadFailureReason = (typeof READ_FAILURE_REASONS)[number];
+
   export const WRITE_FAILURE_REASONS = [
     "stale",
     "parse_error",
     "not_found",
+    "too_large",
+    "io_error",
     // GRIDA-SEC-004 — no-clobber path (see `fs/scope.ts`); only emitted when a
     // host injects a `write_guard` (the workspace-bound agent path).
     "protected",
@@ -1079,12 +1479,13 @@ export namespace AgentFs {
   export type WriteFailureReason = (typeof WRITE_FAILURE_REASONS)[number];
 
   export const EDIT_FAILURE_REASONS = [
-    "not_read",
     "stale",
     "not_found",
     "ambiguous",
     "parse_error",
     "no_op",
+    "too_large",
+    "io_error",
     // GRIDA-SEC-004 — no-clobber path (see `fs/scope.ts`).
     "protected",
     "read_only",
@@ -1127,7 +1528,14 @@ export namespace AgentFs {
     old_string: string;
     new_string: string;
     replace_all?: boolean;
-    expected_version: number;
+  };
+
+  export type EditOptions = {
+    /**
+     * Optional host/model-surface text bound. The generic filesystem leaves
+     * this unset so document stores can persist larger files.
+     */
+    max_bytes?: number;
   };
 
   export type EditSuccess = {
@@ -1230,20 +1638,20 @@ export namespace AgentFs {
   export const tools = {
     [TOOL_NAMES.read_file]: tool({
       description:
-        "Read a file's content and version (a freshness token).\n\n" +
-        "Always call this before your first edit_file on a given path, and " +
-        "re-read whenever an edit / write returns reason='stale'.",
+        "Read a file's current text content. Use this to understand an " +
+        "existing file or obtain exact context for edit_file. You do not " +
+        "need to re-read content you just successfully wrote. Text files are " +
+        `limited to ${MAX_TEXT_FILE_BYTES} UTF-8 bytes.`,
       inputSchema: z.object({
         path: z.string().describe(PATH_DESCRIPTION),
       }),
       outputSchema: z.union([
         z.object({
           content: z.string(),
-          version: z.number().int(),
         }),
         z.object({
           ok: z.literal(false),
-          reason: z.literal("not_found"),
+          reason: z.enum(READ_FAILURE_REASONS),
           message: z.string(),
         }),
       ]),
@@ -1258,16 +1666,19 @@ export namespace AgentFs {
         "fallback (forgives doubled spaces / minor newline drift; not a " +
         "semantic fuzzy match). Must be unique unless `replace_all` is " +
         "true.\n\n" +
-        "Requires a prior read_file on this path. On reason='stale', the " +
-        "human edited in the meantime — read_file again and retry.",
+        "The tool reads the file's current content during this invocation " +
+        "and applies the edit only when `old_string` matches that content. " +
+        "A prior read_file is useful for obtaining context, but is not " +
+        "authorization. Content you just wrote is valid context. Text files " +
+        `are limited to ${MAX_TEXT_FILE_BYTES} UTF-8 bytes.`,
       inputSchema: z.object({
         path: z.string().describe(PATH_DESCRIPTION),
         old_string: z
           .string()
           .min(1)
           .describe(
-            "Exact snippet from the read_file output. Include enough " +
-              "surrounding context to be unique."
+            "Exact snippet expected in the file's current content. It may " +
+              "come from read_file or content you just wrote. Include enough surrounding context to be unique."
           ),
         new_string: z
           .string()
@@ -1281,22 +1692,16 @@ export namespace AgentFs {
             "Default false. When false, ambiguous matches reject with " +
               "reason='ambiguous' so you can disambiguate."
           ),
-        version: z
-          .number()
-          .int()
-          .describe("Version from the most recent read_file."),
       }),
       outputSchema: z.discriminatedUnion("ok", [
         z.object({
           ok: z.literal(true),
-          version: z.number().int(),
           occurrences: z.number().int(),
         }),
         z.object({
           ok: z.literal(false),
           reason: z.enum(EDIT_FAILURE_REASONS),
           message: z.string(),
-          current_version: z.number().int().optional(),
           occurrences: z.number().int().optional(),
         }),
       ]),
@@ -1356,8 +1761,8 @@ export namespace AgentFs {
         "returns one entry per matching line with a 1-indexed line number and " +
         "the full line text.\n\n" +
         "Use this to find references / occurrences before deciding what to " +
-        "edit. Does NOT count as a `read_file` — you still have to read a " +
-        "file before editing it.",
+        "edit. A matching line may not contain enough surrounding context " +
+        "for a unique edit_file call; read the file when you need more.",
       inputSchema: z.object({
         pattern: z
           .string()
@@ -1394,35 +1799,22 @@ export namespace AgentFs {
       description:
         "Full-file upsert. Replace the entire content of `path` with " +
         "`content`. For surgical changes, prefer edit_file — it's safer " +
-        "(must locate the change) and cheaper (smaller payload).\n\n" +
-        "`version` is optional:\n" +
-        "  • include it (from the most recent read_file) for an explicit " +
-        "wholesale rewrite — same staleness safety as edit_file.\n" +
-        "  • omit it for a permissive write (creates the file if missing; " +
-        "overwrites without a freshness check). Only use when you don't " +
-        "care what's currently there.",
+        "(must locate the change) and cheaper (smaller payload). This is an " +
+        "intentional last-writer-wins operation: it creates a missing file " +
+        "and overwrites an existing one. Content is limited to " +
+        `${MAX_TEXT_FILE_BYTES} UTF-8 bytes so every successful write remains readable and editable.`,
       inputSchema: z.object({
         path: z.string().describe(PATH_DESCRIPTION),
         content: z.string().describe("Complete new content for the file."),
-        version: z
-          .number()
-          .int()
-          .optional()
-          .describe(
-            "Optional. When provided, the write fails with reason='stale' " +
-              "unless the current version matches. Omit for permissive write."
-          ),
       }),
       outputSchema: z.discriminatedUnion("ok", [
         z.object({
           ok: z.literal(true),
-          version: z.number().int(),
         }),
         z.object({
           ok: z.literal(false),
           reason: z.enum(WRITE_FAILURE_REASONS),
           message: z.string(),
-          current_version: z.number().int().optional(),
         }),
       ]),
     }),
@@ -1459,9 +1851,8 @@ export namespace AgentFs {
     old_string: string;
     new_string: string;
     replace_all?: boolean;
-    version: number;
   };
-  type WriteFileInput = { path: string; content: string; version?: number };
+  type WriteFileInput = { path: string; content: string };
   type ListFilesInput = {
     path?: string;
     offset?: number;
@@ -1472,6 +1863,53 @@ export namespace AgentFs {
     path_prefix?: string;
     case_sensitive?: boolean;
   };
+
+  function modelReadResult(
+    result: ReadResult,
+    path: string
+  ): { content: string } | { ok: false; reason: "too_large"; message: string } {
+    const bytes = utf8ByteLength(result.content);
+    if (bytes > MAX_TEXT_FILE_BYTES) {
+      return {
+        ok: false,
+        reason: "too_large",
+        message: new TextFileTooLargeError(path, bytes).message,
+      };
+    }
+    return { content: result.content };
+  }
+
+  function modelEditResult(result: EditResult):
+    | { ok: true; occurrences: number }
+    | {
+        ok: false;
+        reason: EditFailureReason;
+        message: string;
+        occurrences?: number;
+      } {
+    if (result.ok) {
+      return { ok: true, occurrences: result.occurrences };
+    }
+    return {
+      ok: false,
+      reason: result.reason,
+      message: result.message,
+      ...(result.occurrences === undefined
+        ? {}
+        : { occurrences: result.occurrences }),
+    };
+  }
+
+  function modelWriteResult(
+    result: WriteResult
+  ): { ok: true } | { ok: false; reason: WriteFailureReason; message: string } {
+    if (result.ok) return { ok: true };
+    return {
+      ok: false,
+      reason: result.reason,
+      message: result.message,
+    };
+  }
 
   export function resolveToolCall(
     fs: AgentFs,
@@ -1489,7 +1927,7 @@ export namespace AgentFs {
             message: `No file at ${path}.`,
           };
         }
-        return r;
+        return modelReadResult(r, path);
       }
       case TOOL_NAMES.list_files: {
         const { path, offset, limit } = (toolCall.input ??
@@ -1502,18 +1940,29 @@ export namespace AgentFs {
         return fs.grep({ pattern, path_prefix, case_sensitive });
       }
       case TOOL_NAMES.edit_file: {
-        const { path, old_string, new_string, replace_all, version } =
+        const { path, old_string, new_string, replace_all } =
           toolCall.input as EditFileInput;
-        return fs.edit(path, {
-          old_string,
-          new_string,
-          replace_all,
-          expected_version: version,
-        });
+        return modelEditResult(
+          fs.edit(
+            path,
+            {
+              old_string,
+              new_string,
+              replace_all,
+            },
+            {
+              max_bytes: MAX_TEXT_FILE_BYTES,
+            }
+          )
+        );
       }
       case TOOL_NAMES.write_file: {
-        const { path, content, version } = toolCall.input as WriteFileInput;
-        return fs.write(path, { content, expected_version: version ?? null });
+        const { path, content } = toolCall.input as WriteFileInput;
+        const oversized = textSizeFailure(path, content, MAX_TEXT_FILE_BYTES);
+        if (oversized) return oversized;
+        return modelWriteResult(
+          fs.write(path, { content, expected_version: null })
+        );
       }
       default:
         return undefined;
@@ -1528,14 +1977,25 @@ export namespace AgentFs {
     switch (toolCall.tool_name) {
       case TOOL_NAMES.read_file: {
         const { path } = toolCall.input as ReadFileInput;
-        const result = await fs.read_fresh(path);
-        return (
-          result ?? {
-            ok: false,
-            reason: "not_found",
-            message: `No file at ${path}.`,
+        try {
+          const result = await fs.read_fresh(path);
+          return (
+            (result ? modelReadResult(result, path) : null) ?? {
+              ok: false,
+              reason: "not_found",
+              message: `No file at ${path}.`,
+            }
+          );
+        } catch (err) {
+          if (err instanceof TextFileTooLargeError) {
+            return {
+              ok: false,
+              reason: "too_large",
+              message: err.message,
+            };
           }
-        );
+          throw err;
+        }
       }
       case TOOL_NAMES.list_files: {
         const { path, offset, limit } = (toolCall.input ??
@@ -1550,6 +2010,34 @@ export namespace AgentFs {
           path_prefix,
           case_sensitive,
         });
+      }
+      case TOOL_NAMES.edit_file: {
+        const { path, old_string, new_string, replace_all } =
+          toolCall.input as EditFileInput;
+        return modelEditResult(
+          await fs.edit_fresh(
+            path,
+            {
+              old_string,
+              new_string,
+              replace_all,
+            },
+            {
+              max_bytes: MAX_TEXT_FILE_BYTES,
+            }
+          )
+        );
+      }
+      case TOOL_NAMES.write_file: {
+        const { path, content } = toolCall.input as WriteFileInput;
+        const oversized = textSizeFailure(path, content, MAX_TEXT_FILE_BYTES);
+        if (oversized) return oversized;
+        return modelWriteResult(
+          await fs.write_fresh(path, {
+            content,
+            expected_version: null,
+          })
+        );
       }
       default:
         return resolveToolCall(fs, toolCall);

--- a/packages/grida-ai-agent/src/fs/index.ts
+++ b/packages/grida-ai-agent/src/fs/index.ts
@@ -600,7 +600,7 @@ export class AgentFs {
     } catch (err) {
       if (err instanceof AgentFs.TextFileTooLargeError) throw err;
       console.warn(`[agent-fs] backend.read(${path}) failed:`, err);
-      return null;
+      throw err;
     }
     if (content === null) {
       this.files.delete(path);
@@ -718,7 +718,22 @@ export class AgentFs {
       }
 
       if (args.expected_version !== null) {
-        await this.readFreshUnlocked(path);
+        try {
+          await this.readFreshUnlocked(path);
+        } catch (err) {
+          if (err instanceof AgentFs.TextFileTooLargeError) {
+            return {
+              ok: false,
+              reason: "too_large",
+              message: err.message,
+            };
+          }
+          return {
+            ok: false,
+            reason: "io_error",
+            message: `The backing store rejected the read of ${path}.`,
+          };
+        }
         const current = this.lookup(path);
         if (current === null) {
           return {
@@ -1460,7 +1475,11 @@ export namespace AgentFs {
   // derived from these tuples, so they can't drift.
   // -------------------------------------------------------------------------
 
-  export const READ_FAILURE_REASONS = ["not_found", "too_large"] as const;
+  export const READ_FAILURE_REASONS = [
+    "not_found",
+    "too_large",
+    "io_error",
+  ] as const;
   export type ReadFailureReason = (typeof READ_FAILURE_REASONS)[number];
 
   export const WRITE_FAILURE_REASONS = [
@@ -1994,7 +2013,11 @@ export namespace AgentFs {
               message: err.message,
             };
           }
-          throw err;
+          return {
+            ok: false,
+            reason: "io_error",
+            message: `The backing store rejected the read of ${path}; this does not mean the file is missing.`,
+          };
         }
       }
       case TOOL_NAMES.list_files: {

--- a/packages/grida-ai-agent/src/prompts.ts
+++ b/packages/grida-ai-agent/src/prompts.ts
@@ -58,30 +58,34 @@ Filesystem tools:
   truncated, next_offset? }. List direct children of a directory only.
   Defaults to \`/\`; this is not recursive and not a whole-workspace
   inventory.
-- ${fs.read_file}: { path } → { content, version }.
-- ${fs.edit_file}: { path, old_string, new_string, replace_all?, version }.
+- ${fs.read_file}: { path } → { content }.
+- ${fs.edit_file}: { path, old_string, new_string, replace_all? }.
   Match-and-replace. The default write path.
-- ${fs.write_file}: { path, content, version? }. Full-file upsert;
-  \`version\` optional for permissive writes.
+- ${fs.write_file}: { path, content }. Full-file upsert; creates a
+  missing file or intentionally replaces the whole existing file.
 - ${fs.grep_files}: { pattern, path_prefix?, case_sensitive? }.
   Literal substring search across files (mirrors \`grep -n -F\`).
   Returns one entry per matching line with a 1-indexed line number.
-  Use it to find references before editing — does NOT count as a
-  \`read_file\`.
+  Use it to find references before editing; read the file when a
+  matching line does not provide enough unique context.
 
 Rules:
-1. Call ${fs.read_file} on a path before your first edit. Re-read on
-   any reason="stale".
-2. Pass the most recent \`version\` you received back to every
-   version-checked write on that path.
-3. Prefer ${fs.edit_file} for targeted changes. Reach for ${fs.write_file}
+1. Read an existing file when you need to understand it or obtain
+   exact edit context. Do not re-read content you just successfully
+   wrote merely to authorize an edit.
+2. ${fs.edit_file} checks \`old_string\` against the file's current
+   content during that invocation. Follow the failure message. When the
+   current content no longer matches, read it, reconcile, and retry.
+3. On reason="too_large" from any text-file tool, use a shell/streaming
+   workflow or split the artifact.
+4. Prefer ${fs.edit_file} for targeted changes. Reach for ${fs.write_file}
    only for wholesale rewrites where edit_file would mean pasting most
    of the document as \`old_string\`.
-4. For ${fs.edit_file}, copy \`old_string\` verbatim from the read
-   output. Include enough surrounding context to be unique; on
+5. For ${fs.edit_file}, use exact text from the current file or from
+   content you just wrote. Include enough surrounding context to be unique; on
    reason="ambiguous" you'll get the count — add more context and retry.
-5. Multiple unrelated edits → multiple ${fs.edit_file} calls.
-6. Treat ${fs.list_files} results as one directory page. If \`truncated\`
+6. Multiple unrelated edits → multiple ${fs.edit_file} calls.
+7. Treat ${fs.list_files} results as one directory page. If \`truncated\`
    is true, call it again with \`next_offset\`; use ${fs.grep_files} or
    command/search tools for broad searches.
 </filesystem>

--- a/packages/grida-ai-agent/src/runtime/command-backend.ts
+++ b/packages/grida-ai-agent/src/runtime/command-backend.ts
@@ -35,14 +35,23 @@ import {
  * @param beforeRun Optional hook awaited just before a command spawns — used to
  *   flush the agent fs's pending (debounced) writes to disk, so a command that
  *   reads the workspace sees files the agent just wrote via the fs tools.
+ * @param runExclusive Optional shared workspace-operation FIFO. When present,
+ *   the whole command (not only its pre-run flush) is serialized with
+ *   server-bound read/write/edit tool calls.
  */
 export function createAgentCommandBackend(
   registry: WorkspaceRegistry,
   protectedReadRoots: ProtectedReadRoots = [],
   additionalAllowedRoots: AdditionalAllowedRoots = [],
-  beforeRun?: () => Promise<void>
+  beforeRun?: () => Promise<void>,
+  runExclusive?: <T>(action: () => Promise<T>) => Promise<T>
 ): RunCommandBackend {
-  return async ({ command, args, workdir, timeout_ms: timeoutMs }) => {
+  const execute: RunCommandBackend = async ({
+    command,
+    args,
+    workdir,
+    timeout_ms: timeoutMs,
+  }) => {
     // Make the agent's just-written files visible on disk before the command
     // reads them (the fs tools flush on a debounce; a command bypasses the fs
     // and reads the backing store directly).
@@ -71,6 +80,8 @@ export function createAgentCommandBackend(
       duration_ms: r.duration_ms,
     };
   };
+  return (input) =>
+    runExclusive ? runExclusive(() => execute(input)) : execute(input);
 }
 
 function describeError(err: ShellRunError): string {

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
@@ -41,6 +41,10 @@ describe("WorkspaceAgentFsBackend — path mapping", () => {
     await fs.rm(baseDir, { recursive: true, force: true });
   });
 
+  it("shares the workspace text-reader bound", () => {
+    expect(AgentFs.MAX_TEXT_FILE_BYTES).toBe(workspaceFs.MAX_FILE_BYTES);
+  });
+
   it("maps a logical '/'-rooted path to the workspace root", async () => {
     await backend.write("/a.txt", "hello");
     expect(await fs.readFile(path.join(workspaceRoot, "a.txt"), "utf8")).toBe(
@@ -67,6 +71,96 @@ describe("WorkspaceAgentFsBackend — path mapping", () => {
 
   it("still rejects a path that escapes the workspace", async () => {
     await expect(backend.write("/../escape.txt", "x")).rejects.toBeDefined();
+  });
+
+  it("conditionally publishes only while the read revision is current", async () => {
+    await backend.write("/a.txt", "alpha");
+    const current = await backend.readWithRevision("/a.txt");
+    expect(current).not.toBeNull();
+    const published = await backend.writeIfRevision(
+      "/a.txt",
+      "ALPHA",
+      current!.revision
+    );
+    expect(published.ok).toBe(true);
+    expect(await backend.read("/a.txt")).toBe("ALPHA");
+  });
+
+  it("rejects a conditional write after an external change", async () => {
+    await backend.write("/a.txt", "alpha");
+    const current = await backend.readWithRevision("/a.txt");
+    expect(current).not.toBeNull();
+
+    const abs = path.join(workspaceRoot, "a.txt");
+    await fs.writeFile(abs, "human");
+    const future = new Date(Date.now() + 2_000);
+    await fs.utimes(abs, future, future);
+    expect(
+      await backend.writeIfRevision("/a.txt", "agent", current!.revision)
+    ).toEqual({ ok: false, reason: "stale" });
+    expect(await backend.read("/a.txt")).toBe("human");
+  });
+
+  it("rejects replaced content even when its mtime is restored", async () => {
+    await backend.write("/a.txt", "alpha");
+    const abs = path.join(workspaceRoot, "a.txt");
+    const stableSeconds = Math.floor(Date.now() / 1_000) - 10;
+    await fs.utimes(abs, stableSeconds, stableSeconds);
+    const current = await backend.readWithRevision("/a.txt");
+    expect(current).not.toBeNull();
+    const { mtime } = JSON.parse(current!.revision) as { mtime: number };
+
+    await fs.writeFile(abs, "human");
+    await fs.utimes(abs, stableSeconds, stableSeconds);
+    expect((await fs.stat(abs)).mtimeMs).toBe(mtime);
+
+    expect(
+      await backend.writeIfRevision("/a.txt", "agent", current!.revision)
+    ).toEqual({ ok: false, reason: "stale" });
+    expect(await backend.read("/a.txt")).toBe("human");
+  });
+
+  it("keeps every successful model write editable after reconstruction", async () => {
+    const suffix = " alpha";
+    const content =
+      "x".repeat(AgentFs.MAX_TEXT_FILE_BYTES - suffix.length) + suffix;
+    const first = new AgentFs(backend);
+    expect(
+      await AgentFs.resolveToolCallAsync(first, {
+        tool_name: "write_file",
+        input: { path: "/large.txt", content },
+      })
+    ).toEqual({ ok: true });
+
+    const resumed = new AgentFs(backend);
+    await resumed.hydrate();
+    expect(
+      await AgentFs.resolveToolCallAsync(resumed, {
+        tool_name: "edit_file",
+        input: {
+          path: "/large.txt",
+          old_string: " alpha",
+          new_string: " ALPHA",
+        },
+      })
+    ).toEqual({ ok: true, occurrences: 1 });
+    expect((await backend.read("/large.txt"))?.endsWith(" ALPHA")).toBe(true);
+  });
+
+  it("rejects a model write above the editable text bound", async () => {
+    const agentFs = new AgentFs(backend);
+    expect(
+      await AgentFs.resolveToolCallAsync(agentFs, {
+        tool_name: "write_file",
+        input: {
+          path: "/too-large.txt",
+          content: "x".repeat(AgentFs.MAX_TEXT_FILE_BYTES + 1),
+        },
+      })
+    ).toMatchObject({ ok: false, reason: "too_large" });
+    await expect(
+      fs.access(path.join(workspaceRoot, "too-large.txt"))
+    ).rejects.toBeDefined();
   });
 });
 
@@ -285,6 +379,35 @@ describe("createWorkspaceAgentBindings — supervised approval wiring", () => {
       { workspace_registry: registry, shell_execution_allowed: false }
     );
     expect(bindings?.command).toBeUndefined();
+  });
+
+  it("serializes a concurrent write before a later command reads it", async () => {
+    const bindings = await createWorkspaceAgentBindings(
+      { workspace_root: workspaceRoot, mode: "auto" },
+      { workspace_registry: registry, shell_execution_allowed: true }
+    );
+    expect(bindings?.command).toBeDefined();
+
+    const write = AgentFs.resolveToolCallAsync(bindings!.fs, {
+      tool_name: "write_file",
+      input: { path: "/ordered.txt", content: "persisted first" },
+    });
+    const command = bindings!.command!.backend({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write(require('node:fs').readFileSync('ordered.txt','utf8'))",
+      ],
+      workdir: workspaceRoot,
+      description: "read the ordered write",
+    });
+
+    const [writeResult, commandResult] = await Promise.all([write, command]);
+    expect(writeResult).toEqual({ ok: true });
+    expect(commandResult).toMatchObject({
+      exit_code: 0,
+      stdout: "persisted first",
+    });
   });
 });
 

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.test.ts
@@ -866,7 +866,7 @@ describe("createWorkspaceAgentBindings — read-only directory references", () =
       viewError = err;
     }
 
-    expect(readOutput).toMatchObject({ ok: false, reason: "not_found" });
+    expect(readOutput).toMatchObject({ ok: false, reason: "io_error" });
     expect(listOutput).toMatchObject({ folders: [], files: [] });
     expect(grepOutput).toMatchObject({ matches: [] });
     expect(viewError).toMatchObject({
@@ -983,7 +983,15 @@ describe("createWorkspaceAgentBindings — read-only directory references", () =
         path.join(outsideRoot, "secret.txt"),
         path.join(referenceRoot, "escape.txt")
       );
-      expect(await result!.fs.read_fresh(`${mount}/escape.txt`)).toBeNull();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const output = await AgentFs.resolveToolCallAsync(result!.fs, {
+        tool_name: "read_file",
+        input: { path: `${mount}/escape.txt` },
+      });
+      warn.mockRestore();
+
+      expect(output).toMatchObject({ ok: false, reason: "io_error" });
+      expect(JSON.stringify(output)).not.toContain(outsideRoot);
     }
   );
 });

--- a/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
+++ b/packages/grida-ai-agent/src/runtime/workspace-agent-bindings.ts
@@ -8,6 +8,7 @@
  */
 
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import { generateImage } from "ai";
 import { AgentFs } from "../fs";
@@ -232,7 +233,11 @@ export async function createWorkspaceAgentBindings(
             // Flush the agent fs's pending writes before a command runs, so a
             // script the agent just wrote via write_file is on disk when the
             // shell reads it (closes the debounced-write vs immediate-read race).
-            () => fs.flush()
+            () => fs.flush(),
+            // Tool calls in one model step may execute concurrently. Share the
+            // fs FIFO across the entire command so call order, persistence, and
+            // subsequent operation-time reads agree.
+            (action) => fs.runExclusive(action)
           ),
           default_workdir: req.workspace_root,
           scratch_dir: scratchDir,
@@ -558,6 +563,35 @@ class DirectoryReferencePathError extends Error {
   }
 }
 
+type WorkspaceFileRevision = {
+  mtime: number;
+  sha256: string;
+};
+
+function workspaceFileDigest(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function encodeWorkspaceFileRevision(content: string, mtime: number): string {
+  return JSON.stringify({ mtime, sha256: workspaceFileDigest(content) });
+}
+
+function decodeWorkspaceFileRevision(revision: string): WorkspaceFileRevision {
+  const value: unknown = JSON.parse(revision);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("mtime" in value) ||
+    typeof value.mtime !== "number" ||
+    !Number.isFinite(value.mtime) ||
+    !("sha256" in value) ||
+    typeof value.sha256 !== "string"
+  ) {
+    throw new Error("invalid workspace file revision");
+  }
+  return { mtime: value.mtime, sha256: value.sha256 };
+}
+
 const REFERENCE_GREP_MAX_TRAVERSAL_STEPS = Math.min(SCAN_MAX_FILES, 1_000);
 const REFERENCE_GREP_MAX_MATCHES = 1_000;
 
@@ -862,16 +896,33 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
   }
 
   async read(path: string): Promise<string | null> {
+    return (await this.readWithRevision(path))?.content ?? null;
+  }
+
+  async readWithRevision(
+    path: string
+  ): Promise<AgentFs.BackendReadWithRevisionResult | null> {
     try {
       const { scope, rel } = this.scopeFor(path);
       const result = await workspaceFs.readFile(scope, rel);
-      return result.content;
+      return {
+        content: result.content,
+        revision: encodeWorkspaceFileRevision(result.content, result.mtime),
+      };
     } catch (err) {
+      if (isWorkspaceFsCode(err, "file-too-large")) {
+        const size =
+          err instanceof workspaceFs.Exception &&
+          typeof err.detail.size === "number"
+            ? err.detail.size
+            : AgentFs.MAX_TEXT_FILE_BYTES + 1;
+        throw new AgentFs.TextFileTooLargeError(path, size);
+      }
       // The AgentFs.Backend contract is "null when there's no readable text
       // here". That covers a raw ENOENT *and* the structured workspaceFs
-      // codes for content we deliberately don't serve as text (a directory,
-      // an oversized file, or a binary/non-utf8 file). Policy violations
-      // (path escapes, etc.) still throw.
+      // codes for content we deliberately don't serve as text (a directory or
+      // binary/non-utf8 file). Oversized text is the typed error above; policy
+      // violations (path escapes, etc.) still throw.
       if (isAbsentForRead(err) || err instanceof DirectoryReferencePathError) {
         return null;
       }
@@ -917,12 +968,53 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
   }
 
   async write(path: string, content: string): Promise<void> {
+    assertWorkspaceAgentTextSize(path, content);
     const resolved = this.scopeFor(path);
     if (resolved.kind === "reference") {
       throw new DirectoryReferencePathError("read_only", path);
     }
     const { scope, rel } = resolved;
     await workspaceFs.writeFile(scope, rel, content);
+  }
+
+  async writeIfRevision(
+    path: string,
+    content: string,
+    revision: string
+  ): Promise<AgentFs.BackendWriteIfRevisionResult> {
+    assertWorkspaceAgentTextSize(path, content);
+    const resolved = this.scopeFor(path);
+    if (resolved.kind === "reference") {
+      throw new DirectoryReferencePathError("read_only", path);
+    }
+    const expected = decodeWorkspaceFileRevision(revision);
+    try {
+      const { scope, rel } = resolved;
+      // mtime alone is not a content identity: an editor or sync client can
+      // replace bytes and restore the timestamp. Pair it with a digest of the
+      // text actually observed by the edit. The daemon still performs its late
+      // mtime check immediately before rename, narrowing the remaining
+      // cross-process check→publish window.
+      const current = await workspaceFs.readFile(scope, rel);
+      if (
+        current.mtime !== expected.mtime ||
+        workspaceFileDigest(current.content) !== expected.sha256
+      ) {
+        return { ok: false, reason: "stale" };
+      }
+      const result = await workspaceFs.writeFile(scope, rel, content, {
+        expected_mtime: expected.mtime,
+      });
+      return {
+        ok: true,
+        revision: encodeWorkspaceFileRevision(content, result.mtime),
+      };
+    } catch (err) {
+      if (isWorkspaceFsCode(err, "modified-since") || isAbsentForRead(err)) {
+        return { ok: false, reason: "stale" };
+      }
+      throw err;
+    }
   }
 
   async delete(path: string): Promise<void> {
@@ -1137,6 +1229,13 @@ export class WorkspaceAgentFsBackend implements AgentFs.Backend {
       }
     }
     return truncated;
+  }
+}
+
+function assertWorkspaceAgentTextSize(path: string, content: string): void {
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (bytes > AgentFs.MAX_TEXT_FILE_BYTES) {
+    throw new AgentFs.TextFileTooLargeError(path, bytes);
   }
 }
 

--- a/test/desktop-chat-session-header.md
+++ b/test/desktop-chat-session-header.md
@@ -7,7 +7,7 @@ tags: [chat, history, title, rename, session]
 status: untested
 severity: medium
 date: 2026-07-23
-updated: 2026-07-23
+updated: 2026-07-24
 automatable: false
 covered_by: []
 ---
@@ -37,15 +37,22 @@ title; Escape cancels it.
 3. Move the pointer over the title without clicking.
    - Expected: the chat list does not open.
 4. Activate the list button.
-   - Expected: the recent chat list opens.
-5. Close the list, then double-click the active title.
+   - Expected: the recent chat list opens with every row's overflow button
+     hidden and each title using the row's full available width.
+5. Hover a chat row, then open its overflow menu.
+   - Expected: only the hovered row's overflow button appears. It remains
+     visible while keyboard-focused or while its menu is open, and the menu
+     remains interactive when the pointer leaves the row. After pointer-
+     dismissing the menu outside the row, the button hides even though focus
+     returns to its trigger.
+6. Close the list, then double-click the active title.
    - Expected: the title becomes an inline text field with its text selected;
      its size, weight, color, and position match the read-state title, with no
      generic input border or shadow. No dialog appears.
-6. Type a new title and press Enter.
+7. Type a new title and press Enter.
    - Expected: the inline field closes and the renamed title remains visible.
-7. Open the active chat's overflow menu and choose Rename.
+8. Open the active chat's overflow menu and choose Rename.
    - Expected: the same inline title field opens. Pressing Escape restores the
      existing title without renaming it.
-8. Open the chat list, use a different row's overflow menu, and choose Rename.
+9. Open the chat list, use a different row's overflow menu, and choose Rename.
    - Expected: that chat becomes active and its title opens in the header editor.

--- a/test/desktop-workbench-scrolled-tab-drag-region.md
+++ b/test/desktop-workbench-scrolled-tab-drag-region.md
@@ -15,11 +15,12 @@ covered_by:
 
 ## Behavior
 
-Only the visible portions of interactive editor tabs exclude native window
-dragging. Tabs that are horizontally clipped or fully scrolled out of view must
-not leave ghost hit regions over the neighboring title bars. Visually empty
-title-bar space and the gaps between visible tabs remain draggable at every
-scroll position.
+Only the visible occupied tab run—interactive tabs and the gaps between
+them—excludes native window dragging. The gaps remain part of the horizontal
+scroll surface, so wheel input works continuously while crossing the tab rail.
+Tabs that are horizontally clipped or fully scrolled out of view must not leave
+ghost hit regions over neighboring title bars. Visually empty title-bar space
+after the final tab remains draggable at every scroll position.
 
 ## Steps
 
@@ -36,11 +37,15 @@ scroll position.
 6. Select a visible tab, open and dismiss its context menu, then close a
    disposable tab with its close button.
    - Expected: tab selection, context menus, and close actions still work.
-7. Scroll the rail in both directions with the trackpad or mouse, stopping with
-   a tab partially clipped at each edge.
-   - Expected: visible tab portions remain interactive while newly exposed
-     gaps and neighboring title bars remain draggable.
-8. Repeat with the file-tree pane both hidden and visible.
+7. Place the pointer directly over a gap between two tabs and scroll the rail
+   in both directions with the trackpad or mouse.
+   - Expected: the tabs scroll continuously; crossing a gap does not interrupt
+     wheel input.
+8. Close enough tabs to leave visibly unused rail space after the final tab,
+   then drag from that empty space.
+   - Expected: the OS window moves. The horizontal strips above and below the
+     tabs also remain draggable.
+9. Repeat with the file-tree pane both hidden and visible.
    - Expected: the left, editor, and right title-bar drag regions behave
      consistently.
 


### PR DESCRIPTION
## Summary

- Refine the desktop agent composer, context meter, session picker, permission-mode picker, and workspace-tab interactions.
- Keep wheel scrolling active across tab gaps while preserving the remaining native titlebar drag region.
- Stop counting persisted inline media bytes as prompt text in the context estimate.
- Align `read_file`, `write_file`, and `edit_file` with Codex-style current-content semantics: no prior-read authorization ledger or model-facing version tokens, and a newly written file can be edited without rereading it.
- Serialize server filesystem operations and commands, await persistence, add optimistic workspace revision checks, and give the model-facing text tools a consistent 1 MiB bound.
- Reconcile the agent filesystem prompt, implementation documentation, WG specifications, UI failures, and regression coverage.

Desktop release impact: version bump included (`0.0.10` → `0.0.11`).

## Etiology

The visible failures came from three contract mismatches rather than isolated presentation bugs:

- The context meter serialized durable base64 UI payloads as if they were model-facing prompt text.
- The native draggable overlay intercepted wheel input in the visual gaps between workspace tabs.
- File editing treated an ephemeral, session-local read/version ledger as authorization even though targeted edits can validate their precondition against current content during the operation.

This change fixes those underlying contracts: the context estimate now models only prompt-facing text, tab hit testing assigns gap events to the scrolling strip while retaining truly unused drag space, and `edit_file` proves applicability from current content plus `old_string`.

## Validation

- `pnpm --filter @grida/agent test` — 841 passed, 24 skipped, 3 todo.
- `pnpm --filter @grida/agent typecheck`.
- `pnpm --filter @grida/agent build`.
- `pnpm --filter editor typecheck`.
- Desktop TypeScript check — passed.
- Desktop Vitest suite — 204 passed.
- Focused agent filesystem/runtime regression suite — 115 passed.
- Focused desktop context/tab suite — 27 passed.
- Live two-turn smoke test: write a new SVG, then apply two targeted edits on the resumed turn without `read_file`; both edits persisted.
- Pre-commit `oxlint` and `oxfmt` — clean.

## Security review

`GRIDA-SEC-004` remains intact: shell registration stays fail-closed, command validation still runs before spawn, workspace/scratch containment and protected-path guards are unchanged, and directory references remain read-only. The touched `GRIDA-SEC-006` / `GRIDA-GG` branches are unchanged; hosted-token custody and provider routing are unaffected.