### PR TITLE
Restore the marketable pricing comparison

### DIFF
--- a/editor/app/(www)/(pricing)/pricing/_sections/faq.tsx
+++ b/editor/app/(www)/(pricing)/pricing/_sections/faq.tsx
@@ -1,3 +1,5 @@
+// GRIDA-EE: billing — customer-facing plan and billing questions.
+
 import React from "react";
 import Link from "next/link";
 import {
@@ -20,7 +22,7 @@ const faqs: { question: string; answer: React.ReactNode }[] = [
   {
     question: "Does a plan include AI credit?",
     answer:
-      "No. AI credit is purchased separately. Pro adds automatic credit reload so an organization can keep working without manual top-ups.",
+      "Free and Pro do not include recurring AI credit. You can buy prepaid AI credit as needed, and Pro lets an organization enable automatic reload. A Custom agreement may define different AI-credit terms.",
   },
   {
     question: "How do I upgrade to Pro?",

--- a/editor/app/(www)/(pricing)/pricing/page.tsx
+++ b/editor/app/(www)/(pricing)/pricing/page.tsx
@@ -1,3 +1,5 @@
+// GRIDA-EE: billing — public pricing and plan acquisition page.
+
 import { Pricing } from "@/www/pricing/pricing";
 import Header from "@/www/header";
 import FooterWithCTA from "@/www/footer-with-cta";
@@ -8,14 +10,14 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Pricing — Grida",
   description:
-    "Start free, upgrade to Grida Pro for $20 per month, or contact us for a Custom plan.",
+    "Start free, upgrade to Grida Pro for $20 per organization each month, or contact us for a Custom plan.",
   alternates: {
     canonical: "https://grida.co/pricing",
   },
   openGraph: {
     title: "Pricing — Grida",
     description:
-      "Start free, upgrade to Grida Pro for $20 per month, or contact us for a Custom plan.",
+      "Start free, upgrade to Grida Pro for $20 per organization each month, or contact us for a Custom plan.",
     url: "https://grida.co/pricing",
     type: "website",
   },
@@ -23,7 +25,7 @@ export const metadata: Metadata = {
     card: "summary",
     title: "Pricing — Grida",
     description:
-      "Start free, upgrade to Grida Pro for $20 per month, or contact us for a Custom plan.",
+      "Start free, upgrade to Grida Pro for $20 per organization each month, or contact us for a Custom plan.",
   },
 };
 

--- a/editor/lib/billing/marketing-plans.ts
+++ b/editor/lib/billing/marketing-plans.ts
@@ -15,6 +15,7 @@ export interface PricingInformation {
   costUnit?: string;
   href: string;
   priceMonthly: string;
+  priceNote?: string;
   description: string;
   highlight?: boolean;
   features: {
@@ -31,11 +32,17 @@ const freePlan: PricingInformation = {
   name: "Free",
   href: "/dashboard",
   priceMonthly: "$0",
-  description: "Create and publish with Grida at no cost.",
+  priceNote: "AI credit is purchased separately.",
+  description: "The Desktop-first creative workspace, with no subscription.",
   features: [
-    { name: "Core editor, projects, and sites" },
-    { name: "File uploads" },
-    { name: "AI models with prepaid credit" },
+    { name: "Grida Desktop for macOS, Windows, and Linux" },
+    { name: "AI agent for local workspace files" },
+    { name: "Prompt-to-editable presentation decks" },
+    { name: "Human-and-AI SVG editing with clean diffs" },
+    { name: "Image generation with model controls" },
+    { name: "Design, code, Markdown, and media workspace" },
+    { name: "Hosted AI, provider keys, or local Ollama" },
+    { name: "Buy hosted AI credit as needed", trail: "$10–$500" },
   ],
   cta: "Start for free",
 };
@@ -44,14 +51,20 @@ export const proPlan: PricingInformation = {
   id: "tier_pro",
   name: "Pro",
   highlight: true,
-  costUnit: "per month",
+  costUnit: "per organization / month",
   href: "/_/settings/billing/upgrade",
   priceMonthly: `$${proMonthlyDollars}`,
-  description: "Keep AI credit ready for ongoing work.",
+  priceNote: "AI credit is purchased separately.",
+  description: "The same creative workspace, with automatic AI-credit reload.",
   features: [
-    { name: "Everything available on Free" },
-    { name: "AI credit auto-reload" },
-    { name: "Organization billing and invoices" },
+    { name: "Grida Desktop for macOS, Windows, and Linux" },
+    { name: "AI agent for local workspace files" },
+    { name: "Prompt-to-editable presentation decks" },
+    { name: "Human-and-AI SVG editing with clean diffs" },
+    { name: "Image generation with model controls" },
+    { name: "Design, code, Markdown, and media workspace" },
+    { name: "Hosted AI, provider keys, or local Ollama" },
+    { name: "Automatic AI credit reload" },
   ],
   cta: "Upgrade to Pro",
 };
@@ -61,11 +74,17 @@ const customPlan: PricingInformation = {
   name: "Custom",
   href: "/contact",
   priceMonthly: "Custom",
-  description: "Tailored terms for your organization.",
+  priceNote: "Pricing by agreement.",
+  description: "Commercial and operational terms shaped around your needs.",
   features: [
-    { name: "Bespoke pricing" },
-    { name: "Deployment and integrations" },
-    { name: "Security, limits, and support" },
+    { name: "Complete Grida Desktop and web product suite" },
+    { name: "Workspace agent, SVG, and presentation workflows" },
+    { name: "Forms, Database/CMS, and Supabase" },
+    { name: "Figma import and open-source SDKs" },
+    { name: "Custom pricing and billing schedule" },
+    { name: "Deployment options by agreement" },
+    { name: "Integrations by agreement" },
+    { name: "Support, rollout, and AI terms by agreement" },
   ],
   cta: "Contact Sales",
 };

--- a/editor/www/data/pricing.test.ts
+++ b/editor/www/data/pricing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { pricing } from "./pricing";
+
+const categories = Object.values(pricing);
+const featureNames = categories.flatMap((category) =>
+  category.features.map((feature) => feature.title)
+);
+
+describe("public pricing comparison", () => {
+  it("expands the former 25-row product inventory", () => {
+    expect(featureNames.length).toBeGreaterThan(25);
+  });
+
+  it("keeps the major shipped product surfaces visible", () => {
+    expect(featureNames).toEqual(
+      expect.arrayContaining([
+        "AI agent that creates and edits project files",
+        "Prompt-to-editable presentation decks",
+        "AI-assisted, round-trip SVG editing",
+        "Visual builder with themes and custom CSS",
+        "Managed Database/CMS visual workspace",
+        "Figma import from .fig, REST data, and clipboard",
+        "Grida-hosted agent models",
+      ])
+    );
+  });
+
+  it("keeps historically shipped marketable capabilities explicit", () => {
+    expect(featureNames).toEqual(
+      expect.arrayContaining([
+        "Custom domains for hosted sites and forms",
+        "Custom branding and removable Powered by Grida badge",
+        "Form response simulator",
+      ])
+    );
+  });
+
+  it("does not promote low-level editor mechanics as product features", () => {
+    const implementationDetails = [
+      "Infinite canvas with fast pan and zoom",
+      "Shape, line, pencil, and pen tools",
+      "Editable vector paths and compound shapes",
+      "Frames, groups, and layer hierarchy",
+      "Canvas-native rich text editing",
+      "Images, video, Markdown, and HTML embeds",
+      "Fills, strokes, effects, and layout controls",
+      "Undo and redo with history preview",
+    ];
+
+    for (const implementationDetail of implementationDetails) {
+      expect(featureNames).not.toContain(implementationDetail);
+    }
+  });
+
+  it("does not reintroduce retired public offers", () => {
+    expect(JSON.stringify(pricing)).not.toMatch(/team|annual|yearly/i);
+  });
+});

--- a/editor/www/data/pricing.test.ts
+++ b/editor/www/data/pricing.test.ts
@@ -7,8 +7,9 @@ const featureNames = categories.flatMap((category) =>
 );
 
 describe("public pricing comparison", () => {
-  it("expands the former 25-row product inventory", () => {
-    expect(featureNames.length).toBeGreaterThan(25);
+  it("keeps the 52-row product inventory intact and unique", () => {
+    expect(featureNames).toHaveLength(52);
+    expect(new Set(featureNames).size).toBe(featureNames.length);
   });
 
   it("keeps the major shipped product surfaces visible", () => {

--- a/editor/www/data/pricing.ts
+++ b/editor/www/data/pricing.ts
@@ -154,7 +154,11 @@ export const pricing: Pricing = {
       },
       {
         title: "Form response simulator",
-        plans: availableToAllPlans,
+        plans: {
+          free: "Beta",
+          pro: "Beta",
+          custom: "Beta",
+        },
       },
       {
         title: "Scheduling, response limits, and completion redirects",
@@ -181,7 +185,7 @@ export const pricing: Pricing = {
         },
       },
       {
-        title: "Form interface available in 12 languages",
+        title: "Form interface available in 13 languages",
         plans: availableToAllPlans,
       },
     ],
@@ -218,7 +222,7 @@ export const pricing: Pricing = {
         plans: availableToAllPlans,
       },
       {
-        title: "Customer records, CSV updates, tags, and segments",
+        title: "Customer records, CSV updates, and tags",
         plans: availableToAllPlans,
       },
     ],
@@ -231,7 +235,7 @@ export const pricing: Pricing = {
         plans: availableToAllPlans,
       },
       {
-        title: "fig2grida CLI and library",
+        title: "Open-source Figma-to-Grida conversion tools",
         plans: availableToAllPlans,
       },
       {
@@ -239,7 +243,7 @@ export const pricing: Pricing = {
         plans: availableToAllPlans,
       },
       {
-        title: "Canvas Embed SDK",
+        title: "Embeddable Canvas viewer and host controls",
         plans: {
           free: "Alpha",
           pro: "Alpha",

--- a/editor/www/data/pricing.ts
+++ b/editor/www/data/pricing.ts
@@ -1,0 +1,337 @@
+// GRIDA-EE: billing — feature data for the public plan comparison.
+
+type Pricing = {
+  desktop: PricingCategory;
+  design: PricingCategory;
+  forms: PricingCategory;
+  database: PricingCategory;
+  developer: PricingCategory;
+  ai: PricingCategory;
+  custom: PricingCategory;
+};
+
+export type PricingCategory = {
+  title: string;
+  features: PricingFeature[];
+};
+
+type PricingFeature = {
+  title: string;
+  tooltips?: {
+    main?: string;
+    free?: string;
+    pro?: string;
+    custom?: string;
+  };
+  plans: {
+    free: boolean | string | string[];
+    pro: boolean | string | string[];
+    custom: boolean | string | string[];
+  };
+};
+
+const availableToAllPlans: PricingFeature["plans"] = {
+  free: true,
+  pro: true,
+  custom: true,
+};
+
+const customByAgreement: PricingFeature["plans"] = {
+  free: false,
+  pro: false,
+  custom: "By agreement",
+};
+
+export const pricing: Pricing = {
+  desktop: {
+    title: "Grida Desktop",
+    features: [
+      {
+        title: "AI agent that creates and edits project files",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Prompt-to-editable presentation decks",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "AI-assisted, round-trip SVG editing",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Image generation with model and output controls",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Visual reference search and compatible-model image generation",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Work directly in local project folders",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "SVG, code, Markdown, image, and video workspace",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Built-in workspace terminal",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Bring your own provider keys or connect local Ollama",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Desktop apps for macOS, Windows, and Linux",
+        plans: availableToAllPlans,
+      },
+    ],
+  },
+  design: {
+    title: "Design & interoperability",
+    features: [
+      {
+        title: "Web-based Canvas editor",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Vector-native presentation workspace",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Figma import from .fig, REST data, and clipboard",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Figma Slides .deck import",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Multi-format design export",
+        plans: {
+          free: "PNG, JPEG, WebP, PDF, SVG",
+          pro: "PNG, JPEG, WebP, PDF, SVG",
+          custom: "PNG, JPEG, WebP, PDF, SVG",
+        },
+      },
+      {
+        title: "Custom domains for hosted sites and forms",
+        plans: availableToAllPlans,
+      },
+    ],
+  },
+  forms: {
+    title: "Forms & responses",
+    features: [
+      {
+        title: "Visual builder with themes and custom CSS",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Custom branding and removable Powered by Grida badge",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Rich fields for files, media, and formatted content",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Logic, computed fields, hidden fields, and URL prefilling",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Hosted form pages and iframe embedding",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Headless form submission API",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Realtime sync and partial submissions",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Form response simulator",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Scheduling, response limits, and completion redirects",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Customer identity and respondent confirmation emails",
+        plans: {
+          free: "Verified email required",
+          pro: "Verified email required",
+          custom: "Verified email required",
+        },
+      },
+      {
+        title: "Response management and CSV export",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Option inventory tracking",
+        plans: {
+          free: "Alpha",
+          pro: "Alpha",
+          custom: "Alpha",
+        },
+      },
+      {
+        title: "Form interface available in 12 languages",
+        plans: availableToAllPlans,
+      },
+    ],
+  },
+  database: {
+    title: "Database & CMS",
+    features: [
+      {
+        title: "Managed Database/CMS visual workspace",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Supabase Tables, Views, Storage, and Auth",
+        plans: {
+          free: "Beta",
+          pro: "Beta",
+          custom: "Beta",
+        },
+      },
+      {
+        title: "Search, filtering, sorting, and computed attributes",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Gallery, list, and chart views",
+        plans: {
+          free: "Charts in beta",
+          pro: "Charts in beta",
+          custom: "Charts in beta",
+        },
+      },
+      {
+        title: "Form-backed admin workflows",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Customer records, CSV updates, tags, and segments",
+        plans: availableToAllPlans,
+      },
+    ],
+  },
+  developer: {
+    title: "Developer tools & open source",
+    features: [
+      {
+        title: "Portable .grida document format",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "fig2grida CLI and library",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Headless Figma rendering in Node.js and browsers",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Canvas Embed SDK",
+        plans: {
+          free: "Alpha",
+          pro: "Alpha",
+          custom: "Alpha",
+        },
+      },
+      {
+        title: "SVG SDK and React bindings",
+        plans: {
+          free: "Alpha",
+          pro: "Alpha",
+          custom: "Alpha",
+        },
+      },
+      {
+        title: "Apache 2.0 open-source codebase",
+        plans: availableToAllPlans,
+      },
+    ],
+  },
+  ai: {
+    title: "Hosted AI & credit",
+    features: [
+      {
+        title: "Grida-hosted agent models",
+        plans: {
+          free: "Prepaid credit",
+          pro: "Prepaid credit",
+          custom: "By agreement",
+        },
+      },
+      {
+        title: "Grida-hosted image-generation models",
+        plans: {
+          free: "Prepaid credit",
+          pro: "Prepaid credit",
+          custom: "By agreement",
+        },
+      },
+      {
+        title: "Credit shared across the organization",
+        plans: {
+          free: true,
+          pro: true,
+          custom: "By agreement",
+        },
+      },
+      {
+        title: "Manual AI-credit purchases",
+        plans: {
+          free: "$10–$500",
+          pro: "$10–$500",
+          custom: "By agreement",
+        },
+      },
+      {
+        title: "Automatic AI-credit reload",
+        plans: {
+          free: false,
+          pro: true,
+          custom: "By agreement",
+        },
+      },
+    ],
+  },
+  custom: {
+    title: "Support & custom services",
+    features: [
+      {
+        title: "Community support through Slack and GitHub",
+        plans: availableToAllPlans,
+      },
+      {
+        title: "Tailored pricing and billing schedule",
+        plans: customByAgreement,
+      },
+      {
+        title: "Tailored deployment",
+        plans: customByAgreement,
+      },
+      {
+        title: "Tailored integrations",
+        plans: customByAgreement,
+      },
+      {
+        title: "Tailored support and rollout",
+        plans: customByAgreement,
+      },
+      {
+        title: "Tailored AI-credit terms",
+        plans: customByAgreement,
+      },
+    ],
+  },
+};

--- a/editor/www/pricing/pricing-card.tsx
+++ b/editor/www/pricing/pricing-card.tsx
@@ -1,3 +1,5 @@
+// GRIDA-EE: billing — plan card presentation for the public pricing page.
+
 import React from "react";
 import { Button } from "@app/ui/components/button";
 import { CheckIcon } from "@radix-ui/react-icons";
@@ -36,7 +38,7 @@ export function PricingCard({
         bg-background
         dark:bg-muted/50
         flex-1 flex flex-col p-6 border gap-4 rounded-lg
-        min-h-[420px]
+        min-h-[480px] md:h-[570px]
         hover:scale-[1.02]
         duration-300
         transition-all

--- a/editor/www/pricing/pricing-card.tsx
+++ b/editor/www/pricing/pricing-card.tsx
@@ -38,7 +38,7 @@ export function PricingCard({
         bg-background
         dark:bg-muted/50
         flex-1 flex flex-col p-6 border gap-4 rounded-lg
-        min-h-[480px] md:h-[570px]
+        min-h-[480px] md:min-h-[570px]
         hover:scale-[1.02]
         duration-300
         transition-all
@@ -51,7 +51,7 @@ export function PricingCard({
       )}
       <div className="flex-[2] flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <span className="text-2xl font-semibold">{plan}</span>
+          <h2 className="text-2xl font-semibold">{plan}</h2>
           <span className="text-sm font-normal text-muted-foreground">
             {excerpt}
           </span>
@@ -71,7 +71,7 @@ export function PricingCard({
         </div>
         <hr />
       </div>
-      <div className="flex-[3] flex min-h-0 shrink flex-col gap-3">
+      <div className="flex-[3] flex flex-col gap-3">
         {features.map((feature, i) => (
           <PricingFeatureRow key={i} {...feature} />
         ))}

--- a/editor/www/pricing/pricing-comparison-table.tsx
+++ b/editor/www/pricing/pricing-comparison-table.tsx
@@ -1,0 +1,358 @@
+// GRIDA-EE: billing — responsive public plan comparison.
+
+"use client";
+
+import React, { useState } from "react";
+import { pricing } from "../data/pricing";
+import type { PricingInformation } from "@/lib/billing/marketing-plans";
+import {
+  PricingTableRowDesktop,
+  PricingTableRowMobile,
+} from "./pricing-table-row";
+import { Button } from "@app/ui/components/button";
+import Link from "next/link";
+import {
+  ArrowLeftRightIcon,
+  Building2Icon,
+  DatabaseIcon,
+  ListChecksIcon,
+  MonitorDownIcon,
+  PresentationIcon,
+  SparklesIcon,
+} from "lucide-react";
+
+function PricingMobileHeader({
+  plans,
+  priceDescription,
+  price,
+  plan,
+  showDollarSign = true,
+  from = false,
+}: {
+  plans: PricingInformation[];
+  description: string;
+  priceDescription: string;
+  price: string;
+  plan: string;
+  showDollarSign?: boolean;
+  from?: boolean;
+}) {
+  const selectedPlan = plans.find((candidate) => candidate.name === plan)!;
+
+  return (
+    <div className="mt-8 px-4 mobile-header">
+      <h2 className="text-foreground text-3xl font-medium uppercase font-mono">
+        {plan}
+      </h2>
+      <div className="flex items-baseline gap-2">
+        {from && <span className="text-foreground text-base">From</span>}
+        {price ? (
+          showDollarSign ? (
+            <span className="h1 font-mono">{price}</span>
+          ) : (
+            <span className="text-foreground-light">{price}</span>
+          )
+        ) : null}
+
+        <p className="p opacity-50">{priceDescription}</p>
+      </div>
+      <Button asChild className="mt-2">
+        <Link href={selectedPlan.href}>{selectedPlan.cta}</Link>
+      </Button>
+    </div>
+  );
+}
+
+const PricingComparisonTable = ({ plans }: { plans: PricingInformation[] }) => {
+  const [activeMobilePlan, setActiveMobilePlan] = useState("Free");
+  const proPlan = plans.find((plan) => plan.name === "Pro")!;
+  const customPlan = plans.find((plan) => plan.name === "Custom")!;
+
+  return (
+    <div
+      id="compare-plans"
+      className="sm:pb-18 container relative mt-48 mx-auto px-0 pb-16 md:pb-16 lg:px-16 xl:px-20"
+    >
+      {/* xs to lg */}
+      <div className="lg:hidden">
+        <div className="bg-background p-2 sticky top-0 z-10 pt-4">
+          <div className="bg-surface-100 rounded-lg border dark:border-white/25 py-2 px-4 flex justify-between items-center">
+            <label className="text-foreground-lighter" htmlFor="change-plan">
+              Change plan
+            </label>
+            <select
+              id="change-plan"
+              name="Change plan"
+              value={activeMobilePlan}
+              className="bg-transparent min-w-[120px]"
+              onChange={(event) => setActiveMobilePlan(event.target.value)}
+            >
+              <option value="Free">Free</option>
+              <option value="Pro">Pro</option>
+              <option value="Custom">Custom</option>
+            </select>
+          </div>
+        </div>
+
+        {activeMobilePlan === "Free" && (
+          <>
+            <PricingMobileHeader
+              plans={plans}
+              plan="Free"
+              price="$0"
+              priceDescription=""
+              description="Create and publish with Grida at no cost."
+            />
+            <PricingTableRowMobile
+              category={pricing.desktop}
+              plan="free"
+              icon={<MonitorDownIcon className="size-4" />}
+              sectionId="desktop"
+            />
+            <PricingTableRowMobile
+              category={pricing.design}
+              plan="free"
+              icon={<PresentationIcon className="size-4" />}
+              sectionId="design"
+            />
+            <PricingTableRowMobile
+              category={pricing.forms}
+              plan="free"
+              icon={<ListChecksIcon className="size-4" />}
+              sectionId="forms"
+            />
+            <PricingTableRowMobile
+              category={pricing.database}
+              plan="free"
+              icon={<DatabaseIcon className="size-4" />}
+              sectionId="database"
+            />
+            <PricingTableRowMobile
+              category={pricing.developer}
+              plan="free"
+              icon={<ArrowLeftRightIcon className="size-4" />}
+              sectionId="developer"
+            />
+            <PricingTableRowMobile
+              category={pricing.ai}
+              plan="free"
+              icon={<SparklesIcon className="size-4" />}
+              sectionId="ai"
+            />
+            <PricingTableRowMobile
+              category={pricing.custom}
+              plan="free"
+              icon={<Building2Icon className="size-4" />}
+              sectionId="custom"
+            />
+          </>
+        )}
+
+        {activeMobilePlan === "Pro" && (
+          <>
+            <PricingMobileHeader
+              plans={plans}
+              plan="Pro"
+              price={proPlan.priceMonthly}
+              priceDescription="per organization / month"
+              description={proPlan.description}
+            />
+            <PricingTableRowMobile
+              category={pricing.desktop}
+              plan="pro"
+              icon={<MonitorDownIcon className="size-4" />}
+              sectionId="desktop"
+            />
+            <PricingTableRowMobile
+              category={pricing.design}
+              plan="pro"
+              icon={<PresentationIcon className="size-4" />}
+              sectionId="design"
+            />
+            <PricingTableRowMobile
+              category={pricing.forms}
+              plan="pro"
+              icon={<ListChecksIcon className="size-4" />}
+              sectionId="forms"
+            />
+            <PricingTableRowMobile
+              category={pricing.database}
+              plan="pro"
+              icon={<DatabaseIcon className="size-4" />}
+              sectionId="database"
+            />
+            <PricingTableRowMobile
+              category={pricing.developer}
+              plan="pro"
+              icon={<ArrowLeftRightIcon className="size-4" />}
+              sectionId="developer"
+            />
+            <PricingTableRowMobile
+              category={pricing.ai}
+              plan="pro"
+              icon={<SparklesIcon className="size-4" />}
+              sectionId="ai"
+            />
+            <PricingTableRowMobile
+              category={pricing.custom}
+              plan="pro"
+              icon={<Building2Icon className="size-4" />}
+              sectionId="custom"
+            />
+          </>
+        )}
+
+        {activeMobilePlan === "Custom" && (
+          <>
+            <PricingMobileHeader
+              plans={plans}
+              plan="Custom"
+              price=""
+              priceDescription={customPlan.priceNote ?? ""}
+              description={customPlan.description}
+              showDollarSign={false}
+            />
+            <PricingTableRowMobile
+              category={pricing.desktop}
+              plan="custom"
+              icon={<MonitorDownIcon className="size-4" />}
+              sectionId="desktop"
+            />
+            <PricingTableRowMobile
+              category={pricing.design}
+              plan="custom"
+              icon={<PresentationIcon className="size-4" />}
+              sectionId="design"
+            />
+            <PricingTableRowMobile
+              category={pricing.forms}
+              plan="custom"
+              icon={<ListChecksIcon className="size-4" />}
+              sectionId="forms"
+            />
+            <PricingTableRowMobile
+              category={pricing.database}
+              plan="custom"
+              icon={<DatabaseIcon className="size-4" />}
+              sectionId="database"
+            />
+            <PricingTableRowMobile
+              category={pricing.developer}
+              plan="custom"
+              icon={<ArrowLeftRightIcon className="size-4" />}
+              sectionId="developer"
+            />
+            <PricingTableRowMobile
+              category={pricing.ai}
+              plan="custom"
+              icon={<SparklesIcon className="size-4" />}
+              sectionId="ai"
+            />
+            <PricingTableRowMobile
+              category={pricing.custom}
+              plan="custom"
+              icon={<Building2Icon className="size-4" />}
+              sectionId="custom"
+            />
+          </>
+        )}
+      </div>
+
+      {/* lg+ */}
+      <div className="hidden lg:block">
+        <table className="h-px w-full table-fixed">
+          <caption className="sr-only">Pricing plan comparison</caption>
+          <thead className="bg-background sticky top-0 z-10">
+            <tr>
+              <th
+                className="text-foreground w-1/3 px-6 pt-2 pb-2 text-left text-sm font-normal"
+                scope="col"
+              >
+                <span className="sr-only">Feature by</span>
+                <span
+                  className="h-0.25 absolute bottom-0 left-0 w-full"
+                  style={{ height: "1px" }}
+                />
+              </th>
+
+              {plans.map((plan) => (
+                <th
+                  className="text-foreground w-1/4 px-0 text-left text-sm font-normal"
+                  scope="col"
+                  key={plan.name}
+                >
+                  <span className="flex flex-col px-6 pr-2 pt-2 gap-1 items-start">
+                    <div className="flex flex-row items-center gap-2">
+                      <h3 className="text-lg xl:text-xl 2xl:text-2xl leading-5 uppercase font-mono font-normal">
+                        {plan.name}
+                      </h3>
+                      {plan.name !== "Custom" && (
+                        <span className="text-foreground-lighter font-mono text-lg tracking-tighter">
+                          {plan.priceMonthly}
+                        </span>
+                      )}
+                    </div>
+                    <div className="h-5">
+                      {plan.name === "Pro" && plan.costUnit && (
+                        <span className="text-[13px] opacity-50 leading-4">
+                          {plan.costUnit}
+                        </span>
+                      )}
+                      {plan.name === "Custom" && plan.priceNote && (
+                        <span className="text-[13px] opacity-50 leading-4">
+                          {plan.priceNote}
+                        </span>
+                      )}
+                    </div>
+                    <Button asChild className="mt-2 w-full">
+                      <Link href={plan.href}>{plan.cta}</Link>
+                    </Button>
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="border-default divide-border dark:divide-white/25 divide-y first:divide-y-0">
+            <PricingTableRowDesktop
+              category={pricing.desktop}
+              icon={<MonitorDownIcon className="size-4" />}
+              sectionId="desktop"
+            />
+            <PricingTableRowDesktop
+              category={pricing.design}
+              icon={<PresentationIcon className="size-4" />}
+              sectionId="design"
+            />
+            <PricingTableRowDesktop
+              category={pricing.forms}
+              icon={<ListChecksIcon className="size-4" />}
+              sectionId="forms"
+            />
+            <PricingTableRowDesktop
+              category={pricing.database}
+              icon={<DatabaseIcon className="size-4" />}
+              sectionId="database"
+            />
+            <PricingTableRowDesktop
+              category={pricing.developer}
+              icon={<ArrowLeftRightIcon className="size-4" />}
+              sectionId="developer"
+            />
+            <PricingTableRowDesktop
+              category={pricing.ai}
+              icon={<SparklesIcon className="size-4" />}
+              sectionId="ai"
+            />
+            <PricingTableRowDesktop
+              category={pricing.custom}
+              icon={<Building2Icon className="size-4" />}
+              sectionId="custom"
+            />
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default PricingComparisonTable;

--- a/editor/www/pricing/pricing-table-row.tsx
+++ b/editor/www/pricing/pricing-table-row.tsx
@@ -1,0 +1,196 @@
+// GRIDA-EE: billing — responsive rows for the public plan comparison.
+
+import React, { Fragment, ReactNode } from "react";
+import {
+  InfoCircledIcon,
+  CheckCircledIcon,
+  MinusCircledIcon,
+} from "@radix-ui/react-icons";
+import { PricingCategory } from "../data/pricing";
+
+interface PricingTableRowDesktopProps {
+  category: PricingCategory;
+  sectionId: string;
+  icon: ReactNode;
+}
+
+export const PricingTableRowDesktop = (props: PricingTableRowDesktopProps) => {
+  const category = props.category;
+
+  return (
+    <>
+      <tr
+        className="divide-border -scroll-mt-5"
+        style={{ borderTop: "none" }}
+        id={`${props.sectionId}-desktop`}
+      >
+        <th
+          className="bg-background text-foreground sticky top-[60px] xl:top-[40px] z-10 py-3 pl-6 text-left text-sm font-medium"
+          scope="colgroup"
+        >
+          <div className="flex items-center gap-4">
+            {props.icon}
+            <h4 className="m-0 text-base font-normal">{category.title}</h4>
+          </div>
+        </th>
+        <td className="bg-background px-6 py-5 free"></td>
+        <td className="bg-background px-6 py-5 pro"></td>
+        <td className="bg-background px-6 py-5 custom"></td>
+      </tr>
+
+      {category.features.map((feat, i) => {
+        return (
+          <Fragment key={feat.title}>
+            <tr className="divide-border" key={i}>
+              <th
+                className="text-foreground flex items-center px-6 py-5 last:pb-24 text-left text-xs font-normal"
+                scope="row"
+              >
+                <span>{feat.title}</span>
+                {feat.tooltips?.main && (
+                  <span
+                    className="text-muted hover:text-foreground ml-2 cursor-pointer transition-colors"
+                    data-tip={feat.tooltips.main}
+                  >
+                    <InfoCircledIcon width={14} height={14} strokeWidth={2} />
+                  </span>
+                )}
+              </th>
+
+              {Object.entries(feat.plans).map(
+                (entry: [string, boolean | string | string[]], i) => {
+                  const planName = entry[0] as keyof NonNullable<
+                    typeof feat.tooltips
+                  >;
+                  const planValue = entry[1];
+
+                  return (
+                    <td
+                      key={i}
+                      className={[
+                        `pl-6 pr-2 tier-${planName}`,
+                        typeof planValue === "boolean" ? "text-center" : "",
+                      ].join(" ")}
+                    >
+                      {typeof planValue === "boolean" && planValue === true ? (
+                        <CheckCircledIcon />
+                      ) : typeof planValue === "boolean" &&
+                        planValue === false ? (
+                        <div className="opacity-20">
+                          <MinusCircledIcon />
+                        </div>
+                      ) : (
+                        <div className="text-foreground text-xs flex flex-col justify-center">
+                          <span className="flex items-center gap-2">
+                            {feat.tooltips?.[planName] && (
+                              <span
+                                className="shrink-0 hover:text-background-overlay-default cursor-pointer transition-colors"
+                                data-tip={feat.tooltips[planName]}
+                              >
+                                <InfoCircledIcon />
+                              </span>
+                            )}
+                            {typeof planValue === "string"
+                              ? planValue
+                              : planValue[0]}
+                          </span>
+                          {typeof planValue !== "string" && (
+                            <span className="text-lighter leading-4">
+                              {planValue[1]}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </td>
+                  );
+                }
+              )}
+            </tr>
+            {i === category.features.length - 1 && (
+              <tr className="my-16 bg-green-400 border-none"></tr>
+            )}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+interface PricingTableRowMobileProps {
+  category: PricingCategory;
+  plan: "free" | "pro" | "custom";
+  sectionId?: string;
+  icon: ReactNode;
+}
+
+export const PricingTableRowMobile = (props: PricingTableRowMobileProps) => {
+  const category = props.category;
+  const plan = props.plan;
+
+  return (
+    <table
+      className="mt-8 w-full -scroll-mt-5"
+      id={`${props.sectionId}-mobile`}
+    >
+      <caption className="bg-background border-default divide-border dark:divide-border/25 dark:border-white/25 border-t border-b px-4 py-3 text-left text-sm font-medium text-foreground">
+        <span className="flex items-center gap-2">
+          {props.icon}
+          <span className="text-foreground font-normal">{category.title}</span>
+        </span>
+      </caption>
+      <thead>
+        <tr>
+          <th className="sr-only" scope="col">
+            Feature
+          </th>
+          <th className="sr-only" scope="col">
+            Included
+          </th>
+        </tr>
+      </thead>
+      <tbody className="border-default divide-border dark:divide-white/25 divide-y first:divide-y-0">
+        {category.features.map((feat, i) => {
+          return (
+            <tr
+              key={i}
+              className="border-default border-t border-neutral-500/10"
+            >
+              <th
+                className="text-foreground-light px-4 py-3 text-left text-sm font-normal"
+                scope="row"
+              >
+                <p>{feat.title}</p>
+              </th>
+              <td className="py-3 pr-4 text-right">
+                {typeof feat.plans[plan] === "boolean" &&
+                feat.plans[plan] === true ? (
+                  <span className="inline-block">
+                    <CheckCircledIcon />
+                  </span>
+                ) : typeof feat.plans[plan] === "boolean" &&
+                  feat.plans[plan] === false ? (
+                  <span className="inline-block">
+                    <MinusCircledIcon />
+                  </span>
+                ) : (
+                  <span className="text-foreground flex flex-col text-sm">
+                    <span>
+                      {typeof feat.plans[plan] === "string"
+                        ? feat.plans[plan]
+                        : feat.plans[plan][0]}
+                    </span>
+                    {typeof feat.plans[plan] !== "string" && (
+                      <span className="text-lighter leading-5">
+                        {feat.plans[plan][1]}
+                      </span>
+                    )}
+                  </span>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/editor/www/pricing/pricing-table-row.tsx
+++ b/editor/www/pricing/pricing-table-row.tsx
@@ -26,7 +26,7 @@ export const PricingTableRowDesktop = (props: PricingTableRowDesktopProps) => {
       >
         <th
           className="bg-background text-foreground sticky top-[60px] xl:top-[40px] z-10 py-3 pl-6 text-left text-sm font-medium"
-          scope="colgroup"
+          scope="row"
         >
           <div className="flex items-center gap-4">
             {props.icon}
@@ -73,11 +73,15 @@ export const PricingTableRowDesktop = (props: PricingTableRowDesktopProps) => {
                       ].join(" ")}
                     >
                       {typeof planValue === "boolean" && planValue === true ? (
-                        <CheckCircledIcon />
+                        <>
+                          <span className="sr-only">Included</span>
+                          <CheckCircledIcon aria-hidden="true" />
+                        </>
                       ) : typeof planValue === "boolean" &&
                         planValue === false ? (
                         <div className="opacity-20">
-                          <MinusCircledIcon />
+                          <span className="sr-only">Not included</span>
+                          <MinusCircledIcon aria-hidden="true" />
                         </div>
                       ) : (
                         <div className="text-foreground text-xs flex flex-col justify-center">
@@ -165,12 +169,14 @@ export const PricingTableRowMobile = (props: PricingTableRowMobileProps) => {
                 {typeof feat.plans[plan] === "boolean" &&
                 feat.plans[plan] === true ? (
                   <span className="inline-block">
-                    <CheckCircledIcon />
+                    <span className="sr-only">Included</span>
+                    <CheckCircledIcon aria-hidden="true" />
                   </span>
                 ) : typeof feat.plans[plan] === "boolean" &&
                   feat.plans[plan] === false ? (
                   <span className="inline-block">
-                    <MinusCircledIcon />
+                    <span className="sr-only">Not included</span>
+                    <MinusCircledIcon aria-hidden="true" />
                   </span>
                 ) : (
                   <span className="text-foreground flex flex-col text-sm">

--- a/editor/www/pricing/pricing-table-row.tsx
+++ b/editor/www/pricing/pricing-table-row.tsx
@@ -110,9 +110,6 @@ export const PricingTableRowDesktop = (props: PricingTableRowDesktopProps) => {
                 }
               )}
             </tr>
-            {i === category.features.length - 1 && (
-              <tr className="my-16 bg-green-400 border-none"></tr>
-            )}
           </Fragment>
         );
       })}

--- a/editor/www/pricing/pricing.tsx
+++ b/editor/www/pricing/pricing.tsx
@@ -3,40 +3,43 @@
 import React from "react";
 import { PricingCard, PricingCardButton } from "@/www/pricing/pricing-card";
 import { plans, proPlan } from "@/lib/billing/marketing-plans";
+import PricingComparisonTable from "./pricing-comparison-table";
 import Link from "next/link";
 
 export function Pricing() {
   return (
-    <section>
-      <div className="pt-12 pb-20 flex flex-col items-center gap-7">
-        <h1 className="text-4xl font-semibold text-center">Simple pricing</h1>
-        <p className="text-muted-foreground text-center max-w-xl">
-          Start free, upgrade to Pro for {proPlan.priceMonthly} a month, or talk
-          to us about a Custom plan.
-        </p>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-10 w-full max-w-6xl mx-auto">
-        {plans.map((plan) => (
-          <PricingCard
-            key={plan.id}
-            plan={plan.name}
-            price={{
-              primary: plan.priceMonthly,
-              secondary: plan.costUnit,
-            }}
-            features={plan.features}
-            excerpt={plan.description}
-            highlight={plan.highlight}
-            action={
-              <PricingCardButton asChild inverted={plan.highlight}>
-                <Link href={plan.href} className="w-full">
-                  {plan.cta}
-                </Link>
-              </PricingCardButton>
-            }
-          />
-        ))}
-      </div>
-    </section>
+    <>
+      <section>
+        <div className="pt-12 pb-20 flex flex-col items-center gap-7">
+          <h1 className="text-4xl font-semibold text-center">Pricing</h1>
+          <p className="opacity-50 text-center max-w-md">
+            Start free, upgrade to Pro for {proPlan.priceMonthly} per
+            organization each month, or talk to us about a Custom plan.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-6 gap-y-10 w-full">
+          {plans.map((plan) => (
+            <PricingCard
+              key={plan.id}
+              plan={plan.name}
+              price={{
+                primary: plan.priceMonthly,
+                secondary: plan.costUnit,
+                note: plan.priceNote,
+              }}
+              features={plan.features}
+              excerpt={plan.description}
+              highlight={plan.highlight}
+              action={
+                <PricingCardButton asChild inverted={plan.highlight}>
+                  <Link href={plan.href}>{plan.cta}</Link>
+                </PricingCardButton>
+              }
+            />
+          ))}
+        </div>
+      </section>
+      <PricingComparisonTable plans={plans} />
+    </>
   );
 }


### PR DESCRIPTION
## What changed

- restores the pre-renewal responsive pricing-card and comparison-table design
- keeps the simplified Free, Pro, and Custom offer with Pro at $20 per organization per month
- expands the comparison from the former 25 rows to 52 shipped, marketable capabilities
- leads with Grida Desktop workflows while retaining Forms, Database/CMS, developer, AI-credit, and Custom-service inventory
- makes Custom domains, the form response simulator, and removable Grida branding explicit
- clarifies that Free and Pro use separately purchased prepaid AI credit, with automatic reload on Pro

## Why

The initial pricing simplification correctly removed Team and yearly offers, but it also removed the established comparison experience and too much product inventory. The pricing page is both an acquisition surface and an important searchable description of Grida's shipped capabilities.

## Impact

This changes public pricing presentation and copy only. It does not change billing behavior, entitlements, database state, Stripe infrastructure, or existing subscriptions.

## Validation

- `pnpm --filter editor exec vitest run lib/billing/marketing-plans.test.ts www/data/pricing.test.ts`
- `pnpm --filter editor typecheck`
- targeted `oxlint`
- targeted `oxfmt --check`
- `git diff --check`
- desktop and mobile browser verification, including the mobile plan selector and overflow checks
