### PR TITLE
feat(ai): add Gemini 3.8 Flash and remove superseded models

### DIFF
--- a/desktop/docs/chatgpt-subscription-oauth.md
+++ b/desktop/docs/chatgpt-subscription-oauth.md
@@ -39,12 +39,11 @@ The authorization query also pins
 `codex_cli_simplified_flow=true`, and `originator=grida`. Inference sends
 `originator: grida`.
 
-The current closed model compatibility projection is
+The current closed model compatibility projection consists of
 `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`,
-`openai/gpt-5.6-luna`, `openai/gpt-5.5`, `openai/gpt-5.4`, and
-`openai/gpt-5.4-mini`. It mirrors the observed Zed/Codex-compatible surface,
-not authenticated discovery; it may drift, and an account can refuse a listed
-model.
+`openai/gpt-5.6-luna`, `openai/gpt-5.5`, and `openai/gpt-5.4`. It mirrors the
+observed Zed/Codex-compatible surface, not authenticated discovery; it may
+drift, and an account can refuse a listed model.
 
 The main-owned provider network grant admits exact `auth.openai.com` and
 `chatgpt.com` HTTPS origins only on the credential-bearing provider lane.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -44,11 +44,10 @@ Claude Fable 5.1 and Claude Opus 5 remain active, non-tiered catalogue models.
 `nano` and `mini` currently resolve to the same model. `nano` is a floor —
 the cheapest model still good enough for background work (title generation,
 summarisation, compaction) — so it is never more expensive than `mini`, but
-it is not guaranteed to be strictly cheaper. OpenAI's 2026-07-30 price cut
-dropped GPT-5.6 Luna below the older GPT-5.4 Nano while giving it more
-context, leaving nothing that is both cheaper and adequate. Expect the two
-tiers to separate again as new models are released; picking `nano` is always
-safe for cost-sensitive work regardless.
+it is not guaranteed to be strictly cheaper. GPT-5.6 Luna is currently both
+the lowest-cost model considered adequate for background work and the best
+value at `mini`. Expect the two tiers to separate again as new models are
+released; picking `nano` is always safe for cost-sensitive work regardless.
 
 ### Cache Pricing
 
@@ -65,34 +64,34 @@ All tiers support prompt caching, which reduces cost for repeated context:
 
 Per 1M tokens.
 
