### PR TITLE
AI model catalogue update — 2026-09

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -71,11 +71,12 @@ Per 1M tokens.
 | GPT-5.4 Mini (`openai/gpt-5.4-mini`)                         | $0.75  | —           | $0.075     | $4.50   |
 | Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $2.00  | $2.50       | $0.20      | $10.00  |
 | Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
-| Claude Fable 5 (`anthropic/claude-fable-5`)                  | $10.00 | $12.50      | $1.00      | $50.00  |
+| Claude Fable 5.1 (`anthropic/claude-fable-5.1`)              | $10.00 | $12.50      | $0.25      | $50.00  |
+| Claude Fable 5 (`anthropic/claude-fable-5`) _(legacy)_       | $10.00 | $12.50      | $1.00      | $50.00  |
 | Claude Opus 5 (`anthropic/claude-opus-5`)                    | $5.00  | $6.25       | $0.50      | $25.00  |
 | Claude Opus 4.8 (`anthropic/claude-opus-4.8`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
 | Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
-| GPT-5.6 Sol (`openai/gpt-5.6-sol`)                           | $5.00  | $6.25       | $0.50      | $30.00  |
+| GPT-5.6 Sol (`openai/gpt-5.6-sol`)                           | $4.00  | $5.00       | $0.40      | $20.00  |
 | GPT-5.6 Terra (`openai/gpt-5.6-terra`)                       | $2.00  | $2.50       | $0.20      | $12.00  |
 | GPT-5.6 Luna (`openai/gpt-5.6-luna`)                         | $0.20  | $0.25       | $0.02      | $1.20   |
 | GPT-5.5 (`openai/gpt-5.5`) _(legacy)_                        | $5.00  | —           | $0.50      | $30.00  |
@@ -99,6 +100,13 @@ this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.
 `Claude Opus 4.8` is deprecated in Grida's catalogue in favor of
 `Claude Opus 5`, its drop-in successor at the same rate card; this is not an
 upstream Anthropic retirement.
+
+`Claude Fable 5` is deprecated in Grida's catalogue in favor of
+`Claude Fable 5.1`, which carries the same input, output, and cache-write
+rates at a quarter of the cache-read price. It is kept rather than dropped
+because `Claude Fable 5.1` rejects forced tool choice, so `Claude Fable 5`
+remains the only Fable that serves it. Neither is an upstream Anthropic
+retirement.
 
 ## Image Generation Models
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,7 +1,7 @@
 ---
 title: Models & Pricing
 description: Compare Grida AI model tiers, context windows, and text, image, and music generation costs.
-keywords: [AI models, AI pricing, GPT-5.6, Claude Fable 5, Lyria, Grida AI]
+keywords: [AI models, AI pricing, GPT-5.6, Claude Fable 5.1, Lyria, Grida AI]
 slug: pricing
 format: md
 ---
@@ -36,10 +36,10 @@ Models are organized into **tiers** based on capability and cost:
 | `nano` | GPT-5.6 Luna (`openai/gpt-5.6-luna`)   | 1.05M   | 128K       | $0.20          | $1.20           |
 | `mini` | GPT-5.6 Luna (`openai/gpt-5.6-luna`)   | 1.05M   | 128K       | $0.20          | $1.20           |
 | `pro`  | GPT-5.6 Terra (`openai/gpt-5.6-terra`) | 1.05M   | 128K       | $2.00          | $12.00          |
-| `max`  | GPT-5.6 Sol (`openai/gpt-5.6-sol`)     | 1.05M   | 128K       | $5.00          | $30.00          |
+| `max`  | GPT-5.6 Sol (`openai/gpt-5.6-sol`)     | 1.05M   | 128K       | $4.00          | $20.00          |
 
 All tier models support **multimodal** inputs (text + images).
-Claude Fable 5 and Claude Opus 5 remain active, non-tiered catalogue models.
+Claude Fable 5.1 and Claude Opus 5 remain active, non-tiered catalogue models.
 
 `nano` and `mini` currently resolve to the same model. `nano` is a floor —
 the cheapest model still good enough for background work (title generation,
@@ -59,7 +59,7 @@ All tiers support prompt caching, which reduces cost for repeated context:
 | `nano` | $0.02               | $0.25                |
 | `mini` | $0.02               | $0.25                |
 | `pro`  | $0.20               | $2.50                |
-| `max`  | $0.50               | $6.25                |
+| `max`  | $0.40               | $5.00                |
 
 ### All Models
 

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -60,7 +60,10 @@ describe("GET /api/v1/ai/models", () => {
     ] as const) {
       expect(byId.get(id)?.grida).toMatchObject({ modality: "text", tier });
     }
-    for (const id of ["anthropic/claude-fable-5", "anthropic/claude-opus-5"]) {
+    for (const id of [
+      "anthropic/claude-fable-5.1",
+      "anthropic/claude-opus-5",
+    ]) {
       expect(byId.get(id)?.grida).toMatchObject({
         modality: "text",
         tier: null,
@@ -68,11 +71,16 @@ describe("GET /api/v1/ai/models", () => {
       });
     }
     // A deprecated catalogue card still lists, flagged.
-    expect(byId.get("anthropic/claude-opus-4.8")?.grida).toMatchObject({
-      modality: "text",
-      tier: null,
-      deprecated: true,
-    });
+    for (const id of [
+      "anthropic/claude-opus-4.8",
+      "anthropic/claude-fable-5",
+    ]) {
+      expect(byId.get(id)?.grida).toMatchObject({
+        modality: "text",
+        tier: null,
+        deprecated: true,
+      });
+    }
     // Every modality is represented.
     const modalities = new Set(body.data.map((e) => e.grida.modality));
     expect(modalities).toEqual(new Set(["text", "image", "video"]));

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -328,8 +328,12 @@ describe("models.video catalogue invariants", () => {
 
     const grok = models.video.models["xai/grok-imagine-video-1.5"]!;
     expect(grok).toMatchObject({ min_duration: 1, max_duration: 15 });
+    // Vercel serves every xAI model under `spacexai/`, so the call id is not
+    // this card's canonical `xai/` id. Reusing the canonical id here is a 404
+    // at call time — which is how the binding was first shipped.
+    // https://vercel.com/ai-gateway/models/grok-imagine-video-1.5
     expect(models.video.binding(grok, "vercel")).toMatchObject({
-      id: "xai/grok-imagine-video-1.5",
+      id: "spacexai/grok-imagine-video-1.5",
       pricing: {
         usd_per_second: {
           "480p": { audio: 0.08 },
@@ -432,11 +436,13 @@ describe("models.text current catalogue", () => {
       id: "openai/gpt-5.6-sol",
       contextWindow: 1_050_000,
       outputLimit: 128_000,
+      // Deliberately below GPT-5.5's $5/$30 — Sol is the cheaper successor,
+      // and this card once carried 5.5's rates by mistake.
       cost: {
-        input: 5,
-        output: 30,
-        cacheRead: 0.5,
-        cacheWrite: 6.25,
+        input: 4,
+        output: 20,
+        cacheRead: 0.4,
+        cacheWrite: 5,
         longContext,
       },
     },
@@ -463,6 +469,14 @@ describe("models.text current catalogue", () => {
         cacheWrite: 0.25,
         longContext,
       },
+    },
+    {
+      id: "anthropic/claude-fable-5.1",
+      contextWindow: 1_000_000,
+      outputLimit: 128_000,
+      // Same card as Fable 5 apart from the cache read, which is the whole
+      // reason this entry is pinned separately.
+      cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
     },
     {
       id: "anthropic/claude-fable-5",
@@ -545,8 +559,11 @@ describe("models.text current catalogue", () => {
       models.text.catalog["openai/gpt-5.5-pro"].deprecated
     ).toBeUndefined();
     expect(
-      models.text.catalog["anthropic/claude-fable-5"].deprecated
+      models.text.catalog["anthropic/claude-fable-5.1"].deprecated
     ).toBeUndefined();
+    expect(models.text.catalog["anthropic/claude-fable-5"].deprecated).toBe(
+      true
+    );
     expect(
       models.text.catalog["anthropic/claude-opus-5"].deprecated
     ).toBeUndefined();

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -317,6 +317,10 @@ export namespace models {
       },
       // Base rates; OPENAI_LONG_CONTEXT_PRICING represents the request-wide
       // band that applies above 272K total input tokens.
+      //
+      // Sol is cheaper than GPT-5.5, the card directly above it. It was
+      // introduced carrying 5.5's rates verbatim; these are OpenAI's own.
+      // https://developers.openai.com/api/docs/models/gpt-5.6-sol
       "openai/gpt-5.6-sol": {
         id: "openai/gpt-5.6-sol",
         label: "GPT-5.6 Sol",
@@ -326,10 +330,10 @@ export namespace models {
         contextWindow: 1_050_000,
         outputLimit: 128_000,
         cost: {
-          input: 5,
-          output: 30,
-          cacheRead: 0.5,
-          cacheWrite: 6.25,
+          input: 4,
+          output: 20,
+          cacheRead: 0.4,
+          cacheWrite: 5,
           longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
@@ -392,6 +396,25 @@ export namespace models {
         cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
         deprecated: true,
       },
+      // Same input/output/cacheWrite card as Claude Fable 5, with cache reads
+      // cut to $0.25/MTok. Not a drop-in successor — forced tool choice
+      // (`tool_choice` `any`/`tool`) is rejected here — which is why Fable 5
+      // stays catalogued rather than being removed.
+      // https://platform.claude.com/docs/en/about-claude/pricing
+      "anthropic/claude-fable-5.1": {
+        id: "anthropic/claude-fable-5.1",
+        label: "Claude Fable 5.1",
+        short_label: "Fable 5.1",
+        multimodal: true,
+        imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_000_000,
+        outputLimit: 128_000,
+        cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
+      },
+      // Superseded by Claude Fable 5.1, which is never more expensive, but
+      // still the only Fable that accepts forced tool choice — so it is
+      // deprecated, not removed.
       "anthropic/claude-fable-5": {
         id: "anthropic/claude-fable-5",
         label: "Claude Fable 5",
@@ -402,6 +425,7 @@ export namespace models {
         contextWindow: 1_000_000,
         outputLimit: 128_000,
         cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+        deprecated: true,
       },
       // Drop-in successor to Opus 4.8 at the same rate card.
       "anthropic/claude-opus-5": {
@@ -2355,10 +2379,12 @@ export namespace models {
         url: "https://docs.x.ai/developers/models/grok-imagine-video-1.5",
         providers: {
           // Vercel AI Gateway — image-to-video; mirrors xAI's list price (no markup).
+          // The gateway namespaces every xAI model under `spacexai/`, so the
+          // call id deliberately differs from this card's canonical `xai/` id.
           // https://vercel.com/changelog/grok-imagine-video-1-5-on-ai-gateway
           vercel: {
             provider: "vercel",
-            id: "xai/grok-imagine-video-1.5",
+            id: "spacexai/grok-imagine-video-1.5",
             pricing: {
               type: "per_second",
               usd_per_second: {


### PR DESCRIPTION
Regular catalogue pass. One new text model, plus two defects found while auditing every card against first-party sources.

Media models are **not** in this PR — several image/video cards are a generation or two stale, but each addition needs its own grounded pricing. Queued as a follow-up.

## Add Claude Fable 5.1

`anthropic/claude-fable-5.1` — 1M context, 128K output, $10 in / $50 out, **cache read $0.25** (down from $1.00 on Fable 5), cache write $12.50. Verified against Anthropic's published pricing and models.dev independently; served by the Vercel gateway, so it satisfies the catalogue's "never list a model we cannot call" rule.

Fable 5 is **deprecated, not removed**. 5.1 rejects forced tool choice (`tool_choice` `any`/`tool` → 400), so Fable 5 remains the only Fable that serves it — still a real choice under the catalogue's own lifecycle rule. Grida's agent never forces tool choice; the only caller that can is a client going through the OpenAI-compat gateway, which is exactly who would still need Fable 5.

Not tier-mapped, matching Fable 5.

## Fix: GPT-5.6 Sol carried GPT-5.5's rate card

|  | input | output | cache read | cache write |
| --- | --- | --- | --- | --- |
| was | $5.00 | $30.00 | $0.50 | $6.25 |
| now | $4.00 | $20.00 | $0.40 | $5.00 |

Introduced in #981 with the rates of the entry directly above it in the file. Terra and Luna got correct rates; only Sol inherited its neighbour's. Confirmed against [OpenAI's model page](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and models.dev's first-party `openai` feed.

Sol is the `max` tier, so the inflated card was over-deducting organization credit on every hosted call.

## Fix: Grok Imagine Video's Vercel binding was un-callable

The binding's call id was `xai/grok-imagine-video-1.5`. Vercel namespaces every xAI model under `spacexai/` — there is no `xai/` prefix anywhere in its catalogue — so that route 404s, and the card is `listed: true`. Vercel's own model page confirms `spacexai/grok-imagine-video-1.5`.

This is the failure the canonical-vs-binding split exists to prevent: the card's canonical id was reused as the provider call string. The fal binding was already correct (fal genuinely uses `xai/`).

The existing `binding()` test asserted the broken value — written from the code rather than the provider — so it is corrected in place with a comment, rather than adding a second overlapping test.

## Verified

- 168 `@grida/ai-models` tests, 180 editor AI/billing/model-picker tests, oxlint + oxfmt clean.
- Every other text card re-checked against its vendor's own provider feed. All matched. `gemini-3.7-flash` shows an apparent mismatch because the catalogue holds the steady-state $1.50/$7.50 rather than Google's promo through 2026-12-31 — that is the "price the steady state, not the promotion" rule working as intended.

## Not covered

fal and Replicate are absent from the models.dev feed, so audio (Lyria), 3D (Hunyuan/TRELLIS), sound effects, and the four image tools were **not** verified in this pass — they need provider-page checks.
