### PR TITLE
feat(ai-models): add Claude Opus 5, deprecate Opus 4.8

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -39,7 +39,7 @@ Models are organized into **tiers** based on capability and cost:
 | `max`  | GPT-5.6 Sol (`openai/gpt-5.6-sol`)     | 1.05M   | 128K       | $5.00          | $30.00          |
 
 All tier models support **multimodal** inputs (text + images).
-Claude Fable 5 and Claude Opus 4.8 remain active, non-tiered catalogue models.
+Claude Fable 5 and Claude Opus 5 remain active, non-tiered catalogue models.
 
 ### Cache Pricing
 
@@ -63,7 +63,8 @@ Per 1M tokens.
 | Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Fable 5 (`anthropic/claude-fable-5`)                  | $10.00 | $12.50      | $1.00      | $50.00  |
-| Claude Opus 4.8 (`anthropic/claude-opus-4.8`)                | $5.00  | $6.25       | $0.50      | $25.00  |
+| Claude Opus 5 (`anthropic/claude-opus-5`)                    | $5.00  | $6.25       | $0.50      | $25.00  |
+| Claude Opus 4.8 (`anthropic/claude-opus-4.8`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
 | Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
 | GPT-5.6 Sol (`openai/gpt-5.6-sol`)                           | $5.00  | $6.25       | $0.50      | $30.00  |
 | GPT-5.6 Terra (`openai/gpt-5.6-terra`)                       | $2.50  | $3.125      | $0.25      | $15.00  |
@@ -78,6 +79,10 @@ input tokens are billed at 2x input and 1.5x output for the full request.
 
 `GPT-5.5` is deprecated in Grida's catalogue in favor of `GPT-5.6 Sol`;
 this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.
+
+`Claude Opus 4.8` is deprecated in Grida's catalogue in favor of
+`Claude Opus 5`, its drop-in successor at the same rate card; this is not an
+upstream Anthropic retirement.
 
 ## Image Generation Models
 

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -58,16 +58,19 @@ describe("GET /api/v1/ai/models", () => {
     ] as const) {
       expect(byId.get(id)?.grida).toMatchObject({ modality: "text", tier });
     }
-    for (const id of [
-      "anthropic/claude-fable-5",
-      "anthropic/claude-opus-4.8",
-    ]) {
+    for (const id of ["anthropic/claude-fable-5", "anthropic/claude-opus-5"]) {
       expect(byId.get(id)?.grida).toMatchObject({
         modality: "text",
         tier: null,
         deprecated: false,
       });
     }
+    // A deprecated catalogue card still lists, flagged.
+    expect(byId.get("anthropic/claude-opus-4.8")?.grida).toMatchObject({
+      modality: "text",
+      tier: null,
+      deprecated: true,
+    });
     // Every modality is represented.
     const modalities = new Set(body.data.map((e) => e.grida.modality));
     expect(modalities).toEqual(new Set(["text", "image", "video"]));

--- a/editor/scaffolds/desktop/shared/model-picker.tsx
+++ b/editor/scaffolds/desktop/shared/model-picker.tsx
@@ -60,7 +60,7 @@ function isCatalogId(id: string | undefined | null): id is CatalogId {
 }
 
 // Group the flat catalog by provider for the picker. Vendor is the `vendor/`
-// id prefix (e.g. `anthropic/claude-opus-4.8`); Anthropic is surfaced first.
+// id prefix (e.g. `anthropic/claude-opus-5`); Anthropic is surfaced first.
 type CatalogSpec = (typeof MODEL_OPTIONS)[number];
 const VENDOR_LABELS: Record<string, string> = {
   anthropic: "Anthropic",

--- a/packages/grida-ai-agent/src/agent-provider/run.live.test.ts
+++ b/packages/grida-ai-agent/src/agent-provider/run.live.test.ts
@@ -35,6 +35,15 @@ const LIVE = process.env.GRIDA_LIVE_CLAUDE === "1";
 const TIMEOUT_MS = 300_000;
 const liveDescribe = LIVE ? describe : describe.skip;
 
+/**
+ * Which `AGENT_PROVIDER_MODELS` entry the picker case runs. Defaults to the
+ * cheapest one; override to verify a newly catalogued vendor id actually runs
+ * on a subscription through the bridge — the precondition that map documents:
+ *
+ *   GRIDA_LIVE_CLAUDE=1 GRIDA_LIVE_ACP_MODEL=claude-acp/opus-5 …
+ */
+const ACP_MODEL_ID = process.env.GRIDA_LIVE_ACP_MODEL ?? "claude-acp/haiku-4.5";
+
 type Host = { app: Hono; runtime: AgentRuntime; store: SessionsStore };
 
 function buildHost(baseDir: string): Host {
@@ -165,13 +174,13 @@ liveDescribe("LIVE — agent-provider class, no key (issue #813)", () => {
   );
 
   it(
-    "runs a picker-selected model (issue #813 model picker)",
+    `runs a picker-selected model (issue #813 model picker): ${ACP_MODEL_ID}`,
     async () => {
-      // The synthetic id carries the vendor model (claude-haiku-4-5) → run-input
-      // gate → runtime → _meta.claudeCode.options.model → bridge. A 200 + answer
-      // proves the whole chain accepts the picked model id and runs it.
+      // The synthetic id carries a vendor model → run-input gate → runtime →
+      // _meta.claudeCode.options.model → bridge. A 200 + answer proves the
+      // whole chain accepts the picked model id and runs it.
       const turn = await runTurn(host, {
-        model_id: "claude-acp/haiku-4.5",
+        model_id: ACP_MODEL_ID,
         messages: [
           {
             role: "user",

--- a/packages/grida-ai-agent/src/agent-provider/types.test.ts
+++ b/packages/grida-ai-agent/src/agent-provider/types.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_PROVIDER_MODELS,
+  agentProviderModel,
+  isAgentProviderModel,
+  type AgentProviderModelId,
+} from "./types";
+
+/**
+ * Claude Code's own alias vocabulary. An alias resolves to whatever version is
+ * current, so one landing in {@link AGENT_PROVIDER_MODELS} would silently
+ * change model under us — the map's contract is full vendor ids only.
+ */
+const CLAUDE_CODE_ALIASES = [
+  "sonnet",
+  "opus",
+  "haiku",
+  "fable",
+  "best",
+  "opusplan",
+  "sonnet[1m]",
+  "opus[1m]",
+  "fable[1m]",
+] as const;
+
+/**
+ * A full vendor id — `claude-`-prefixed, optionally carrying the `[1m]`
+ * suffix. Deliberately loose about the version shape (dated snapshots and
+ * `claude-3-5-haiku`-style ids are legitimate); the alias check below is what
+ * carries the real constraint.
+ */
+const FULL_VENDOR_ID = /^claude-[a-z0-9-]+(\[1m\])?$/;
+
+const ids = Object.keys(AGENT_PROVIDER_MODELS) as AgentProviderModelId[];
+
+/** Entries that pin a vendor model — everything but the subscription default. */
+const pinned = ids.filter((id) => id !== "claude-acp");
+
+describe("AGENT_PROVIDER_MODELS", () => {
+  it.each(ids)("routes %s to the single agent-provider id", (id) => {
+    expect(AGENT_PROVIDER_MODELS[id].id).toBe("claude");
+  });
+
+  it("leaves the bare id unpinned so it takes the subscription default", () => {
+    expect(ids).toContain("claude-acp");
+    expect(agentProviderModel("claude-acp")).toBeUndefined();
+    // …and it is the only unpinned entry.
+    expect(pinned.length).toBe(ids.length - 1);
+  });
+
+  it.each(pinned)("pins %s to a full vendor id, never an alias", (id) => {
+    const model = agentProviderModel(id);
+    expect(model).toBeDefined();
+    expect(model).toMatch(FULL_VENDOR_ID);
+    expect(CLAUDE_CODE_ALIASES).not.toContain(model);
+  });
+
+  it.each(pinned)("keeps %s's context suffix honest", (id) => {
+    // A `-1m` key must carry the `[1m]` vendor suffix and vice versa. The
+    // suffix only adds the 1M-context beta (Claude Code strips it before the
+    // request), so a key that advertises it without setting it — or sets it
+    // without saying so — misdescribes what the entry asks for.
+    expect(id.endsWith("-1m")).toBe(
+      agentProviderModel(id)?.endsWith("[1m]") === true
+    );
+  });
+
+  it("retains superseded entries, newest first", () => {
+    // Grida-catalogue deprecation does not transfer to this map: these run on
+    // the user's own subscription. Dropping a key is a hard break for anything
+    // pinned to it — the id stops passing the run-input gate, and this map is
+    // the only record of a persisted session's vendor model.
+    expect(agentProviderModel("claude-acp/opus-5")).toBe("claude-opus-5");
+    expect(agentProviderModel("claude-acp/opus-4.8-1m")).toBe(
+      "claude-opus-4-8[1m]"
+    );
+    expect(ids.indexOf("claude-acp/opus-5")).toBeLessThan(
+      ids.indexOf("claude-acp/opus-4.8-1m")
+    );
+  });
+});
+
+describe("isAgentProviderModel", () => {
+  it.each(ids)("accepts the catalogued key %s", (id) => {
+    expect(isAgentProviderModel(id)).toBe(true);
+  });
+
+  // Prototype keys must not pass: the later AGENT_PROVIDER_MODELS[id] lookup
+  // would otherwise yield junk instead of a provider entry.
+  it.each([
+    "anthropic/claude-opus-5",
+    "claude-acp/opus-5-1m",
+    "claude-code/opus-4.8-1m",
+    "",
+    "toString",
+    "__proto__",
+    "constructor",
+  ])("rejects %s", (id) => {
+    expect(isAgentProviderModel(id)).toBe(false);
+  });
+
+  it("rejects nullish", () => {
+    expect(isAgentProviderModel(null)).toBe(false);
+    expect(isAgentProviderModel(undefined)).toBe(false);
+  });
+});

--- a/packages/grida-ai-agent/src/agent-provider/types.ts
+++ b/packages/grida-ai-agent/src/agent-provider/types.ts
@@ -67,22 +67,43 @@ export interface OpenProviderOptions {
   /**
    * The vendor model id to run (issue #813 model picker), passed to the bridge
    * via `_meta.claudeCode.options.model`. Omit to use the subscription default.
-   * Full ids only (aliases like `opus` resolve to an older version).
+   * Full ids only (an alias like `opus` floats to whatever Claude Code
+   * currently ships, so it silently changes model between versions).
    */
   model?: string;
 }
 
 /**
  * Synthetic catalog model ids that select an agent-provider (and a specific
- * vendor model). The contract shared by the UI picker, the run-input gate, and
- * the runtime branch. NEUTRAL (no node/SDK imports) — browser-safe. Keep the
- * keys + models in sync with the desktop picker. Each model id was verified to
- * run on a Claude Pro/Max subscription via the bridge. Opus 4.8 maps to the
- * 1M-context variant `claude-opus-4-8[1m]` — a DISTINCT model id from plain
- * `claude-opus-4-8` (the smaller-context build, intentionally not surfaced).
+ * vendor model). The contract shared by the run-input gate and the runtime
+ * branch; these ids are runtime-only — no picker enumerates them today (see
+ * `default-model.ts` in the desktop renderer). NEUTRAL (no node/SDK imports)
+ * — browser-safe.
+ *
+ * Values are FULL Claude Code model ids, newest first, each checked against
+ * Claude Code's model registry (a live subscription turn is the
+ * `GRIDA_LIVE_CLAUDE=1` test). Never an alias (`opus`, `sonnet`, `opus[1m]`,
+ * …): an alias floats to whatever Claude Code currently ships, so it would
+ * change model under us.
+ *
+ * Prefer the PLAIN id. A `[1m]` suffix is not part of the model id — Claude
+ * Code strips it before the request and uses it only to add the 1M-context
+ * beta, so it buys nothing for a model whose window is already natively 1M
+ * (every Opus here) and it relies on suffix handling in whichever bridge/SDK
+ * version `npx` resolves. `opus-4.8-1m` keeps its suffix only because the key
+ * already shipped.
+ *
+ * Superseded entries STAY listed. Grida-catalogue deprecation does not
+ * transfer here: these run on the user's own Claude subscription, so what
+ * Anthropic still serves a subscriber is not ours to retire. Dropping a key
+ * is also a hard break for anything already pinned to it: the id stops
+ * passing the run-input gate (400), and this map is the only place a
+ * persisted session's vendor model is recorded — the session row keeps just
+ * the synthetic id (see {@link agentProviderModel}).
  */
 export const AGENT_PROVIDER_MODELS = {
   "claude-acp": { id: "claude" }, // subscription default
+  "claude-acp/opus-5": { id: "claude", model: "claude-opus-5" },
   "claude-acp/opus-4.8-1m": { id: "claude", model: "claude-opus-4-8[1m]" },
   "claude-acp/sonnet-4.6": { id: "claude", model: "claude-sonnet-4-6" },
   "claude-acp/haiku-4.5": { id: "claude", model: "claude-haiku-4-5" },

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -258,6 +258,12 @@ describe("models.text current catalogue", () => {
       outputLimit: 128_000,
       cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
     },
+    {
+      id: "anthropic/claude-opus-5",
+      contextWindow: 1_000_000,
+      outputLimit: 128_000,
+      cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    },
   ] as const;
 
   it.each(newModels)("stores the published $id rate card", (expected) => {
@@ -290,8 +296,11 @@ describe("models.text current catalogue", () => {
       models.text.catalog["anthropic/claude-fable-5"].deprecated
     ).toBeUndefined();
     expect(
-      models.text.catalog["anthropic/claude-opus-4.8"].deprecated
+      models.text.catalog["anthropic/claude-opus-5"].deprecated
     ).toBeUndefined();
+    expect(models.text.catalog["anthropic/claude-opus-4.8"].deprecated).toBe(
+      true
+    );
   });
 });
 

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -301,6 +301,18 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
       },
+      // Drop-in successor to Opus 4.8 at the same rate card.
+      "anthropic/claude-opus-5": {
+        id: "anthropic/claude-opus-5",
+        label: "Claude Opus 5",
+        short_label: "Opus 5",
+        multimodal: true,
+        imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_000_000,
+        outputLimit: 128_000,
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      },
       "anthropic/claude-opus-4.8": {
         id: "anthropic/claude-opus-4.8",
         label: "Claude Opus 4.8",
@@ -311,6 +323,7 @@ export namespace models {
         contextWindow: 1_000_000,
         outputLimit: 128_000,
         cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        deprecated: true,
       },
       "anthropic/claude-opus-4.7": {
         id: "anthropic/claude-opus-4.7",


### PR DESCRIPTION
## What

Introduces **Claude Opus 5** and deprecates **Opus 4.8** across both model surfaces.

Opus 5 is a drop-in successor at Opus 4.8's rate card — `$5` / `$25` per MTok, `$0.50` cache read, `$6.25` cache write, 1M context, 128K output. Verified against `models.dev`, which lists it as served by the Vercel gateway.

### Gateway catalogue — `@grida/ai-models`

- Adds `anthropic/claude-opus-5`, ordered newest-first like the other families.
- Marks `anthropic/claude-opus-4.8` `deprecated: true`. This is a **Grida catalogue lifecycle marker, not an upstream Anthropic retirement** — the card stays callable, and both the public `/ai/models` page and `GET /api/v1/ai/models` surface the flag. Same treatment Sonnet 4.6 and Opus 4.7 already have.

Both consumer surfaces are catalogue-driven, so nothing else needed wiring: the desktop model picker has no allowlist (Opus 5 appears automatically under Anthropic) and the public page renders the badge off `spec.deprecated`. Defaults are untouched — `DEFAULT_MODEL_ID` / `GG_INCLUDED_MODEL_ID` resolve through `TIER_MODEL_IDS.pro`, an OpenAI model.

### ACP path — `@grida/agent`

Adds `claude-acp/opus-5` → `claude-opus-5` to `AGENT_PROVIDER_MODELS`.

Two decisions a reviewer should know about, because both look inconsistent with the neighbouring entries at first glance:

**1. The vendor id is plain, not `[1m]`-suffixed.** The Opus 4.8 entry uses `claude-opus-4-8[1m]`, and its comment claimed that was "a DISTINCT model id from plain `claude-opus-4-8` (the smaller-context build)". That is not what the suffix does. In Claude Code's model registry:

| vendor id | context |
|---|---|
| `claude-opus-5` | `window:1e6, native_1m:true, supports_1m_beta:true, supports_1m_suffix:true` |
| `claude-opus-4-8` | `window:1e6, native_1m:true, supports_1m_beta:true, supports_1m_suffix:true` |
| `claude-sonnet-4-6` | `window:200000, supports_1m_beta:true, supports_1m_suffix:true` |

`[1m]` is stripped from the wire model (`e.replace(/\[1m\]$/i,"")`) and only adds the `context-1m-2025-08-07` beta header plus a picker label. Both Opus models are **already 1M natively**, so the suffix buys nothing there — the one map entry where it would change capability is `claude-sonnet-4-6` (200K → 1M), which is deliberately pinned plain. Plain is also more robust: suffix handling lives in the Claude Code CLI, but this path spawns `npx -y @agentclientprotocol/claude-agent-acp` (the Agent SDK's own bundled CLI), so relying on it would bet on a version we can't pin. The 4.8 key keeps its suffix only because it already shipped.

**2. The Opus 4.8 entry is retained, not deprecated or removed.** Catalogue deprecation does not transfer to this map — these ids run on the user's *own* Claude subscription through the bridge, with no Grida serving or billing, so what Anthropic still serves a subscriber is not ours to retire (upstream still ships 4.8, labelled "Previous Opus version"). Dropping a key is also a hard break for anything already pinned to it: the id stops passing the run-input gate (400), and this map is the only place a persisted session's vendor model is recorded. A `deprecated` field here would additionally have zero readers — no picker, page, or API route enumerates this map.

Supersession is therefore expressed by ordering plus a docstring note.

Two stale claims in `agent-provider/types.ts` are corrected in passing, since both would mislead the next editor of the lines being touched: "keep the keys + models in sync with the desktop picker" (no picker enumerates these — they're runtime-only, per `default-model.ts`), and "aliases like `opus` resolve to an older version" (an alias floats to whatever ships currently; that's the real reason to pin a full id).

## Tests

- **New** `packages/grida-ai-agent/src/agent-provider/types.test.ts` makes the map's contract executable: full vendor ids only (never a floating alias), a `-1m` key must agree with the vendor `[1m]`, superseded entries retained, ordering newest-first, and `isAgentProviderModel` rejecting prototype keys (`__proto__`, `constructor`, …).
- Catalogue rate-card and lifecycle-marker coverage for Opus 5.
- The models-API test now also asserts that a **deprecated card still lists, flagged** — the flag's propagation to the payload previously had no coverage.
- `run.live.test.ts` takes `GRIDA_LIVE_ACP_MODEL` so a newly added ACP entry can be exercised against a real subscription; it defaults to haiku, so the standard live run's cost is unchanged.

The new invariants were mutation-tested (aliasing the id, dropping the 4.8 key, a key claiming `-1m` without the suffix, reversed ordering, and the bare id accidentally pinned): **5/5 caught**.

## Verification

- `pnpm turbo test typecheck --filter='./packages/*' --filter=editor` → **99/99 tasks green**
- `pnpm lint` → 0 errors (4 pre-existing `.todo` warnings elsewhere)
- `just fmt` clean; pre-commit hooks green
- `/ai/models` checked in the browser: the Opus 5 row renders at the right price with no badge, Opus 4.8 now shows **Deprecated**, no console errors

## Not verified

**No live bridge turn has run for Opus 5 on the ACP path.** The vendor id rests on Claude Code's model registry, not on a completion. To close it:

```
GRIDA_LIVE_CLAUDE=1 GRIDA_LIVE_ACP_MODEL=claude-acp/opus-5 pnpm --filter @grida/agent vitest run src/agent-provider/run.live.test.ts
```

## Out of scope — pre-existing bug found while investigating

The ACP **queue drain** is broken today, independent of this change. `drainTurn` resolves the provider from the persisted `provider_id`, which is the literal `"claude"` for an ACP session; `resolveExplicit` handles only gg / BYOK / endpoint ids (`BYOK_PROVIDER_IDS === ["openrouter","vercel","fal"]`), so it throws `ProviderUnavailableError("claude")` before `startTurn`. The scheduler has already dequeued the row and swallows the throw, so a queued turn on a `claude-acp` session leaves the user's message visible and unanswered with no error. This also falsifies the comment at `runtime/index.ts:1220-1221` claiming the vendor-model lookup "works on BOTH the HTTP run and the queue-drain path". Not fixed here — filed separately.

## Desktop release impact: version bump included

The audit (`.agents/skills/desktop/scripts/audit-release-impact.sh`) reports both `packages/grida-ai-models` and `packages/grida-ai-agent` in the release-scoped diff — they are `link:` dependencies bundled into the native sidecar via `build:linked-packages`, so this changes the packaged Desktop payload. `desktop/package.json` is at `0.0.11`, and `v0.0.11` is already published (at `69e4ef3ad`, this branch's merge-base).

**This is release-coupled, not merely payload-changing.** The desktop model picker is catalogue-driven (`Object.values(_models.text.catalog)`) and the renderer ships from `https://grida.co/desktop/*` on the next web deploy — reaching every installed client immediately. The sidecar's run gate is frozen at install time:

```ts
// packages/grida-ai-agent/src/runtime/run-input.ts:45
const CATALOG_MODEL_IDS = new Set<string>(Object.keys(models.text.catalog));
```

`git show v0.0.11:packages/grida-ai-models/src/models.ts | grep -c claude-opus-5` → `0`. So a user on Desktop 0.0.11 who picks Opus 5 sends `model_id: "anthropic/claude-opus-5"` to a sidecar that rejects it with `400 modelId not allowed`.

Scoped by change:

| Change | Native payload | Hosted renderer sends it | Effect on installed 0.0.11 |
|---|---|---|---|
| Catalogue: add `anthropic/claude-opus-5` | yes (bundled gate) | **yes** — picker is catalogue-driven | **400 at the run gate** |
| Catalogue: deprecate `anthropic/claude-opus-4.8` | display-only | flag not read by the picker | none |
| ACP: add `claude-acp/opus-5` | yes | no — ACP ids are runtime-only | inert until a native release |

So the deprecation is safe to ship on the web alone; the **addition** is not. Needs a Desktop version bump plus a published build before (or with) the web deploy that surfaces Opus 5 in the desktop picker — note that publishing and auto-update notification alone do not update installed clients. `desktop/package.json` is bumped to **0.0.12** in this PR (`chore(desktop): bump version to 0.0.12`), so the release assembler can build it — it refuses to modify an already-published `v<version>`, which `0.0.11` was.

**Ordering still matters:** publish the 0.0.12 build before (or with) the web deploy that surfaces Opus 5 in the desktop picker. Publishing and auto-update notification alone do not update installed clients, so 0.0.11 users hit the 400 for as long as the hosted picker is ahead of their build.

A longer-term fix that would make future model additions genuinely release-free: have the desktop picker filter to ids the connected sidecar reports, rather than the renderer's own bundled catalogue. Not in scope here.

