### PR TITLE
Add reusable audio player for generated music and SFX

### DIFF
--- a/editor/kits/AGENTS.md
+++ b/editor/kits/AGENTS.md
@@ -60,6 +60,7 @@ General conventions:
 | `email-template-authoring` | Email-client-style template authoring UI.        | `@/kits/email-template-authoring` |
 | `library-explorer`         | Embedded infinite Library browser.               | `@/kits/library-explorer`         |
 | `memory-navigator`         | Scoped, typed in-memory navigation stack.        | `@/kits/memory-navigator`         |
+| `audio-player`             | Single-track audio playback and metadata UI.     | `@/kits/audio-player`             |
 
 ## API design guidelines
 

--- a/editor/kits/audio-player/README.md
+++ b/editor/kits/audio-player/README.md
@@ -31,6 +31,8 @@ import { AudioPlayer } from "@/kits/audio-player";
 
 Pass `artwork={{ src, alt }}` when real artwork is available. Without it, the
 kit renders a deliberate, platform-neutral music placeholder.
+`active={false}` pauses audio and disables the play control without discarding
+the current position.
 
 For short voice or sound-effect clips, select the waveform visualization:
 

--- a/editor/kits/audio-player/README.md
+++ b/editor/kits/audio-player/README.md
@@ -1,0 +1,32 @@
+# `@/kits/audio-player`
+
+For Grida feature authors who need single-track playback, this kit is a
+drop-in player for one audio source. It owns playback, seeking, volume,
+metadata loading, object URL cleanup, and its neutral artwork placeholder. It
+has no model, storage, route, or desktop dependency.
+
+The source may be a browser-loadable URL or a `Blob`/`File`. Product-specific
+metadata and side effects stay with the consumer:
+
+```tsx
+import { FolderSearch } from "lucide-react";
+import { AudioPlayer } from "@/kits/audio-player";
+
+<AudioPlayer
+  source={file}
+  title="Generated track"
+  subtitle="Lyria"
+  eyebrow="AI generated track"
+  details="track.mp3 · MP3 audio"
+  actions={[
+    {
+      label: "Show in Finder",
+      icon: <FolderSearch aria-hidden />,
+      onSelect: revealStoredFile,
+    },
+  ]}
+/>;
+```
+
+Pass `artwork={{ src, alt }}` when real artwork is available. Without it, the
+kit renders a deliberate, platform-neutral music placeholder.

--- a/editor/kits/audio-player/README.md
+++ b/editor/kits/audio-player/README.md
@@ -2,8 +2,9 @@
 
 For Grida feature authors who need single-track playback, this kit is a
 drop-in player for one audio source. It owns playback, seeking, volume,
-metadata loading, object URL cleanup, and its neutral artwork placeholder. It
-has no model, storage, route, or desktop dependency.
+metadata loading, object URL cleanup, and either a neutral artwork placeholder
+or an audio-derived waveform. It has no model, storage, route, or desktop
+dependency.
 
 The source may be a browser-loadable URL or a `Blob`/`File`. Product-specific
 metadata and side effects stay with the consumer:
@@ -30,3 +31,20 @@ import { AudioPlayer } from "@/kits/audio-player";
 
 Pass `artwork={{ src, alt }}` when real artwork is available. Without it, the
 kit renders a deliberate, platform-neutral music placeholder.
+
+For short voice or sound-effect clips, select the waveform visualization:
+
+```tsx
+<AudioPlayer
+  source={file}
+  visualization="waveform"
+  title="Generated sound effect"
+  subtitle="ElevenLabs Sound Effects"
+/>
+```
+
+The waveform variant decodes the complete source with the browser's Web Audio
+API, reduces all channels into a normalized peak envelope, and falls back to a
+regular seek slider if decoding is unavailable. URL sources must therefore be
+fetchable under the page's CORS policy; Blob and File sources have no network
+dependency.

--- a/editor/kits/audio-player/audio-player.tsx
+++ b/editor/kits/audio-player/audio-player.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
 import { Music2, Pause, Play, Volume2, VolumeX } from "lucide-react";
 import { Button } from "@app/ui/components/button";
 import { Slider } from "@app/ui/components/slider";
 import { cn } from "@app/ui/lib/utils";