-| Name                                                         | Input  | Cache Write | Cache Read | Output  |
-| ------------------------------------------------------------ | ------ | ----------- | ---------- | ------- |
-| GPT-5.4 Nano (`openai/gpt-5.4-nano`)                         | $0.20  | —           | $0.02      | $1.25   |
-| GPT-5.4 Mini (`openai/gpt-5.4-mini`)                         | $0.75  | —           | $0.075     | $4.50   |
-| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)                | $2.00  | $2.50       | $0.20      | $10.00  |
-| Claude Sonnet 4.6 (`anthropic/claude-sonnet-4.6`) _(legacy)_ | $3.00  | $3.75       | $0.30      | $15.00  |
-| Claude Fable 5.1 (`anthropic/claude-fable-5.1`)              | $10.00 | $12.50      | $0.25      | $50.00  |
-| Claude Fable 5 (`anthropic/claude-fable-5`) _(legacy)_       | $10.00 | $12.50      | $1.00      | $50.00  |
-| Claude Opus 5 (`anthropic/claude-opus-5`)                    | $5.00  | $6.25       | $0.50      | $25.00  |
-| Claude Opus 4.8 (`anthropic/claude-opus-4.8`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
-| Claude Opus 4.7 (`anthropic/claude-opus-4.7`) _(legacy)_     | $5.00  | $6.25       | $0.50      | $25.00  |
-| GPT-5.6 Sol (`openai/gpt-5.6-sol`)                           | $4.00  | $5.00       | $0.40      | $20.00  |
-| GPT-5.6 Terra (`openai/gpt-5.6-terra`)                       | $2.00  | $2.50       | $0.20      | $12.00  |
-| GPT-5.6 Luna (`openai/gpt-5.6-luna`)                         | $0.20  | $0.25       | $0.02      | $1.20   |
-| GPT-5.5 (`openai/gpt-5.5`) _(legacy)_                        | $5.00  | —           | $0.50      | $30.00  |
-| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                           | $30.00 | —           | —          | $180.00 |
-| Gemini 3.7 Flash (`google/gemini-3.7-flash`)                 | $1.50  | —           | $0.15      | $7.50   |
-| Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`)     | $2.00  | —           | $0.20      | $12.00  |
+| Name                                                     | Input  | Cache Write | Cache Read | Output  |
+| -------------------------------------------------------- | ------ | ----------- | ---------- | ------- |
+| Claude Sonnet 5 (`anthropic/claude-sonnet-5`)            | $2.00  | $2.50       | $0.20      | $10.00  |
+| Claude Fable 5.1 (`anthropic/claude-fable-5.1`)          | $10.00 | $12.50      | $0.25      | $50.00  |
+| Claude Fable 5 (`anthropic/claude-fable-5`) _(legacy)_   | $10.00 | $12.50      | $1.00      | $50.00  |
+| Claude Opus 5 (`anthropic/claude-opus-5`)                | $5.00  | $6.25       | $0.50      | $25.00  |
+| Claude Opus 4.8 (`anthropic/claude-opus-4.8`) _(legacy)_ | $5.00  | $6.25       | $0.50      | $25.00  |
+| GPT-5.6 Sol (`openai/gpt-5.6-sol`)                       | $4.00  | $5.00       | $0.40      | $20.00  |
+| GPT-5.6 Terra (`openai/gpt-5.6-terra`)                   | $2.00  | $2.50       | $0.20      | $12.00  |
+| GPT-5.6 Luna (`openai/gpt-5.6-luna`)                     | $0.20  | $0.25       | $0.02      | $1.20   |
+| GPT-5.5 (`openai/gpt-5.5`) _(legacy)_                    | $5.00  | —           | $0.50      | $30.00  |
+| GPT-5.5 Pro (`openai/gpt-5.5-pro`)                       | $30.00 | —           | —          | $180.00 |
+| Gemini 3.8 Flash (`google/gemini-3.8-flash`)             | $1.50  | —           | $0.15      | $7.50   |
+| Gemini 3.7 Flash (`google/gemini-3.7-flash`) _(legacy)_  | $1.50  | —           | $0.15      | $7.50   |
+| Gemini 3.1 Pro Preview (`google/gemini-3.1-pro-preview`) | $2.00  | —           | $0.20      | $12.00  |
 
 GPT-5.6 and GPT-5.5 prices above are base rates. Requests with more than 272K
 input tokens are billed at 2x input and 1.5x output for the full request.
 `Gemini 3.1 Pro Preview` is tiered the same way at a 200K threshold ($4.00
 input / $18.00 output / $0.40 cache read for the full request).
 
-`Gemini 3.7 Flash` is listed at its steady-state rate. Google is running a
-promotion through 2026-12-31 at $0.75 input / $3.75 output / $0.075 cache
-read; the table holds the price that applies from 2027-01-01 so an expiring
-promotion is never a silent cost increase.
+`Gemini 3.8 Flash` is the current GA Flash model. Its catalogue ID is available
+through Vercel AI Gateway and OpenRouter. `Gemini 3.7 Flash` remains callable
+as a legacy option for compute-efficient workloads because Google notes that
+3.8 can consume more tokens. Both are listed at their steady-state rates.
+Google is running a promotion through 2026-12-31 at $0.75 input / $3.75 output
+/ $0.075 cache read; the table holds the price that applies from 2027-01-01 so
+an expiring promotion is never a silent cost increase.
 
 `GPT-5.5` is deprecated in Grida's catalogue in favor of `GPT-5.6 Sol`;
 this is not an upstream OpenAI retirement. `GPT-5.5 Pro` remains active.

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -63,6 +63,7 @@ describe("GET /api/v1/ai/models", () => {
     for (const id of [
       "anthropic/claude-fable-5.1",
       "anthropic/claude-opus-5",
+      "google/gemini-3.8-flash",
     ]) {
       expect(byId.get(id)?.grida).toMatchObject({
         modality: "text",
@@ -74,6 +75,7 @@ describe("GET /api/v1/ai/models", () => {
     for (const id of [
       "anthropic/claude-opus-4.8",
       "anthropic/claude-fable-5",
+      "google/gemini-3.7-flash",
     ]) {
       expect(byId.get(id)?.grida).toMatchObject({
         modality: "text",

--- a/editor/lib/agent-chat/build-agent-send.test.ts
+++ b/editor/lib/agent-chat/build-agent-send.test.ts
@@ -20,7 +20,7 @@ describe("buildAgentSend", () => {
     const send = buildAgentSend({
       sendMessage,
       sessionId: null,
-      modelId: "anthropic/claude-sonnet-4.6",
+      modelId: "anthropic/claude-sonnet-5",
     });
 
     send("hello");
@@ -31,7 +31,7 @@ describe("buildAgentSend", () => {
       {
         body: {
           session_id: undefined,
-          model_id: "anthropic/claude-sonnet-4.6",
+          model_id: "anthropic/claude-sonnet-5",
         },
       }
     );
@@ -129,7 +129,7 @@ describe("buildAgentSend — explicit provider/model selection", () => {
     const send = buildAgentSend({
       sendMessage,
       sessionId: "s1",
-      modelId: "anthropic/claude-sonnet-4.6",
+      modelId: "anthropic/claude-sonnet-5",
     });
 
     send("hi");

--- a/editor/lib/ai/__tests__/server.test.ts
+++ b/editor/lib/ai/__tests__/server.test.ts
@@ -144,27 +144,27 @@ describe("methods.generateMusic", () => {
 });
 
 describe("costMillsFromTokenUsage", () => {
-  it("computes cost from a flat-rate model card", () => {
-    // openai/gpt-5.4-mini → input 0.75, output 4.50 per 1M
-    const mills = costMillsFromTokenUsage("openai/gpt-5.4-mini", {
+  it("computes cost from a base-rate model card", () => {
+    // openai/gpt-5.6-luna → input 0.20, output 1.20 per 1M
+    const mills = costMillsFromTokenUsage("openai/gpt-5.6-luna", {
       inputTokens: { total: 1000 },
       outputTokens: { total: 1000 },
     });
-    // 0.75e-3 + 4.5e-3 = 5.25e-3 USD = 5.25 mills (fractional —
+    // 0.2e-3 + 1.2e-3 = 1.4e-3 USD = 1.4 mills (fractional —
     // Metronome aggregates exactly, Stripe rounds once at invoice).
-    expect(mills).toBeCloseTo(5.25);
+    expect(mills).toBeCloseTo(1.4);
   });
 
   it("applies cacheRead rate for cached input tokens", () => {
-    // claude-sonnet-4.6: input 3, cacheRead 0.3, output 15 (per 1M).
-    const mills = costMillsFromTokenUsage("anthropic/claude-sonnet-4.6", {
+    // claude-sonnet-5: input 2, cacheRead 0.2, output 10 (per 1M).
+    const mills = costMillsFromTokenUsage("anthropic/claude-sonnet-5", {
       inputTokens: { total: 10000, cacheRead: 8000 },
       outputTokens: { total: 0 },
     });
-    // nonCached = 10000 - 8000 = 2000 → 2000*3/1e6 = 6e-3 USD
-    // cacheRead = 8000*0.3/1e6 = 2.4e-3 USD
-    // total = 8.4e-3 USD = 8.4 mills (fractional, un-rounded).
-    expect(mills).toBeCloseTo(8.4);
+    // nonCached = 10000 - 8000 = 2000 → 2000*2/1e6 = 4e-3 USD
+    // cacheRead = 8000*0.2/1e6 = 1.6e-3 USD
+    // total = 5.6e-3 USD = 5.6 mills (fractional, un-rounded).
+    expect(mills).toBeCloseTo(5.6);
   });
 
   // GRIDA-GG: gateway — pin request pricing used by hosted chat metering.
@@ -281,7 +281,7 @@ describe("withTransaction", () => {
       {
         organizationId: 7,
         feature: "test/feature",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
         transactionId: "tx-1",
       },
       op
@@ -309,7 +309,7 @@ describe("withTransaction", () => {
         {
           organizationId: 7,
           feature: "test/feature",
-          model_id: "openai/gpt-5.4-mini",
+          model_id: "openai/gpt-5.6-luna",
         },
         op
       )
@@ -334,7 +334,7 @@ describe("withTransaction", () => {
         {
           organizationId: 7,
           feature: "test/feature",
-          model_id: "openai/gpt-5.4-mini",
+          model_id: "openai/gpt-5.6-luna",
         },
         op
       )
@@ -351,7 +351,7 @@ describe("withTransaction", () => {
         {
           organizationId: 0 as number,
           feature: "test/feature",
-          model_id: "openai/gpt-5.4-mini",
+          model_id: "openai/gpt-5.6-luna",
         },
         op
       )
@@ -382,7 +382,7 @@ describe("withTransaction", () => {
       {
         organizationId: 7,
         feature: "ai/chat",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
         awaitIngest: true,
       },
       op
@@ -482,7 +482,7 @@ describe("checkGate", () => {
       checkGate({
         organizationId: 7,
         feature: "test",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
       })
     ).rejects.toBeInstanceOf(BillingMetronomeError);
   });
@@ -497,7 +497,7 @@ describe("checkGate", () => {
       checkGate({
         organizationId: 7,
         feature: "test",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
       })
     ).resolves.toBeUndefined();
   });

--- a/editor/lib/ai/server.ts
+++ b/editor/lib/ai/server.ts
@@ -469,7 +469,7 @@ export type GridaProvider = ((modelId: string) => LanguageModel) & {
  * is a bare provider that bypasses billing — see the BYOK carve-out in
  * this file's header / `models.ts` / SECURITY.md GRIDA-SEC-003.
  *
- *     grida("openai/gpt-5.4-mini")       // → LanguageModel (callable shorthand)
+ *     grida("openai/gpt-5.6-luna")       // → LanguageModel (callable shorthand)
  *     grida.languageModel("openai/...")  // → LanguageModel (explicit)
  *     grida.imageModel("bfl/flux-2-pro") // → ImageModel
  */

--- a/editor/scaffolds/desktop/shared/default-model.test.ts
+++ b/editor/scaffolds/desktop/shared/default-model.test.ts
@@ -71,7 +71,7 @@ describe("resolveDefaultModelSelection", () => {
   });
 
   it("an explicit caller-seeded initial wins over the GG default", () => {
-    const initial = "openai/gpt-5.4-mini";
+    const initial = "openai/gpt-5.6-luna";
     expect(
       resolveDefaultModelSelection({
         initial,

--- a/editor/scaffolds/desktop/shared/registered-models.test.ts
+++ b/editor/scaffolds/desktop/shared/registered-models.test.ts
@@ -8,7 +8,7 @@ const endpoint: EndpointProviderConfig = {
   base_url: "http://127.0.0.1:11434/v1",
   models: [
     {
-      id: "openai/gpt-5.4-mini",
+      id: "openai/gpt-5.6-luna",
       label: "Local collision",
       multimodal: false,
       overrides: { imageInputMimes: ["image/png"] },
@@ -19,11 +19,11 @@ const endpoint: EndpointProviderConfig = {
 describe("registered_models", () => {
   it("resolves capabilities from the endpoint that a colliding id pins", () => {
     expect(
-      registered_models.providerIdForModel("openai/gpt-5.4-mini", [endpoint])
+      registered_models.providerIdForModel("openai/gpt-5.6-luna", [endpoint])
     ).toBe("endpoint-local");
     expect(
       registered_models.resolve(
-        "openai/gpt-5.4-mini",
+        "openai/gpt-5.6-luna",
         [endpoint],
         "endpoint-local"
       )
@@ -35,17 +35,17 @@ describe("registered_models", () => {
 
   it("does not leak endpoint capabilities into another explicit provider", () => {
     const resolved = registered_models.resolve(
-      "openai/gpt-5.4-mini",
+      "openai/gpt-5.6-luna",
       [endpoint],
       "gg"
     );
-    expect(resolved?.label).toBe("GPT-5.4 Mini");
+    expect(resolved?.label).toBe("GPT-5.6 Luna");
     expect(resolved?.imageInputMimes).toContain("image/jpeg");
   });
 
   it("still resolves the static catalog when no endpoint owns the id", () => {
-    expect(registered_models.resolve("openai/gpt-5.4-mini", [])).toMatchObject({
-      label: "GPT-5.4 Mini",
+    expect(registered_models.resolve("openai/gpt-5.6-luna", [])).toMatchObject({
+      label: "GPT-5.6 Luna",
     });
   });
 });

--- a/packages/grida-ai-agent/docs/chatgpt-subscription-provider.md
+++ b/packages/grida-ai-agent/docs/chatgpt-subscription-provider.md
@@ -105,8 +105,7 @@ supported set to the bare model names required by the subscription backend:
 - `openai/gpt-5.6-terra`;
 - `openai/gpt-5.6-luna`;
 - `openai/gpt-5.5`;
-- `openai/gpt-5.4`;
-- `openai/gpt-5.4-mini`.
+- `openai/gpt-5.4`.
 
 This allowlist mirrors the current observed Zed/Codex-compatible surface. It
 is not authenticated model discovery, may drift, and cannot prove that a

--- a/packages/grida-ai-agent/src/__public-api__.test.ts
+++ b/packages/grida-ai-agent/src/__public-api__.test.ts
@@ -191,7 +191,7 @@ describe("@grida/agent public API", () => {
       // Tier constants.
       expect(AGENT_TIERS).toContain(AGENT_DEFAULT_TIER);
       const tier: ModelTier = AGENT_DEFAULT_TIER;
-      const modelId: AgentModelId = "anthropic/claude-sonnet-4.6";
+      const modelId: AgentModelId = "anthropic/claude-sonnet-5";
       expect(typeof tier).toBe("string");
       expect(modelId).toContain("/");
 

--- a/packages/grida-ai-agent/src/cli.test.ts
+++ b/packages/grida-ai-agent/src/cli.test.ts
@@ -346,14 +346,14 @@ describe("CLI — parseRunArgs", () => {
       "--mode",
       "auto",
       "--model",
-      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-sonnet-5",
       "draw",
       "a",
       "cat",
     ]);
     expect(r.workspace).toBe("/proj");
     expect(r.mode).toBe("auto");
-    expect(r.model_id).toBe("anthropic/claude-sonnet-4.6");
+    expect(r.model_id).toBe("anthropic/claude-sonnet-5");
     expect(r.message).toBe("draw a cat");
     // The -w alias works too.
     expect(parseRunArgs(["-w", "/p", "hi"]).workspace).toBe("/p");

--- a/packages/grida-ai-agent/src/e2e-approval-resume.test.ts
+++ b/packages/grida-ai-agent/src/e2e-approval-resume.test.ts
@@ -64,7 +64,7 @@ function promptHasToolResult(prompt: unknown): boolean {
 function makeMockModel(): MockLanguageModelV3 {
   return new MockLanguageModelV3({
     provider: "openrouter",
-    modelId: "openai/gpt-5.4-nano",
+    modelId: "openai/gpt-5.6-luna",
     doStream: async (options) => {
       const prompt = options.prompt as unknown[];
       const wantsCommand =

--- a/packages/grida-ai-agent/src/e2e.test.ts
+++ b/packages/grida-ai-agent/src/e2e.test.ts
@@ -62,7 +62,7 @@ function makeMockModel(): MockLanguageModelV3 {
   let call = 0;
   return new MockLanguageModelV3({
     provider: "openrouter",
-    modelId: "openai/gpt-5.4-nano",
+    modelId: "openai/gpt-5.6-luna",
     doStream: async (options) => {
       call += 1;
       const prompt = options.prompt as unknown[];

--- a/packages/grida-ai-agent/src/http/routes/agent.test.ts
+++ b/packages/grida-ai-agent/src/http/routes/agent.test.ts
@@ -592,7 +592,7 @@ describe("HTTP wire — agent routes (run/stream/abort)", () => {
       method: "POST",
       body: JSON.stringify({
         messages: [{ id: "m", role: "user", content: "hi" }],
-        model_id: "anthropic/claude-opus-4.7",
+        model_id: "anthropic/claude-opus-5",
       }),
     });
     expect(res.status).toBe(200);
@@ -602,7 +602,7 @@ describe("HTTP wire — agent routes (run/stream/abort)", () => {
     // The catalog id the user picked is stamped on the row — so a
     // reload re-seeds the picker with the same model.
     const session = await sessionsStore.get(sessionId);
-    expect(session?.model?.model_id).toBe("anthropic/claude-opus-4.7");
+    expect(session?.model?.model_id).toBe("anthropic/claude-opus-5");
 
     // Settle the recorder's full async write chain before teardown
     // closes the DB — wait for the streamed text part to land, not just

--- a/packages/grida-ai-agent/src/protocol/chatgpt.ts
+++ b/packages/grida-ai-agent/src/protocol/chatgpt.ts
@@ -28,7 +28,6 @@ export const CHATGPT_SUBSCRIPTION_MODEL_IDS = [
   "openai/gpt-5.6-luna",
   "openai/gpt-5.5",
   "openai/gpt-5.4",
-  "openai/gpt-5.4-mini",
 ] as const;
 
 export type ChatGptSubscriptionModelId =
@@ -41,7 +40,6 @@ export const CHATGPT_SUBSCRIPTION_MODEL_METADATA = {
   "openai/gpt-5.6-luna": { label: "GPT-5.6 Luna" },
   "openai/gpt-5.5": { label: "GPT-5.5" },
   "openai/gpt-5.4": { label: "GPT-5.4" },
-  "openai/gpt-5.4-mini": { label: "GPT-5.4 Mini" },
 } as const satisfies Record<
   ChatGptSubscriptionModelId,
   Readonly<{ label: string }>

--- a/packages/grida-ai-agent/src/protocol/run.ts
+++ b/packages/grida-ai-agent/src/protocol/run.ts
@@ -91,7 +91,7 @@ export type AgentRunOptions = {
   tier?: ModelTier;
   /**
    * Explicit catalog model id (`creator/model`, e.g.
-   * `"anthropic/claude-opus-4.7"`). When set, it overrides the
+   * `"anthropic/claude-opus-5"`). When set, it overrides the
    * tier-to-model mapping; the agent host runs this exact model instead of
    * the one `tier` would resolve to.
    */

--- a/packages/grida-ai-agent/src/providers/chatgpt.test.ts
+++ b/packages/grida-ai-agent/src/providers/chatgpt.test.ts
@@ -34,7 +34,7 @@ const CONFIG: ChatGptProviderConfig = {
   originator: "grida-test",
   default_model_id: "openai/gpt-5.6-terra",
   tier_model_ids: {
-    nano: "openai/gpt-5.4-mini",
+    nano: "openai/gpt-5.6-luna",
     pro: "openai/gpt-5.6-terra",
     max: "openai/gpt-5.6-sol",
   },
@@ -60,14 +60,13 @@ afterEach(async () => {
 });
 
 describe("ChatGptProvider", () => {
-  it("pins the six-model namespaced allowlist mirrored from the reference client", () => {
+  it("pins the five-model namespaced allowlist mirrored from the reference client", () => {
     expect(CHATGPT_SUBSCRIPTION_MODEL_IDS).toEqual([
       "openai/gpt-5.6-sol",
       "openai/gpt-5.6-terra",
       "openai/gpt-5.6-luna",
       "openai/gpt-5.5",
       "openai/gpt-5.4",
-      "openai/gpt-5.4-mini",
     ]);
     for (const id of CHATGPT_SUBSCRIPTION_MODEL_IDS) {
       expect(isChatGptSubscriptionModelId(id)).toBe(true);
@@ -156,7 +155,7 @@ describe("ChatGptProvider", () => {
     let requestBody: Record<string, unknown> = {};
     const { factory } = runtime(async (_input, init) => {
       requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
-      return completedResponse("gpt-5.4-mini");
+      return completedResponse("gpt-5.6-luna");
     });
 
     await generateText({
@@ -554,7 +553,7 @@ function completedStreamEvent(): Record<string, unknown> {
 // chain has one definition.
 describe("tierModelId", () => {
   it("prefers the configured tier entry", () => {
-    expect(tierModelId(CONFIG, "nano")).toBe("openai/gpt-5.4-mini");
+    expect(tierModelId(CONFIG, "nano")).toBe("openai/gpt-5.6-luna");
     expect(tierModelId(CONFIG, "max")).toBe("openai/gpt-5.6-sol");
   });
 

--- a/packages/grida-ai-agent/src/providers/chatgpt.ts
+++ b/packages/grida-ai-agent/src/providers/chatgpt.ts
@@ -231,7 +231,6 @@ const CHATGPT_WIRE_MODEL_BY_ID: Record<ChatGptSubscriptionModelId, string> = {
   "openai/gpt-5.6-luna": "gpt-5.6-luna",
   "openai/gpt-5.5": "gpt-5.5",
   "openai/gpt-5.4": "gpt-5.4",
-  "openai/gpt-5.4-mini": "gpt-5.4-mini",
 };
 
 function toWireModelId(modelId: ChatGptSubscriptionModelId): string {

--- a/packages/grida-ai-agent/src/providers/gg.test.ts
+++ b/packages/grida-ai-agent/src/providers/gg.test.ts
@@ -114,11 +114,11 @@ describe("makeGridaGatewayFactory", () => {
     ) as { model: string };
     expect(body1.model).toBe(TIER_MODEL_IDS.pro);
 
-    await callModel(store, "openai/gpt-5.4-mini");
+    await callModel(store, "google/gemini-3.8-flash");
     const body2 = JSON.parse(
       (fetchMock.mock.calls[1]![1] as RequestInit).body as string
     ) as { model: string };
-    expect(body2.model).toBe("openai/gpt-5.4-mini");
+    expect(body2.model).toBe("google/gemini-3.8-flash");
   });
 
   it("missing/expired session → GridaGatewayAuthError before any fetch", async () => {

--- a/packages/grida-ai-agent/src/runtime/image-gen.live.test.ts
+++ b/packages/grida-ai-agent/src/runtime/image-gen.live.test.ts
@@ -42,7 +42,7 @@ const PROVIDER_ID = (process.env.GRIDA_BYOK_PROVIDER ?? "openrouter") as
   | "openrouter"
   | "vercel"
   | "fal";
-const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6";
+const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-5";
 // The image model is HOST config (the user's selection), not an agent arg — the
 // tool is prompt-only. Inject a fast, reliable one for the test (seedream) via
 // the runtime's `image_model_id`, overridable per provider.

--- a/packages/grida-ai-agent/src/runtime/runtime.live.test.ts
+++ b/packages/grida-ai-agent/src/runtime/runtime.live.test.ts
@@ -55,7 +55,7 @@ const LIVE_AUTH_DIR = process.env.GRIDA_LIVE_AUTH_DIR?.trim() || undefined;
 const PROVIDER_ID = (process.env.GRIDA_BYOK_PROVIDER ?? "openrouter") as
   | "openrouter"
   | "vercel";
-const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6";
+const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-5";
 const TIMEOUT_MS = 90_000;
 
 // The shipped bundled skills tree (<repo>/skills), four levels up from here.

--- a/packages/grida-ai-agent/src/runtime/runtime.test.ts
+++ b/packages/grida-ai-agent/src/runtime/runtime.test.ts
@@ -168,7 +168,7 @@ describe("agent workspace bindings", () => {
       () =>
         new MockLanguageModelV3({
           provider: "openrouter",
-          modelId: "openai/gpt-5.4-nano",
+          modelId: "openai/gpt-5.6-luna",
           doStream: {
             stream: simulateReadableStream({
               chunks: [
@@ -242,7 +242,7 @@ describe("agent workspace bindings", () => {
     const providerHttp = new ProviderHttp({ request, download });
     const model = new MockLanguageModelV3({
       provider: "openrouter",
-      modelId: "openai/gpt-5.4-nano",
+      modelId: "openai/gpt-5.6-luna",
       supportedUrls: {},
       doStream: {
         stream: simulateReadableStream({
@@ -322,7 +322,7 @@ describe("agent workspace bindings", () => {
       () =>
         new MockLanguageModelV3({
           provider: "openrouter",
-          modelId: "openai/gpt-5.4-nano",
+          modelId: "openai/gpt-5.6-luna",
           doStream: {
             stream: simulateReadableStream({
               chunks: [

--- a/packages/grida-ai-agent/src/runtime/sandbox-repro.live.test.ts
+++ b/packages/grida-ai-agent/src/runtime/sandbox-repro.live.test.ts
@@ -49,7 +49,7 @@ const PROVIDER_KEY =
 const PROVIDER_ID = (process.env.GRIDA_BYOK_PROVIDER ?? "openrouter") as
   | "openrouter"
   | "vercel";
-const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6";
+const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-5";
 const TIMEOUT_MS = 240_000;
 
 const liveDescribe = LIVE && PROVIDER_KEY ? describe : describe.skip;

--- a/packages/grida-ai-agent/src/runtime/scratch.live.test.ts
+++ b/packages/grida-ai-agent/src/runtime/scratch.live.test.ts
@@ -43,7 +43,7 @@ const PROVIDER_KEY =
 const PROVIDER_ID = (process.env.GRIDA_BYOK_PROVIDER ?? "openrouter") as
   | "openrouter"
   | "vercel";
-const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6";
+const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-5";
 const TIMEOUT_MS = 240_000;
 
 const liveDescribe = LIVE && PROVIDER_KEY ? describe : describe.skip;

--- a/packages/grida-ai-agent/src/session/store.test.ts
+++ b/packages/grida-ai-agent/src/session/store.test.ts
@@ -614,7 +614,7 @@ describe("SessionsStore rollups", () => {
       model: {
         provider_id: "openrouter",
         tier: "mini",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
       },
       usage: { input: 50, output: 10 },
     });
@@ -654,7 +654,7 @@ describe("SessionsStore rollups", () => {
     const model = {
       provider_id: "openrouter",
       tier: "mini",
-      model_id: "openai/gpt-5.4-mini",
+      model_id: "openai/gpt-5.6-luna",
     } as const;
 
     await store.setMessageAccounting(a.id, {
@@ -697,7 +697,7 @@ describe("SessionsStore rollups", () => {
       model: {
         provider_id: "openrouter",
         tier: "mini",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
       },
       usage: { input: 100, output: 10 },
     });
@@ -708,7 +708,7 @@ describe("SessionsStore rollups", () => {
       model: {
         provider_id: "openrouter",
         tier: "mini",
-        model_id: "openai/gpt-5.4-mini",
+        model_id: "openai/gpt-5.6-luna",
       },
       usage: { input: 50, output: 5 },
     });

--- a/packages/grida-ai-agent/src/vision/view-image.live.test.ts
+++ b/packages/grida-ai-agent/src/vision/view-image.live.test.ts
@@ -45,7 +45,7 @@ const PROVIDER_ID = (process.env.GRIDA_BYOK_PROVIDER ?? "openrouter") as
   | "openrouter"
   | "vercel"
   | "fal";
-const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-4.6";
+const MODEL_ID = process.env.GRIDA_LIVE_MODEL ?? "anthropic/claude-sonnet-5";
 const TIMEOUT_MS = 240_000;
 const liveDescribe = LIVE && PROVIDER_KEY ? describe : describe.skip;
 

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -192,9 +192,9 @@ out of the catalogue until that support exists.
 
 `models.text.modelSpecById(modelId)` accepts:
 
-- Full ids, such as `openai/gpt-5.4-mini`
-- Bare ids, such as `gpt-5.4-mini`
-- Date-suffixed provider ids, such as `gpt-5.4-mini-2025-08-07`
+- Full ids, such as `openai/gpt-5.6-luna`
+- Bare ids, such as `gpt-5.6-luna`
+- Date-suffixed provider ids, such as `gpt-5.6-luna-2026-07-30`
 
 `models.image.findImageModelCard(model)` accepts:
 

--- a/packages/grida-ai-models/__tests__/modelSpecById.test.ts
+++ b/packages/grida-ai-models/__tests__/modelSpecById.test.ts
@@ -18,6 +18,10 @@ describe("models.text.modelSpecById", () => {
       id: "anthropic/claude-fable-5",
       label: "Claude Fable 5",
     },
+    {
+      id: "google/gemini-3.8-flash",
+      label: "Gemini 3.8 Flash",
+    },
   ])("resolves the exact $id gateway id", ({ id, label }) => {
     const spec = models.text.modelSpecById(id);
     expect(spec?.id).toBe(id);
@@ -25,15 +29,15 @@ describe("models.text.modelSpecById", () => {
   });
 
   it("resolves a bare provider id", () => {
-    const spec = models.text.modelSpecById("gpt-5.4-mini");
-    expect(spec?.id).toBe("openai/gpt-5.4-mini");
+    const spec = models.text.modelSpecById("gpt-5.6-luna");
+    expect(spec?.id).toBe("openai/gpt-5.6-luna");
   });
 
   it("tolerates a snapshot date suffix on a bare id", () => {
     // Providers often append a snapshot date to the model id in
     // streaming response payloads.
-    const spec = models.text.modelSpecById("gpt-5.4-mini-2025-08-07");
-    expect(spec?.id).toBe("openai/gpt-5.4-mini");
+    const spec = models.text.modelSpecById("gpt-5.6-luna-2026-07-30");
+    expect(spec?.id).toBe("openai/gpt-5.6-luna");
   });
 
   it("returns undefined for an unknown id", () => {
@@ -41,9 +45,9 @@ describe("models.text.modelSpecById", () => {
   });
 
   it("returns undefined for a bare suffix without leading -<digit>", () => {
-    // `gpt-5.4-miniature` is not a snapshot suffix — must not match
-    // `openai/gpt-5.4-mini`.
-    expect(models.text.modelSpecById("gpt-5.4-miniature")).toBeUndefined();
+    // `gpt-5.6-lunatic` is not a snapshot suffix — must not match
+    // `openai/gpt-5.6-luna`.
+    expect(models.text.modelSpecById("gpt-5.6-lunatic")).toBeUndefined();
   });
 
   it("resolves every tier-mapped id to a real spec", () => {

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -709,6 +709,13 @@ describe("models.text current catalogue", () => {
       cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
     },
     {
+      id: "google/gemini-3.8-flash",
+      contextWindow: 1_048_576,
+      outputLimit: 65_536,
+      // Steady state, not Google's promotional rate through 2026-12-31.
+      cost: { input: 1.5, output: 7.5, cacheRead: 0.15 },
+    },
+    {
       id: "google/gemini-3.7-flash",
       contextWindow: 1_048_576,
       outputLimit: 65_536,
@@ -782,6 +789,12 @@ describe("models.text current catalogue", () => {
     expect(models.text.catalog["anthropic/claude-opus-4.8"].deprecated).toBe(
       true
     );
+    expect(
+      models.text.catalog["google/gemini-3.8-flash"].deprecated
+    ).toBeUndefined();
+    expect(models.text.catalog["google/gemini-3.7-flash"].deprecated).toBe(
+      true
+    );
   });
 });
 
@@ -815,10 +828,10 @@ describe("models.text image-input MIME capabilities", () => {
     }
 
     expect(
-      models.text.catalog["google/gemini-3.7-flash"].imageInputMimes
+      models.text.catalog["google/gemini-3.8-flash"].imageInputMimes
     ).toContain("image/heic");
     expect(
-      models.text.catalog["openai/gpt-5.4-mini"].imageInputMimes
+      models.text.catalog["openai/gpt-5.6-luna"].imageInputMimes
     ).not.toContain("image/heic");
   });
 });
@@ -831,7 +844,7 @@ describe("models.text.displayLabel", () => {
   });
 
   it("falls back to the full label when short_label is unset", () => {
-    const spec = models.text.catalog["openai/gpt-5.4-nano"];
+    const spec = models.text.catalog["openai/gpt-5.6-luna"];
     expect(spec.short_label).toBeUndefined();
     expect(models.text.displayLabel(spec)).toBe(spec.label);
   });

--- a/packages/grida-ai-models/__tests__/registry.test.ts
+++ b/packages/grida-ai-models/__tests__/registry.test.ts
@@ -58,7 +58,7 @@ describe("models.text.registry.normalize", () => {
 describe("models.text.registry.resolve", () => {
   const custom = [
     { id: "llama3.1:8b" },
-    { id: "anthropic/claude-sonnet-4.6", label: "shadowed" },
+    { id: "anthropic/claude-sonnet-5", label: "shadowed" },
   ];
 
   it("resolves a catalogue id with custom: false and cost present", () => {
@@ -91,9 +91,9 @@ describe("models.text.registry.resolve", () => {
   });
 
   it("catalogue wins over a colliding custom entry", () => {
-    const spec = registry.resolve("anthropic/claude-sonnet-4.6", custom);
+    const spec = registry.resolve("anthropic/claude-sonnet-5", custom);
     expect(spec?.custom).toBe(false);
-    expect(spec?.label).toBe("Claude Sonnet 4.6");
+    expect(spec?.label).toBe("Claude Sonnet 5");
   });
 
   it("returns undefined for an unknown id", () => {

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -271,26 +271,6 @@ export namespace models {
     } as const satisfies NonNullable<ModelCostPerMillion["longContext"]>;
 
     const catalogSpecs = {
-      "openai/gpt-5.4-nano": {
-        id: "openai/gpt-5.4-nano",
-        label: "GPT-5.4 Nano",
-        multimodal: true,
-        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
-        tool_call: true,
-        contextWindow: 400_000,
-        outputLimit: 128_000,
-        cost: { input: 0.2, output: 1.25, cacheRead: 0.02 },
-      },
-      "openai/gpt-5.4-mini": {
-        id: "openai/gpt-5.4-mini",
-        label: "GPT-5.4 Mini",
-        multimodal: true,
-        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
-        tool_call: true,
-        contextWindow: 400_000,
-        outputLimit: 128_000,
-        cost: { input: 0.75, output: 4.5, cacheRead: 0.075 },
-      },
       "openai/gpt-5.5": {
         id: "openai/gpt-5.5",
         label: "GPT-5.5",
@@ -386,18 +366,6 @@ export namespace models {
         outputLimit: 128_000,
         cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       },
-      "anthropic/claude-sonnet-4.6": {
-        id: "anthropic/claude-sonnet-4.6",
-        label: "Claude Sonnet 4.6",
-        short_label: "Sonnet 4.6",
-        multimodal: true,
-        imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
-        tool_call: true,
-        contextWindow: 1_000_000,
-        outputLimit: 128_000,
-        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-        deprecated: true,
-      },
       // Same input/output/cacheWrite card as Claude Fable 5, with cache reads
       // cut to $0.25/MTok. Not a drop-in successor — forced tool choice
       // (`tool_choice` `any`/`tool`) is rejected here — which is why Fable 5
@@ -453,26 +421,33 @@ export namespace models {
         cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
         deprecated: true,
       },
-      "anthropic/claude-opus-4.7": {
-        id: "anthropic/claude-opus-4.7",
-        label: "Claude Opus 4.7",
-        short_label: "Opus 4.7",
-        multimodal: true,
-        imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
-        tool_call: true,
-        contextWindow: 1_000_000,
-        outputLimit: 128_000,
-        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-        deprecated: true,
-      },
       // Google's cache model is read + hourly storage (no one-time write
       // premium that matches `cacheWrite` semantics), so the field is omitted.
       //
       // Steady-state rates. Google is promoting $0.75 in / $3.75 out / $0.075
       // cacheRead through 2026-12-31; these are the prices that apply from
       // 2027-01-01. Checking Google's page before then will show the lower
-      // set — that is the promotion, not a correction.
+      // set — that is the promotion, not a correction. Gemini 3.8 Flash is GA,
+      // and this exact id is live on both Vercel AI Gateway and OpenRouter.
+      // https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
       // https://ai.google.dev/gemini-api/docs/pricing
+      // https://vercel.com/ai-gateway/models/gemini-3.8-flash
+      // https://openrouter.ai/google/gemini-3.8-flash
+      "google/gemini-3.8-flash": {
+        id: "google/gemini-3.8-flash",
+        label: "Gemini 3.8 Flash",
+        multimodal: true,
+        imageInputMimes: GOOGLE_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_048_576,
+        outputLimit: 65_536,
+        cost: { input: 1.5, output: 7.5, cacheRead: 0.15 },
+      },
+      // 3.8 improves accuracy and reliability at the same rate, but Google
+      // still recommends 3.7 when compute efficiency matters because 3.8 can
+      // consume more tokens. Keep it callable as a deprecated choice rather
+      // than deleting a model that remains better on a real axis.
+      // https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash
       "google/gemini-3.7-flash": {
         id: "google/gemini-3.7-flash",
         label: "Gemini 3.7 Flash",
@@ -482,6 +457,7 @@ export namespace models {
         contextWindow: 1_048_576,
         outputLimit: 65_536,
         cost: { input: 1.5, output: 7.5, cacheRead: 0.15 },
+        deprecated: true,
       },
       "google/gemini-3.1-pro-preview": {
         id: "google/gemini-3.1-pro-preview",
@@ -532,9 +508,9 @@ export namespace models {
      * Look up a model spec by id.
      *
      * Accepts:
-     * - Namespaced id: `"openai/gpt-5.4-mini"` (exact match)
-     * - Bare id: `"gpt-5.4-mini"` (matches `openai/gpt-5.4-mini`)
-     * - Date-suffixed id: `"gpt-5.4-mini-2025-08-07"` (providers often
+     * - Namespaced id: `"openai/gpt-5.6-luna"` (exact match)
+     * - Bare id: `"gpt-5.6-luna"` (matches `openai/gpt-5.6-luna`)
+     * - Date-suffixed id: `"gpt-5.6-luna-2026-07-30"` (providers often
      *   append a snapshot date in their API responses)
      */
     export function modelSpecById(modelId: string): ModelSpec | undefined {

--- a/packages/grida-ai-models/src/tiers.ts
+++ b/packages/grida-ai-models/src/tiers.ts
@@ -41,12 +41,10 @@ export type ModelTier = "nano" | "mini" | "pro" | "max";
  * cheaper — when one model is both the lowest reasonable choice and
  * the best value at `mini`, the two tiers collapse onto the same id.
  *
- * That is the state today. OpenAI's 2026-07-30 cut dropped GPT-5.6
- * Luna to $0.20 in / $1.20 out, past the older GPT-5.4 Nano ($0.20 in
- * / $1.25 out) while carrying 1.05M context against Nano's 400K —
- * leaving nothing that is both cheaper and adequate. OpenAI positions
- * Luna as the 5.6 generation's nano-class model, so this is one model
- * serving two tiers, not a tier being over-served.
+ * That is the state today. OpenAI positions GPT-5.6 Luna as the 5.6
+ * generation's nano-class model, and its current rate and 1.05M context
+ * make it both the lowest reasonable choice and the best value at `mini`.
+ * This is one model serving two tiers, not a tier being over-served.
  * See https://github.com/gridaco/grida/pull/1009.
  *
  * Expect the tiers to separate again as new models land. The invariant


### PR DESCRIPTION
## Summary

- add `google/gemini-3.8-flash` with verified Google, Vercel AI Gateway, and OpenRouter availability
- deprecate Gemini 3.7 Flash while retaining it for compute-efficient workloads
- remove GPT-5.4 Nano, GPT-5.4 Mini, Claude Sonnet 4.6, and Claude Opus 4.7 from the model catalog and dependent fixtures
- narrow the ChatGPT subscription compatibility projection and bump Desktop to 0.0.20

## Verification

- `pnpm --filter @grida/ai-models test` — 182 passed
- `pnpm --filter @grida/agent test` — 1,180 passed
- focused editor model tests — 60 passed
- Desktop test suite — 387 passed
- AI models, agent, editor, and Desktop typechecks passed
- formatting and lint passed with no errors
- repository-wide stale-model search returned no matches

## Security

Reviewed `GRIDA-SEC-008`. This change only narrows the closed ChatGPT model allowlist; OAuth correlation, credential custody, renderer DTOs, endpoint pinning, provider stickiness, and ACP isolation remain unchanged. All boundary tags remain in place and adjacent provider/Desktop tests pass.

Desktop release impact: version bump included.