### PR TITLE
chore(ai-models): replace Gemini 3.5 Flash with 3.7; correct Sonnet 5 and Gemini Pro rates

### DIFF
--- a/.agents/skills/ai-models/SKILL.md
+++ b/.agents/skills/ai-models/SKILL.md
@@ -88,6 +88,29 @@ providers; an id is never portable. Two cataloguing patterns:
 
 ---
 
+## What the catalogue is for
+
+The catalogue states what is true and useful **now**. Its shape must never be a
+record of how recently someone got round to updating it — a stale entry is a
+wrong answer, not a conservative one.
+
+- **Price the steady state, not the promotion.** When a vendor runs an
+  introductory or time-limited rate, catalogue the price that applies once it
+  ends and note the date in a comment. Otherwise the promotion expiring is a
+  silent cost increase. Recheck when that date passes: a promotion can also be
+  made permanent, which changes the fact, not the rule.
+- **Deprecate a card that is still a real choice; remove one that is not.**
+  `deprecated: true` is for a model someone might still reasonably pick — same
+  price as its successor, or better at something. Delete the entry when the
+  successor is _strictly dominant_ (never worse on any axis, better on at least
+  one): a card nobody should choose is noise in every picker, and keeping it is
+  not caution.
+
+Removal is the kill switch — the id stops passing the run gate, and on a
+published catalogue that reaches installed clients within a refresh interval
+(`docs/wg/platform/hosted-ai.md`). That decisiveness is the point; it also means
+removal is the wrong tool for tidying.
+
 ## Text Models
 
 Live in `packages/grida-ai-models/src/models.ts` under `models.text.catalog: Record<CatalogId, ModelSpec>`. The tier set and tier→model id table sit in `packages/grida-ai-models/src/tiers.ts` and type-use `models.text.CatalogId` from `models.ts` — so every tier id must resolve to a real catalogued spec.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -69,7 +69,7 @@ Per 1M tokens.
 | ------------------------------------------------------------ | ------ | ----------- | ---------- | ------- |
 | GPT-5.4 Nano (`openai/gpt-5.4-nano`)                         | $0.20  | —           | $0.02      | $1.25   |
 | GPT-5.4 Mini (`openai/gpt-5.4-mini`)                         | $0.75  | —           | $0.075     | $4.50   |
-| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $3.00  | $3.75       | $0.30      | $15.00  |
+| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $2.00  | $2.50       | $0.20      | $10.00  |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
 | Claude Fable 5 (`anthropic/claude-fable-5`)                  | $10.00 | $12.50      | $1.00      | $50.00  |
 | Claude Opus 5 (`anthropic/claude-opus-5`)                    | $5.00  | $6.25       | $0.50      | $25.00  |
@@ -80,11 +80,18 @@ Per 1M tokens.
 | GPT-5.6 Luna (`openai/gpt-5.6-luna`)                         | $0.20  | $0.25       | $0.02      | $1.20   |
 | GPT-5.5 (`openai/gpt-5.5`) _(legacy)_                        | $5.00  | —           | $0.50      | $30.00  |
 | GPT-5.5 Pro (`openai/gpt-5.5-pro`)                           | $30.00 | —           | —          | $180.00 |