+import { AudioWaveform } from "./waveform";
 
 export type AudioPlayerArtwork = {
   src: string;
@@ -18,17 +26,34 @@ export type AudioPlayerAction = {
   disabled?: boolean;
 };
 
-export type AudioPlayerProps = {
+type AudioPlayerSharedProps = {
   source: string | Blob;
   title: string;
   subtitle?: string;
   eyebrow?: string;
   details?: string;
-  artwork?: AudioPlayerArtwork;
   actions?: readonly AudioPlayerAction[];
   active?: boolean;
   className?: string;
 };
+
+export type AudioPlayerVisualization = "artwork" | "waveform";
+
+export type AudioPlayerProps = AudioPlayerSharedProps &
+  (
+    | {
+        visualization?: "artwork";
+        artwork?: AudioPlayerArtwork;
+      }
+    | {
+        visualization: "waveform";
+        artwork?: never;
+      }
+  );
+
+type WaveformState =
+  | { kind: "idle" | "loading" | "failed" }
+  | { kind: "ready"; peaks: number[] };
 
 /** Opinionated single-track audio playback for URL and Blob sources. */
 export function AudioPlayer({
@@ -38,6 +63,7 @@ export function AudioPlayer({
   eyebrow,
   details,
   artwork,
+  visualization = "artwork",
   actions = [],
   active = true,
   className,
@@ -50,6 +76,7 @@ export function AudioPlayer({
   const [muted, setMuted] = useState(false);
   const [metadataReady, setMetadataReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [waveform, setWaveform] = useState<WaveformState>({ kind: "idle" });
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -86,6 +113,30 @@ export function AudioPlayer({
   }, [source]);
 
   useEffect(() => {
+    if (visualization !== "waveform") {
+      setWaveform({ kind: "idle" });
+      return;
+    }
+
+    const controller = new AbortController();
+    setWaveform({ kind: "loading" });
+    void AudioWaveform.decode(
+      source,
+      AudioWaveform.DEFAULT_BAR_COUNT,
+      controller.signal
+    )
+      .then((peaks) => {
+        if (!controller.signal.aborted) {
+          setWaveform({ kind: "ready", peaks });
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setWaveform({ kind: "failed" });
+      });
+    return () => controller.abort();
+  }, [source, visualization]);
+
+  useEffect(() => {
     if (!active) audioRef.current?.pause();
   }, [active]);
 
@@ -103,11 +154,16 @@ export function AudioPlayer({
     }
   };
 
-  const seek = ([nextTime]: number[]) => {
+  const seekTo = (nextTime: number) => {
     const audio = audioRef.current;
-    if (!audio || nextTime === undefined) return;
-    audio.currentTime = nextTime;
-    setTime(nextTime);
+    if (!audio) return;
+    const boundedTime = Math.max(0, Math.min(nextTime, duration));
+    audio.currentTime = boundedTime;
+    setTime(boundedTime);
+  };
+
+  const seek = ([nextTime]: number[]) => {
+    if (nextTime !== undefined) seekTo(nextTime);
   };
 
   const changeVolume = ([nextVolume]: number[]) => {
@@ -164,8 +220,14 @@ export function AudioPlayer({
         }}
       />
 
-      <div className="grid items-center gap-6 sm:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)] sm:gap-8">
-        <Artwork artwork={artwork} />
+      <div
+        className={cn(
+          "grid items-center gap-6",
+          visualization === "artwork" &&
+            "sm:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)] sm:gap-8"
+        )}
+      >
+        {visualization === "artwork" && <Artwork artwork={artwork} />}
 
         <div className="min-w-0">
           <div className="text-center sm:text-left">
@@ -184,17 +246,30 @@ export function AudioPlayer({
             )}
           </div>
 
-          <div className="mt-7">
-            <Slider
-              min={0}
-              max={duration || 1}
-              step={0.01}
-              value={[Math.min(time, duration || 0)]}
-              disabled={!metadataReady || Boolean(error)}
-              onValueChange={seek}
-              aria-label="Track position"
-              className="[&_[data-slot=slider-thumb]]:size-3"
-            />
+          <div className={visualization === "waveform" ? "mt-6" : "mt-7"}>
+            {visualization === "waveform" && waveform.kind !== "failed" ? (
+              <WaveformScrubber
+                peaks={waveform.kind === "ready" ? waveform.peaks : []}
+                currentTime={time}
+                duration={duration}
+                disabled={
+                  !metadataReady || Boolean(error) || waveform.kind !== "ready"
+                }
+                loading={waveform.kind === "loading"}
+                onSeek={seekTo}
+              />
+            ) : (
+              <Slider
+                min={0}
+                max={duration || 1}
+                step={0.01}
+                value={[Math.min(time, duration || 0)]}
+                disabled={!metadataReady || Boolean(error)}
+                onValueChange={seek}
+                aria-label="Track position"
+                className="[&_[data-slot=slider-thumb]]:size-3"
+              />
+            )}
             <div className="mt-2 flex justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
               <span>{formatTime(time)}</span>
               <span>{metadataReady ? formatTime(duration) : "--:--"}</span>
@@ -280,6 +355,139 @@ export function AudioPlayer({
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function WaveformScrubber({
+  peaks,
+  currentTime,
+  duration,
+  disabled,
+  loading,
+  onSeek,
+}: {
+  peaks: readonly number[];
+  currentTime: number;
+  duration: number;
+  disabled: boolean;
+  loading: boolean;
+  onSeek: (time: number) => void;
+}) {
+  const values =
+    peaks.length > 0
+      ? peaks
+      : Array<number>(AudioWaveform.DEFAULT_BAR_COUNT).fill(0);
+  const progress = duration > 0 ? Math.min(1, currentTime / duration) : 0;
+  const step = 4;
+  const barWidth = 2.5;
+  const width = values.length * step - (step - barWidth);
+  const height = 80;
+
+  const seekFromPointer = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const position = Math.max(
+      0,
+      Math.min(1, (event.clientX - bounds.left) / bounds.width)
+    );
+    onSeek(position * duration);
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    seekFromPointer(event);
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      seekFromPointer(event);
+    }
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    const stepSeconds = Math.max(0.5, duration / 100);
+    let nextTime: number | undefined;
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        nextTime = currentTime - stepSeconds;
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        nextTime = currentTime + stepSeconds;
+        break;
+      case "Home":
+        nextTime = 0;
+        break;
+      case "End":
+        nextTime = duration;
+        break;
+    }
+    if (nextTime === undefined) return;
+    event.preventDefault();
+    onSeek(nextTime);
+  };
+
+  return (
+    <div
+      role="slider"
+      aria-label="Track position"
+      aria-orientation="horizontal"
+      aria-valuemin={0}
+      aria-valuemax={duration}
+      aria-valuenow={currentTime}
+      aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
+      aria-disabled={disabled}
+      aria-busy={loading}
+      tabIndex={disabled ? -1 : 0}
+      className={cn(
+        "relative h-28 touch-none overflow-hidden rounded-xl border bg-muted/20 px-3 py-2 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        disabled ? "cursor-default" : "cursor-pointer",
+        loading && "animate-pulse"
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onKeyDown={onKeyDown}
+    >
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className="size-full"
+        aria-hidden
+      >
+        {values.map((value, index) => {
+          const barHeight = Math.max(5, Math.sqrt(value) * 64);
+          const played =
+            progress > 0 && (index + 0.5) / values.length <= progress;
+          return (
+            <rect
+              key={index}
+              x={index * step}
+              y={(height - barHeight) / 2}
+              width={barWidth}
+              height={barHeight}
+              rx={barWidth / 2}
+              fill="currentColor"
+              opacity={played ? 0.95 : loading ? 0.12 : 0.24}
+            />
+          );
+        })}
+        {progress > 0 && (
+          <line
+            x1={progress * width}
+            x2={progress * width}
+            y1={4}
+            y2={height - 4}
+            stroke="currentColor"
+            strokeWidth={1.5}
+            vectorEffect="non-scaling-stroke"
+            opacity={0.85}
+          />
+        )}
+      </svg>
     </div>
   );
 }

--- a/editor/kits/audio-player/audio-player.tsx
+++ b/editor/kits/audio-player/audio-player.tsx
@@ -1,35 +1,47 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import {
-  FolderSearch,
-  Music2,
-  Pause,
-  Play,
-  Volume2,
-  VolumeX,
-} from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Music2, Pause, Play, Volume2, VolumeX } from "lucide-react";
 import { Button } from "@app/ui/components/button";
 import { Slider } from "@app/ui/components/slider";
-import { AudioCompatibility } from "../media-formats/audio-compatibility";
+import { cn } from "@app/ui/lib/utils";
 
-export function MusicPlayer({
-  file,
-  active = true,
-  title = trackTitle(file.name),
-  artist = "Local audio",
-  generated = false,
-  revealLabel = "Show in folder",
-  onReveal,
-}: {
-  file: File;
+export type AudioPlayerArtwork = {
+  src: string;
+  alt: string;
+};
+
+export type AudioPlayerAction = {
+  label: string;
+  icon: ReactNode;
+  onSelect: () => void;
+  disabled?: boolean;
+};
+
+export type AudioPlayerProps = {
+  source: string | Blob;
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+  details?: string;
+  artwork?: AudioPlayerArtwork;
+  actions?: readonly AudioPlayerAction[];
   active?: boolean;
-  title?: string;
-  artist?: string;
-  generated?: boolean;
-  revealLabel?: string;
-  onReveal?: () => void;
-}) {
+  className?: string;
+};
+
+/** Opinionated single-track audio playback for URL and Blob sources. */
+export function AudioPlayer({
+  source,
+  title,
+  subtitle,
+  eyebrow,
+  details,
+  artwork,
+  actions = [],
+  active = true,
+  className,
+}: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [duration, setDuration] = useState(0);
   const [time, setTime] = useState(0);
@@ -38,7 +50,6 @@ export function MusicPlayer({
   const [muted, setMuted] = useState(false);
   const [metadataReady, setMetadataReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const support = AudioCompatibility.probe(file);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -50,13 +61,19 @@ export function MusicPlayer({
     setMetadataReady(false);
     setError(null);
 
-    let url: string;
+    let sourceUrl: string;
+    let objectUrl: string | undefined;
     try {
-      url = URL.createObjectURL(file);
-      audio.src = url;
+      if (typeof source === "string") {
+        sourceUrl = source;
+      } else {
+        objectUrl = URL.createObjectURL(source);
+        sourceUrl = objectUrl;
+      }
+      audio.src = sourceUrl;
       audio.load();
     } catch {
-      setError("This audio file could not be opened.");
+      setError("This audio source could not be opened.");
       return;
     }
 
@@ -64,9 +81,9 @@ export function MusicPlayer({
       audio.pause();
       audio.removeAttribute("src");
       audio.load();
-      URL.revokeObjectURL(url);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [file]);
+  }, [source]);
 
   useEffect(() => {
     if (!active) audioRef.current?.pause();
@@ -113,8 +130,11 @@ export function MusicPlayer({
 
   return (
     <div
-      data-testid="player-music"
-      className="w-full rounded-2xl border bg-card p-5 shadow-sm sm:p-6"
+      data-testid="kit-audio-player"
+      className={cn(
+        "w-full rounded-2xl border bg-card p-5 shadow-sm sm:p-6",
+        className
+      )}
     >
       <audio
         ref={audioRef}
@@ -140,37 +160,28 @@ export function MusicPlayer({
         onError={() => {
           setMetadataReady(false);
           setPlaying(false);
-          setError("This audio codec could not be played.");
+          setError("This audio source could not be played.");
         }}
       />
 
       <div className="grid items-center gap-6 sm:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)] sm:gap-8">
-        <div
-          className="relative mx-auto flex aspect-square w-full max-w-64 items-center justify-center overflow-hidden rounded-xl border border-black/5 bg-gradient-to-br from-zinc-100 via-zinc-200 to-zinc-300 shadow-[0_18px_45px_-24px_rgba(0,0,0,0.55)] dark:border-white/10 dark:from-zinc-700 dark:via-zinc-800 dark:to-zinc-950"
-          role="img"
-          aria-label="Album artwork placeholder"
-        >
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_28%_20%,rgba(255,255,255,0.7),transparent_42%)] opacity-80 dark:opacity-15" />
-          <Music2
-            className="relative size-[34%] text-zinc-500/65 drop-shadow-sm dark:text-zinc-300/65"
-            strokeWidth={1.45}
-            aria-hidden
-          />
-        </div>
+        <Artwork artwork={artwork} />
 
         <div className="min-w-0">
           <div className="text-center sm:text-left">
-            {generated && (
+            {eyebrow && (
               <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                AI generated track
+                {eyebrow}
               </div>
             )}
             <h3 className="line-clamp-2 text-xl font-semibold tracking-tight sm:text-2xl">
               {title}
             </h3>
-            <p className="mt-1 truncate text-sm text-muted-foreground">
-              {artist}
-            </p>
+            {subtitle && (
+              <p className="mt-1 truncate text-sm text-muted-foreground">
+                {subtitle}
+              </p>
+            )}
           </div>
 
           <div className="mt-7">
@@ -235,24 +246,28 @@ export function MusicPlayer({
             </div>
           </div>
 
-          <div className="mt-5 flex min-w-0 items-center gap-2 border-t pt-3 text-xs text-muted-foreground">
-            <span className="min-w-0 flex-1 truncate">
-              {file.name} · {support.label}
-            </span>
-            {onReveal && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="-mr-2 shrink-0"
-                onClick={onReveal}
-                aria-label={revealLabel}
-                title={revealLabel}
-              >
-                <FolderSearch aria-hidden />
-              </Button>
-            )}
-          </div>
+          {(details || actions.length > 0) && (
+            <div className="mt-5 flex min-w-0 items-center gap-2 border-t pt-3 text-xs text-muted-foreground">
+              {details && (
+                <span className="min-w-0 flex-1 truncate">{details}</span>
+              )}
+              {actions.map((action) => (
+                <Button
+                  key={action.label}
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="-mr-2 shrink-0"
+                  onClick={action.onSelect}
+                  disabled={action.disabled}
+                  aria-label={action.label}
+                  title={action.label}
+                >
+                  {action.icon}
+                </Button>
+              ))}
+            </div>
+          )}
           {!metadataReady && !error && (
             <p className="mt-2 text-xs text-muted-foreground" role="status">
               Reading audio metadata…
@@ -269,9 +284,29 @@ export function MusicPlayer({
   );
 }
 
-function trackTitle(filename: string): string {
-  const withoutExtension = filename.replace(/\.[^.]+$/, "").trim();
-  return withoutExtension || "Untitled track";
+function Artwork({ artwork }: { artwork?: AudioPlayerArtwork }) {
+  return (
+    <div className="relative mx-auto flex aspect-square w-full max-w-64 items-center justify-center overflow-hidden rounded-xl border border-black/5 bg-gradient-to-br from-zinc-100 via-zinc-200 to-zinc-300 shadow-[0_18px_45px_-24px_rgba(0,0,0,0.55)] dark:border-white/10 dark:from-zinc-700 dark:via-zinc-800 dark:to-zinc-950">
+      {artwork ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={artwork.src}
+          alt={artwork.alt}
+          className="absolute inset-0 size-full object-cover"
+        />
+      ) : (
+        <>
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_28%_20%,rgba(255,255,255,0.7),transparent_42%)] opacity-80 dark:opacity-15" />
+          <Music2
+            className="relative size-[34%] text-zinc-500/65 drop-shadow-sm dark:text-zinc-300/65"
+            strokeWidth={1.45}
+            aria-hidden
+          />
+          <span className="sr-only">Album artwork placeholder</span>
+        </>
+      )}
+    </div>
+  );
 }
 
 function formatTime(seconds: number): string {

--- a/editor/kits/audio-player/audio-player.tsx
+++ b/editor/kits/audio-player/audio-player.tsx
@@ -12,6 +12,7 @@ import { Music2, Pause, Play, Volume2, VolumeX } from "lucide-react";
 import { Button } from "@app/ui/components/button";
 import { Slider } from "@app/ui/components/slider";
 import { cn } from "@app/ui/lib/utils";
+import { AudioPlayback } from "./playback";
 import { AudioWaveform } from "./waveform";
 
 export type AudioPlayerArtwork = {
@@ -69,6 +70,8 @@ export function AudioPlayer({
   className,
 }: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
+  const playbackAttemptRef = useRef(0);
+  const lastAudibleVolumeRef = useRef(1);
   const [duration, setDuration] = useState(0);
   const [time, setTime] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -77,10 +80,13 @@ export function AudioPlayer({
   const [metadataReady, setMetadataReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [waveform, setWaveform] = useState<WaveformState>({ kind: "idle" });
+  const showTenths = duration > 0 && duration < 1;
 
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
+
+    playbackAttemptRef.current += 1;
 
     setDuration(0);
     setTime(0);
@@ -105,6 +111,7 @@ export function AudioPlayer({
     }
 
     return () => {
+      playbackAttemptRef.current += 1;
       audio.pause();
       audio.removeAttribute("src");
       audio.load();
@@ -137,20 +144,32 @@ export function AudioPlayer({
   }, [source, visualization]);
 
   useEffect(() => {
-    if (!active) audioRef.current?.pause();
+    if (!active) {
+      playbackAttemptRef.current += 1;
+      audioRef.current?.pause();
+    }
   }, [active]);
 
   const togglePlayback = async () => {
     const audio = audioRef.current;
-    if (!audio || error) return;
+    if (!audio || !active || error) return;
+    const attempt = ++playbackAttemptRef.current;
     if (!audio.paused) {
       audio.pause();
       return;
     }
     try {
       await audio.play();
-    } catch {
-      setError("Playback could not be started.");
+    } catch (cause) {
+      if (
+        AudioPlayback.shouldReportPlayError(
+          cause,
+          attempt,
+          playbackAttemptRef.current
+        )
+      ) {
+        setError("Playback could not be started.");
+      }
     }
   };
 
@@ -169,6 +188,7 @@ export function AudioPlayer({
   const changeVolume = ([nextVolume]: number[]) => {
     const audio = audioRef.current;
     if (!audio || nextVolume === undefined) return;
+    if (nextVolume > 0) lastAudibleVolumeRef.current = nextVolume;
     const nextMuted = nextVolume === 0;
     audio.volume = nextVolume;
     audio.muted = nextMuted;
@@ -179,9 +199,20 @@ export function AudioPlayer({
   const toggleMuted = () => {
     const audio = audioRef.current;
     if (!audio) return;
-    const nextMuted = !audio.muted;
-    audio.muted = nextMuted;
-    setMuted(nextMuted);
+    const currentlySilent = audio.muted || audio.volume === 0;
+    if (currentlySilent) {
+      const nextVolume = AudioPlayback.volumeAfterUnmute(
+        audio.volume,
+        lastAudibleVolumeRef.current
+      );
+      audio.volume = nextVolume;
+      audio.muted = false;
+      setVolume(nextVolume);
+      setMuted(false);
+      return;
+    }
+    audio.muted = true;
+    setMuted(true);
   };
 
   return (
@@ -210,7 +241,9 @@ export function AudioPlayer({
         onPause={() => setPlaying(false)}
         onEnded={() => setPlaying(false)}
         onVolumeChange={(event) => {
-          setVolume(event.currentTarget.volume);
+          const nextVolume = event.currentTarget.volume;
+          if (nextVolume > 0) lastAudibleVolumeRef.current = nextVolume;
+          setVolume(nextVolume);
           setMuted(event.currentTarget.muted);
         }}
         onError={() => {
@@ -271,8 +304,12 @@ export function AudioPlayer({
               />
             )}
             <div className="mt-2 flex justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
-              <span>{formatTime(time)}</span>
-              <span>{metadataReady ? formatTime(duration) : "--:--"}</span>
+              <span>{AudioPlayback.formatTime(time, showTenths)}</span>
+              <span>
+                {metadataReady
+                  ? AudioPlayback.formatTime(duration, showTenths)
+                  : "--:--"}
+              </span>
             </div>
           </div>
 
@@ -283,7 +320,7 @@ export function AudioPlayer({
               size="icon-lg"
               className="size-12 rounded-full shadow-sm"
               onClick={() => void togglePlayback()}
-              disabled={!metadataReady || Boolean(error)}
+              disabled={!active || !metadataReady || Boolean(error)}
               aria-label={playing ? "Pause" : "Play"}
             >
               {playing ? (
@@ -300,7 +337,7 @@ export function AudioPlayer({
                 className="shrink-0"
                 onClick={toggleMuted}
                 disabled={!metadataReady || Boolean(error)}
-                aria-label={muted ? "Unmute" : "Mute"}
+                aria-label={muted || volume === 0 ? "Unmute" : "Mute"}
               >
                 {muted || volume === 0 ? (
                   <VolumeX aria-hidden />
@@ -439,7 +476,13 @@ function WaveformScrubber({
       aria-valuemin={0}
       aria-valuemax={duration}
       aria-valuenow={currentTime}
-      aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
+      aria-valuetext={`${AudioPlayback.formatTime(
+        currentTime,
+        duration > 0 && duration < 1
+      )} of ${AudioPlayback.formatTime(
+        duration,
+        duration > 0 && duration < 1
+      )}`}
       aria-disabled={disabled}
       aria-busy={loading}
       tabIndex={disabled ? -1 : 0}
@@ -515,11 +558,4 @@ function Artwork({ artwork }: { artwork?: AudioPlayerArtwork }) {
       )}
     </div>
   );
-}
-
-function formatTime(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
-  const minutes = Math.floor(seconds / 60);
-  const remainder = Math.floor(seconds % 60);
-  return `${minutes}:${remainder.toString().padStart(2, "0")}`;
 }

--- a/editor/kits/audio-player/index.ts
+++ b/editor/kits/audio-player/index.ts
@@ -1,0 +1,6 @@
+export { AudioPlayer } from "./audio-player";
+export type {
+  AudioPlayerAction,
+  AudioPlayerArtwork,
+  AudioPlayerProps,
+} from "./audio-player";

--- a/editor/kits/audio-player/index.ts
+++ b/editor/kits/audio-player/index.ts
@@ -3,4 +3,5 @@ export type {
   AudioPlayerAction,
   AudioPlayerArtwork,
   AudioPlayerProps,
+  AudioPlayerVisualization,
 } from "./audio-player";

--- a/editor/kits/audio-player/playback.test.ts
+++ b/editor/kits/audio-player/playback.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { AudioPlayback } from "./playback";
+
+describe("AudioPlayback.shouldReportPlayError", () => {
+  it("ignores an interrupted current attempt", () => {
+    expect(
+      AudioPlayback.shouldReportPlayError({ name: "AbortError" }, 2, 2)
+    ).toBe(false);
+  });
+
+  it("ignores a failure from a stale attempt", () => {
+    expect(AudioPlayback.shouldReportPlayError(new Error("stale"), 1, 2)).toBe(
+      false
+    );
+  });
+
+  it("reports a genuine failure from the current attempt", () => {
+    expect(AudioPlayback.shouldReportPlayError(new Error("failed"), 2, 2)).toBe(
+      true
+    );
+  });
+});
+
+describe("AudioPlayback.volumeAfterUnmute", () => {
+  it("keeps an already audible volume", () => {
+    expect(AudioPlayback.volumeAfterUnmute(0.25, 0.75)).toBe(0.25);
+  });
+
+  it("restores the last audible volume from zero", () => {
+    expect(AudioPlayback.volumeAfterUnmute(0, 0.75)).toBe(0.75);
+  });
+
+  it("falls back to full volume without audible history", () => {
+    expect(AudioPlayback.volumeAfterUnmute(0, 0)).toBe(1);
+  });
+});
+
+describe("AudioPlayback.formatTime", () => {
+  it("formats whole-second playback time", () => {
+    expect(AudioPlayback.formatTime(65.9)).toBe("1:05");
+  });
+
+  it("preserves tenths for sub-second clips", () => {
+    expect(AudioPlayback.formatTime(0.5, true)).toBe("0:00.5");
+  });
+
+  it("sanitizes invalid time", () => {
+    expect(AudioPlayback.formatTime(Number.NaN)).toBe("0:00");
+    expect(AudioPlayback.formatTime(-1)).toBe("0:00");
+  });
+});

--- a/editor/kits/audio-player/playback.ts
+++ b/editor/kits/audio-player/playback.ts
@@ -1,0 +1,38 @@
+/** State decisions shared by the audio player's media controls. */
+export namespace AudioPlayback {
+  export function shouldReportPlayError(
+    cause: unknown,
+    attempt: number,
+    currentAttempt: number
+  ): boolean {
+    return attempt === currentAttempt && !isAbortError(cause);
+  }
+
+  export function volumeAfterUnmute(
+    currentVolume: number,
+    lastAudibleVolume: number
+  ): number {
+    if (currentVolume > 0) return currentVolume;
+    return lastAudibleVolume > 0 ? lastAudibleVolume : 1;
+  }
+
+  export function formatTime(seconds: number, showTenths = false): string {
+    const safeSeconds = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+    const precision = showTenths ? 10 : 1;
+    const totalUnits = Math.floor(safeSeconds * precision);
+    const wholeSeconds = Math.floor(totalUnits / precision);
+    const minutes = Math.floor(wholeSeconds / 60);
+    const remainder = wholeSeconds % 60;
+    const base = `${minutes}:${remainder.toString().padStart(2, "0")}`;
+    return showTenths ? `${base}.${totalUnits % precision}` : base;
+  }
+}
+
+function isAbortError(cause: unknown): boolean {
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    "name" in cause &&
+    cause.name === "AbortError"
+  );
+}

--- a/editor/kits/audio-player/waveform.test.ts
+++ b/editor/kits/audio-player/waveform.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { AudioWaveform } from "./waveform";
+
+describe("AudioWaveform.peaks", () => {
+  it("reduces all channels into normalized peak buckets", () => {
+    const left = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+    const right = new Float32Array([0.8, 0.1, -0.6, 0.2]);
+
+    const peaks = AudioWaveform.peaks([left, right], 2);
+    expect(peaks[0]).toBe(1);
+    expect(peaks[1]).toBeCloseTo(0.75);
+  });
+
+  it("preserves silence", () => {
+    expect(AudioWaveform.peaks([new Float32Array(8)], 4)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("supports an empty decoded buffer", () => {
+    expect(AudioWaveform.peaks([], 3)).toEqual([0, 0, 0]);
+  });
+
+  it("rejects invalid bar counts", () => {
+    expect(() => AudioWaveform.peaks([], 0)).toThrowError(RangeError);
+    expect(() => AudioWaveform.peaks([], 1.5)).toThrowError(RangeError);
+  });
+});

--- a/editor/kits/audio-player/waveform.ts
+++ b/editor/kits/audio-player/waveform.ts
@@ -1,0 +1,74 @@
+/** Browser-native waveform extraction for complete audio sources. */
+export namespace AudioWaveform {
+  export const DEFAULT_BAR_COUNT = 112;
+
+  export async function decode(
+    source: string | Blob,
+    barCount = DEFAULT_BAR_COUNT,
+    signal?: AbortSignal
+  ): Promise<number[]> {
+    const encoded = await readSource(source, signal);
+    if (signal?.aborted) throw abortError();
+
+    const context = new OfflineAudioContext(1, 1, 44_100);
+    const decoded = await context.decodeAudioData(encoded);
+    if (signal?.aborted) throw abortError();
+
+    const channels = Array.from(
+      { length: decoded.numberOfChannels },
+      (_, channel) => decoded.getChannelData(channel)
+    );
+    return peaks(channels, barCount);
+  }
+
+  export function peaks(
+    channels: readonly Float32Array[],
+    barCount = DEFAULT_BAR_COUNT
+  ): number[] {
+    if (!Number.isInteger(barCount) || barCount <= 0) {
+      throw new RangeError("Waveform bar count must be a positive integer.");
+    }
+
+    const sampleCount = channels.reduce(
+      (largest, channel) => Math.max(largest, channel.length),
+      0
+    );
+    if (sampleCount === 0) return Array<number>(barCount).fill(0);
+
+    const values = Array.from({ length: barCount }, (_, bar) => {
+      const start = Math.floor((bar * sampleCount) / barCount);
+      const end = Math.max(
+        start + 1,
+        Math.floor(((bar + 1) * sampleCount) / barCount)
+      );
+      let peak = 0;
+      for (const channel of channels) {
+        const channelEnd = Math.min(end, channel.length);
+        for (let sample = start; sample < channelEnd; sample++) {
+          peak = Math.max(peak, Math.abs(channel[sample] ?? 0));
+        }
+      }
+      return peak;
+    });
+
+    const loudest = Math.max(...values);
+    return loudest > 0 ? values.map((value) => value / loudest) : values;
+  }
+}
+
+async function readSource(
+  source: string | Blob,
+  signal?: AbortSignal
+): Promise<ArrayBuffer> {
+  if (typeof source !== "string") return await source.arrayBuffer();
+
+  const response = await fetch(source, { signal });
+  if (!response.ok) {
+    throw new Error(`Could not load audio source (${response.status}).`);
+  }
+  return await response.arrayBuffer();
+}
+
+function abortError(): DOMException {
+  return new DOMException("Waveform decoding was cancelled.", "AbortError");
+}

--- a/editor/scaffolds/desktop/audio-gen/music-player.tsx
+++ b/editor/scaffolds/desktop/audio-gen/music-player.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  FolderSearch,
+  Music2,
+  Pause,
+  Play,
+  Volume2,
+  VolumeX,
+} from "lucide-react";
+import { Button } from "@app/ui/components/button";
+import { Slider } from "@app/ui/components/slider";
+import { AudioCompatibility } from "../media-formats/audio-compatibility";
+
+export function MusicPlayer({
+  file,
+  active = true,
+  title = trackTitle(file.name),
+  artist = "Local audio",
+  generated = false,
+  revealLabel = "Show in folder",
+  onReveal,
+}: {
+  file: File;
+  active?: boolean;
+  title?: string;
+  artist?: string;
+  generated?: boolean;
+  revealLabel?: string;
+  onReveal?: () => void;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [duration, setDuration] = useState(0);
+  const [time, setTime] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [volume, setVolume] = useState(1);
+  const [muted, setMuted] = useState(false);
+  const [metadataReady, setMetadataReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const support = AudioCompatibility.probe(file);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    setDuration(0);
+    setTime(0);
+    setPlaying(false);
+    setMetadataReady(false);
+    setError(null);
+
+    let url: string;
+    try {
+      url = URL.createObjectURL(file);
+      audio.src = url;
+      audio.load();
+    } catch {
+      setError("This audio file could not be opened.");
+      return;
+    }
+
+    return () => {
+      audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  useEffect(() => {
+    if (!active) audioRef.current?.pause();
+  }, [active]);
+
+  const togglePlayback = async () => {
+    const audio = audioRef.current;
+    if (!audio || error) return;
+    if (!audio.paused) {
+      audio.pause();
+      return;
+    }
+    try {
+      await audio.play();
+    } catch {
+      setError("Playback could not be started.");
+    }
+  };
+
+  const seek = ([nextTime]: number[]) => {
+    const audio = audioRef.current;
+    if (!audio || nextTime === undefined) return;
+    audio.currentTime = nextTime;
+    setTime(nextTime);
+  };
+
+  const changeVolume = ([nextVolume]: number[]) => {
+    const audio = audioRef.current;
+    if (!audio || nextVolume === undefined) return;
+    const nextMuted = nextVolume === 0;
+    audio.volume = nextVolume;
+    audio.muted = nextMuted;
+    setVolume(nextVolume);
+    setMuted(nextMuted);
+  };
+
+  const toggleMuted = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const nextMuted = !audio.muted;
+    audio.muted = nextMuted;
+    setMuted(nextMuted);
+  };
+
+  return (
+    <div
+      data-testid="player-music"
+      className="w-full rounded-2xl border bg-card p-5 shadow-sm sm:p-6"
+    >
+      <audio
+        ref={audioRef}
+        preload="metadata"
+        onLoadedMetadata={(event) => {
+          const nextDuration = event.currentTarget.duration;
+          setDuration(
+            Number.isFinite(nextDuration) && nextDuration >= 0
+              ? nextDuration
+              : 0
+          );
+          setMetadataReady(true);
+          setError(null);
+        }}
+        onTimeUpdate={(event) => setTime(event.currentTarget.currentTime)}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        onVolumeChange={(event) => {
+          setVolume(event.currentTarget.volume);
+          setMuted(event.currentTarget.muted);
+        }}
+        onError={() => {
+          setMetadataReady(false);
+          setPlaying(false);
+          setError("This audio codec could not be played.");
+        }}
+      />
+
+      <div className="grid items-center gap-6 sm:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)] sm:gap-8">
+        <div
+          className="relative mx-auto flex aspect-square w-full max-w-64 items-center justify-center overflow-hidden rounded-xl border border-black/5 bg-gradient-to-br from-zinc-100 via-zinc-200 to-zinc-300 shadow-[0_18px_45px_-24px_rgba(0,0,0,0.55)] dark:border-white/10 dark:from-zinc-700 dark:via-zinc-800 dark:to-zinc-950"
+          role="img"
+          aria-label="Album artwork placeholder"
+        >
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_28%_20%,rgba(255,255,255,0.7),transparent_42%)] opacity-80 dark:opacity-15" />
+          <Music2
+            className="relative size-[34%] text-zinc-500/65 drop-shadow-sm dark:text-zinc-300/65"
+            strokeWidth={1.45}
+            aria-hidden
+          />
+        </div>
+
+        <div className="min-w-0">
+          <div className="text-center sm:text-left">
+            {generated && (
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                AI generated track
+              </div>
+            )}
+            <h3 className="line-clamp-2 text-xl font-semibold tracking-tight sm:text-2xl">
+              {title}
+            </h3>
+            <p className="mt-1 truncate text-sm text-muted-foreground">
+              {artist}
+            </p>
+          </div>
+
+          <div className="mt-7">
+            <Slider
+              min={0}
+              max={duration || 1}
+              step={0.01}
+              value={[Math.min(time, duration || 0)]}
+              disabled={!metadataReady || Boolean(error)}
+              onValueChange={seek}
+              aria-label="Track position"
+              className="[&_[data-slot=slider-thumb]]:size-3"
+            />
+            <div className="mt-2 flex justify-between font-mono text-[11px] tabular-nums text-muted-foreground">
+              <span>{formatTime(time)}</span>
+              <span>{metadataReady ? formatTime(duration) : "--:--"}</span>
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-center justify-between gap-4">
+            <div className="w-24" aria-hidden />
+            <Button
+              type="button"
+              size="icon-lg"
+              className="size-12 rounded-full shadow-sm"
+              onClick={() => void togglePlayback()}
+              disabled={!metadataReady || Boolean(error)}
+              aria-label={playing ? "Pause" : "Play"}
+            >
+              {playing ? (
+                <Pause className="fill-current" aria-hidden />
+              ) : (
+                <Play className="ml-0.5 fill-current" aria-hidden />
+              )}
+            </Button>
+            <div className="flex w-24 items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0"
+                onClick={toggleMuted}
+                disabled={!metadataReady || Boolean(error)}
+                aria-label={muted ? "Unmute" : "Mute"}
+              >
+                {muted || volume === 0 ? (
+                  <VolumeX aria-hidden />
+                ) : (
+                  <Volume2 aria-hidden />
+                )}
+              </Button>
+              <Slider
+                min={0}
+                max={1}
+                step={0.01}
+                value={[muted ? 0 : volume]}
+                disabled={!metadataReady || Boolean(error)}
+                onValueChange={changeVolume}
+                aria-label="Volume"
+                className="[&_[data-slot=slider-thumb]]:size-3"
+              />
+            </div>
+          </div>
+
+          <div className="mt-5 flex min-w-0 items-center gap-2 border-t pt-3 text-xs text-muted-foreground">
+            <span className="min-w-0 flex-1 truncate">
+              {file.name} · {support.label}
+            </span>
+            {onReveal && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="-mr-2 shrink-0"
+                onClick={onReveal}
+                aria-label={revealLabel}
+                title={revealLabel}
+              >
+                <FolderSearch aria-hidden />
+              </Button>
+            )}
+          </div>
+          {!metadataReady && !error && (
+            <p className="mt-2 text-xs text-muted-foreground" role="status">
+              Reading audio metadata…
+            </p>
+          )}
+          {error && (
+            <p className="mt-2 text-xs text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function trackTitle(filename: string): string {
+  const withoutExtension = filename.replace(/\.[^.]+$/, "").trim();
+  return withoutExtension || "Untitled track";
+}
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.floor(seconds % 60);
+  return `${minutes}:${remainder.toString().padStart(2, "0")}`;
+}

--- a/editor/scaffolds/desktop/audio-gen/music-playground.tsx
+++ b/editor/scaffolds/desktop/audio-gen/music-playground.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, type ChangeEvent } from "react";
-import { FileUp, FolderSearch, Music2, X } from "lucide-react";
+import { FileUp, Music2, X } from "lucide-react";
 import { models } from "@grida/ai-models";
 import { Button } from "@app/ui/components/button";
 import {
@@ -11,14 +11,14 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@app/ui/components/empty";
-import type { MediaItem } from "@/lib/desktop/bridge";
+import { useDesktopBridge, type MediaItem } from "@/lib/desktop/bridge";
 import { AudioCompatibility } from "../media-formats/audio-compatibility";
-import { LocalAudioPlayer } from "../media-formats/local-audio-player";
 import { FileDownloadButton } from "../shared/file-download-button";
 import {
   MusicGenerationControls,
   type MusicGeneratedPreview,
 } from "./music-generation-controls";
+import { MusicPlayer } from "./music-player";
 
 /** Hosted Lyria music playground with an MP3 output boundary. */
 export function MusicPlayground({
@@ -38,8 +38,13 @@ export function MusicPlayground({
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [source, setSource] = useState<"local" | "generated" | null>(null);
+  const [generatedModelId, setGeneratedModelId] =
+    useState<models.audio.music.ModelId | null>(null);
   const [storedMedia, setStoredMedia] = useState<MediaItem | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const bridge = useDesktopBridge();
+  const revealLabel =
+    bridge?.app.platform === "darwin" ? "Show in Finder" : "Show in folder";
 
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextFile = event.currentTarget.files?.[0] ?? null;
@@ -47,12 +52,14 @@ export function MusicPlayground({
     if (!nextFile) return;
     setFile(nextFile);
     setSource("local");
+    setGeneratedModelId(null);
     setStoredMedia(null);
   };
 
   const onGenerated = (result: MusicGeneratedPreview) => {
     setFile(result.file);
     setSource("generated");
+    setGeneratedModelId(result.modelId);
     setStoredMedia(result.storedMedia ?? null);
     if (result.storedMedia) onStoredMediaCreated?.(result.storedMedia);
   };
@@ -60,6 +67,7 @@ export function MusicPlayground({
   const clear = () => {
     setFile(null);
     setSource(null);
+    setGeneratedModelId(null);
     setStoredMedia(null);
   };
 
@@ -74,17 +82,6 @@ export function MusicPlayground({
         </h2>
         <div className="ml-auto flex items-center gap-2">
           {source === "generated" && file && <FileDownloadButton file={file} />}
-          {storedMedia && onRevealStoredMedia && (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() => onRevealStoredMedia(storedMedia)}
-            >
-              <FolderSearch aria-hidden />
-              Show in folder
-            </Button>
-          )}
           {file && (
             <>
               <Button
@@ -121,7 +118,23 @@ export function MusicPlayground({
           {file ? (
             <div className="flex h-full items-center justify-center overflow-auto rounded-lg border bg-muted/20 p-6">
               <div className="w-full max-w-2xl">
-                <LocalAudioPlayer file={file} active />
+                <MusicPlayer
+                  file={file}
+                  active
+                  generated={source === "generated"}
+                  title={source === "generated" ? "Generated track" : undefined}
+                  artist={
+                    generatedModelId
+                      ? models.audio.music.models[generatedModelId].label
+                      : "Local audio"
+                  }
+                  revealLabel={revealLabel}
+                  onReveal={
+                    storedMedia && onRevealStoredMedia
+                      ? () => onRevealStoredMedia(storedMedia)
+                      : undefined
+                  }
+                />
               </div>
             </div>
           ) : (

--- a/editor/scaffolds/desktop/audio-gen/music-playground.tsx
+++ b/editor/scaffolds/desktop/audio-gen/music-playground.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, type ChangeEvent } from "react";
-import { FileUp, Music2, X } from "lucide-react";
+import { FileUp, FolderSearch, Music2, X } from "lucide-react";
 import { models } from "@grida/ai-models";
 import { Button } from "@app/ui/components/button";
 import {
@@ -11,6 +11,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@app/ui/components/empty";
+import { AudioPlayer } from "@/kits/audio-player";
 import { useDesktopBridge, type MediaItem } from "@/lib/desktop/bridge";
 import { AudioCompatibility } from "../media-formats/audio-compatibility";
 import { FileDownloadButton } from "../shared/file-download-button";
@@ -18,7 +19,6 @@ import {
   MusicGenerationControls,
   type MusicGeneratedPreview,
 } from "./music-generation-controls";
-import { MusicPlayer } from "./music-player";
 
 /** Hosted Lyria music playground with an MP3 output boundary. */
 export function MusicPlayground({
@@ -118,21 +118,33 @@ export function MusicPlayground({
           {file ? (
             <div className="flex h-full items-center justify-center overflow-auto rounded-lg border bg-muted/20 p-6">
               <div className="w-full max-w-2xl">
-                <MusicPlayer
-                  file={file}
+                <AudioPlayer
+                  source={file}
                   active
-                  generated={source === "generated"}
-                  title={source === "generated" ? "Generated track" : undefined}
-                  artist={
+                  title={
+                    source === "generated"
+                      ? "Generated track"
+                      : trackTitle(file.name)
+                  }
+                  subtitle={
                     generatedModelId
                       ? models.audio.music.models[generatedModelId].label
                       : "Local audio"
                   }
-                  revealLabel={revealLabel}
-                  onReveal={
+                  eyebrow={
+                    source === "generated" ? "AI generated track" : undefined
+                  }
+                  details={`${file.name} · ${AudioCompatibility.probe(file).label}`}
+                  actions={
                     storedMedia && onRevealStoredMedia
-                      ? () => onRevealStoredMedia(storedMedia)
-                      : undefined
+                      ? [
+                          {
+                            label: revealLabel,
+                            icon: <FolderSearch aria-hidden />,
+                            onSelect: () => onRevealStoredMedia(storedMedia),
+                          },
+                        ]
+                      : []
                   }
                 />
               </div>
@@ -165,4 +177,9 @@ export function MusicPlayground({
       </div>
     </section>
   );
+}
+
+function trackTitle(filename: string): string {
+  const withoutExtension = filename.replace(/\.[^.]+$/, "").trim();
+  return withoutExtension || "Untitled track";
 }

--- a/editor/scaffolds/desktop/audio-gen/sound-effect-playground.tsx
+++ b/editor/scaffolds/desktop/audio-gen/sound-effect-playground.tsx
@@ -11,9 +11,9 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@app/ui/components/empty";
-import type { MediaItem } from "@/lib/desktop/bridge";
+import { AudioPlayer } from "@/kits/audio-player";
+import { useDesktopBridge, type MediaItem } from "@/lib/desktop/bridge";
 import { AudioCompatibility } from "../media-formats/audio-compatibility";
-import { LocalAudioPlayer } from "../media-formats/local-audio-player";
 import { FileDownloadButton } from "../shared/file-download-button";
 import {
   SoundEffectGenerationControls,
@@ -38,8 +38,13 @@ export function SoundEffectPlayground({
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [source, setSource] = useState<"local" | "generated" | null>(null);
+  const [generatedModelId, setGeneratedModelId] =
+    useState<models.audio.sound_effects.ModelId | null>(null);
   const [storedMedia, setStoredMedia] = useState<MediaItem | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const bridge = useDesktopBridge();
+  const revealLabel =
+    bridge?.app.platform === "darwin" ? "Show in Finder" : "Show in folder";
 
   const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextFile = event.currentTarget.files?.[0] ?? null;
@@ -47,12 +52,14 @@ export function SoundEffectPlayground({
     if (!nextFile) return;
     setFile(nextFile);
     setSource("local");
+    setGeneratedModelId(null);
     setStoredMedia(null);
   };
 
   const onGenerated = (result: SoundEffectGeneratedPreview) => {
     setFile(result.file);
     setSource("generated");
+    setGeneratedModelId(result.modelId);
     setStoredMedia(result.storedMedia ?? null);
     if (result.storedMedia) onStoredMediaCreated?.(result.storedMedia);
   };
@@ -60,6 +67,7 @@ export function SoundEffectPlayground({
   const clear = () => {
     setFile(null);
     setSource(null);
+    setGeneratedModelId(null);
     setStoredMedia(null);
   };
 
@@ -72,17 +80,6 @@ export function SoundEffectPlayground({
         <h2 className="mr-2 min-w-0 text-2xl font-bold tracking-tight">SFX</h2>
         <div className="ml-auto flex items-center gap-2">
           {source === "generated" && file && <FileDownloadButton file={file} />}
-          {storedMedia && onRevealStoredMedia && (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() => onRevealStoredMedia(storedMedia)}
-            >
-              <FolderSearch aria-hidden />
-              Show in folder
-            </Button>
-          )}
           {file && (
             <>
               <Button
@@ -119,7 +116,39 @@ export function SoundEffectPlayground({
           {file ? (
             <div className="flex h-full items-center justify-center overflow-auto rounded-lg border bg-muted/20 p-6">
               <div className="w-full max-w-2xl">
-                <LocalAudioPlayer file={file} active />
+                <AudioPlayer
+                  source={file}
+                  visualization="waveform"
+                  active
+                  title={
+                    source === "generated"
+                      ? "Generated sound effect"
+                      : soundEffectTitle(file.name)
+                  }
+                  subtitle={
+                    generatedModelId
+                      ? models.audio.sound_effects.models[generatedModelId]
+                          .label
+                      : "Local audio"
+                  }
+                  eyebrow={
+                    source === "generated"
+                      ? "AI generated sound effect"
+                      : undefined
+                  }
+                  details={`${file.name} · ${AudioCompatibility.probe(file).label}`}
+                  actions={
+                    storedMedia && onRevealStoredMedia
+                      ? [
+                          {
+                            label: revealLabel,
+                            icon: <FolderSearch aria-hidden />,
+                            onSelect: () => onRevealStoredMedia(storedMedia),
+                          },
+                        ]
+                      : []
+                  }
+                />
               </div>
             </div>
           ) : (
@@ -150,4 +179,9 @@ export function SoundEffectPlayground({
       </div>
     </section>
   );
+}
+
+function soundEffectTitle(filename: string): string {
+  const withoutExtension = filename.replace(/\.[^.]+$/, "").trim();
+  return withoutExtension || "Untitled sound effect";
 }

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -11,6 +11,8 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
@@ -53,11 +55,23 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
+          aria-label={thumbAriaLabel(ariaLabel, index, _values.length)}
+          aria-labelledby={ariaLabelledBy}
           className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>
   );
+}
+
+function thumbAriaLabel(
+  label: string | undefined,
+  index: number,
+  count: number
+): string | undefined {
+  if (!label || count === 1) return label;
+  if (count === 2) return `${label} ${index === 0 ? "minimum" : "maximum"}`;
+  return `${label} ${index + 1}`;
 }
 
 export { Slider };


### PR DESCRIPTION
## Summary

- add a reusable `@/kits/audio-player` player for URL and Blob/File sources, with bounded artwork and waveform visualizations
- replace the native audio control shown after Lyria generation with neutral artwork, metadata, seeking, time, playback, and volume UI
- give generated and local SFX the same player with an audio-derived, pointer- and keyboard-seekable waveform
- decode and reduce complete audio sources with browser-native Web Audio, falling back to the regular seek slider when waveform decoding is unavailable
- inject stored-media actions so generated tracks and SFX can be revealed in Finder on macOS or their containing folder on other platforms

No waveform dependency is added. The kit keeps source decoding and tested peak reduction separate from the React playback surface, and stays independent of models, routes, storage, and Desktop APIs.

## Verification

- `pnpm --filter editor typecheck`
- `pnpm --filter editor test` (1,500 passed, 4 skipped, 1 todo)
- targeted `oxlint` and `oxfmt` for the kit and Desktop adapters
- browser-verified SFX generation, 112 decoded waveform bars, seeking, playback, zero-volume mute/unmute recovery, interrupted-play recovery, and stored-media reveal with no console errors or framework overlay
- browser-verified inactive playback gating, sub-second time labels, and accessible slider names
- browser-verified the artwork player generation, playback, mute/unmute, and stored-media reveal flow

Desktop release impact: none

### Music

![Desktop music generator output player with neutral artwork and Finder reveal action](https://github.com/user-attachments/assets/e96f2142-ecc7-4b8b-9c22-4447429acabe)

### Sound effects

![Desktop SFX generator output player with decoded waveform and Finder reveal action](https://github.com/user-attachments/assets/1088bada-bfa7-4a33-88d0-7687fe592acd)
