### PR TITLE
AI model catalogue — image/video refresh 2026-09

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -258,7 +258,10 @@ catalogued for bring-your-own-key use through fal, but are **not available on
 the hosted route**: the gateway meters them per video token rather than per
 second, and there is no honest per-second conversion, so Grida cannot
 pre-price a hosted request. This will change when hosted video is metered
-after generation.
+after generation. `Seedance 2.5` is the newer generation but not a cheaper
+one — on fal it costs $0.47/s at 720p and $1.16/s at 1080p against 2.0's
+$0.30/s and $0.68/s, and it does not offer 4K — so both are kept: 2.0 for
+price and 4K, 2.5 for clips up to 30 seconds and editing.
 
 ## Image Tools
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -214,25 +214,25 @@ which is cheaper on every provider; this is not an upstream Recraft retirement.
 
 ### Image Sizes
 
-| Model                  | Min Size  | Max Size                            | Aspect Ratios |
-| ---------------------- | --------- | ----------------------------------- | ------------- |
-| GPT Image 2            | —         | edges ≤ 3840 px, ≤ 8.3M px total    | up to 3:1     |
-| GPT Image 1.5          | 1024x1024 | 1536x1536                           | 1:1, 2:3, 3:2 |
-| GPT Image Mini         | 1024x1024 | 1536x1536                           | 1:1, 2:3, 3:2 |
-| Gemini Flash Image     | —         | 1536x1536                           | Flexible      |
-| Gemini Flash Lite      | —         | 1024x1024 (1K only)                 | Flexible      |
-| Gemini Pro Image       | —         | 1536x1536                           | Flexible      |
-| Flux 2 Max             | 256x256   | 1440x1440                           | Flexible      |
-| Flux 2 Pro             | 256x256   | 1440x1440                           | Flexible      |
-| Flux Kontext Max       | —         | 1820x1820                           | Flexible      |
-| Flux Kontext Pro       | —         | 1820x1820                           | Flexible      |
-| Flux Pro 1.1           | 256x256   | 1440x1440                           | Flexible      |
-| Recraft V4.1           | —         | 2048x2048                           | Flexible      |
-| Recraft V3             | —         | 2048x2048                           | Flexible      |
-| Seedream 5.0 Pro       | 1024x1024 | 2048x2048                           | Flexible      |
-| Seedream 5.0 Lite      | —         | 4096x4096 (2K–4K; smaller upscaled) | Flexible      |
-| Grok Imagine Image 2.0 | —         | 2048x2048 (1K or 2K)                | Flexible      |
-| Muse Image 1.0         | —         | chosen by the model                 | 21:9 to 9:21  |
+| Model                  | Min Size  | Max Size                         | Aspect Ratios |
+| ---------------------- | --------- | -------------------------------- | ------------- |
+| GPT Image 2            | —         | edges ≤ 3840 px, ≤ 8.3M px total | up to 3:1     |
+| GPT Image 1.5          | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
+| GPT Image Mini         | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
+| Gemini Flash Image     | —         | 1536x1536                        | Flexible      |
+| Gemini Flash Lite      | —         | 1024x1024 (1K only)              | Flexible      |
+| Gemini Pro Image       | —         | 1536x1536                        | Flexible      |
+| Flux 2 Max             | 256x256   | 1440x1440                        | Flexible      |
+| Flux 2 Pro             | 256x256   | 1440x1440                        | Flexible      |
+| Flux Kontext Max       | —         | 1820x1820                        | Flexible      |
+| Flux Kontext Pro       | —         | 1820x1820                        | Flexible      |
+| Flux Pro 1.1           | 256x256   | 1440x1440                        | Flexible      |
+| Recraft V4.1           | —         | 2048x2048                        | Flexible      |
+| Recraft V3             | —         | 2048x2048                        | Flexible      |
+| Seedream 5.0 Pro       | 1.0 MP    | 4.2 MP (1024² to 2048² total px) | up to 16:1    |
+| Seedream 5.0 Lite      | 3.7 MP    | 16.8 MP (2560x1440 to 4096²)     | Flexible      |
+| Grok Imagine Image 2.0 | —         | 2048x2048 (1K or 2K)             | Flexible      |
+| Muse Image 1.0         | —         | chosen by the model              | 21:9 to 9:21  |
 
 ## Video Generation Models
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -160,14 +160,45 @@ Per-token pricing (same model as text, with image output).
 
 ### Black Forest Labs
 
-Flat per-image pricing.
+Metered per megapixel by every provider; the table shows the 1-megapixel (1024x1024) baseline.
 
 | Model                                     | Price/Image |
 | ----------------------------------------- | ----------- |
-| Flux 2 Pro (`bfl/flux-2-pro`)             | $0.060      |
+| Flux 2 Max (`bfl/flux-2-max`)             | $0.070      |
+| Flux 2 Pro (`bfl/flux-2-pro`)             | $0.030      |
 | Flux Kontext Max (`bfl/flux-kontext-max`) | $0.080      |
 | Flux Kontext Pro (`bfl/flux-kontext-pro`) | $0.040      |
 | Flux Pro 1.1 (`bfl/flux-pro-1.1`)         | $0.040      |
+
+### ByteDance
+
+Flat per-image pricing.
+
+| Model                                              | Price/Image |
+| -------------------------------------------------- | ----------- |
+| Seedream 5.0 Pro (`bytedance/seedream-5.0-pro`)    | $0.035      |
+| Seedream 5.0 Lite (`bytedance/seedream-5.0-lite`)  | $0.035      |
+| Seedream 4.5 (`bytedance/seedream-4.5`) _(legacy)_ | $0.040      |
+
+`Seedream 4.5` is deprecated in Grida's catalogue in favor of the 5.0 models,
+which are cheaper on every provider; this is not an upstream retirement.
+
+### xAI
+
+Tiered by quality and size.
+
+| Model                                                 | 1K low | 1K medium | 2K low | 2K medium |
+| ----------------------------------------------------- | ------ | --------- | ------ | --------- |
+| Grok Imagine Image 2.0 (`xai/grok-imagine-image-2.0`) | $0.04  | $0.06     | $0.06  | $0.08     |
+
+### Meta
+
+| Model                                  | Price/Image |
+| -------------------------------------- | ----------- |
+| Muse Image 1.0 (`meta/muse-image-1.0`) | $0.010      |
+
+`Muse Image 1.0` is catalogued but not offered in the default picker: OpenRouter
+lists it without a serving endpoint, so it is not available on every provider.
 
 ### Recraft
 
@@ -183,18 +214,51 @@ which is cheaper on every provider; this is not an upstream Recraft retirement.
 
 ### Image Sizes
 
