### PR TITLE
feat(ai): add model release provenance

### DIFF
--- a/.agents/skills/ai-models/SKILL.md
+++ b/.agents/skills/ai-models/SKILL.md
@@ -3,7 +3,7 @@ name: ai-models
 description: >
   Research, compare, and update AI model configurations.
   Covers text model tiers, image and video generation models, image tool models,
-  pricing data sourcing, and provider-cost metering against prepaid org credit.
+  release provenance, pricing data sourcing, and provider-cost metering against prepaid org credit.
   Use when bumping model versions, adding new models, updating pricing, or
   auditing model specs against provider documentation.
 ---
@@ -16,6 +16,7 @@ description: >
 - Adding a new image/video generation model or provider (Vercel gateway, Replicate, fal.ai)
 - Updating pricing data (per-token, per-image flat, per-image tiered, per-second)
 - Verifying model specs (context window, output limit, cost) against providers
+- Grounding a model's first broad public release date and source
 - Auditing hosted usage metering against prepaid organization credit
 
 ---
@@ -48,7 +49,7 @@ python .agents/skills/ai-models/scripts/model_info.py --image <model_id>
 python .agents/skills/ai-models/scripts/model_info.py --image --all
 ```
 
-Source: `models.dev/api.json`. Accepts exact IDs (`anthropic/claude-sonnet-4.6`) or substring search (`gpt-5.4`).
+Discovery source: `models.dev/api.json`. Accepts exact IDs (`anthropic/claude-sonnet-4.6`) or substring search (`gpt-5.4`). Its `release_date` is a lead to verify, not authoritative provenance to copy into the catalogue.
 
 Note: `models.dev` has per-token costs but not per-image tier breakdowns. For per-image pricing (OpenAI quality tiers, BFL flat rates), consult provider docs directly.
 
@@ -68,8 +69,10 @@ Note: `models.dev` has per-token costs but not per-image tier breakdowns. For pe
 The same model has different ids — and different availability and pricing — across
 providers; an id is never portable. Two cataloguing patterns:
 
-- **text / image / audio / image_tools** — one card = one provider; `id` is in that
-  provider's format, and the `provider` field (or the namespace) fixes the route.
+- **text / audio / image_tools / 3D** — one card = one provider or exact endpoint;
+  `id` is in that provider's format, and the `provider` field (or namespace) fixes the route.
+- **image** — one intrinsic card carries per-provider bindings, like video, plus a
+  primary provider retained for older single-provider consumers.
 - **video** — the ecosystem is fragmented, so a card is **canonical** (`vendor/model`,
   e.g. `google/veo-3.1`) and carries a `providers` record (keyed by provider) of bindings,
   each with its own call id + meter. Default-provider choice is deferred (see Video Models).
@@ -84,7 +87,8 @@ providers; an id is never portable. Two cataloguing patterns:
 
 - **Availability + price differ per provider.** **Veo 3.1 Lite** is on OpenRouter/fal.ai but **not** the Vercel gateway — a canonical card just omits the Vercel binding. Veo 3.1 audio-on is `$0.40/s` on both Vercel and fal, but fal also meters silent (`$0.20/s`) and 4K, while **OpenRouter exposes only `$0/MTok` token pricing for video — no usable per-second meter (don't invent one).**
 - **fal.ai** is the broadest video/image catalogue (pay-per-use); billing unit is per-model — per-image, per-megapixel, or per-second video — retrievable from its Platform pricing API.
-- Image is still Vercel-gateway-only in code; a non-Vercel image provider would mirror video's binding shape (or add a `provider` label like audio's `"replicate"`).
+- Image cards are multi-homed across Vercel, fal, and OpenRouter where verified;
+  `listed` cards must retain the catalogue's one-key/universal-provider promise.
 
 ---
 
@@ -111,6 +115,49 @@ published catalogue that reaches installed clients within a refresh interval
 (`docs/wg/platform/hosted-ai.md`). That decisiveness is the point; it also means
 removal is the wrong tool for tidying.
 
+## Release dates and provenance
+
+Every bundled entry carries a `release` object:
+
+```ts
+{
+  date: "2026-07-09", // YYYY-MM-DD, or null only when an endpoint day is unknown
+  basis: "model", // or "provider_endpoint"
+  source_url: "https://vendor.example/release-note"
+}
+```
+
+The date means the earliest day the exact named model or variant became broadly
+available. A public preview counts; a closed, invitation-only, or limited
+preview does not. This is intrinsic model metadata, so adding a provider binding
+does not change a `basis: "model"` release. Use `basis: "provider_endpoint"`
+only when the release fact describes a serving route because no exact upstream
+model launch can be established. An endpoint-shaped card may still use
+`basis: "model"` when its exact underlying model and launch are documented.
+
+Do not substitute any of these:
+
+- snapshot `generated_at`
+- the date Grida added the card
+- the date one provider added a binding
+- a later GA date when an exact public preview date exists
+- an API object's opaque `created` timestamp
+
+Source priority for release facts:
+
+1. Vendor release note, changelog, announcement, or model card that names the exact variant.
+2. Vendor-maintained repository or official provider documentation for the exact endpoint.
+3. First-party vendor social announcement when no durable release page exists.
+4. Serving-provider history, only for `basis: "provider_endpoint"` or when the vendor has no usable record.
+5. `models.dev` only to discover candidates; verify its date against one of the sources above.
+
+If no authoritative source establishes the exact day, keep `date: null` with an
+HTTPS source showing the endpoint's history. Never infer a day from search-result
+ordering, repository commit time, or Grida history. Base snapshot types keep the
+field optional solely for older snapshots and custom models; every bundled card
+must include it, and tests enforce valid calendar dates, complete provenance,
+and the narrow `null` rule.
+
 ## Text Models
 
 Live in `packages/grida-ai-models/src/models.ts` under `models.text.catalog: Record<CatalogId, ModelSpec>`. The tier set and tier→model id table sit in `packages/grida-ai-models/src/tiers.ts` and type-use `models.text.CatalogId` from `models.ts` — so every tier id must resolve to a real catalogued spec.
@@ -119,6 +166,7 @@ Fields to update per tier:
 
 - `id` — gateway format: `provider/model-name`
 - `label` — human-readable name
+- `release` — grounded date, basis, and first-party source under the contract above
 - `contextWindow`, `outputLimit` — from `model_info.py`
 - `cost` — `{ input, output, cacheRead?, cacheWrite? }` per 1M tokens
 
@@ -145,6 +193,7 @@ per_token         — charged by token (e.g. Google Gemini)
 
 - `pricing` — real provider data, one of the three types above
 - `avg_cost_usd` — fallback billable-cost estimate, not displayed to users. Mid-tier for tiered, flat rate for flat, conservative estimate for per-token.
+- `release` — intrinsic model release; do not use a provider-binding date
 - `min_width`, `max_width`, `min_height`, `max_height`, `sizes` — dimension constraints
 - Add new model IDs to the `ImageModelId` type union
 
@@ -162,7 +211,7 @@ Live in `models.video.models` in `packages/grida-ai-models/src/models.ts`. The v
 
 ### Card shape
 
-- **Model (intrinsic):** `id` (canonical), `label`, `vendor`, `aspect_ratios`, `min_duration`/`max_duration`, `audio`, `default` (resolution/aspect/duration/audio), `url` (original vendor's model card).
+- **Model (intrinsic):** `id` (canonical), `label`, `release`, `vendor`, `aspect_ratios`, `min_duration`/`max_duration`, `audio`, `default` (resolution/aspect/duration/audio), `url` (original vendor's model card).
 - **`providers: Partial<Record<VideoProvider, VideoProviderBinding>>`** — one binding per serving provider: `provider`, `id`, `pricing`, `avg_cost_usd`, optional `url`/`deprecated`. **No preference order** — the default-provider choice is deliberately deferred to the runtime. Look a route up with `video.binding(card, provider)`.
 
 Cards catalogue the **image-to-video** route only (canvas-relevant; Grok's sole mode), so each binding has a single `id` — on fal the capability is keyed into the id (`fal-ai/veo3.1/image-to-video`). Don't add a per-capability `endpoints` map until a second capability is actually served: identical ids across capabilities are YAGNI, and divergent ones (other fal endpoints) are a new binding/id when needed.
@@ -222,6 +271,8 @@ credit. Unit: **mills** (1 mill = $0.001 USD).
 
 ## After Any Update
 
+- [ ] Every bundled model has a complete `release`; date semantics and source priority were followed
+- [ ] `models.dev` dates were treated as discovery hints and verified against authoritative sources
 - [ ] `pnpm tsc --noEmit` passes
 - [ ] `docs/models/index.md` matches the code
 - [ ] `/ai/models` page renders correctly

--- a/.tools/model_info.py
+++ b/.tools/model_info.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python3
 """
-model_info.py - Look up model specs from models.dev
+model_info.py - Discover model specs from models.dev
 
 Fetches the models.dev catalog and prints context window, output limit,
-cost, and other metadata for a given model ID.
+cost, release-date hints, and other metadata for a given model ID. Release
+dates are discovery hints: verify them against an authoritative vendor source
+before adding release provenance to the catalogue.
 
 Source: https://models.dev/api.json
 
 Usage:
-    python .tools/model_info.py <model_id>
-    python .tools/model_info.py --image <model_id>
-    python .tools/model_info.py --image --all
+    python .agents/skills/ai-models/scripts/model_info.py <model_id>
+    python .agents/skills/ai-models/scripts/model_info.py --image <model_id>
+    python .agents/skills/ai-models/scripts/model_info.py --image --all
 
 Examples:
-    python .tools/model_info.py openai/gpt-5-mini
-    python .tools/model_info.py anthropic/claude-sonnet-4
-    python .tools/model_info.py claude-opus-4
-    python .tools/model_info.py --image gpt-image-1.5
-    python .tools/model_info.py --image flux-kontext
-    python .tools/model_info.py --image --all
+    python .agents/skills/ai-models/scripts/model_info.py openai/gpt-5-mini
+    python .agents/skills/ai-models/scripts/model_info.py anthropic/claude-sonnet-4
+    python .agents/skills/ai-models/scripts/model_info.py claude-opus-4
+    python .agents/skills/ai-models/scripts/model_info.py --image gpt-image-1.5
+    python .agents/skills/ai-models/scripts/model_info.py --image flux-kontext
+    python .agents/skills/ai-models/scripts/model_info.py --image --all
 
 The model ID can be an exact match (e.g. "openai/gpt-5-mini") or a
 substring search (e.g. "gpt-5-mini", "claude-sonnet-4"). When multiple
@@ -163,7 +165,10 @@ def print_model(model: dict, indent: str = "") -> None:
     if model.get("open_weights"):
         print(f"{indent}Open weights   : yes")
     if model.get("release_date"):
-        print(f"{indent}Released       : {model['release_date']}")
+        print(
+            f"{indent}Release hint   : {model['release_date']} "
+            "(models.dev discovery; verify with vendor)"
+        )
 
 
 def print_summary(groups: dict[str, list[dict]], *, image_mode: bool) -> None:
@@ -190,11 +195,16 @@ def print_summary(groups: dict[str, list[dict]], *, image_mode: bool) -> None:
                 detail = f"in=${cost.get('input')} out=${cost.get('output')}"
             else:
                 detail = "per-image"
-            print(f"  {base_id}: {detail}")
+            release = primary.get("release_date", "?")
+            print(f"  {base_id}: {detail}, release_hint={release}")
         else:
             ctx = limit.get("context", "?")
             out = limit.get("output", "?")
-            print(f"  {base_id}: contextWindow={ctx}, outputLimit={out}")
+            release = primary.get("release_date", "?")
+            print(
+                f"  {base_id}: contextWindow={ctx}, outputLimit={out}, "
+                f"release_hint={release}"
+            )
 
 
 def main() -> None:
@@ -205,14 +215,20 @@ def main() -> None:
 
     if not positional and not show_all:
         print(
-            "Usage: python .tools/model_info.py [--image] <model_id>\n"
-            "       python .tools/model_info.py --image --all\n"
+            "Usage: python .agents/skills/ai-models/scripts/model_info.py "
+            "[--image] <model_id>\n"
+            "       python .agents/skills/ai-models/scripts/model_info.py "
+            "--image --all\n"
             "\n"
             "Examples:\n"
-            "  python .tools/model_info.py openai/gpt-5-mini\n"
-            "  python .tools/model_info.py --image gpt-image-1.5\n"
-            "  python .tools/model_info.py --image flux-kontext\n"
-            "  python .tools/model_info.py --image --all",
+            "  python .agents/skills/ai-models/scripts/model_info.py "
+            "openai/gpt-5-mini\n"
+            "  python .agents/skills/ai-models/scripts/model_info.py "
+            "--image gpt-image-1.5\n"
+            "  python .agents/skills/ai-models/scripts/model_info.py "
+            "--image flux-kontext\n"
+            "  python .agents/skills/ai-models/scripts/model_info.py "
+            "--image --all",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/.tools/model_info.py
+++ b/.tools/model_info.py
@@ -195,12 +195,12 @@ def print_summary(groups: dict[str, list[dict]], *, image_mode: bool) -> None:
                 detail = f"in=${cost.get('input')} out=${cost.get('output')}"
             else:
                 detail = "per-image"
-            release = primary.get("release_date", "?")
+            release = primary.get("release_date") or "?"
             print(f"  {base_id}: {detail}, release_hint={release}")
         else:
             ctx = limit.get("context", "?")
             out = limit.get("output", "?")
-            release = primary.get("release_date", "?")
+            release = primary.get("release_date") or "?"
             print(
                 f"  {base_id}: contextWindow={ctx}, outputLimit={out}, "
                 f"release_hint={release}"

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -5,6 +5,7 @@ import {
   models as textModels,
   catalog as textCatalog,
   type CatalogId,
+  type ModelRelease,
   type ModelSpec,
   type ModelTier,
 } from "@/lib/ai/models";
@@ -46,7 +47,7 @@ import {
 export const metadata: Metadata = {
   title: "AI Models & Pricing — Grida",
   description:
-    "Compare text, image, video, music, sound effect, and 3D AI models on Grida, including provider-native pricing and staged compatibility.",
+    "Compare release dates and provider-native pricing for text, image, video, music, sound effect, and 3D AI models on Grida.",
   alternates: {
     canonical: "https://grida.co/ai/models",
   },
@@ -79,6 +80,48 @@ function MakerLogo({
   return (
     <span aria-hidden="true" className="inline-flex shrink-0">
       <Logo className={className} />
+    </span>
+  );
+}
+
+const releaseDateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+function ReleaseDate({
+  release,
+  prefix = false,
+  className,
+}: {
+  release?: ModelRelease;
+  prefix?: boolean;
+  className?: string;
+}) {
+  const date = release?.date;
+  const label = date
+    ? releaseDateFormatter.format(new Date(`${date}T00:00:00.000Z`))
+    : "Date unavailable";
+  const content = date ? <time dateTime={date}>{label}</time> : label;
+
+  return (
+    <span className={className}>
+      {prefix && "Released "}
+      {release ? (
+        <a
+          href={release.source_url}
+          target="_blank"
+          rel="noreferrer"
+          className="underline decoration-muted-foreground/40 underline-offset-2 hover:text-foreground"
+          aria-label={`Release source: ${label}`}
+        >
+          {content}
+        </a>
+      ) : (
+        content
+      )}
     </span>
   );
 }
@@ -370,6 +413,10 @@ function ModelCard({ model }: { model: AITypes.image.ImageModelCard }) {
             <span>Model ID</span>
             <code className="text-foreground">{model.id}</code>
           </div>
+          <div className="flex justify-between">
+            <span>Released</span>
+            <ReleaseDate release={model.release} className="text-foreground" />
+          </div>
           {model.deprecated && (
             <div className="flex justify-between">
               <span>Status</span>
@@ -411,6 +458,11 @@ function TextModelRow({ tier, spec }: { tier: ModelTier; spec: ModelSpec }) {
           <div>
             <div className="font-medium">{spec.label}</div>
             <code className="text-xs text-muted-foreground">{spec.id}</code>
+            <ReleaseDate
+              release={spec.release}
+              prefix
+              className="block text-xs text-muted-foreground md:hidden"
+            />
           </div>
         </div>
       </TableCell>
@@ -431,6 +483,9 @@ function TextModelRow({ tier, spec }: { tier: ModelTier; spec: ModelSpec }) {
       </TableCell>
       <TableCell className="text-right font-mono text-xs">
         {fmtCost(spec.cost.output)}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+        <ReleaseDate release={spec.release} />
       </TableCell>
     </TableRow>
   );
@@ -465,6 +520,11 @@ function CatalogRow({ spec }: { spec: ModelSpec }) {
               )}
             </div>
             <code className="text-xs text-muted-foreground">{spec.id}</code>
+            <ReleaseDate
+              release={spec.release}
+              prefix
+              className="block text-xs text-muted-foreground md:hidden"
+            />
           </div>
         </div>
       </TableCell>
@@ -479,6 +539,9 @@ function CatalogRow({ spec }: { spec: ModelSpec }) {
       </TableCell>
       <TableCell className="text-right font-mono text-xs">
         {fmtCost(spec.cost.output)}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+        <ReleaseDate release={spec.release} />
       </TableCell>
     </TableRow>
   );
@@ -506,6 +569,7 @@ function CatalogSection() {
               <TableHead className="text-right">Cache Write</TableHead>
               <TableHead className="text-right">Cache Read</TableHead>
               <TableHead className="text-right">Output</TableHead>
+              <TableHead className="hidden md:table-cell">Released</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -563,6 +627,7 @@ function TextModelsSection() {
                 <TableHead className="text-right">Cache Write</TableHead>
                 <TableHead className="text-right">Cache Read</TableHead>
                 <TableHead className="text-right">Output</TableHead>
+                <TableHead className="hidden md:table-cell">Released</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -613,6 +678,7 @@ export default function AIModelsCatalogPage() {
                 <TableHead className="hidden lg:table-cell">
                   Dimensions
                 </TableHead>
+                <TableHead className="hidden md:table-cell">Released</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -627,6 +693,11 @@ export default function AIModelsCatalogPage() {
                           <code className="text-xs text-muted-foreground">
                             {model.id}
                           </code>
+                          <ReleaseDate
+                            release={model.release}
+                            prefix
+                            className="block text-xs text-muted-foreground md:hidden"
+                          />
                         </div>
                       </div>
                     </TableCell>
@@ -646,6 +717,9 @@ export default function AIModelsCatalogPage() {
                     </TableCell>
                     <TableCell className="hidden lg:table-cell text-xs text-muted-foreground">
                       {dimLabel(model)}
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+                      <ReleaseDate release={model.release} />
                     </TableCell>
                   </TableRow>
                 ));
@@ -798,6 +872,7 @@ function VideoModelsSection() {
               <TableHead className="w-[320px]">Model</TableHead>
               <TableHead className="hidden md:table-cell">Output</TableHead>
               <TableHead>Provider pricing</TableHead>
+              <TableHead className="hidden md:table-cell">Released</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -815,6 +890,11 @@ function VideoModelsSection() {
                         <code className="text-xs text-muted-foreground">
                           {model.id}
                         </code>
+                        <ReleaseDate
+                          release={model.release}
+                          prefix
+                          className="block text-xs text-muted-foreground md:hidden"
+                        />
                         <div className="mt-1 max-w-sm text-xs font-normal text-muted-foreground">
                           {model.short_description}
                         </div>
@@ -826,6 +906,9 @@ function VideoModelsSection() {
                   </TableCell>
                   <TableCell className="align-top">
                     <VideoProviderPricing model={model} />
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell align-top text-xs text-muted-foreground">
+                    <ReleaseDate release={model.release} />
                   </TableCell>
                 </TableRow>
               );
@@ -922,6 +1005,10 @@ function MusicModelCard({ model }: { model: AITypes.audio.music.ModelCard }) {
             <span>Model ID</span>
             <code className="text-foreground">{model.id}</code>
           </div>
+          <div className="flex justify-between">
+            <span>Released</span>
+            <ReleaseDate release={model.release} className="text-foreground" />
+          </div>
           {model.deprecated && (
             <div className="flex justify-between">
               <span>Status</span>
@@ -948,6 +1035,7 @@ function MusicModelsTable() {
               <TableHead>Pricing</TableHead>
               <TableHead className="hidden md:table-cell">Speed</TableHead>
               <TableHead className="hidden lg:table-cell">Output</TableHead>
+              <TableHead className="hidden md:table-cell">Released</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -962,6 +1050,11 @@ function MusicModelsTable() {
                         <code className="text-xs text-muted-foreground">
                           {model.id}
                         </code>
+                        <ReleaseDate
+                          release={model.release}
+                          prefix
+                          className="block text-xs text-muted-foreground md:hidden"
+                        />
                       </div>
                     </div>
                   </TableCell>
@@ -981,6 +1074,9 @@ function MusicModelsTable() {
                   </TableCell>
                   <TableCell className="hidden lg:table-cell text-xs text-muted-foreground">
                     {model.duration_label} · {model.sample_rate_label}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+                    <ReleaseDate release={model.release} />
                   </TableCell>
                 </TableRow>
               ));
@@ -1031,8 +1127,7 @@ function SoundEffectModelsSection() {
         </h2>
         <p className="text-base text-muted-foreground max-w-2xl">
           Provider-specific text-to-sound-effect compatibility from ElevenLabs.
-          Status is reported explicitly; catalogue presence does not imply web
-          generation availability.
+          Catalogue presence does not imply web generation availability.
         </p>
       </div>
 
@@ -1044,7 +1139,7 @@ function SoundEffectModelsSection() {
               <TableHead className="hidden md:table-cell">Input</TableHead>
               <TableHead className="hidden lg:table-cell">Output</TableHead>
               <TableHead>Provider pricing</TableHead>
-              <TableHead className="text-right">Status</TableHead>
+              <TableHead className="hidden md:table-cell">Released</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -1059,6 +1154,11 @@ function SoundEffectModelsSection() {
                         <code className="text-xs text-muted-foreground">
                           {model.id}
                         </code>
+                        <ReleaseDate
+                          release={model.release}
+                          prefix
+                          className="block text-xs text-muted-foreground md:hidden"
+                        />
                       </div>
                     </div>
                   </TableCell>
@@ -1080,13 +1180,8 @@ function SoundEffectModelsSection() {
                       ElevenLabs credits/s when specified
                     </div>
                   </TableCell>
-                  <TableCell className="text-right">
-                    <Badge
-                      variant="outline"
-                      className="capitalize font-normal text-xs"
-                    >
-                      {model.status}
-                    </Badge>
+                  <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+                    <ReleaseDate release={model.release} />
                   </TableCell>
                 </TableRow>
               );
@@ -1176,8 +1271,8 @@ function ThreeDModelsSection() {
         <p className="text-base text-muted-foreground max-w-2xl">
           fal-hosted text-to-3D and image-to-3D endpoints supported by Grida.
           GLB is the portable primary result; additional formats are endpoint
-          specific. Status is reported explicitly; catalogue presence does not
-          imply web generation availability.
+          specific. Catalogue presence does not imply web generation
+          availability.
         </p>
       </div>
 
@@ -1189,7 +1284,7 @@ function ThreeDModelsSection() {
               <TableHead className="hidden md:table-cell">Input</TableHead>
               <TableHead className="hidden lg:table-cell">Output</TableHead>
               <TableHead>Provider pricing</TableHead>
-              <TableHead className="text-right">Status</TableHead>
+              <TableHead className="hidden md:table-cell">Released</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -1207,6 +1302,11 @@ function ThreeDModelsSection() {
                         <div className="text-xs text-muted-foreground mt-1">
                           via {model.provider}
                         </div>
+                        <ReleaseDate
+                          release={model.release}
+                          prefix
+                          className="block text-xs text-muted-foreground md:hidden"
+                        />
                       </div>
                     </div>
                   </TableCell>
@@ -1227,13 +1327,8 @@ function ThreeDModelsSection() {
                   <TableCell>
                     <ThreeDPricing pricing={model.pricing} />
                   </TableCell>
-                  <TableCell className="text-right">
-                    <Badge
-                      variant="outline"
-                      className="capitalize font-normal text-xs"
-                    >
-                      {model.status}
-                    </Badge>
+                  <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+                    <ReleaseDate release={model.release} />
                   </TableCell>
                 </TableRow>
               );

--- a/editor/lib/ai/models.ts
+++ b/editor/lib/ai/models.ts
@@ -29,6 +29,7 @@ export type { ModelTier } from "@grida/ai-models";
 
 export type ModelCostPerMillion = _catalog.text.ModelCostPerMillion;
 export type ModelSpec = _catalog.text.ModelSpec;
+export type ModelRelease = _catalog.ModelRelease;
 export type CatalogId = _catalog.text.CatalogId;
 
 export const catalog = _catalog.text.catalog;

--- a/packages/grida-ai-models/README.md
+++ b/packages/grida-ai-models/README.md
@@ -2,10 +2,10 @@
 
 A standalone model catalog.
 
-This package publishes typed data for AI model selection, display, pricing, and
-size validation. It does not create provider clients, make network requests,
-enforce billing, or decide access. Its scope ends at exported objects, types,
-and lookup helpers.
+This package publishes typed data for AI model selection, display, release
+provenance, pricing, and size validation. It does not create provider clients,
+make network requests, enforce billing, or decide access. Its scope ends at
+exported objects, types, and lookup helpers.
 
 ## Anti-goals
 
@@ -23,6 +23,7 @@ and lookup helpers.
 - Agentic model: `nano`, `mini`, `pro`, and `max`
 - Text model specs: labels, modality, context windows, output limits, and token
   pricing
+- Source-backed release dates shared across model families
 - Image generation model cards: labels, vendors, speed hints, supported sizes,
   size constraints, defaults, and pricing
 - Video generation model cards: canonical (provider-agnostic) models, each with
@@ -74,6 +75,8 @@ Each `ModelSpec` contains:
 - `label` — full human-readable name (e.g. `"Claude Opus 4.8"`)
 - `short_label` — optional, manually-curated compact name for space-constrained
   UI (e.g. `"Opus 4.8"`); falls back to `label` when unset
+- `release` — earliest broad public availability of the exact model or variant,
+  with its basis and authoritative source URL
 - `multimodal`
 - `imageInputMimes` — exact provider-documented image MIME types accepted as
   native model input. This list is independent of `multimodal`: a broad
@@ -121,6 +124,14 @@ Media model data lives under the `models` namespace:
 - `models.three_d`
 - `models.video`
 - `models.image_tools`
+
+Every bundled model card includes `release`. Public preview counts as release;
+closed or limited preview does not. A model-level date is intrinsic and does
+not change when a new serving provider adds a binding. Endpoint-shaped tools
+may instead use `basis: "provider_endpoint"`; when their official history does
+not expose an exact day, `date` is `null` rather than guessed. The base text,
+image, and video types keep `release` optional only so older published
+snapshots and custom model records remain readable.
 
 Image cards can describe both preset sizes and continuous size constraints.
 When both are present, `constraints` is the validation envelope and `sizes` is a
@@ -224,6 +235,12 @@ Keep the stored data literal and portable:
   `avg_cost_usd`, which is explicitly a coarse invocation estimate.
 - Keep provider and vendor values as data labels. This package should not
   import SDKs or contain routing logic.
+- Ground `release` in a first-party vendor release note, changelog,
+  announcement, or model card. Treat models.dev dates as discovery hints, not
+  final provenance; use serving-provider history only for endpoint facts.
+- Never substitute snapshot generation time, Grida insertion time, provider
+  binding availability, or a later GA date for the model's first broad public
+  release.
 - Prefer adding explicit types before widening existing ones.
 
 ## Scripts

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -1,5 +1,67 @@
 import models, { TIER_MODEL_IDS } from "..";
 
+describe("bundled model release metadata", () => {
+  const cards: readonly { id: string; release?: models.ModelRelease }[] = [
+    ...Object.values(models.text.catalog),
+    ...Object.values(models.image.models).filter((card) => card !== undefined),
+    ...Object.values(models.audio.music.models),
+    ...Object.values(models.audio.sound_effects.models),
+    ...Object.values(models.audio.text_to_speech.models),
+    ...Object.values(models.three_d.models),
+    ...Object.values(models.video.models).filter((card) => card !== undefined),
+    ...Object.values(models.image_tools.models),
+    ...Object.values(models.embedding.models),
+  ];
+  const grounded = cards.filter(
+    (card): card is { id: string; release: models.ModelRelease } =>
+      card.release !== undefined
+  );
+
+  it("grounds every built-in card with a valid HTTPS source", () => {
+    expect(
+      cards.filter((card) => !card.release).map((card) => card.id)
+    ).toEqual([]);
+    for (const card of grounded) {
+      expect(card.release.source_url).toMatch(/^https:\/\/[^\s]+$/);
+    }
+  });
+
+  it("stores real YYYY-MM-DD calendar dates and never guesses model dates", () => {
+    const dated = grounded.flatMap((card) =>
+      card.release.date === null
+        ? []
+        : [{ id: card.id, date: card.release.date }]
+    );
+    for (const release of dated) {
+      expect(release.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      const parsed = new Date(`${release.date}T00:00:00.000Z`);
+      expect(parsed.toISOString().slice(0, 10)).toBe(release.date);
+    }
+  });
+
+  it("uses null only for endpoints whose exact first day is unavailable", () => {
+    expect(
+      cards.filter((card) => card.release?.date === null).map((card) => card.id)
+    ).toEqual([
+      "recraft-ai/recraft-remove-background",
+      "851-labs/background-remover",
+    ]);
+    expect(
+      grounded
+        .filter((card) => card.release.date === null)
+        .map((card) => card.release.basis)
+    ).toEqual(["provider_endpoint", "provider_endpoint"]);
+  });
+
+  it("gives both Hunyuan routes the intrinsic model release", () => {
+    expect(
+      models.three_d.models["fal-ai/hunyuan-3d/v3.1/pro/text-to-3d"].release
+    ).toEqual(
+      models.three_d.models["fal-ai/hunyuan-3d/v3.1/pro/image-to-3d"].release
+    );
+  });
+});
+
 describe("models.image.findImageModelCard", () => {
   it("resolves a full vercel id", () => {
     const card = models.image.findImageModelCard("bfl/flux-pro-1.1");
@@ -45,7 +107,7 @@ describe("models.image catalogue invariants", () => {
     }
   });
 
-  it("toCompact preserves id, label, pricing, speed_label, deprecated", () => {
+  it("toCompact preserves id, label, release, pricing, speed_label, deprecated", () => {
     const card = models.image.models["bfl/flux-pro-1.1"]!;
     const compact = models.image.toCompact(card);
     expect(compact).toEqual({
@@ -53,6 +115,7 @@ describe("models.image catalogue invariants", () => {
       label: card.label,
       deprecated: card.deprecated,
       short_description: card.short_description,
+      release: card.release,
       speed_label: card.speed_label,
       pricing: card.pricing,
     });

--- a/packages/grida-ai-models/__tests__/snapshot.test.ts
+++ b/packages/grida-ai-models/__tests__/snapshot.test.ts
@@ -126,6 +126,11 @@ describe("models.snapshot.parse — acceptance", () => {
     const rich = spec("acme/rich", {
       short_label: "Rich",
       deprecated: true,
+      release: {
+        date: "2026-02-03",
+        basis: "model",
+        source_url: "https://example.com/releases/acme-rich",
+      },
       multimodal: true,
       imageInputMimes: ["image/png", "image/webp"],
       cost: {
@@ -259,6 +264,40 @@ describe("models.snapshot.parse — rejection", () => {
     ],
     ["a non-boolean deprecated", { deprecated: 1 }],
     ["an empty short_label", { short_label: "" }],
+    [
+      "an impossible release date",
+      {
+        release: {
+          date: "2026-02-30",
+          basis: "model",
+          source_url: "https://example.com/release",
+        },
+      },
+    ],
+    [
+      "a non-HTTPS release source",
+      {
+        release: {
+          date: "2026-02-03",
+          basis: "model",
+          source_url: "http://example.com/release",
+        },
+      },
+    ],
+    [
+      "a half-populated release",
+      { release: { date: "2026-02-03", basis: "model" } },
+    ],
+    [
+      "a null intrinsic model date",
+      {
+        release: {
+          date: null,
+          basis: "model",
+          source_url: "https://example.com/release",
+        },
+      },
+    ],
   ])("rejects a spec with %s", (_label, over) => {
     expect(
       snapshot.parse(mutateSpec(over as Record<string, unknown>))
@@ -475,6 +514,16 @@ describe("models.snapshot media — image validation", () => {
       { default: { width: 1, height: 1, aspect_ratio: "square" } },
     ],
     ["an unknown pricing arm", { pricing: { type: "per_furlong", usd: 1 } }],
+    [
+      "a malformed release",
+      {
+        release: {
+          date: "not-a-date",
+          basis: "model",
+          source_url: "https://example.com/release",
+        },
+      },
+    ],
     ["no provider bindings", { providers: {} }],
   ])("rejects %s", (_label, over) => {
     const parsed = snapshot.parse(mutateCard("openai/gpt-image-2", over));
@@ -659,6 +708,16 @@ describe("models.snapshot media — video validation", () => {
     ["a missing url", { url: "" }],
     ["a bad aspect ratio", { aspect_ratios: ["wide"] }],
     ["a non-boolean audio", { audio: "yes" }],
+    [
+      "a malformed release",
+      {
+        release: {
+          date: "2026-13-01",
+          basis: "model",
+          source_url: "https://example.com/release",
+        },
+      },
+    ],
   ])("rejects %s", (_label, over) => {
     const video = seedVideo();
     video["google/veo-3.1"] = {

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -158,6 +158,35 @@ export namespace models {
    */
   export type CatalogueStatus = "listed" | "staged";
 
+  /** Calendar date serialized as `YYYY-MM-DD`. Runtime snapshot parsing also
+   * validates that the value is a real Gregorian calendar date. */
+  export type ISODate = `${number}-${number}-${number}`;
+
+  /** What the release date describes. Model dates are intrinsic and therefore
+   * shared by every provider binding; endpoint dates describe a serving route
+   * when no exact upstream model launch can be established. */
+  export type ModelReleaseBasis = "model" | "provider_endpoint";
+
+  /**
+   * Source-backed release metadata.
+   *
+   * `date` is the first broad public availability of the exact named model or
+   * variant; public preview counts, closed/limited preview does not. A missing
+   * exact date is represented as `null`, never guessed, and is only valid for
+   * a provider endpoint whose linked history does not expose a day.
+   */
+  export type ModelRelease =
+    | Readonly<{
+        date: ISODate;
+        basis: ModelReleaseBasis;
+        source_url: string;
+      }>
+    | Readonly<{
+        date: null;
+        basis: "provider_endpoint";
+        source_url: string;
+      }>;
+
   // ── models.text ───────────────────────────────────────────────────
   //
   // Text-model spec catalogue. Single source of truth for per-model
@@ -205,6 +234,12 @@ export namespace models {
        * unset; use {@link displayLabel} to resolve.
        */
       short_label?: string;
+      /**
+       * Source-backed first public release. Optional only so custom models and
+       * pre-field catalogue snapshots remain readable; every bundled entry has
+       * it.
+       */
+      release?: ModelRelease;
       /** Whether the model accepts image/file inputs. */
       multimodal: boolean;
       /**
@@ -232,6 +267,10 @@ export namespace models {
        */
       deprecated?: boolean;
     }
+
+    /** A bundled text-model spec. Unlike the snapshot-compatible base shape,
+     * every built-in has grounded release metadata. */
+    type BundledModelSpec = ModelSpec & { release: ModelRelease };
 
     // Provider-family capabilities are kept private so catalogue entries remain
     // explicit while sharing one source-backed value. Do not derive these from
@@ -275,6 +314,11 @@ export namespace models {
       "openai/gpt-5.5": {
         id: "openai/gpt-5.5",
         label: "GPT-5.5",
+        release: {
+          date: "2026-04-23",
+          basis: "model",
+          source_url: "https://openai.com/index/introducing-gpt-5-5/",
+        },
         multimodal: true,
         imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -291,6 +335,11 @@ export namespace models {
       "openai/gpt-5.5-pro": {
         id: "openai/gpt-5.5-pro",
         label: "GPT-5.5 Pro",
+        release: {
+          date: "2026-04-23",
+          basis: "model",
+          source_url: "https://openai.com/index/introducing-gpt-5-5/",
+        },
         multimodal: true,
         imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -307,6 +356,11 @@ export namespace models {
       "openai/gpt-5.6-sol": {
         id: "openai/gpt-5.6-sol",
         label: "GPT-5.6 Sol",
+        release: {
+          date: "2026-07-09",
+          basis: "model",
+          source_url: "https://openai.com/index/gpt-5-6/",
+        },
         multimodal: true,
         imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -323,6 +377,11 @@ export namespace models {
       "openai/gpt-5.6-terra": {
         id: "openai/gpt-5.6-terra",
         label: "GPT-5.6 Terra",
+        release: {
+          date: "2026-07-09",
+          basis: "model",
+          source_url: "https://openai.com/index/gpt-5-6/",
+        },
         multimodal: true,
         imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -339,6 +398,11 @@ export namespace models {
       "openai/gpt-5.6-luna": {
         id: "openai/gpt-5.6-luna",
         label: "GPT-5.6 Luna",
+        release: {
+          date: "2026-07-09",
+          basis: "model",
+          source_url: "https://openai.com/index/gpt-5-6/",
+        },
         multimodal: true,
         imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -359,6 +423,12 @@ export namespace models {
       "anthropic/claude-sonnet-5": {
         id: "anthropic/claude-sonnet-5",
         label: "Claude Sonnet 5",
+        release: {
+          date: "2026-06-30",
+          basis: "model",
+          source_url:
+            "https://platform.claude.com/docs/en/release-notes/overview",
+        },
         short_label: "Sonnet 5",
         multimodal: true,
         imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
@@ -375,6 +445,12 @@ export namespace models {
       "anthropic/claude-fable-5.1": {
         id: "anthropic/claude-fable-5.1",
         label: "Claude Fable 5.1",
+        release: {
+          date: "2026-09-01",
+          basis: "model",
+          source_url:
+            "https://platform.claude.com/docs/en/release-notes/overview",
+        },
         short_label: "Fable 5.1",
         multimodal: true,
         imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
@@ -389,6 +465,12 @@ export namespace models {
       "anthropic/claude-fable-5": {
         id: "anthropic/claude-fable-5",
         label: "Claude Fable 5",
+        release: {
+          date: "2026-06-09",
+          basis: "model",
+          source_url:
+            "https://platform.claude.com/docs/en/release-notes/overview",
+        },
         short_label: "Fable 5",
         multimodal: true,
         imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
@@ -402,6 +484,12 @@ export namespace models {
       "anthropic/claude-opus-5": {
         id: "anthropic/claude-opus-5",
         label: "Claude Opus 5",
+        release: {
+          date: "2026-07-24",
+          basis: "model",
+          source_url:
+            "https://platform.claude.com/docs/en/release-notes/overview",
+        },
         short_label: "Opus 5",
         multimodal: true,
         imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
@@ -413,6 +501,12 @@ export namespace models {
       "anthropic/claude-opus-4.8": {
         id: "anthropic/claude-opus-4.8",
         label: "Claude Opus 4.8",
+        release: {
+          date: "2026-05-28",
+          basis: "model",
+          source_url:
+            "https://platform.claude.com/docs/en/release-notes/overview",
+        },
         short_label: "Opus 4.8",
         multimodal: true,
         imageInputMimes: ANTHROPIC_IMAGE_INPUT_MIMES,
@@ -437,6 +531,11 @@ export namespace models {
       "google/gemini-3.8-flash": {
         id: "google/gemini-3.8-flash",
         label: "Gemini 3.8 Flash",
+        release: {
+          date: "2026-09-02",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         multimodal: true,
         imageInputMimes: GOOGLE_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -452,6 +551,11 @@ export namespace models {
       "google/gemini-3.7-flash": {
         id: "google/gemini-3.7-flash",
         label: "Gemini 3.7 Flash",
+        release: {
+          date: "2026-08-13",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         multimodal: true,
         imageInputMimes: GOOGLE_IMAGE_INPUT_MIMES,
         tool_call: true,
@@ -463,6 +567,11 @@ export namespace models {
       "google/gemini-3.1-pro-preview": {
         id: "google/gemini-3.1-pro-preview",
         label: "Gemini 3.1 Pro Preview",
+        release: {
+          date: "2026-02-19",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         short_label: "Gemini 3.1 Pro",
         multimodal: true,
         imageInputMimes: GOOGLE_IMAGE_INPUT_MIMES,
@@ -485,20 +594,26 @@ export namespace models {
           },
         },
       },
-    } as const satisfies Record<string, ModelSpec>;
+    } as const satisfies Record<string, BundledModelSpec>;
 
     /** Catalogued text-model id. The literal key set of {@link catalog}. */
     export type CatalogId = keyof typeof catalogSpecs;
 
     /** Read-only map of catalog model id → spec. */
-    export const catalog: Record<CatalogId, ModelSpec> = catalogSpecs;
+    export const catalog: Record<
+      CatalogId,
+      ModelSpec & { release: ModelRelease }
+    > = catalogSpecs;
 
     /**
      * Text-model spec for each tier. Derived from `TIER_MODEL_IDS` +
      * `catalog`; the compiler enforces that every tier's id resolves to
      * a real catalog entry.
      */
-    export const byTier: Record<ModelTier, ModelSpec> = {
+    export const byTier: Record<
+      ModelTier,
+      ModelSpec & { release: ModelRelease }
+    > = {
       nano: catalog[TIER_MODEL_IDS.nano],
       mini: catalog[TIER_MODEL_IDS.mini],
       pro: catalog[TIER_MODEL_IDS.pro],
@@ -893,6 +1008,7 @@ export namespace models {
       label: string;
       deprecated: boolean;
       short_description: string;
+      release?: ModelRelease;
       speed_label: SpeedLabel;
       /** Real provider pricing data. */
       pricing: ImageModelPricing;
@@ -903,6 +1019,8 @@ export namespace models {
       label: string;
       deprecated: boolean;
       short_description: string;
+      /** Optional only for backwards-compatible snapshot parsing. */
+      release?: ModelRelease;
       vendor: Vendor;
       /**
        * Primary/default provider for legacy single-provider readers (the web
@@ -953,18 +1071,23 @@ export namespace models {
       };
     };
 
+    type CatalogCard = ImageModelCard & {
+      release: ModelRelease;
+    };
+
     export const toCompact = (card: ImageModelCard): ImageModelCardCompact => {
       return {
         id: card.id,
         label: card.label,
         deprecated: card.deprecated,
         short_description: card.short_description,
+        release: card.release,
         speed_label: card.speed_label,
         pricing: card.pricing,
       };
     };
 
-    export const models: Partial<Record<ImageModelId, ImageModelCard>> = {
+    export const models: Partial<Record<ImageModelId, CatalogCard>> = {
       // -----------------------------------------------------------------
       // OpenAI
       // -----------------------------------------------------------------
@@ -972,6 +1095,12 @@ export namespace models {
       "openai/gpt-image-2": {
         id: "openai/gpt-image-2",
         label: "GPT Image 2",
+        release: {
+          date: "2026-04-21",
+          basis: "model",
+          source_url:
+            "https://developers.openai.com/api/docs/models/gpt-image-2",
+        },
         deprecated: false,
         short_description:
           "State-of-the-art image generation and editing with flexible resolutions",
@@ -1058,6 +1187,11 @@ export namespace models {
       "openai/gpt-image-1.5": {
         id: "openai/gpt-image-1.5",
         label: "GPT Image 1.5",
+        release: {
+          date: "2025-12-16",
+          basis: "model",
+          source_url: "https://openai.com/index/new-chatgpt-images-is-here/",
+        },
         deprecated: true,
         short_description:
           "Previous-generation image model. Superseded by GPT Image 2.",
@@ -1116,6 +1250,11 @@ export namespace models {
       "openai/gpt-image-1-mini": {
         id: "openai/gpt-image-1-mini",
         label: "GPT Image Mini",
+        release: {
+          date: "2025-10-06",
+          basis: "model",
+          source_url: "https://openai.com/devday/",
+        },
         deprecated: false,
         short_description: "Cost-efficient image generation model",
         vendor: "openai",
@@ -1178,6 +1317,11 @@ export namespace models {
       "google/gemini-3.1-flash-image-preview": {
         id: "google/gemini-3.1-flash-image-preview",
         label: "Gemini 3.1 Flash Image",
+        release: {
+          date: "2026-02-26",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         deprecated: false,
         short_description:
           "Fast, efficient multimodal model with native image generation",
@@ -1234,6 +1378,12 @@ export namespace models {
       "google/gemini-3-pro-image": {
         id: "google/gemini-3-pro-image",
         label: "Gemini 3 Pro Image",
+        release: {
+          date: "2025-11-20",
+          basis: "model",
+          source_url:
+            "https://blog.google/innovation-and-ai/products/nano-banana-pro/",
+        },
         deprecated: false,
         short_description:
           "High-quality multimodal model with native image generation",
@@ -1288,6 +1438,11 @@ export namespace models {
       "google/gemini-3.1-flash-lite-image": {
         id: "google/gemini-3.1-flash-lite-image",
         label: "Gemini 3.1 Flash Lite Image",
+        release: {
+          date: "2026-06-30",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         deprecated: false,
         short_description:
           "Fastest, most cost-efficient Gemini image model; 1K output only.",
@@ -1335,6 +1490,11 @@ export namespace models {
       "bfl/flux-2-pro": {
         id: "bfl/flux-2-pro",
         label: "Flux 2 Pro",
+        release: {
+          date: "2025-11-25",
+          basis: "model",
+          source_url: "https://bfl.ai/blog/flux-2",
+        },
         deprecated: false,
         short_description:
           "Latest Flux model with best-in-class image quality and prompt adherence",
@@ -1394,6 +1554,11 @@ export namespace models {
       "bfl/flux-2-max": {
         id: "bfl/flux-2-max",
         label: "Flux 2 Max",
+        release: {
+          date: "2025-12-16",
+          basis: "model",
+          source_url: "https://playground.bfl.ai/changelog",
+        },
         deprecated: false,
         short_description:
           "Black Forest Labs' highest-fidelity Flux 2 — maximum prompt adherence and detail.",
@@ -1442,6 +1607,11 @@ export namespace models {
       "bfl/flux-kontext-max": {
         id: "bfl/flux-kontext-max",
         label: "Flux Kontext Max",
+        release: {
+          date: "2025-05-29",
+          basis: "model",
+          source_url: "https://bfl.ai/blog/flux-1-kontext",
+        },
         deprecated: false,
         short_description:
           "Highest quality Flux model for context-aware image generation and editing",
@@ -1481,6 +1651,11 @@ export namespace models {
       "bfl/flux-kontext-pro": {
         id: "bfl/flux-kontext-pro",
         label: "Flux Kontext Pro",
+        release: {
+          date: "2025-05-29",
+          basis: "model",
+          source_url: "https://bfl.ai/blog/flux-1-kontext",
+        },
         deprecated: false,
         short_description: "Fast context-aware image generation and editing",
         vendor: "black-forest-labs",
@@ -1523,6 +1698,11 @@ export namespace models {
       "bfl/flux-pro-1.1": {
         id: "bfl/flux-pro-1.1",
         label: "Flux Pro 1.1",
+        release: {
+          date: "2024-10-02",
+          basis: "model",
+          source_url: "https://bfl.ai/blog/24-10-02-flux",
+        },
         deprecated: false,
         short_description:
           "Faster, better FLUX Pro. Text-to-image model with excellent image quality and output diversity.",
@@ -1562,6 +1742,12 @@ export namespace models {
       "bytedance/seedream-5.0-pro": {
         id: "bytedance/seedream-5.0-pro",
         label: "Seedream 5.0 Pro",
+        release: {
+          date: "2026-07-08",
+          basis: "model",
+          source_url:
+            "https://seed.bytedance.com/en/blog/beyond-generation-it-understands-design-introducing-seedream-5-0-pro",
+        },
         deprecated: false,
         short_description:
           "ByteDance's flagship image model — dense layouts, infographics and text-heavy compositions at 1K–2K.",
@@ -1622,6 +1808,12 @@ export namespace models {
       "bytedance/seedream-5.0-lite": {
         id: "bytedance/seedream-5.0-lite",
         label: "Seedream 5.0 Lite",
+        release: {
+          date: "2026-02-13",
+          basis: "model",
+          source_url:
+            "https://seed.bytedance.com/en/blog/deeper-thinking-more-accurate-generation-introducing-seedream-5-0-lite",
+        },
         deprecated: false,
         short_description:
           "ByteDance's fast 2K–4K image model — Seedream 5.0 quality at the 4.5 price point.",
@@ -1679,6 +1871,12 @@ export namespace models {
       "bytedance/seedream-4.5": {
         id: "bytedance/seedream-4.5",
         label: "Seedream 4.5",
+        release: {
+          date: "2025-12-03",
+          basis: "model",
+          source_url:
+            "https://blog.fal.ai/seedream-4-5-is-now-available-on-fal/",
+        },
         deprecated: true,
         short_description:
           "ByteDance's unified image generation and editing model.",
@@ -1736,6 +1934,11 @@ export namespace models {
       "xai/grok-imagine-image-2.0": {
         id: "xai/grok-imagine-image-2.0",
         label: "Grok Imagine Image 2.0",
+        release: {
+          date: "2026-08-07",
+          basis: "model",
+          source_url: "https://x.ai/news/grok-imagine-image-2",
+        },
         deprecated: false,
         short_description:
           "SpaceXAI's image model — fast 1K/2K generation with a low-cost quality tier.",
@@ -1822,6 +2025,12 @@ export namespace models {
       "meta/muse-image-1.0": {
         id: "meta/muse-image-1.0",
         label: "Muse Image 1.0",
+        release: {
+          date: "2026-07-07",
+          basis: "model",
+          source_url:
+            "https://about.fb.com/news/2026/07/introducing-muse-image-meta-ai/",
+        },
         deprecated: false,
         short_description:
           "Meta's agentic image model — reasons before it renders; generates and edits from text and references.",
@@ -1872,6 +2081,12 @@ export namespace models {
       "recraft/recraft-v4.1": {
         id: "recraft/recraft-v4.1",
         label: "Recraft V4.1",
+        release: {
+          date: "2026-05-14",
+          basis: "model",
+          source_url:
+            "https://www.recraft.ai/blog/recraft-v4-1-more-beautiful-by-nature",
+        },
         deprecated: false,
         short_description:
           "Design-first image model — sharper prompt control and production-ready raster for brand and editorial work.",
@@ -1927,6 +2142,12 @@ export namespace models {
       "recraft/recraft-v3": {
         id: "recraft/recraft-v3",
         label: "Recraft V3",
+        release: {
+          date: "2024-10-30",
+          basis: "model",
+          source_url:
+            "https://www.recraft.ai/blog/recraft-introduces-a-revolutionary-ai-model-that-thinks-in-design-language",
+        },
         deprecated: true,
         short_description:
           "Design-grade image model with strong text rendering and vector styles.",
@@ -2052,6 +2273,7 @@ export namespace models {
       export type ModelCard = {
         id: ModelId;
         label: string;
+        release: ModelRelease;
         deprecated: boolean;
         short_description: string;
         vendor: "google";
@@ -2074,6 +2296,11 @@ export namespace models {
         "google/lyria-3": {
           id: "google/lyria-3",
           label: "Lyria 3",
+          release: {
+            date: "2026-02-18",
+            basis: "model",
+            source_url: "https://deepmind.google/models/model-cards/lyria-3/",
+          },
           deprecated: false,
           short_description:
             "Generate 30-second 48kHz stereo music clips from text or images.",
@@ -2101,6 +2328,12 @@ export namespace models {
         "google/lyria-3-pro": {
           id: "google/lyria-3-pro",
           label: "Lyria 3 Pro",
+          release: {
+            date: "2026-03-25",
+            basis: "model",
+            source_url:
+              "https://blog.google/innovation-and-ai/technology/developers-tools/lyria-3-developers/",
+          },
           deprecated: false,
           short_description:
             "Generate full-length tracks up to ~3 minutes from text or images.",
@@ -2171,6 +2404,7 @@ export namespace models {
       export type ModelCard = {
         id: ModelId;
         label: string;
+        release: ModelRelease;
         deprecated: boolean;
         short_description: string;
         vendor: "elevenlabs";
@@ -2191,6 +2425,12 @@ export namespace models {
         eleven_text_to_sound_v2: {
           id: "eleven_text_to_sound_v2",
           label: "Eleven Text to Sound v2",
+          release: {
+            date: "2025-09-02",
+            basis: "model",
+            source_url:
+              "https://www.linkedin.com/posts/elevenlabsio_introducing-v2-of-our-sfx-model-generate-activity-7368680062662909953-aeBg",
+          },
           deprecated: false,
           short_description:
             "Generate loopable sound effects up to 30 seconds from text.",
@@ -2259,6 +2499,7 @@ export namespace models {
       export type ModelCard = {
         id: ModelId;
         label: string;
+        release: ModelRelease;
         deprecated: boolean;
         short_description: string;
         vendor: "elevenlabs";
@@ -2276,6 +2517,11 @@ export namespace models {
         eleven_v3: {
           id: "eleven_v3",
           label: "Eleven v3",
+          release: {
+            date: "2025-06-03",
+            basis: "model",
+            source_url: "https://elevenlabs.io/blog/eleven-v3",
+          },
           deprecated: false,
           short_description:
             "Generate expressive speech with bracketed audio and emotion tags.",
@@ -2380,6 +2626,7 @@ export namespace models {
       /** Exact fal endpoint id; unlike video, there is no canonical indirection. */
       id: ThreeDModelId;
       label: string;
+      release: ModelRelease;
       deprecated: boolean;
       short_description: string;
       vendor: Vendor;
@@ -2405,6 +2652,11 @@ export namespace models {
       "fal-ai/hunyuan-3d/v3.1/pro/text-to-3d": {
         id: "fal-ai/hunyuan-3d/v3.1/pro/text-to-3d",
         label: "Hunyuan 3D v3.1 Pro — Text",
+        release: {
+          date: "2026-01-16",
+          basis: "model",
+          source_url: "https://cloud.tencent.com/document/product/1804/120694",
+        },
         deprecated: false,
         short_description: "Generate a textured 3D asset from a text prompt.",
         vendor: "tencent",
@@ -2424,6 +2676,11 @@ export namespace models {
       "fal-ai/hunyuan-3d/v3.1/pro/image-to-3d": {
         id: "fal-ai/hunyuan-3d/v3.1/pro/image-to-3d",
         label: "Hunyuan 3D v3.1 Pro — Image",
+        release: {
+          date: "2026-01-16",
+          basis: "model",
+          source_url: "https://cloud.tencent.com/document/product/1804/120694",
+        },
         deprecated: false,
         short_description:
           "Generate a textured 3D asset from one image or up to eight views.",
@@ -2448,6 +2705,11 @@ export namespace models {
       "fal-ai/trellis-2": {
         id: "fal-ai/trellis-2",
         label: "TRELLIS.2",
+        release: {
+          date: "2025-12-16",
+          basis: "model",
+          source_url: "https://huggingface.co/microsoft/TRELLIS.2-4B",
+        },
         deprecated: false,
         short_description:
           "Generate a textured GLB asset from a single reference image.",
@@ -2645,6 +2907,8 @@ export namespace models {
       /** Canonical, provider-agnostic id. */
       id: VideoModelId;
       label: string;
+      /** Optional only for backwards-compatible snapshot parsing. */
+      release?: ModelRelease;
       deprecated: boolean;
       short_description: string;
       vendor: Vendor;
@@ -2679,13 +2943,22 @@ export namespace models {
       providers: Partial<Record<VideoProvider, VideoProviderBinding>>;
     };
 
-    export const models: Partial<Record<VideoModelId, VideoModelCard>> = {
+    type CatalogCard = VideoModelCard & {
+      release: ModelRelease;
+    };
+
+    export const models: Partial<Record<VideoModelId, CatalogCard>> = {
       // -----------------------------------------------------------------
       // Google — Veo 3.1
       // -----------------------------------------------------------------
       "google/veo-3.1": {
         id: "google/veo-3.1",
         label: "Veo 3.1",
+        release: {
+          date: "2025-10-15",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         deprecated: false,
         short_description:
           "Google's flagship video model — strong prompt adherence with native, synchronized audio.",
@@ -2779,6 +3052,11 @@ export namespace models {
       "google/veo-3.1-fast": {
         id: "google/veo-3.1-fast",
         label: "Veo 3.1 Fast",
+        release: {
+          date: "2025-10-15",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         deprecated: false,
         short_description:
           "Faster, cheaper Veo 3.1 — the same envelope and native audio at a fraction of the price.",
@@ -2839,6 +3117,12 @@ export namespace models {
       "google/veo-3.1-lite": {
         id: "google/veo-3.1-lite",
         label: "Veo 3.1 Lite",
+        release: {
+          date: "2026-03-31",
+          basis: "model",
+          source_url:
+            "https://blog.google/innovation-and-ai/technology/ai/veo-3-1-lite/",
+        },
         deprecated: false,
         short_description:
           "Budget Veo 3.1 — 720p/1080p clips with native audio for a few cents a second.",
@@ -2896,6 +3180,12 @@ export namespace models {
       "alibaba/wan-3.0": {
         id: "alibaba/wan-3.0",
         label: "Wan 3.0",
+        release: {
+          date: "2026-08-06",
+          basis: "model",
+          source_url:
+            "https://www.alibabacloud.com/help/en/model-studio/newly-released-models",
+        },
         deprecated: false,
         short_description:
           "Alibaba's flagship video model — long clips (up to 30s) with bundled audio at the lowest per-second rates in the catalogue.",
@@ -2951,6 +3241,12 @@ export namespace models {
       "bytedance/seedance-2.0": {
         id: "bytedance/seedance-2.0",
         label: "Seedance 2.0",
+        release: {
+          date: "2026-02-12",
+          basis: "model",
+          source_url:
+            "https://seed.bytedance.com/en/blog/seedance-2-0-%E6%AD%A3%E5%BC%8F%E5%8F%91%E5%B8%83",
+        },
         deprecated: false,
         short_description:
           "ByteDance's video model — image-to-video with reference modes, up to 4K, at roughly two-thirds the price of Seedance 2.5.",
@@ -3020,7 +3316,7 @@ export namespace models {
       // -----------------------------------------------------------------
       // ByteDance — Seedance 2.5
       // -----------------------------------------------------------------
-      // Newer generation (2026-08-07), NOT a drop-in successor: ~55% more
+      // Newer generation (2026-07-31), NOT a drop-in successor: ~55% more
       // per token on the gateway ($10.70/MTok at 480p/720p, $11.70 at 1080p
       // vs 2.0's $7.00/$7.70), ~56–71% more per second on fal, and no 4K.
       // It buys 4–30s clips, video-editing and extend-video. 2.0 is cheaper
@@ -3031,6 +3327,12 @@ export namespace models {
       "bytedance/seedance-2.5": {
         id: "bytedance/seedance-2.5",
         label: "Seedance 2.5",
+        release: {
+          date: "2026-07-31",
+          basis: "model",
+          source_url:
+            "https://seed.bytedance.com/en/blog/one-take-creation-flexible-referencing-introducing-seedance-2-5",
+        },
         deprecated: false,
         short_description:
           "ByteDance's latest video model — up to 30-second clips with native audio, reference and editing modes.",
@@ -3079,6 +3381,11 @@ export namespace models {
       "xai/grok-imagine-video-1.5": {
         id: "xai/grok-imagine-video-1.5",
         label: "Grok Imagine Video 1.5",
+        release: {
+          date: "2026-06-03",
+          basis: "model",
+          source_url: "https://x.ai/news/grok-imagine-1-5",
+        },
         deprecated: false,
         short_description:
           "SpaceXAI's image-to-video model — animates a still into cinematic video with native, lip-synced audio.",
@@ -3181,6 +3488,7 @@ export namespace models {
     export type ImageToolModelCard = {
       id: ImageToolModelId;
       label: string;
+      release: ModelRelease;
       url: string;
       category: ImageToolModelCategory;
       /** Cost per invocation in USD (flat rate from provider). */
@@ -3191,6 +3499,12 @@ export namespace models {
       "recraft-ai/recraft-remove-background": {
         id: "recraft-ai/recraft-remove-background",
         label: "Recraft Remove Background",
+        release: {
+          date: null,
+          basis: "provider_endpoint",
+          source_url:
+            "https://replicate.com/recraft-ai/recraft-remove-background/versions",
+        },
         url: "https://replicate.com/recraft-ai/recraft-remove-background",
         category: "image/tool/remove-background",
         cost_usd: 0.01,
@@ -3198,6 +3512,12 @@ export namespace models {
       "851-labs/background-remover": {
         id: "851-labs/background-remover",
         label: "851 Labs Background Remover",
+        release: {
+          date: null,
+          basis: "provider_endpoint",
+          source_url:
+            "https://replicate.com/851-labs/background-remover/versions",
+        },
         url: "https://replicate.com/851-labs/background-remover",
         category: "image/tool/remove-background",
         cost_usd: 0.00048,
@@ -3205,6 +3525,12 @@ export namespace models {
       "bria/remove-background": {
         id: "bria/remove-background",
         label: "Bria Remove Background",
+        release: {
+          date: "2024-11-12",
+          basis: "model",
+          source_url:
+            "https://bria.ai/blog/brias-new-state-of-the-art-remove-background-outperforms-the-competition",
+        },
         url: "https://replicate.com/bria/remove-background",
         category: "image/tool/remove-background",
         cost_usd: 0.018,
@@ -3212,6 +3538,12 @@ export namespace models {
       "nightmareai/real-esrgan": {
         id: "nightmareai/real-esrgan",
         label: "Real-ESRGAN",
+        release: {
+          date: "2021-07-22",
+          basis: "model",
+          source_url:
+            "https://github.com/xinntao/Real-ESRGAN/releases/tag/v0.1.0",
+        },
         url: "https://replicate.com/nightmareai/real-esrgan",
         category: "image/tool/upscale",
         cost_usd: 0.002,
@@ -3256,6 +3588,7 @@ export namespace models {
     export type EmbeddingModelCard = {
       id: EmbeddingModelId;
       label: string;
+      release: ModelRelease;
       deprecated: boolean;
       short_description: string;
       vendor: Vendor;
@@ -3291,6 +3624,11 @@ export namespace models {
       "google/gemini-embedding-2": {
         id: "google/gemini-embedding-2",
         label: "Gemini Embedding 2",
+        release: {
+          date: "2026-03-10",
+          basis: "model",
+          source_url: "https://ai.google.dev/gemini-api/docs/changelog",
+        },
         deprecated: false,
         short_description:
           "Natively multimodal embedding (text + image into one space); 3072-d, MRL-truncatable.",
@@ -3476,6 +3814,39 @@ export namespace models {
       return typeof v === "string" && v.length > 0;
     }
 
+    function isISODate(v: unknown): v is ISODate {
+      if (typeof v !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+        return false;
+      }
+      const parsed = new Date(`${v}T00:00:00.000Z`);
+      return (
+        !Number.isNaN(parsed.valueOf()) &&
+        parsed.toISOString().slice(0, 10) === v
+      );
+    }
+
+    function isHttpsUrl(v: unknown): v is string {
+      return isText(v) && /^https:\/\/[^\s]+$/.test(v);
+    }
+
+    /**
+     * `undefined` means the additive field is absent on an older snapshot;
+     * `null` means it was present but malformed and the containing record must
+     * be rejected.
+     */
+    function parseRelease(v: unknown): ModelRelease | null | undefined {
+      if (v === undefined) return undefined;
+      if (!isRecord(v) || !isHttpsUrl(v.source_url)) return null;
+      if (v.basis !== "model" && v.basis !== "provider_endpoint") return null;
+      if (v.date === null) {
+        return v.basis === "provider_endpoint"
+          ? { date: null, basis: v.basis, source_url: v.source_url }
+          : null;
+      }
+      if (!isISODate(v.date)) return null;
+      return { date: v.date, basis: v.basis, source_url: v.source_url };
+    }
+
     /** A token count: positive and exactly representable. */
     function isCount(v: unknown): v is number {
       return typeof v === "number" && Number.isSafeInteger(v) && v > 0;
@@ -3539,6 +3910,8 @@ export namespace models {
       }
       const cost = parseCost(v.cost);
       if (!cost) return undefined;
+      const release = parseRelease(v.release);
+      if (release === null) return undefined;
 
       const spec: text.ModelSpec = {
         id: key,
@@ -3550,6 +3923,7 @@ export namespace models {
         outputLimit: v.outputLimit,
         cost,
       };
+      if (release) spec.release = release;
       if (v.short_label !== undefined) {
         if (!isText(v.short_label)) return undefined;
         spec.short_label = v.short_label;
@@ -3866,6 +4240,8 @@ export namespace models {
       if (typeof v.deprecated !== "boolean") return undefined;
       if (typeof v.listed !== "boolean") return undefined;
       if (!isRate(v.avg_cost_usd)) return undefined;
+      const release = parseRelease(v.release);
+      if (release === null) return undefined;
 
       const pricing = parseImagePricing(v.pricing);
       if (!pricing) return undefined;
@@ -3924,6 +4300,7 @@ export namespace models {
           aspect_ratio: v.default.aspect_ratio,
         },
       };
+      if (release) card.release = release;
       if (!optional(card, v, "listed_reason", isText)) return undefined;
       return card;
     }
@@ -3944,6 +4321,8 @@ export namespace models {
       // otherwise is malformed, not a hidden card.
       if (v.listed !== true) return undefined;
       if (typeof v.audio !== "boolean") return undefined;
+      const release = parseRelease(v.release);
+      if (release === null) return undefined;
       if (!isCount(v.min_duration) || !isCount(v.max_duration))
         return undefined;
       if (v.min_duration > v.max_duration) return undefined;
@@ -4004,6 +4383,7 @@ export namespace models {
         url: v.url,
         providers,
       };
+      if (release) card.release = release;
       return card;
     }
 


### PR DESCRIPTION
## Summary

- add source-backed release metadata to every bundled model family
- validate release provenance in catalogue invariants and snapshot parsing
- show linked release dates as the final column on `/ai/models`, replacing visitor-facing staged status
- teach the AI-model research workflow to treat models.dev dates as discovery hints that require vendor verification

## Review findings resolved

- keep the bundled text-model helper private instead of adding an unnecessary package export
- distinguish intrinsic model releases from provider-endpoint availability
- link unknown endpoint dates to provider version history rather than a general product video
- keep `docs/models` unchanged because it is customer documentation outside this task

## Verification

- `pnpm --filter @grida/ai-models test` — 194 passed
- `pnpm --filter @grida/ai-models typecheck`
- `pnpm --filter @grida/ai-models build`
- `pnpm --filter editor typecheck`
- focused oxlint and Python syntax checks
- browser render: HTTP 200, no console errors, all seven catalogue tables end with Released