-| Gemini 3.5 Flash (`google/gemini-3.5-flash`)                 | $1.50  | —           | $0.15      | $9.00   |
+| Gemini 3.7 Flash (`google/gemini-3.7-flash`)                 | $1.50  | —           | $0.15      | $7.50   |
 | Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`)     | $2.00  | —           | $0.20      | $12.00  |
 
 GPT-5.6 and GPT-5.5 prices above are base rates. Requests with more than 272K
 input tokens are billed at 2x input and 1.5x output for the full request.
+`Gemini 3.1 Pro Preview` is tiered the same way at a 200K threshold ($4.00
+input / $18.00 output / $0.40 cache read for the full request).
+
+`Gemini 3.7 Flash` is listed at its steady-state rate. Google is running a
+promotion through 2026-12-31 at $0.75 input / $3.75 output / $0.075 cache
+read; the table holds the price that applies from 2027-01-01 so an expiring
+promotion is never a silent cost increase.
 
 `GPT-5.5` is deprecated in Grida's catalogue in favor of `GPT-5.6 Sol`;
 this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.

--- a/editor/lib/ai/__tests__/server.test.ts
+++ b/editor/lib/ai/__tests__/server.test.ts
@@ -220,6 +220,36 @@ describe("costMillsFromTokenUsage", () => {
     );
   });
 
+  it("keeps Gemini 3.1 Pro base rates at the 200K input boundary", () => {
+    // The band is strictly-greater-than, so 200,000 exactly is still base.
+    const mills = costMillsFromTokenUsage("google/gemini-3.1-pro-preview", {
+      inputTokens: { total: 200_000, noCache: 150_000, cacheRead: 50_000 },
+      outputTokens: { total: 10_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      ((150_000 * 2 + 50_000 * 0.2 + 10_000 * 12) / 1_000_000) * 1000
+    );
+  });
+
+  it("bands Gemini 3.1 Pro above 200K input, cache reads included", () => {
+    // `inputMultiplier` covers every input bucket, so the cache-read rate
+    // above the band is 0.2 x 2 = $0.40/MTok — the figure Google publishes.
+    const mills = costMillsFromTokenUsage("google/gemini-3.1-pro-preview", {
+      inputTokens: { total: 200_001, noCache: 150_001, cacheRead: 50_000 },
+      outputTokens: { total: 10_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      (((150_001 * 2 + 50_000 * 0.2) * 2 + 10_000 * 12 * 1.5) / 1_000_000) *
+        1000
+    );
+    // Stated as a rate, not just a total: $0.40 is the published number.
+    expect(mills).toBeCloseTo(
+      ((150_001 * 4 + 50_000 * 0.4 + 10_000 * 18) / 1_000_000) * 1000
+    );
+  });
+
   it("throws on unknown model id", () => {
     expect(() =>
       costMillsFromTokenUsage("acme/totally-fake-model", {

--- a/editor/lib/ai/__tests__/server.test.ts
+++ b/editor/lib/ai/__tests__/server.test.ts
@@ -233,8 +233,11 @@ describe("costMillsFromTokenUsage", () => {
   });
 
   it("bands Gemini 3.1 Pro above 200K input, cache reads included", () => {
-    // `inputMultiplier` covers every input bucket, so the cache-read rate
-    // above the band is 0.2 x 2 = $0.40/MTok — the figure Google publishes.
+    // `inputMultiplier` covers every input bucket, so above the band the
+    // effective rates are Google's published $4 in / $0.40 cacheRead /
+    // $18 out. That the catalogue figures multiply out to those numbers is
+    // pinned on the catalogue itself, in `models.test.ts` — asserting it a
+    // second time here would just be this same expression, undistributed.
     const mills = costMillsFromTokenUsage("google/gemini-3.1-pro-preview", {
       inputTokens: { total: 200_001, noCache: 150_001, cacheRead: 50_000 },
       outputTokens: { total: 10_000 },
@@ -243,10 +246,6 @@ describe("costMillsFromTokenUsage", () => {
     expect(mills).toBeCloseTo(
       (((150_001 * 2 + 50_000 * 0.2) * 2 + 10_000 * 12 * 1.5) / 1_000_000) *
         1000
-    );
-    // Stated as a rate, not just a total: $0.40 is the published number.
-    expect(mills).toBeCloseTo(
-      ((150_001 * 4 + 50_000 * 0.4 + 10_000 * 18) / 1_000_000) * 1000
     );
   });
 

--- a/packages/grida-ai-agent/src/providers/index.test.ts
+++ b/packages/grida-ai-agent/src/providers/index.test.ts
@@ -72,11 +72,11 @@ describe("resolveProvider", () => {
 
     const picked = provider.model_factory(
       "nano",
-      "google/gemini-3.5-flash"
+      "google/gemini-3.7-flash"
     ) as {
       modelId: string;
     };
-    expect(picked.modelId).toBe("google/gemini-3.5-flash");
+    expect(picked.modelId).toBe("google/gemini-3.7-flash");
   });
 });
 

--- a/packages/grida-ai-agent/src/session/cost.test.ts
+++ b/packages/grida-ai-agent/src/session/cost.test.ts
@@ -29,8 +29,10 @@ describe("session cost accounting", () => {
       }
     );
 
+    // Sonnet 5's rate card, spelled out rather than read from the catalogue:
+    // reading it back would assert nothing.
     expect(cost).toBeCloseTo(
-      (2_000 * 3 + 8_000 * 0.3 + 1_000 * 3.75 + 1_000 * 15 + 500 * 15) /
+      (2_000 * 2 + 8_000 * 0.2 + 1_000 * 2.5 + 1_000 * 10 + 500 * 10) /
         1_000_000
     );
   });

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -546,7 +546,7 @@ describe("models.text image-input MIME capabilities", () => {
     }
 
     expect(
-      models.text.catalog["google/gemini-3.5-flash"].imageInputMimes
+      models.text.catalog["google/gemini-3.7-flash"].imageInputMimes
     ).toContain("image/heic");
     expect(
       models.text.catalog["openai/gpt-5.4-mini"].imageInputMimes

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -476,6 +476,34 @@ describe("models.text current catalogue", () => {
       outputLimit: 128_000,
       cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
     },
+    {
+      id: "anthropic/claude-sonnet-5",
+      contextWindow: 1_000_000,
+      outputLimit: 128_000,
+      cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+    },
+    {
+      id: "google/gemini-3.7-flash",
+      contextWindow: 1_048_576,
+      outputLimit: 65_536,
+      // Steady state, not Google's promotional rate through 2026-12-31.
+      cost: { input: 1.5, output: 7.5, cacheRead: 0.15 },
+    },
+    {
+      id: "google/gemini-3.1-pro-preview",
+      contextWindow: 1_048_576,
+      outputLimit: 65_536,
+      cost: {
+        input: 2,
+        output: 12,
+        cacheRead: 0.2,
+        longContext: {
+          inputTokensAbove: 200_000,
+          inputMultiplier: 2,
+          outputMultiplier: 1.5,
+        },
+      },
+    },
   ] as const;
 
   it.each(newModels)("stores the published $id rate card", (expected) => {
@@ -497,6 +525,18 @@ describe("models.text current catalogue", () => {
     expect(
       models.text.catalog["openai/gpt-5.5-pro"].cost.longContext
     ).toBeUndefined();
+  });
+
+  it("multiplies Gemini 3.1 Pro out to Google's published banded rates", () => {
+    // The catalogue stores base rates plus multipliers; Google publishes the
+    // banded rates directly. This is where the two are held to agree — the
+    // cost function's own tests assert totals, not rates.
+    const { input, output, cacheRead, longContext } =
+      models.text.catalog["google/gemini-3.1-pro-preview"].cost;
+    expect(longContext).toBeDefined();
+    expect(input * longContext!.inputMultiplier).toBe(4);
+    expect(cacheRead! * longContext!.inputMultiplier).toBeCloseTo(0.4);
+    expect(output * longContext!.outputMultiplier).toBe(18);
   });
 
   it("keeps catalogue lifecycle markers scoped to the requested models", () => {

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -471,9 +471,9 @@ export namespace models {
           output: 12,
           cacheRead: 0.2,
           // Google bills the full request at $4 in / $18 out / $0.40
-          // cacheRead above 200K tokens. cacheRead doubling is not
-          // expressible here — a gap this shape has for every model that
-          // bands, including the OpenAI entries above.
+          // cacheRead above 200K tokens. `inputMultiplier` covers every
+          // input bucket, so cacheRead 0.2 x 2 lands on $0.40 without a
+          // separate field.
           // https://ai.google.dev/gemini-api/docs/pricing
           longContext: {
             inputTokensAbove: 200_000,

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -365,10 +365,10 @@ export namespace models {
           longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
-      // Standard rates stored as canonical (identical to Sonnet 4.6).
-      // Anthropic ran an introductory discount ($2 in / $10 out / $0.20
-      // cacheRead / $2.50 cacheWrite) through 2026-08-31; not modelled — the
-      // catalogue holds steady-state provider pricing.
+      // $2/$10 is the standard rate, not a live discount: it launched as an
+      // introductory rate and Anthropic made it permanent, cancelling the
+      // announced step up to $3/$15. Do not restore the higher card.
+      // https://platform.claude.com/docs/en/about-claude/pricing
       "anthropic/claude-sonnet-5": {
         id: "anthropic/claude-sonnet-5",
         label: "Claude Sonnet 5",
@@ -378,7 +378,7 @@ export namespace models {
         tool_call: true,
         contextWindow: 1_000_000,
         outputLimit: 128_000,
-        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       },
       "anthropic/claude-sonnet-4.6": {
         id: "anthropic/claude-sonnet-4.6",
@@ -441,15 +441,21 @@ export namespace models {
       },
       // Google's cache model is read + hourly storage (no one-time write
       // premium that matches `cacheWrite` semantics), so the field is omitted.
-      "google/gemini-3.5-flash": {
-        id: "google/gemini-3.5-flash",
-        label: "Gemini 3.5 Flash",
+      //
+      // Steady-state rates. Google is promoting $0.75 in / $3.75 out / $0.075
+      // cacheRead through 2026-12-31; these are the prices that apply from
+      // 2027-01-01. Checking Google's page before then will show the lower
+      // set — that is the promotion, not a correction.
+      // https://ai.google.dev/gemini-api/docs/pricing
+      "google/gemini-3.7-flash": {
+        id: "google/gemini-3.7-flash",
+        label: "Gemini 3.7 Flash",
         multimodal: true,
         imageInputMimes: GOOGLE_IMAGE_INPUT_MIMES,
         tool_call: true,
         contextWindow: 1_048_576,
         outputLimit: 65_536,
-        cost: { input: 1.5, output: 9, cacheRead: 0.15 },
+        cost: { input: 1.5, output: 7.5, cacheRead: 0.15 },
       },
       "google/gemini-3.1-pro-preview": {
         id: "google/gemini-3.1-pro-preview",
@@ -460,7 +466,21 @@ export namespace models {
         tool_call: true,
         contextWindow: 1_048_576,
         outputLimit: 65_536,
-        cost: { input: 2, output: 12, cacheRead: 0.2 },
+        cost: {
+          input: 2,
+          output: 12,
+          cacheRead: 0.2,
+          // Google bills the full request at $4 in / $18 out / $0.40
+          // cacheRead above 200K tokens. cacheRead doubling is not
+          // expressible here — a gap this shape has for every model that
+          // bands, including the OpenAI entries above.
+          // https://ai.google.dev/gemini-api/docs/pricing
+          longContext: {
+            inputTokensAbove: 200_000,
+            inputMultiplier: 2,
+            outputMultiplier: 1.5,
+          },
+        },
       },
     } as const satisfies Record<string, ModelSpec>;
 


### PR DESCRIPTION
Catalogue-only. **No tier retarget** — `nano`/`mini` stay on Luna, `pro` on Terra,
`max` on Sol. Catalogue stays at 15 entries: one in, one out.

## What changed

| Entry | Action | Detail |
| --- | --- | --- |
| `google/gemini-3.7-flash` | added | `$1.50` in / `$7.50` out / `$0.15` cacheRead, 1M context, 65,536 output |
| `google/gemini-3.5-flash` | **removed** | superseded outright — not deprecated, see below |
| `anthropic/claude-sonnet-5` | corrected | `$3`/`$15` → `$2`/`$10`, cacheRead `0.3` → `0.2`, cacheWrite `3.75` → `2.5` |
| `google/gemini-3.1-pro-preview` | corrected | added the missing `longContext` band (`>200K`, ×2 input, ×1.5 output) |

## Why

**Sonnet 5 was over-estimating every session by 50%.** The old `$3`/`$15` was
*not* stale data — a comment on the entry explained that `$2`/`$10` was an
introductory rate through 2026-08-31 and that the catalogue deliberately holds
steady-state pricing. That was correct when written. On 2026-08-10 Anthropic
[made the introductory rate permanent](https://platform.claude.com/docs/en/about-claude/pricing)
and cancelled the 2026-09-01 step up, so the policy did not change — the fact
did. The comment was rewritten, since it asserted a discount that no longer ends.

**Gemini 3.1 Pro was under-estimating long sessions by up to 2×.** Google bills
the full request at `$4` / `$18` / `$0.40` above 200K tokens. `ModelCostPerMillion.longContext`
already models exactly this (four OpenAI entries use it); the entry just didn't
carry it. `inputMultiplier` covers every input bucket, so `cacheRead: 0.2` lands
on Google's published `$0.40` above the band with no extra field. Boundary pair
added mirroring the existing 272K pair: 200,000 exactly stays on base rates,
200,001 bands.

**Gemini Flash was two generations behind.** 3.7 (2026-08-13) supersedes both
3.5 (2026-05-19) and 3.6 (2026-07-21).

## Reviewer notes

**Why 3.5 is removed rather than deprecated.** This is the first removal instead
of a deprecation, so the rule is now written down in the `ai-models` skill:
deprecate a card someone might still reasonably pick (same price as its
successor, or better at something); remove one whose successor is *strictly
dominant* — never worse on any axis. 3.7 qualifies against both predecessors:

| | 3.5 Flash | 3.6 Flash | 3.7 Flash |
| --- | --- | --- | --- |
| input / output (steady state) | `$1.50` / `$9.00` | `$1.50` / `$7.50` | `$1.50` / `$7.50` |
| output limit | 64,000 | 64,000 | **65,536** |
| context | 1M | 1M | 1M |

3.6 is not catalogued for the same reason: identical rates to 3.7, a month
older, smaller output limit. A card nobody should choose is noise in every
picker.

**Removal is the kill switch, and that now propagates.** Anyone with a session
explicitly pinned to `gemini-3.5-flash` gets a `modelId not allowed` 400 once
their host refreshes (within the interval, per #1016). Recoverable by picking
another model, and it is the designed semantic — but it is not silent, so it is
worth knowing. It is not a tier target, so nothing defaults to it.

**Gemini Flash is listed at its steady-state rate, above what Google charges
today.** Google is promoting `$0.75` / `$3.75` / `$0.075` through 2026-12-31,
reverting 2027-01-01. The catalogue holds the price that applies after the
promotion so an expiring promotion is never a silent 2× cost increase — the
same rule Sonnet 5's history illustrates. Checking Google's page before January
will show the lower set; that is the promotion, not a correction. Flagging
because it means we over-estimate Flash cost for the next four months, which is
the deliberate trade.

**No Gemini Pro bump exists to make.** `gemini-3.1-pro-preview` (2026-02-19) is
the newest text Pro on `google`, `google-vertex`, the Vercel gateway, and
OpenRouter, and the only Pro on Google's pricing page. Gemini 3.5 Pro has missed
three ship dates and may be
[shelved for Gemini 4](https://nokiapoweruser.com/google-shelves-gemini-3-5-pro-pivot-gemini-4/).
Our entry is current, not stale.

**models.dev's gateway rows are not authoritative for price banding.** They
carry tier data for 2 of 350 models versus 8 of 47 first-party, so absence there
is missing data, not evidence a band does not apply. Every rate here was
verified against Anthropic's and Google's own pricing pages.

**Follow-up this makes visible, deliberately not taken here.**
`anthropic/claude-sonnet-4.6` (`$3`/`$15`) is now also strictly dominated by
Sonnet 5 (`$2`/`$10`, same context, same output limit) and would be a removal
candidate under the new rule. It is a shipped model that sessions may be pinned
to, so that is a separate call. The other legacy entries are unaffected —
`gpt-5.5`, `opus-4.8`, and `opus-4.7` all match their successors' price exactly,
so they are deprecate-not-remove.

## Tests

`cost.test.ts` spells Sonnet 5's rate card out by hand rather than reading the
catalogue, so it moved with the rates — that is the test working, not collateral
damage. Two other tests referenced 3.5 Flash incidentally (an explicit-model
pick, a Google image-MIME sample) and were repointed at 3.7.

## Verification

48/48 typecheck · 3,215 tests · 0 lint errors · snapshot round-trips · tier map
byte-identical. `docs/models/index.md` updated to match, including why 3.7 Flash
is listed above its current promotional price.