-| Model              | Min Size  | Max Size                         | Aspect Ratios |
-| ------------------ | --------- | -------------------------------- | ------------- |
-| GPT Image 2        | —         | edges ≤ 3840 px, ≤ 8.3M px total | up to 3:1     |
-| GPT Image 1.5      | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
-| GPT Image Mini     | 1024x1024 | 1536x1536                        | 1:1, 2:3, 3:2 |
-| Gemini Flash Image | —         | 1536x1536                        | Flexible      |
-| Gemini Flash Lite  | —         | 1024x1024 (1K only)              | Flexible      |
-| Gemini Pro Image   | —         | 1536x1536                        | Flexible      |
-| Flux 2 Pro         | 256x256   | 1440x1440                        | Flexible      |
-| Flux Kontext Max   | —         | 1820x1820                        | Flexible      |
-| Flux Kontext Pro   | —         | 1820x1820                        | Flexible      |
-| Flux Pro 1.1       | 256x256   | 1440x1440                        | Flexible      |
+| Model                  | Min Size  | Max Size                            | Aspect Ratios |
+| ---------------------- | --------- | ----------------------------------- | ------------- |
+| GPT Image 2            | —         | edges ≤ 3840 px, ≤ 8.3M px total    | up to 3:1     |
+| GPT Image 1.5          | 1024x1024 | 1536x1536                           | 1:1, 2:3, 3:2 |
+| GPT Image Mini         | 1024x1024 | 1536x1536                           | 1:1, 2:3, 3:2 |
+| Gemini Flash Image     | —         | 1536x1536                           | Flexible      |
+| Gemini Flash Lite      | —         | 1024x1024 (1K only)                 | Flexible      |
+| Gemini Pro Image       | —         | 1536x1536                           | Flexible      |
+| Flux 2 Max             | 256x256   | 1440x1440                           | Flexible      |
+| Flux 2 Pro             | 256x256   | 1440x1440                           | Flexible      |
+| Flux Kontext Max       | —         | 1820x1820                           | Flexible      |
+| Flux Kontext Pro       | —         | 1820x1820                           | Flexible      |
+| Flux Pro 1.1           | 256x256   | 1440x1440                           | Flexible      |
+| Recraft V4.1           | —         | 2048x2048                           | Flexible      |
+| Recraft V3             | —         | 2048x2048                           | Flexible      |
+| Seedream 5.0 Pro       | 1024x1024 | 2048x2048                           | Flexible      |
+| Seedream 5.0 Lite      | —         | 4096x4096 (2K–4K; smaller upscaled) | Flexible      |
+| Grok Imagine Image 2.0 | —         | 2048x2048 (1K or 2K)                | Flexible      |
+| Muse Image 1.0         | —         | chosen by the model                 | 21:9 to 9:21  |
+
+## Video Generation Models
+
+Video models are billed per second of generated output, by resolution and
+whether audio is generated. The rates below are the Grida-hosted (Vercel
+gateway) rates; the hosted route always generates the model's default audio
+mode, so the silent rates are informational until the request can carry an
+audio mode.
+
+| Model                                                 | 480p  | 720p          | 1080p         | 4K            | Duration |
+| ----------------------------------------------------- | ----- | ------------- | ------------- | ------------- | -------- |
+| Veo 3.1 (`google/veo-3.1`)                            | —     | $0.40 ($0.20) | $0.40 ($0.20) | $0.60 ($0.40) | 4–8s     |
+| Veo 3.1 Fast (`google/veo-3.1-fast`)                  | —     | $0.15 ($0.10) | $0.15 ($0.10) | $0.35 ($0.30) | 4–8s     |
+| Veo 3.1 Lite (`google/veo-3.1-lite`)                  | —     | $0.05 ($0.03) | $0.08 ($0.05) | —             | 4–8s     |
+| Wan 3.0 (`alibaba/wan-3.0`)                           | $0.05 | $0.10         | $0.20         | —             | 2–30s    |
+| Grok Imagine Video 1.5 (`xai/grok-imagine-video-1.5`) | $0.08 | $0.14         | $0.25         | —             | 1–15s    |
+
+Per second of output; the figure in parentheses is the silent rate where the
+provider meters one. Wan and Grok bundle audio into a single rate.
+
+`Seedance 2.0` and `Seedance 2.5` (`bytedance/seedance-2.0`, `-2.5`) are
+catalogued for bring-your-own-key use through fal, but are **not available on
+the hosted route**: the gateway meters them per video token rather than per
+second, and there is no honest per-second conversion, so Grida cannot
+pre-price a hosted request. This will change when hosted video is metered
+after generation.
 
 ## Image Tools
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -166,8 +166,20 @@ Flat per-image pricing.
 | ----------------------------------------- | ----------- |
 | Flux 2 Pro (`bfl/flux-2-pro`)             | $0.060      |
 | Flux Kontext Max (`bfl/flux-kontext-max`) | $0.080      |
-| Flux Kontext Pro (`bfl/flux-kontext-pro`) | $0.050      |
+| Flux Kontext Pro (`bfl/flux-kontext-pro`) | $0.040      |
 | Flux Pro 1.1 (`bfl/flux-pro-1.1`)         | $0.040      |
+
+### Recraft
+
+Flat per-image pricing for raster output. Vector styles are a separate route at $0.08 and are not offered.
+
+| Model                                        | Price/Image |
+| -------------------------------------------- | ----------- |
+| Recraft V4.1 (`recraft/recraft-v4.1`)        | $0.035      |
+| Recraft V3 (`recraft/recraft-v3`) _(legacy)_ | $0.040      |
+
+`Recraft V3` is deprecated in Grida's catalogue in favor of `Recraft V4.1`,
+which is cheaper on every provider; this is not an upstream Recraft retirement.
 
 ### Image Sizes
 

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -104,6 +104,10 @@ const VendorLabels: Record<string, string> = {
   elevenlabs: "ElevenLabs",
   google: "Google",
   "recraft-ai": "Recraft AI",
+  bytedance: "ByteDance",
+  xai: "xAI",
+  alibaba: "Alibaba",
+  meta: "Meta",
 };
 
 function vendorLabel(vendor: string) {

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -774,7 +774,13 @@ export namespace methods {
   } | null {
     const card = ai.image.findImageModelCard(model);
     if (!card) return null;
-    return { model: grida.imageModel(card.id), card };
+    // Call the gateway by the vercel BINDING id, never the canonical card
+    // id. They usually coincide, but not always — the Gemini card's
+    // canonical key is the `-preview` alias while the gateway's current id
+    // is the graduated one. Video already resolves this way.
+    const binding = ai.image.binding(card, "vercel");
+    if (!binding) return null;
+    return { model: grida.imageModel(binding.id), card };
   }
 
   /**

--- a/packages/grida-ai-agent/src/http/routes/video.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/video.test.ts
@@ -274,8 +274,10 @@ describe("POST /video/generate", () => {
   });
 
   it("400 when the connected provider does not serve the model", async () => {
-    // Seedance has no fal binding.
-    const res = await post(appWith({ fal: "sk-fal" }), {
+    // Seedance has no vercel binding (token-metered on the gateway; the
+    // catalogue withholds an unpriceable route). fal DOES serve it — which
+    // is why this case must not use a fal key: it would reach fal for real.
+    const res = await post(appWith({ vercel: "sk-v" }), {
       model_id: "bytedance/seedance-2.0",
       prompt: "x",
     });

--- a/packages/grida-ai-agent/src/providers/resolve-video.test.ts
+++ b/packages/grida-ai-agent/src/providers/resolve-video.test.ts
@@ -8,7 +8,8 @@ function fakeSecrets(keys: Record<string, string>): SecretsStore {
   } as unknown as SecretsStore;
 }
 
-// Veo 3.1 binds vercel + fal; Seedance 2.0 binds vercel only.
+// Veo 3.1 binds vercel + fal; Seedance 2.0 binds fal + openrouter but NOT
+// vercel — the gateway meters it per token, which the catalogue cannot price.
 const VEO = "google/veo-3.1";
 const SEEDANCE = "bytedance/seedance-2.0";
 
@@ -32,18 +33,19 @@ describe("resolveVideoModel", () => {
   });
 
   it("falls through when the only key's provider does not serve the model", async () => {
-    // Seedance has no fal binding — a fal-only user can't run it.
+    // Seedance has no vercel binding — a Vercel-only user can't run it.
     await expect(
-      resolveVideoModel({ secrets: fakeSecrets({ fal: "sk-fal" }) }, SEEDANCE)
+      resolveVideoModel({ secrets: fakeSecrets({ vercel: "sk-v" }) }, SEEDANCE)
     ).rejects.toBeInstanceOf(VideoModelUnavailableError);
   });
 
-  it("resolves Seedance with a Vercel key", async () => {
+  it("resolves Seedance with a fal key", async () => {
     const r = await resolveVideoModel(
-      { secrets: fakeSecrets({ vercel: "sk-v" }) },
+      { secrets: fakeSecrets({ fal: "sk-fal" }) },
       SEEDANCE
     );
-    expect(r.provider_id).toBe("vercel");
+    expect(r.provider_id).toBe("fal");
+    expect(r.binding_id).toBe("bytedance/seedance-2.0/image-to-video");
   });
 
   it("resolves Veo and Seedance with an OpenRouter key", async () => {

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -140,6 +140,91 @@ describe("models.image provider-binding invariants", () => {
     });
   });
 
+  it("prices Flux 2 Pro and Max at the per-megapixel baseline every provider publishes", () => {
+    // Vercel model page, OpenRouter `cost_usd`/megapixel, fal "first megapixel"
+    // — all $0.03 (Pro) and $0.07 (Max), 2026-09-02. Pro's Vercel binding had
+    // shipped at $0.06: a 2x hosted over-billing.
+    for (const [id, usd] of [
+      ["bfl/flux-2-pro", 0.03],
+      ["bfl/flux-2-max", 0.07],
+    ] as const) {
+      const card = models.image.models[id]!;
+      expect(card.listed).toBe(true);
+      expect(card.pricing).toEqual({ type: "per_image_flat", usd });
+      for (const p of ["vercel", "fal", "openrouter"] as const) {
+        expect(models.image.binding(card, p)?.pricing).toEqual({
+          type: "per_image_flat",
+          usd,
+        });
+      }
+    }
+  });
+
+  it("lists Seedream 5.0 and deprecates 4.5", () => {
+    // Vercel feed `pricing.image` $0.035 for both 5.0 cards; fal $0.035 (Lite);
+    // OpenRouter `cost_usd` $0.035 (Lite) / $0.045 (Pro 1K). 4.5 is $0.04 on
+    // Vercel and fal — dominated by Lite on price and generation.
+    const lite = models.image.models["bytedance/seedream-5.0-lite"]!;
+    expect(lite.listed).toBe(true);
+    for (const p of ["vercel", "fal", "openrouter"] as const) {
+      expect(models.image.binding(lite, p)?.pricing).toEqual({
+        type: "per_image_flat",
+        usd: 0.035,
+      });
+    }
+    const pro = models.image.models["bytedance/seedream-5.0-pro"]!;
+    expect(pro.listed).toBe(true);
+    expect(models.image.binding(pro, "vercel")?.pricing).toEqual({
+      type: "per_image_flat",
+      usd: 0.035,
+    });
+    expect(models.image.models["bytedance/seedream-4.5"]).toMatchObject({
+      listed: false,
+      deprecated: true,
+    });
+  });
+
+  it("prices Grok Imagine Image 2.0 by the quality×size tiers all providers share", () => {
+    const grok = models.image.models["xai/grok-imagine-image-2.0"]!;
+    const tiers = {
+      "low/1024x1024": 0.04,
+      "medium/1024x1024": 0.06,
+      "low/2048x2048": 0.06,
+      "medium/2048x2048": 0.08,
+    };
+    expect(grok.listed).toBe(true);
+    expect(grok.pricing).toEqual({ type: "per_image_tiered", tiers });
+    for (const p of ["vercel", "fal", "openrouter"] as const) {
+      expect(models.image.binding(grok, p)?.pricing).toEqual({
+        type: "per_image_tiered",
+        tiers,
+      });
+    }
+  });
+
+  it("keeps Muse Image 1.0 unlisted: OpenRouter lists it with no endpoint", () => {
+    const muse = models.image.models["meta/muse-image-1.0"]!;
+    expect(muse.listed).toBe(false);
+    expect(models.image.binding(muse, "openrouter")).toBeNull();
+    for (const p of ["vercel", "fal"] as const) {
+      expect(models.image.binding(muse, p)?.pricing).toEqual({
+        type: "per_image_flat",
+        usd: 0.01,
+      });
+    }
+  });
+
+  it("calls Gemini 3.1 Flash Image by its graduated ids, canonical key unchanged", () => {
+    const card = models.image.models["google/gemini-3.1-flash-image-preview"]!;
+    expect(models.image.binding(card, "vercel")?.id).toBe(
+      "google/gemini-3.1-flash-image"
+    );
+    expect(models.image.binding(card, "fal")?.id).toBe("fal-ai/nano-banana-2");
+    expect(models.image.binding(card, "openrouter")?.id).toBe(
+      "google/gemini-3.1-flash-image"
+    );
+  });
+
   it("listed_models returns only listed cards", () => {
     for (const card of models.image.listed_models()) {
       expect(card.listed).toBe(true);
@@ -368,6 +453,57 @@ describe("models.video catalogue invariants", () => {
       expect(
         models.video.binding(veo, provider)?.pricing.usd_per_second
       ).toEqual(matrix);
+    }
+  });
+
+  it("prices Veo 3.1 Fast and Lite with the matrices Vercel and fal both publish", () => {
+    const fast = {
+      "720p": { audio: 0.15, silent: 0.1 },
+      "1080p": { audio: 0.15, silent: 0.1 },
+      "4k": { audio: 0.35, silent: 0.3 },
+    };
+    const lite = {
+      "720p": { audio: 0.05, silent: 0.03 },
+      "1080p": { audio: 0.08, silent: 0.05 },
+    };
+    for (const [id, matrix] of [
+      ["google/veo-3.1-fast", fast],
+      ["google/veo-3.1-lite", lite],
+    ] as const) {
+      const card = models.video.models[id]!;
+      for (const p of ["vercel", "fal"] as const) {
+        expect(models.video.binding(card, p)?.pricing.usd_per_second).toEqual(
+          matrix
+        );
+      }
+    }
+  });
+
+  it("prices Wan 3.0 per resolution, audio bundled, identically on Vercel and fal", () => {
+    const wan = models.video.models["alibaba/wan-3.0"]!;
+    expect(wan).toMatchObject({ min_duration: 2, max_duration: 30 });
+    for (const p of ["vercel", "fal"] as const) {
+      expect(models.video.binding(wan, p)?.pricing.usd_per_second).toEqual({
+        "480p": { audio: 0.05 },
+        "720p": { audio: 0.1 },
+        "1080p": { audio: 0.2 },
+      });
+    }
+  });
+
+  it("withholds a Vercel binding from token-metered Seedance", () => {
+    // The gateway serves both Seedance cards but bills `video_token_pricing`,
+    // which `PerSecondPricing` cannot express and the hosted route cannot
+    // pre-price. A per-second Vercel binding here would be invented — and
+    // was, on 2.0, until 2026-09-02. fal states per-second rates.
+    for (const id of ["bytedance/seedance-2.0", "bytedance/seedance-2.5"]) {
+      const card = models.video.models[id]!;
+      expect(models.video.binding(card, "vercel")).toBeNull();
+      expect(
+        models.video.binding(card, "fal")?.pricing.usd_per_second[
+          card.default.resolution
+        ]?.audio
+      ).toBeGreaterThan(0);
     }
   });
 

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -225,6 +225,25 @@ describe("models.image provider-binding invariants", () => {
     );
   });
 
+  it("keeps image-to-image reachable on every new listed card", () => {
+    // Written from OpenRouter's `supported_parameters.input_references`
+    // (2026-09-02). Seedream 4.5 carried the catalogue's Seedream i2i route;
+    // unlisting it without giving 5.0 the same binding would have dropped
+    // Seedream editing from the BYOK surface.
+    for (const [id, max] of [
+      ["bytedance/seedream-5.0-pro", 14],
+      ["bytedance/seedream-5.0-lite", 14],
+      ["bfl/flux-2-max", 8],
+      ["xai/grok-imagine-image-2.0", 3],
+      ["recraft/recraft-v4.1", 1],
+    ] as const) {
+      const card = models.image.models[id]!;
+      expect(models.image.binding(card, "openrouter")?.references?.max).toBe(
+        max
+      );
+    }
+  });
+
   it("listed_models returns only listed cards", () => {
     for (const card of models.image.listed_models()) {
       expect(card.listed).toBe(true);

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -314,6 +314,27 @@ describe("models.video catalogue invariants", () => {
     }
   });
 
+  it("prices Veo 3.1 with the gateway's full audio/resolution matrix", () => {
+    // Written from the provider, not from the card: these are the exact
+    // `video_duration_pricing` rows the Vercel gateway's /v1/models feed
+    // returns for `google/veo-3.1-generate-001` (checked 2026-09-02).
+    // The card previously claimed audio-on-only at <=1080p, so a 4K request
+    // was rejected for want of a rate. The gateway meters both modes, and
+    // fal meters the same matrix.
+    // https://vercel.com/ai-gateway/models/veo-3.1-generate-001
+    const matrix = {
+      "720p": { audio: 0.4, silent: 0.2 },
+      "1080p": { audio: 0.4, silent: 0.2 },
+      "4k": { audio: 0.6, silent: 0.4 },
+    };
+    const veo = models.video.models["google/veo-3.1"]!;
+    for (const provider of ["vercel", "fal"] as const) {
+      expect(
+        models.video.binding(veo, provider)?.pricing.usd_per_second
+      ).toEqual(matrix);
+    }
+  });
+
   it("binding() resolves a present provider and nulls an absent one", () => {
     const veo = models.video.models["google/veo-3.1"]!;
     // fal keys the capability into the id — this is the image-to-video endpoint.

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -104,6 +104,42 @@ describe("models.image provider-binding invariants", () => {
     expect(models.image.binding(kontext, "openrouter")).toBeNull();
   });
 
+  it("prices Recraft V4.1 at the raster rate every provider publishes", () => {
+    // Written from the providers, not the card: Vercel feed `pricing.image`,
+    // OpenRouter `/images/models/.../endpoints` `cost_usd`, and fal's model
+    // page payload all say $0.035 (checked 2026-09-02). V3 is $0.04 on the
+    // same three, which is why V4.1 is listed and V3 is not.
+    const v41 = models.image.models["recraft/recraft-v4.1"]!;
+    expect(v41.listed).toBe(true);
+    for (const p of ["vercel", "fal", "openrouter"] as const) {
+      expect(models.image.binding(v41, p)?.pricing).toEqual({
+        type: "per_image_flat",
+        usd: 0.035,
+      });
+    }
+    expect(models.image.binding(v41, "fal")?.id).toBe(
+      "fal-ai/recraft/v4.1/text-to-image"
+    );
+    const v3 = models.image.models["recraft/recraft-v3"]!;
+    expect(v3).toMatchObject({ listed: false, deprecated: true });
+  });
+
+  it("prices Flux Kontext Pro at $0.04 and binds fal", () => {
+    // The card shipped at $0.05 while the gateway feed's `pricing.image` is
+    // $0.04 — reachable over-deduction, since the hosted route gates on a
+    // vercel binding rather than `listed`. fal's page states the same $0.04.
+    const kontext = models.image.models["bfl/flux-kontext-pro"]!;
+    expect(kontext.pricing).toEqual({ type: "per_image_flat", usd: 0.04 });
+    expect(models.image.binding(kontext, "vercel")?.pricing).toEqual({
+      type: "per_image_flat",
+      usd: 0.04,
+    });
+    expect(models.image.binding(kontext, "fal")).toMatchObject({
+      id: "fal-ai/flux-pro/kontext",
+      pricing: { type: "per_image_flat", usd: 0.04 },
+    });
+  });
+
   it("listed_models returns only listed cards", () => {
     for (const card of models.image.listed_models()) {
       expect(card.listed).toBe(true);

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -688,6 +688,7 @@ export namespace models {
       // ByteDance
       | "bytedance/seedream-4.5"
       // Recraft
+      | "recraft/recraft-v4.1"
       | "recraft/recraft-v3"
       | (string & {});
 
@@ -1434,13 +1435,24 @@ export namespace models {
         provider: "vercel",
         listed: false,
         listed_reason:
-          "Image-editing model; superseded by Flux 2 and not universal.",
+          "Image-editing model; superseded by Flux 2 and not on OpenRouter, so not universal.",
+        // $0.04 on both providers. The card shipped at $0.05 — and because the
+        // hosted route gates on a vercel binding, not on `listed`, that was a
+        // live 25% over-deduction. Gateway feed `pricing.image` + fal's model
+        // page ("Fixed $0.04 cost per image edit"), verified 2026-09-02.
         providers: {
           vercel: {
             provider: "vercel",
             id: "bfl/flux-kontext-pro",
-            pricing: { type: "per_image_flat", usd: 0.05 },
-            avg_cost_usd: 0.05,
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/flux-pro/kontext",
+            pricing: { type: "per_image_flat", usd: 0.04 },
+            avg_cost_usd: 0.04,
+            url: "https://fal.ai/models/fal-ai/flux-pro/kontext",
           },
         },
         speed_label: "medium",
@@ -1448,8 +1460,8 @@ export namespace models {
         styles: null,
         sizes: null,
         constraints: { max_edge: 1820 },
-        pricing: { type: "per_image_flat", usd: 0.05 },
-        avg_cost_usd: 0.05,
+        pricing: { type: "per_image_flat", usd: 0.04 },
+        avg_cost_usd: 0.04,
         default: {
           width: 1024,
           height: 1024,
@@ -1541,19 +1553,76 @@ export namespace models {
         },
       },
       // -----------------------------------------------------------------
+      // Recraft — V4.1
+      // -----------------------------------------------------------------
+      // Universal: $0.035/img raster on every provider (Vercel feed
+      // `pricing.image`, OpenRouter endpoint `cost_usd`, fal page payload),
+      // verified 2026-09-02. Vector styles are $0.08 and a separate route on
+      // fal/OpenRouter (`.../text-to-vector`, `recraft-v4.1-vector`) — not
+      // catalogued; `styles: null` here means the raster route only.
+      // OpenRouter org slug is `recraft`, not `recraft-ai`.
+      "recraft/recraft-v4.1": {
+        id: "recraft/recraft-v4.1",
+        label: "Recraft V4.1",
+        deprecated: false,
+        short_description:
+          "Design-first image model — sharper prompt control and production-ready raster for brand and editorial work.",
+        vendor: "recraft-ai",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "recraft/recraft-v4.1",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "recraft/recraft-v4.1",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+            url: "https://openrouter.ai/recraft/recraft-v4.1",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/recraft/v4.1/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+            url: "https://fal.ai/models/fal-ai/recraft/v4.1/text-to-image",
+          },
+        },
+        speed_label: "medium",
+        speed_max: "30s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 2048 },
+        pricing: { type: "per_image_flat", usd: 0.035 },
+        avg_cost_usd: 0.035,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
       // Recraft — V3
       // -----------------------------------------------------------------
-      // Universal: ~$0.04/img across providers (verified 2026-06-29, see
-      // issues/908). OpenRouter org slug is `recraft`, not `recraft-ai`.
+      // $0.04/img raster on every provider (re-verified 2026-09-02; Recraft's
+      // own pricing table agrees). Superseded by V4.1, which is cheaper on
+      // every provider and equal on vector — deprecated, not removed, only
+      // because V3's positioned-text rendering is an axis V4.1 has not been
+      // shown to match. Remove once that is checked.
       "recraft/recraft-v3": {
         id: "recraft/recraft-v3",
         label: "Recraft V3",
-        deprecated: false,
+        deprecated: true,
         short_description:
           "Design-grade image model with strong text rendering and vector styles.",
         vendor: "recraft-ai",
         provider: "vercel",
-        listed: true,
+        listed: false,
+        listed_reason: "Previous-generation model, superseded by Recraft V4.1.",
         providers: {
           vercel: {
             provider: "vercel",

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -143,7 +143,9 @@ export namespace models {
     | "elevenlabs"
     | "stability-ai"
     | "bytedance"
-    | "xai";
+    | "xai"
+    | "alibaba"
+    | "meta";
 
   /**
    * Catalogue lifecycle for newly grounded media surfaces.
@@ -682,11 +684,18 @@ export namespace models {
       | "google/gemini-3-pro-image"
       // Black Forest Labs
       | "bfl/flux-2-pro"
+      | "bfl/flux-2-max"
       | "bfl/flux-kontext-max"
       | "bfl/flux-kontext-pro"
       | "bfl/flux-pro-1.1"
       // ByteDance
+      | "bytedance/seedream-5.0-pro"
+      | "bytedance/seedream-5.0-lite"
       | "bytedance/seedream-4.5"
+      // xAI
+      | "xai/grok-imagine-image-2.0"
+      // Meta
+      | "meta/muse-image-1.0"
       // Recraft
       | "recraft/recraft-v4.1"
       | "recraft/recraft-v3"
@@ -1200,9 +1209,14 @@ export namespace models {
         listed: true,
         // "Nano Banana 2"; ids/prices verified 2026-06-29, see issues/908
         providers: {
+          // The gateway serves the graduated `google/gemini-3.1-flash-image`
+          // and the `-preview` alias at identical rates (feed, 2026-09-02).
+          // Bindings call the graduated id; the canonical key above stays
+          // `-preview` because it is persisted in selections and published
+          // in the catalogue snapshot — renaming it is a separate change.
           vercel: {
             provider: "vercel",
-            id: "google/gemini-3.1-flash-image-preview",
+            id: "google/gemini-3.1-flash-image",
             pricing: { type: "per_token", input: 0.5, output: 3.0 },
             avg_cost_usd: 0.004,
           },
@@ -1215,12 +1229,14 @@ export namespace models {
             // input_references advertised by OpenRouter (0–14), 2026-07-01.
             references: { id: "google/gemini-3.1-flash-image", max: 14 },
           },
+          // fal's graduated endpoint is `fal-ai/nano-banana-2`; same $0.08
+          // per 1K image as the `-preview` endpoint (2K ×1.5, 4K ×2).
           fal: {
             provider: "fal",
-            id: "fal-ai/gemini-3.1-flash-image-preview",
+            id: "fal-ai/nano-banana-2",
             pricing: { type: "per_image_flat", usd: 0.08 },
             avg_cost_usd: 0.08,
-            url: "https://fal.ai/models/fal-ai/gemini-3.1-flash-image-preview",
+            url: "https://fal.ai/models/fal-ai/nano-banana-2",
           },
         },
         speed_label: "fast",
@@ -1348,14 +1364,18 @@ export namespace models {
         vendor: "black-forest-labs",
         provider: "vercel",
         listed: true,
-        // ids/prices verified 2026-06-29, see issues/908. OR/fal meter per-MP
-        // (~$0.03 first MP); represented as flat at the 1MP baseline.
+        // All three providers meter $0.03 per megapixel (Vercel model page,
+        // OpenRouter endpoint `cost_usd`/megapixel, fal "first megapixel");
+        // represented as flat at the 1MP baseline. The Vercel binding shipped
+        // at $0.06 — a 2x hosted over-billing — corrected 2026-09-02. The
+        // gateway feed carries no `pricing` for BFL cards, so the page is the
+        // source.
         providers: {
           vercel: {
             provider: "vercel",
             id: "bfl/flux-2-pro",
-            pricing: { type: "per_image_flat", usd: 0.06 },
-            avg_cost_usd: 0.06,
+            pricing: { type: "per_image_flat", usd: 0.03 },
+            avg_cost_usd: 0.03,
           },
           openrouter: {
             provider: "openrouter",
@@ -1379,8 +1399,60 @@ export namespace models {
         styles: null,
         sizes: null,
         constraints: { min_edge: 256, max_edge: 1440 },
-        pricing: { type: "per_image_flat", usd: 0.06 },
-        avg_cost_usd: 0.06,
+        pricing: { type: "per_image_flat", usd: 0.03 },
+        avg_cost_usd: 0.03,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // Black Forest Labs — Flux 2 Max
+      // -----------------------------------------------------------------
+      // BFL's top Flux 2 line (2025-12-16). $0.07 per megapixel on all three
+      // (Vercel model page — the feed carries no BFL pricing; OpenRouter
+      // `cost_usd`/megapixel; fal "first megapixel", +$0.03 each additional).
+      // Represented as flat at the 1MP baseline. Verified 2026-09-02.
+      "bfl/flux-2-max": {
+        id: "bfl/flux-2-max",
+        label: "Flux 2 Max",
+        deprecated: false,
+        short_description:
+          "Black Forest Labs' highest-fidelity Flux 2 — maximum prompt adherence and detail.",
+        vendor: "black-forest-labs",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bfl/flux-2-max",
+            pricing: { type: "per_image_flat", usd: 0.07 },
+            avg_cost_usd: 0.07,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "black-forest-labs/flux.2-max",
+            pricing: { type: "per_image_flat", usd: 0.07 },
+            avg_cost_usd: 0.07,
+            url: "https://openrouter.ai/black-forest-labs/flux.2-max",
+          },
+          fal: {
+            provider: "fal",
+            id: "fal-ai/flux-2-max",
+            pricing: { type: "per_image_flat", usd: 0.07 },
+            avg_cost_usd: 0.07,
+            url: "https://fal.ai/models/fal-ai/flux-2-max",
+          },
+        },
+        speed_label: "slow",
+        speed_max: "45s",
+        styles: null,
+        sizes: null,
+        // Same envelope as Flux 2 Pro pending a vendor spec for Max.
+        constraints: { min_edge: 256, max_edge: 1440 },
+        pricing: { type: "per_image_flat", usd: 0.07 },
+        avg_cost_usd: 0.07,
         default: {
           width: 1024,
           height: 1024,
@@ -1500,19 +1572,125 @@ export namespace models {
         },
       },
       // -----------------------------------------------------------------
+      // ByteDance — Seedream 5.0 Pro
+      // -----------------------------------------------------------------
+      // Vercel feed `pricing.image` $0.035 (the model page's rate table shows
+      // $0.04 while its copy says $0.035 — the feed is the billing contract);
+      // OpenRouter `cost_usd` $0.045 at 1K ($0.09 high-res, +$0.003 per
+      // input image, not modelled); fal $0.0675 for ≤1536² area, $0.135 up
+      // to 2048². Represented at the 1024² baseline. Verified 2026-09-02.
+      "bytedance/seedream-5.0-pro": {
+        id: "bytedance/seedream-5.0-pro",
+        label: "Seedream 5.0 Pro",
+        deprecated: false,
+        short_description:
+          "ByteDance's flagship image model — dense layouts, infographics and text-heavy compositions at 1K–2K.",
+        vendor: "bytedance",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bytedance/seedream-5.0-pro",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "bytedance-seed/seedream-5-0-pro",
+            pricing: { type: "per_image_flat", usd: 0.045 },
+            avg_cost_usd: 0.045,
+            url: "https://openrouter.ai/bytedance-seed/seedream-5-0-pro",
+          },
+          fal: {
+            provider: "fal",
+            id: "bytedance/seedream/v5/pro/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.0675 },
+            avg_cost_usd: 0.0675,
+            url: "https://fal.ai/models/bytedance/seedream/v5/pro/text-to-image",
+          },
+        },
+        speed_label: "medium",
+        speed_max: "30s",
+        styles: null,
+        sizes: null,
+        // fal: total pixels between 1024x1024 and 2048x2048.
+        constraints: { min_edge: 1024, max_edge: 2048 },
+        pricing: { type: "per_image_flat", usd: 0.035 },
+        avg_cost_usd: 0.035,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // ByteDance — Seedream 5.0 Lite
+      // -----------------------------------------------------------------
+      // Universal: $0.035/img on all three (Vercel feed `pricing.image`,
+      // OpenRouter `cost_usd`, fal page payload), verified 2026-09-02. A
+      // 2K–4K model: fal scales requests below 2560x1440 up to its floor.
+      "bytedance/seedream-5.0-lite": {
+        id: "bytedance/seedream-5.0-lite",
+        label: "Seedream 5.0 Lite",
+        deprecated: false,
+        short_description:
+          "ByteDance's fast 2K–4K image model — Seedream 5.0 quality at the 4.5 price point.",
+        vendor: "bytedance",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "bytedance/seedream-5.0-lite",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "bytedance-seed/seedream-5-0-lite",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+            url: "https://openrouter.ai/bytedance-seed/seedream-5-0-lite",
+          },
+          fal: {
+            provider: "fal",
+            id: "bytedance/seedream/v5/lite/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.035 },
+            avg_cost_usd: 0.035,
+            url: "https://fal.ai/models/bytedance/seedream/v5/lite/text-to-image",
+          },
+        },
+        speed_label: "fast",
+        speed_max: "15s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 4096 },
+        pricing: { type: "per_image_flat", usd: 0.035 },
+        avg_cost_usd: 0.035,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
       // ByteDance — Seedream 4.5
       // -----------------------------------------------------------------
-      // Universal: $0.04/img identical on all three providers (verified
-      // 2026-06-29, see github.com/gridaco/grida/issues/908).
+      // $0.04/img on all three providers (re-verified 2026-09-02). Superseded
+      // by Seedream 5.0 Lite — cheaper on every provider, newer generation —
+      // so deprecated and unlisted; kept as a real choice for its editing
+      // route until 5.0's i2i is verified on the same providers.
       "bytedance/seedream-4.5": {
         id: "bytedance/seedream-4.5",
         label: "Seedream 4.5",
-        deprecated: false,
+        deprecated: true,
         short_description:
           "ByteDance's unified image generation and editing model.",
         vendor: "bytedance",
         provider: "vercel",
-        listed: true,
+        listed: false,
+        listed_reason: "Previous-generation model, superseded by Seedream 5.0.",
         providers: {
           vercel: {
             provider: "vercel",
@@ -1546,6 +1724,138 @@ export namespace models {
         constraints: { max_edge: 4096 },
         pricing: { type: "per_image_flat", usd: 0.04 },
         avg_cost_usd: 0.04,
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // xAI — Grok Imagine Image 2.0
+      // -----------------------------------------------------------------
+      // Tiered by quality (low/medium) × resolution (1K/2K); the same four
+      // rates on all three providers (Vercel feed
+      // `image_dimension_quality_pricing`, OpenRouter `cost_usd` variants,
+      // fal page). OpenRouter also bills $0.01 per input image (not
+      // modelled). Verified 2026-09-02.
+      "xai/grok-imagine-image-2.0": {
+        id: "xai/grok-imagine-image-2.0",
+        label: "Grok Imagine Image 2.0",
+        deprecated: false,
+        short_description:
+          "xAI's image model — fast 1K/2K generation with a low-cost quality tier.",
+        vendor: "xai",
+        provider: "vercel",
+        listed: true,
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "spacexai/grok-imagine-image-2.0",
+            pricing: {
+              type: "per_image_tiered",
+              tiers: {
+                "low/1024x1024": 0.04,
+                "medium/1024x1024": 0.06,
+                "low/2048x2048": 0.06,
+                "medium/2048x2048": 0.08,
+              },
+            },
+            avg_cost_usd: 0.06,
+          },
+          openrouter: {
+            provider: "openrouter",
+            id: "x-ai/grok-imagine-image-2.0",
+            pricing: {
+              type: "per_image_tiered",
+              tiers: {
+                "low/1024x1024": 0.04,
+                "medium/1024x1024": 0.06,
+                "low/2048x2048": 0.06,
+                "medium/2048x2048": 0.08,
+              },
+            },
+            avg_cost_usd: 0.06,
+            url: "https://openrouter.ai/x-ai/grok-imagine-image-2.0",
+          },
+          fal: {
+            provider: "fal",
+            id: "xai/grok-imagine-image/v2.0/text-to-image",
+            pricing: {
+              type: "per_image_tiered",
+              tiers: {
+                "low/1024x1024": 0.04,
+                "medium/1024x1024": 0.06,
+                "low/2048x2048": 0.06,
+                "medium/2048x2048": 0.08,
+              },
+            },
+            avg_cost_usd: 0.06,
+            url: "https://fal.ai/models/xai/grok-imagine-image/v2.0/text-to-image",
+          },
+        },
+        speed_label: "fast",
+        speed_max: "15s",
+        styles: null,
+        sizes: null,
+        constraints: { max_edge: 2048 },
+        pricing: {
+          type: "per_image_tiered",
+          tiers: {
+            "low/1024x1024": 0.04,
+            "medium/1024x1024": 0.06,
+            "low/2048x2048": 0.06,
+            "medium/2048x2048": 0.08,
+          },
+        },
+        avg_cost_usd: 0.06, // medium 1K
+        default: {
+          width: 1024,
+          height: 1024,
+          aspect_ratio: "1:1",
+        },
+      },
+      // -----------------------------------------------------------------
+      // Meta — Muse Image 1.0
+      // -----------------------------------------------------------------
+      // Meta's agentic image model (2026-08-26): $0.01/img on Vercel (feed
+      // `pricing.image`) and fal (page payload). OpenRouter lists it but
+      // exposes no serving endpoint, so it is not universal → unlisted.
+      // fal exposes aspect ratio only (no size control). Verified 2026-09-02.
+      "meta/muse-image-1.0": {
+        id: "meta/muse-image-1.0",
+        label: "Muse Image 1.0",
+        deprecated: false,
+        short_description:
+          "Meta's agentic image model — reasons before it renders; generates and edits from text and references.",
+        vendor: "meta",
+        provider: "vercel",
+        listed: false,
+        listed_reason:
+          "OpenRouter lists it without a serving endpoint, so not universal (one-key) coverage.",
+        providers: {
+          vercel: {
+            provider: "vercel",
+            id: "meta/muse-image-1.0",
+            pricing: { type: "per_image_flat", usd: 0.01 },
+            avg_cost_usd: 0.01,
+          },
+          fal: {
+            provider: "fal",
+            id: "meta/muse-image/text-to-image",
+            pricing: { type: "per_image_flat", usd: 0.01 },
+            avg_cost_usd: 0.01,
+            url: "https://fal.ai/models/meta/muse-image/text-to-image",
+          },
+        },
+        speed_label: "medium",
+        speed_max: "30s",
+        styles: null,
+        sizes: null,
+        // Muse picks output dimensions from the aspect ratio; neither
+        // provider exposes a size envelope, so none is claimed.
+        constraints: null,
+        pricing: { type: "per_image_flat", usd: 0.01 },
+        avg_cost_usd: 0.01,
         default: {
           width: 1024,
           height: 1024,
@@ -2174,6 +2484,10 @@ export namespace models {
      */
     export type VideoModelId =
       | "google/veo-3.1"
+      | "google/veo-3.1-fast"
+      | "google/veo-3.1-lite"
+      | "alibaba/wan-3.0"
+      | "bytedance/seedance-2.5"
       | "bytedance/seedance-2.0"
       | "xai/grok-imagine-video-1.5"
       | (string & {});
@@ -2374,6 +2688,183 @@ export namespace models {
           },
         },
       },
+      // -----------------------------------------------------------------
+      // Google — Veo 3.1 Fast
+      // -----------------------------------------------------------------
+      // Same envelope as Veo 3.1 (16:9/9:16, 4/6/8s, native audio, ≤4K) at
+      // ~2.7x lower cost. Rate matrix is identical on Vercel and fal —
+      // gateway feed `video_duration_pricing` and fal's stated per-second
+      // rates, verified 2026-09-02.
+      "google/veo-3.1-fast": {
+        id: "google/veo-3.1-fast",
+        label: "Veo 3.1 Fast",
+        deprecated: false,
+        short_description:
+          "Faster, cheaper Veo 3.1 — the same envelope and native audio at a fraction of the price.",
+        vendor: "google",
+        listed: true,
+        aspect_ratios: ["16:9", "9:16"],
+        min_duration: 4,
+        max_duration: 8,
+        audio: true,
+        speed_label: "medium",
+        default: {
+          resolution: "1080p",
+          aspect_ratio: "16:9",
+          duration: 8,
+          audio: true,
+        },
+        url: "https://deepmind.google/models/veo/",
+        providers: {
+          // https://vercel.com/ai-gateway/models/veo-3.1-fast-generate-001
+          vercel: {
+            provider: "vercel",
+            id: "google/veo-3.1-fast-generate-001",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.15, silent: 0.1 },
+                "1080p": { audio: 0.15, silent: 0.1 },
+                "4k": { audio: 0.35, silent: 0.3 },
+              },
+            },
+            avg_cost_usd: 1.2, // 1080p audio × 8s default
+            url: "https://vercel.com/ai-gateway/models/veo-3.1-fast-generate-001",
+          },
+          // https://fal.ai/models/fal-ai/veo3.1/fast/image-to-video
+          fal: {
+            provider: "fal",
+            id: "fal-ai/veo3.1/fast/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.15, silent: 0.1 },
+                "1080p": { audio: 0.15, silent: 0.1 },
+                "4k": { audio: 0.35, silent: 0.3 },
+              },
+            },
+            avg_cost_usd: 1.2, // 1080p audio × 8s default
+            url: "https://fal.ai/models/fal-ai/veo3.1/fast/image-to-video",
+          },
+        },
+      },
+      // -----------------------------------------------------------------
+      // Google — Veo 3.1 Lite
+      // -----------------------------------------------------------------
+      // The budget Veo: 720p/1080p only, 4/6/8s, native audio. Rates
+      // identical on Vercel and fal (verified 2026-09-02). The gateway lists
+      // Lite as text-to-video only — the hosted route is t2v-only anyway;
+      // fal serves the image-to-video endpoint catalogued here.
+      "google/veo-3.1-lite": {
+        id: "google/veo-3.1-lite",
+        label: "Veo 3.1 Lite",
+        deprecated: false,
+        short_description:
+          "Budget Veo 3.1 — 720p/1080p clips with native audio for a few cents a second.",
+        vendor: "google",
+        listed: true,
+        aspect_ratios: ["16:9", "9:16"],
+        min_duration: 4,
+        max_duration: 8,
+        audio: true,
+        speed_label: "fast",
+        default: {
+          resolution: "1080p",
+          aspect_ratio: "16:9",
+          duration: 8,
+          audio: true,
+        },
+        url: "https://deepmind.google/models/veo/",
+        providers: {
+          // https://vercel.com/ai-gateway/models/veo-3.1-lite-generate-001
+          vercel: {
+            provider: "vercel",
+            id: "google/veo-3.1-lite-generate-001",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.05, silent: 0.03 },
+                "1080p": { audio: 0.08, silent: 0.05 },
+              },
+            },
+            avg_cost_usd: 0.64, // 1080p audio × 8s default
+            url: "https://vercel.com/ai-gateway/models/veo-3.1-lite-generate-001",
+          },
+          // https://fal.ai/models/fal-ai/veo3.1/lite/image-to-video
+          fal: {
+            provider: "fal",
+            id: "fal-ai/veo3.1/lite/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "720p": { audio: 0.05, silent: 0.03 },
+                "1080p": { audio: 0.08, silent: 0.05 },
+              },
+            },
+            avg_cost_usd: 0.64, // 1080p audio × 8s default
+            url: "https://fal.ai/models/fal-ai/veo3.1/lite/image-to-video",
+          },
+        },
+      },
+      // -----------------------------------------------------------------
+      // Alibaba — Wan 3.0
+      // -----------------------------------------------------------------
+      // Per-second by resolution, audio bundled into the rate (the gateway
+      // feed has no audio axis; fal exposes an `audio` toggle but bills the
+      // same). Identical on Vercel and fal, verified 2026-09-02. 2–30s.
+      "alibaba/wan-3.0": {
+        id: "alibaba/wan-3.0",
+        label: "Wan 3.0",
+        deprecated: false,
+        short_description:
+          "Alibaba's flagship video model — long clips (up to 30s) with bundled audio at the lowest per-second rates in the catalogue.",
+        vendor: "alibaba",
+        listed: true,
+        aspect_ratios: ["16:9", "4:3", "1:1", "3:4", "9:16"],
+        min_duration: 2,
+        max_duration: 30,
+        audio: true,
+        speed_label: "medium",
+        default: {
+          resolution: "1080p",
+          aspect_ratio: "16:9",
+          duration: 5,
+          audio: true,
+        },
+        url: "https://wan.video/",
+        providers: {
+          // https://vercel.com/ai-gateway/models/wan-v3.0-video
+          vercel: {
+            provider: "vercel",
+            id: "alibaba/wan-v3.0-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.05 },
+                "720p": { audio: 0.1 },
+                "1080p": { audio: 0.2 },
+              },
+            },
+            avg_cost_usd: 1.0, // 1080p × 5s default
+            url: "https://vercel.com/ai-gateway/models/wan-v3.0-video",
+          },
+          // https://fal.ai/models/alibaba/wan-3.0/image-to-video
+          fal: {
+            provider: "fal",
+            id: "alibaba/wan-3.0/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.05 },
+                "720p": { audio: 0.1 },
+                "1080p": { audio: 0.2 },
+              },
+            },
+            avg_cost_usd: 1.0, // 1080p × 5s default
+            url: "https://fal.ai/models/alibaba/wan-3.0/image-to-video",
+          },
+        },
+      },
       // ByteDance — Seedance 2.0
       // -----------------------------------------------------------------
       "bytedance/seedance-2.0": {
@@ -2396,23 +2887,35 @@ export namespace models {
           audio: true,
         },
         url: "https://seed.bytedance.com/en/seedance2_0",
+        // NO Vercel binding, deliberately. The gateway serves
+        // `bytedance/seedance-2.0` but meters it PER TOKEN
+        // (`video_token_pricing`: $7.00/MTok at 480p/720p, $7.70 at 1080p,
+        // $4.00 at 4K; reduced with video input; "minimum token floors based
+        // on output duration"). `PerSecondPricing` cannot express that, the
+        // hosted route pre-prices rate×duration, and ByteDance publishes no
+        // tokens-per-second figure — so there is no honest per-second rate,
+        // and the per-second Vercel binding this card shipped with was
+        // invented. Withheld until the hosted path can meter post-flight;
+        // hosted requests fail with "not available on the hosted provider".
+        // See gridaco/grida#1019 (Blocker A). Feed checked 2026-09-02.
         providers: {
-          // Vercel AI Gateway — image-to-video. Per-second by resolution; audio
-          // bundled into the rate (no separate silent meter). 1080p exists but
-          // its per-second rate is unconfirmed; a `bytedance/seedance-2.0-fast`
-          // route also exists (~20% cheaper).
-          // https://vercel.com/changelog/seedance-2.0-video-now-available-on-ai-gateway
-          vercel: {
-            provider: "vercel",
-            id: "bytedance/seedance-2.0",
+          // fal — image-to-video. fal also meters tokens underneath
+          // ($0.014/1K), but states a per-second price for the two
+          // resolutions it prices: $0.3034/s @720p, $0.682/s @1080p, audio
+          // bundled. Those are fal's own figures, not a conversion of ours.
+          // https://fal.ai/models/bytedance/seedance-2.0/image-to-video
+          fal: {
+            provider: "fal",
+            id: "bytedance/seedance-2.0/image-to-video",
             pricing: {
               type: "per_second",
               usd_per_second: {
-                "480p": { audio: 0.092 },
-                "720p": { audio: 0.199 },
+                "720p": { audio: 0.3034 },
+                "1080p": { audio: 0.682 },
               },
             },
-            avg_cost_usd: 1.0, // 720p audio × 5s default (≈ $0.995)
+            avg_cost_usd: 1.52, // 720p audio × 5s default
+            url: "https://fal.ai/models/bytedance/seedance-2.0/image-to-video",
           },
           // OpenRouter — async `/api/v1/videos`. Flat $0.06726/s (verified
           // 2026-06-29, https://openrouter.ai/bytedance/seedance-2.0) — far
@@ -2431,8 +2934,53 @@ export namespace models {
             avg_cost_usd: 0.34, // 720p audio × 5s default
             url: "https://openrouter.ai/bytedance/seedance-2.0",
           },
-          // Also served by fal.ai and Replicate — add those bindings once
-          // their per-second rates are verified.
+        },
+      },
+      // -----------------------------------------------------------------
+      // ByteDance — Seedance 2.5
+      // -----------------------------------------------------------------
+      // Successor to 2.0 (2026-08-07): 4–30s clips, 21:9, native audio. Same
+      // metering story as 2.0 — the gateway bills tokens ($10.70/MTok at
+      // 480p/720p, $11.70 at 1080p), so no Vercel binding until post-flight
+      // metering exists. fal states per-second prices, audio bundled.
+      "bytedance/seedance-2.5": {
+        id: "bytedance/seedance-2.5",
+        label: "Seedance 2.5",
+        deprecated: false,
+        short_description:
+          "ByteDance's latest video model — up to 30-second clips with native audio, reference and editing modes.",
+        vendor: "bytedance",
+        listed: true,
+        aspect_ratios: ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
+        min_duration: 4,
+        max_duration: 30,
+        audio: true,
+        speed_label: "slow",
+        default: {
+          resolution: "720p",
+          aspect_ratio: "16:9",
+          duration: 5,
+          audio: true,
+        },
+        url: "https://seed.bytedance.com/en/seedance",
+        providers: {
+          // fal's stated rates: $0.2205/s @480p, $0.4730/s @720p, $1.164/s
+          // @1080p (fal meters $0.0214/1K tokens underneath). 2026-09-02.
+          // https://fal.ai/models/bytedance/seedance-2.5/image-to-video
+          fal: {
+            provider: "fal",
+            id: "bytedance/seedance-2.5/image-to-video",
+            pricing: {
+              type: "per_second",
+              usd_per_second: {
+                "480p": { audio: 0.2205 },
+                "720p": { audio: 0.473 },
+                "1080p": { audio: 1.164 },
+              },
+            },
+            avg_cost_usd: 2.37, // 720p audio × 5s default
+            url: "https://fal.ai/models/bytedance/seedance-2.5/image-to-video",
+          },
         },
       },
       // -----------------------------------------------------------------

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -1436,6 +1436,9 @@ export namespace models {
             pricing: { type: "per_image_flat", usd: 0.07 },
             avg_cost_usd: 0.07,
             url: "https://openrouter.ai/black-forest-labs/flux.2-max",
+            // OpenRouter `supported_parameters.input_references` 0–8
+            // (2026-09-02). As on Flux 2 Pro.
+            references: { id: "black-forest-labs/flux.2-max", max: 8 },
           },
           fal: {
             provider: "fal",
@@ -1601,6 +1604,9 @@ export namespace models {
             pricing: { type: "per_image_flat", usd: 0.045 },
             avg_cost_usd: 0.045,
             url: "https://openrouter.ai/bytedance-seed/seedream-5-0-pro",
+            // OpenRouter `supported_parameters.input_references` 0–14
+            // (2026-09-02). Same endpoint as t2i, as on 4.5.
+            references: { id: "bytedance-seed/seedream-5-0-pro", max: 14 },
           },
           fal: {
             provider: "fal",
@@ -1658,6 +1664,9 @@ export namespace models {
             pricing: { type: "per_image_flat", usd: 0.035 },
             avg_cost_usd: 0.035,
             url: "https://openrouter.ai/bytedance-seed/seedream-5-0-lite",
+            // OpenRouter `supported_parameters.input_references` 0–14
+            // (2026-09-02).
+            references: { id: "bytedance-seed/seedream-5-0-lite", max: 14 },
           },
           fal: {
             provider: "fal",
@@ -1785,6 +1794,9 @@ export namespace models {
             },
             avg_cost_usd: 0.06,
             url: "https://openrouter.ai/x-ai/grok-imagine-image-2.0",
+            // OpenRouter `supported_parameters.input_references` 0–3
+            // (2026-09-02). OR bills $0.01 per input image on top (not modelled).
+            references: { id: "x-ai/grok-imagine-image-2.0", max: 3 },
           },
           fal: {
             provider: "fal",
@@ -1902,6 +1914,9 @@ export namespace models {
             pricing: { type: "per_image_flat", usd: 0.035 },
             avg_cost_usd: 0.035,
             url: "https://openrouter.ai/recraft/recraft-v4.1",
+            // OpenRouter `supported_parameters.input_references` 0–1
+            // (2026-09-02).
+            references: { id: "recraft/recraft-v4.1", max: 1 },
           },
           fal: {
             provider: "fal",

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -2896,7 +2896,7 @@ export namespace models {
         label: "Seedance 2.0",
         deprecated: false,
         short_description:
-          "ByteDance's state-of-the-art video model — top-tier image-to-video with reference and editing modes.",
+          "ByteDance's video model — image-to-video with reference modes, up to 4K, at roughly two-thirds the price of Seedance 2.5.",
         vendor: "bytedance",
         listed: true,
         aspect_ratios: ["16:9", "9:16", "1:1"],
@@ -2963,9 +2963,13 @@ export namespace models {
       // -----------------------------------------------------------------
       // ByteDance — Seedance 2.5
       // -----------------------------------------------------------------
-      // Successor to 2.0 (2026-08-07): 4–30s clips, 21:9, native audio. Same
-      // metering story as 2.0 — the gateway bills tokens ($10.70/MTok at
-      // 480p/720p, $11.70 at 1080p), so no Vercel binding until post-flight
+      // Newer generation (2026-08-07), NOT a drop-in successor: ~55% more
+      // per token on the gateway ($10.70/MTok at 480p/720p, $11.70 at 1080p
+      // vs 2.0's $7.00/$7.70), ~56–71% more per second on fal, and no 4K.
+      // It buys 4–30s clips, video-editing and extend-video. 2.0 is cheaper
+      // and serves 4K, so it stays listed and undeprecated — the catalogue
+      // rule keeps a card that is still a real choice. Same metering story:
+      // the gateway bills tokens, so no Vercel binding until post-flight
       // metering exists. fal states per-second prices, audio bundled.
       "bytedance/seedance-2.5": {
         id: "bytedance/seedance-2.5",

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -2114,8 +2114,8 @@ export namespace models {
 
     /**
      * Whether a clip is generated with synchronized audio. A real pricing axis:
-     * fal meters `silent` at roughly half of `audio`; Vercel sells `audio` only;
-     * Seedance bundles audio into its single rate.
+     * both fal and the Vercel gateway meter `silent` at roughly half of
+     * `audio`; Seedance bundles audio into its single rate.
      */
     export type AudioMode = "audio" | "silent";
 
@@ -2127,9 +2127,14 @@ export namespace models {
      *
      * A binding lists only the `(resolution, mode)` combinations its provider
      * actually serves and meters, so the keys double as that provider's
-     * resolution/audio support: Vercel's Veo card omits `"4k"` and `silent`
-     * because the gateway sells neither; fal lists both. Each value is the real
+     * resolution/audio support: Seedance lists only `audio` because it bundles
+     * audio into one rate, and Veo 3.1 Lite omits `"4k"` because the gateway
+     * does not sell it at that line. Each value is the real
      * USD-per-output-second rate for that exact config.
+     *
+     * These keys are provider truth, not Grida's request surface — a
+     * `(resolution, mode)` pair may be catalogued before the hosted wire can
+     * ask for it.
      */
     export type PerSecondPricing = {
       type: "per_second";
@@ -2235,8 +2240,19 @@ export namespace models {
         },
         url: "https://deepmind.google/models/veo/",
         providers: {
-          // Vercel AI Gateway — gateway.video(id), image-to-video. Audio-on
-          // only, ≤1080p, flat $0.40/s.
+          // Vercel AI Gateway — gateway.video(id), image-to-video. The
+          // gateway meters both audio modes and sells 4K; the matrix is
+          // identical to fal's. Verified against the gateway's own
+          // /v1/models feed (`video_duration_pricing`) on 2026-09-02 — the
+          // previous card claimed "audio-on only, ≤1080p", which the feed
+          // contradicts.
+          //
+          // `silent` is catalogued as provider truth but is not yet
+          // reachable on Grida's hosted route: the video wire carries no
+          // audio-mode field, so `generateVideo` prices the card's default
+          // mode (`editor/lib/ai/server.ts`). `"4k"` IS reachable — the
+          // request path maps a 2160 short edge to that label and today
+          // rejects it for want of a rate.
           // https://vercel.com/ai-gateway/models/veo-3.1-generate-001
           vercel: {
             provider: "vercel",
@@ -2244,17 +2260,18 @@ export namespace models {
             pricing: {
               type: "per_second",
               usd_per_second: {
-                "720p": { audio: 0.4 },
-                "1080p": { audio: 0.4 },
+                "720p": { audio: 0.4, silent: 0.2 },
+                "1080p": { audio: 0.4, silent: 0.2 },
+                "4k": { audio: 0.6, silent: 0.4 },
               },
             },
             avg_cost_usd: 3.2, // 1080p audio × 8s default
             url: "https://vercel.com/ai-gateway/models/veo-3.1-generate-001",
           },
           // fal.ai — image-to-video endpoint (capability is keyed into the id;
-          // t2v is a separate `fal-ai/veo3.1` endpoint, not catalogued). Meters
-          // audio/silent and adds 4K. Audio-on matches Vercel ($0.40/s @
-          // 720p/1080p); silent ~half; 4K $0.40 silent / $0.60 audio.
+          // t2v is a separate `fal-ai/veo3.1` endpoint, not catalogued). Rate
+          // matrix is identical to the Vercel gateway's: $0.40/s audio and
+          // $0.20/s silent at 720p/1080p, $0.60/$0.40 at 4K.
           // https://fal.ai/models/fal-ai/veo3.1/image-to-video
           fal: {
             provider: "fal",

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -1614,8 +1614,14 @@ export namespace models {
         speed_max: "30s",
         styles: null,
         sizes: null,
-        // fal: total pixels between 1024x1024 and 2048x2048.
-        constraints: { min_edge: 1024, max_edge: 2048 },
+        // fal: total pixels between 1024x1024 and 2048x2048, aspect ratio
+        // between 1:16 and 16:1 — an area bound, not a per-edge one, so a
+        // 512x2048 request is in-envelope and a 2048x2048 one is the ceiling.
+        constraints: {
+          min_pixels: 1_048_576,
+          max_pixels: 4_194_304,
+          aspect_ratio: { max: 16 },
+        },
         pricing: { type: "per_image_flat", usd: 0.035 },
         avg_cost_usd: 0.035,
         default: {
@@ -1665,12 +1671,15 @@ export namespace models {
         speed_max: "15s",
         styles: null,
         sizes: null,
-        constraints: { max_edge: 4096 },
+        // fal: total pixels between 2560x1440 and 4096x4096 (requests below
+        // the floor are scaled up to it); Vercel and OpenRouter serve 2K/4K
+        // only. An area envelope, so the default is a 2K request.
+        constraints: { min_pixels: 3_686_400, max_pixels: 16_777_216 },
         pricing: { type: "per_image_flat", usd: 0.035 },
         avg_cost_usd: 0.035,
         default: {
-          width: 1024,
-          height: 1024,
+          width: 2048,
+          height: 2048,
           aspect_ratio: "1:1",
         },
       },


### PR DESCRIPTION
Media half of the catalogue pass. Tracks #1019, which carries the full provider-availability matrix and the decisions. Scope is image and video only.

**First-party rule, made explicit:** a media model is `listed` only if the Vercel gateway, fal, *and* OpenRouter serve it (video: Vercel + fal — OpenRouter publishes no video pricing via any API). Vercel∩fal-only cards go in unlisted with a reason. Everything below is grounded against the three live catalogues on 2026-09-02, never against our own cards.

## Corrections — cards that said something their provider contradicts

| card | was | is | consequence |
| --- | --- | --- | --- |
| Veo 3.1 (Vercel) | 720p/1080p audio-only | full 6-cell matrix incl. silent + 4K | 4K was rejected on a route the gateway sells |
| Flux Kontext Pro | $0.05 | **$0.04** + fal binding | 25% hosted over-billing (route gates on a vercel binding, not `listed`) |
| Flux 2 Pro (Vercel) | $0.06 | **$0.03/MP** | 2× hosted over-billing |
| Seedance 2.0 (Vercel) | $0.092/$0.199 per second | **binding removed** | the gateway meters per *token*; that rate was invented |
| Gemini 3.1 Flash Image | calls `-preview` ids | calls graduated ids | canonical key kept (persisted + published) |

## Added

**Image** — Recraft V4.1 ($0.035 ×3), Seedream 5.0 Pro + Lite ($0.035 Vercel; Lite $0.035 ×3), Flux 2 Max ($0.07/MP ×3), Grok Imagine Image 2.0 (same low/medium × 1K/2K tiers ×3) — all listed. Muse Image 1.0 ($0.01 Vercel + fal) unlisted: OpenRouter lists it with no endpoint.

Every new listed image card also carries its OpenRouter image-to-image reference cap (`input_references`: Seedream 5.0 ×14, Flux 2 Max ×8, Grok 2.0 ×3, Recraft V4.1 ×1) — Seedream 4.5 was the catalogue's only Seedream editing route, and unlisting it without this would have dropped Seedream editing from the BYOK surface.

**Video** — Veo 3.1 Fast, Veo 3.1 Lite, Wan 3.0 (Alibaba), Seedance 2.5 — listed. Veo/Wan matrices are identical on Vercel and fal. Seedance 2.5 binds fal only, for the same reason 2.0 lost its Vercel binding. **2.5 is newer, not cheaper** — ~55% more per token on the gateway, ~56–71% more per second on fal, and no 4K; it buys 30s clips and editing. So 2.0 stays listed and undeprecated: cheaper, and the only Seedance with 4K.

## Deprecated (kept, unlisted)

Recraft V3 (V4.1 cheaper on every provider, equal on vector; V3's positioned-text claim is the one unverified axis). Seedream 4.5 (5.0 Lite cheaper on every provider).

## Blocker A — why not a `per_token` video pricing variant

The snapshot validator returns `undefined` for the whole published video table when any binding fails to parse (`parseVideoPricing` requires `per_second`; see the "rejects a binding that cannot price the default" test). A new discriminant in the published catalogue would blank every video model on every installed client. That is a wire-shape change needing its own compatibility plan; this PR withholds the un-priceable binding instead, so hosted Seedance fails with the existing "not available on the hosted provider" rather than mis-billing.

## Deliberately left out

Kling 3.0 — prices by std/pro *mode*, an axis `PerSecondPricing` lacks. Flux 3 Video — empty Vercel rate. MiniMax H3 — 768p/2K labels the hosted resolution map cannot express without known dimensions. Flux 2 Flex/Klein — not flagship.

## Also

- Hosted image resolution now calls the gateway by the vercel **binding** id, as video already did.
- Docs: ByteDance/xAI/Meta/Recraft sections, corrected Flux 2 rates, a **Video Generation** section (the hosted video surface was undocumented), Image Sizes rows for every new card.
- Type-doc comments that asserted the wrong Veo facts corrected; vendor labels for ByteDance/xAI/Alibaba/Meta on the models page.

## Verified

179 `@grida/ai-models` tests, 125 editor AI/billing/route tests, 90 agent provider/route tests; CI 17/17 at `d651df0f6`; package typecheck, oxlint, oxfmt clean. Every new test is written from the provider feed, not the card. Docs text tables re-audited against the built catalogue.

## Not covered

- **Image size envelopes are not validated on any path** (CodeRabbit, pre-existing): `card.constraints` has no consumer — hosted or BYOK — and constraints are per card while provider envelopes differ (Seedream 5.0 Lite: fal 2K–4K area with auto-upscale vs OpenRouter 2K/4K). Needs per-binding constraints + pre-dispatch validation; its own PR. Tracked on #1019.
- **Per-megapixel cards are billed flat at the 1 MP baseline** (CodeRabbit, pre-existing since Flux 2 Pro landed in June): `computeImageCostMills` ignores width/height for `per_image_flat`, so a hosted 1440² Flux 2 request (2.07 MP) is under-priced ≈ $0.075. Fix is a `per_megapixel` pricing variant + size-aware cost — a published-snapshot wire change with the same compatibility question as Blocker A. Tracked on #1019.
- Silent audio on the hosted video wire (no audio-mode field — every silent rate is unreachable hosted).
- Post-flight hosted video metering (the real Blocker A unblock).
- Blocker B (fal BYOK-only).
- Recraft V3 removal, pending the positioned-text parity check.
