### PR TITLE
feat(ai): add GPT-6 Astra and refresh model tiers

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "description": "Grida Desktop App",
   "keywords": [],

--- a/desktop/src/chatgpt-configuration.test.ts
+++ b/desktop/src/chatgpt-configuration.test.ts
@@ -165,5 +165,8 @@ describe("CHATGPT_SUBSCRIPTION_CONFIG.tier_model_ids", () => {
     expect(
       subscriptionModelIds.has(CHATGPT_SUBSCRIPTION_CONFIG.default_model_id)
     ).toBe(true);
+    expect(CHATGPT_SUBSCRIPTION_CONFIG.default_model_id).toBe(
+      CHATGPT_SUBSCRIPTION_CONFIG.tier_model_ids?.pro
+    );
   });
 });

--- a/desktop/src/chatgpt-configuration.ts
+++ b/desktop/src/chatgpt-configuration.ts
@@ -52,7 +52,7 @@ export const CHATGPT_SUBSCRIPTION_CONFIG: ChatGptProviderConfig = {
   },
   responses_url: CHATGPT_RESPONSES_URL,
   originator: "grida",
-  default_model_id: "openai/gpt-5.6-terra",
+  default_model_id: "openai/gpt-5.6-sol",
   // Mirrors `TIER_MODEL_IDS` from the catalogue. It is a SEPARATE table
   // because the subscription serves its own model set — a catalogue tier
   // model the subscription does not offer is the only reason these may
@@ -60,8 +60,8 @@ export const CHATGPT_SUBSCRIPTION_CONFIG: ChatGptProviderConfig = {
   // silent and expensive (background titler/compactor run on `nano`).
   tier_model_ids: {
     nano: "openai/gpt-5.6-luna",
-    mini: "openai/gpt-5.6-luna",
-    pro: "openai/gpt-5.6-terra",
+    mini: "openai/gpt-5.6-terra",
+    pro: "openai/gpt-5.6-sol",
     max: "openai/gpt-5.6-sol",
   },
 };

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -49,14 +49,12 @@ describe("GET /api/v1/ai/models", () => {
     expect(body.object).toBe("list");
 
     const byId = new Map(body.data.map((entry) => [entry.id, entry]));
-    // Tier annotation via the reverse TIER_MODEL_IDS map. `nano` and
-    // `mini` currently collapse onto GPT-5.6 Luna, and a collapsed id is
-    // reported at the lowest tier it serves — so no id is annotated
-    // `mini` today. See TIER_BY_MODEL_ID in lib/ai/openai-compat/hosted-models.ts.
+    // Tier annotation follows the reverse TIER_MODEL_IDS map.
     for (const [tier, id] of [
       ["nano", "openai/gpt-5.6-luna"],
-      ["pro", "openai/gpt-5.6-terra"],
-      ["max", "openai/gpt-5.6-sol"],
+      ["mini", "openai/gpt-5.6-terra"],
+      ["pro", "openai/gpt-5.6-sol"],
+      ["max", "openai/gpt-6-astra"],
     ] as const) {
       expect(byId.get(id)?.grida).toMatchObject({ modality: "text", tier });
     }

--- a/editor/app/(www)/(ai)/ai/models/page.tsx
+++ b/editor/app/(www)/(ai)/ai/models/page.tsx
@@ -127,7 +127,7 @@ function ReleaseDate({
 }
 
 const LONG_CONTEXT_PRICING_NOTE =
-  "For GPT-5.5 and GPT-5.6 Sol, Terra, and Luna, requests above 272K total input tokens use 2× input/cache rates and 1.5× output rates for the full request.";
+  "For GPT-5.5, all GPT-5.6 variants, and GPT-6 Astra, requests above 272K total input tokens use 2× input/cache rates and 1.5× output rates for the full request.";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/editor/lib/ai/__tests__/server.test.ts
+++ b/editor/lib/ai/__tests__/server.test.ts
@@ -203,6 +203,24 @@ describe("costMillsFromTokenUsage", () => {
     );
   });
 
+  it("meters GPT-6 Astra at its published long-context rates", () => {
+    const mills = costMillsFromTokenUsage("openai/gpt-6-astra", {
+      inputTokens: {
+        total: 272_001,
+        noCache: 180_001,
+        cacheRead: 72_000,
+        cacheWrite: 20_000,
+      },
+      outputTokens: { total: 10_000, reasoning: 2_000 },
+    });
+
+    expect(mills).toBeCloseTo(
+      (((180_001 * 10 + 72_000 * 1 + 20_000 * 12.5) * 2 + 10_000 * 50 * 1.5) /
+        1_000_000) *
+        1000
+    );
+  });
+
   it("derives total input from normalized buckets before applying the band", () => {
     const mills = costMillsFromTokenUsage("openai/gpt-5.6-terra", {
       inputTokens: {

--- a/editor/lib/ai/openai-compat/hosted-models.ts
+++ b/editor/lib/ai/openai-compat/hosted-models.ts
@@ -49,10 +49,8 @@ const TIER_ORDER = [
 /**
  * Reverse of `TIER_MODEL_IDS`.
  *
- * Tiers can collapse onto one id: `nano` is a floor (the cheapest model
- * still good enough), so when that model is also the best value at
- * `mini`, both tiers name it — the state today. See `TIER_MODEL_IDS` in
- * `@grida/ai-models` for why.
+ * Tiers can collapse onto one id, although the current capability ladder
+ * assigns a distinct model to every tier.
  *
  * The payload carries one tier per model, so a collapsed id is reported
  * at the LOWEST tier it serves. Walking `TIER_ORDER` ascending with

--- a/editor/scaffolds/desktop/shared/default-model.test.ts
+++ b/editor/scaffolds/desktop/shared/default-model.test.ts
@@ -22,8 +22,8 @@ const knows =
     typeof id === "string" && ids.includes(id);
 
 describe("resolveDefaultModelSelection", () => {
-  it("keeps GPT-5.6 Terra as the generic fallback", () => {
-    expect(DEFAULT_MODEL_ID).toBe("openai/gpt-5.6-terra");
+  it("uses GPT-5.6 Sol as the generic pro-tier fallback", () => {
+    expect(DEFAULT_MODEL_ID).toBe("openai/gpt-5.6-sol");
   });
 
   it("keeps the generic fallback compatible with the first-priority ChatGPT provider", () => {

--- a/editor/scaffolds/desktop/shared/default-model.ts
+++ b/editor/scaffolds/desktop/shared/default-model.ts
@@ -48,15 +48,19 @@ export const DEFAULT_MODEL_ID: string = TIER_MODEL_IDS.pro;
  */
 export const GG_INCLUDED_MODEL_ID: string = TIER_MODEL_IDS.pro;
 
-/** Desktop-only default for an untouched, ready subscription-backed chat. */
+/**
+ * Desktop-only default for an untouched, ready subscription-backed chat.
+ * The compile-time check keeps the catalogue's `pro` tier on the closed,
+ * observed ChatGPT subscription allowlist even when `max` moves ahead of it.
+ */
 export const CHATGPT_READY_DEFAULT_MODEL_ID =
-  TIER_MODEL_IDS.max satisfies ChatGptSubscriptionModelId;
+  TIER_MODEL_IDS.pro satisfies ChatGptSubscriptionModelId;
 
 /**
  * The initial default for a new chat. An explicit caller-seeded `initial`
  * (a known id — e.g. the welcome handoff carrying the home composer's pick)
  * always wins. Otherwise a ready subscription chooses ChatGPT/Sol, a live
- * Grida session chooses Grida/Terra, and the unresolved fallback stays
+ * Grida session chooses Grida/Sol, and the unresolved fallback stays
  * provider-less until availability resolves.
  */
 export function resolveDefaultModelSelection(opts: {

--- a/packages/grida-ai-models/__tests__/modelSpecById.test.ts
+++ b/packages/grida-ai-models/__tests__/modelSpecById.test.ts
@@ -3,6 +3,10 @@ import models, { TIER_MODEL_IDS } from "..";
 describe("models.text.modelSpecById", () => {
   it.each([
     {
+      id: "openai/gpt-6-astra",
+      label: "GPT-6 Astra",
+    },
+    {
       id: "openai/gpt-5.6-sol",
       label: "GPT-5.6 Sol",
     },

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -681,16 +681,16 @@ describe("models.text.byTier", () => {
   it("pins the accepted capability and cost topology", () => {
     expect(TIER_MODEL_IDS).toEqual({
       nano: "openai/gpt-5.6-luna",
-      mini: "openai/gpt-5.6-luna",
-      pro: "openai/gpt-5.6-terra",
-      max: "openai/gpt-5.6-sol",
+      mini: "openai/gpt-5.6-terra",
+      pro: "openai/gpt-5.6-sol",
+      max: "openai/gpt-6-astra",
     });
+    expect(new Set(Object.values(TIER_MODEL_IDS)).size).toBe(4);
   });
 
   // `nano` is the cheapest model still good enough for background work,
-  // so it may equal `mini` (it does today — see TIER_MODEL_IDS in
-  // ../src/tiers.ts) but must never cost more. Guards the tier order
-  // against a repoint that quietly makes cheap work expensive.
+  // so it must never cost more than `mini`. Guards the tier order against a
+  // repoint that quietly makes cheap work expensive.
   it("keeps nano at or below mini on every cost bucket", () => {
     const nano = models.text.byTier.nano.cost;
     const mini = models.text.byTier.mini.cost;
@@ -738,6 +738,18 @@ describe("models.text current catalogue", () => {
   } as const;
 
   const newModels = [
+    {
+      id: "openai/gpt-6-astra",
+      contextWindow: 1_050_000,
+      outputLimit: 128_000,
+      cost: {
+        input: 10,
+        output: 50,
+        cacheRead: 1,
+        cacheWrite: 12.5,
+        longContext,
+      },
+    },
     {
       id: "openai/gpt-5.6-sol",
       contextWindow: 1_050_000,
@@ -840,12 +852,27 @@ describe("models.text current catalogue", () => {
     expect(spec.cost).toEqual(expected.cost);
   });
 
+  it("pins the grounded Astra and Fable 5.1 release facts", () => {
+    expect(models.text.catalog["openai/gpt-6-astra"].release).toEqual({
+      date: "2026-09-04",
+      basis: "provider_endpoint",
+      source_url: "https://vercel.com/ai-gateway/models/gpt-6-astra",
+    });
+    expect(models.text.catalog["anthropic/claude-fable-5.1"].release).toEqual({
+      date: "2026-09-01",
+      basis: "model",
+      source_url:
+        "https://platform.claude.com/docs/en/models/fable-5-1/overview",
+    });
+  });
+
   it("keeps the published long-context rule on every affected OpenAI card", () => {
     for (const id of [
       "openai/gpt-5.5",
       "openai/gpt-5.6-sol",
       "openai/gpt-5.6-terra",
       "openai/gpt-5.6-luna",
+      "openai/gpt-6-astra",
     ] as const) {
       expect(models.text.catalog[id].cost.longContext).toEqual(longContext);
     }
@@ -867,6 +894,12 @@ describe("models.text current catalogue", () => {
   });
 
   it("keeps catalogue lifecycle markers scoped to the requested models", () => {
+    expect(
+      models.text.catalog["openai/gpt-6-astra"].deprecated
+    ).toBeUndefined();
+    expect(
+      models.text.catalog["openai/gpt-5.6-sol"].deprecated
+    ).toBeUndefined();
     expect(models.text.catalog["openai/gpt-5.5"].deprecated).toBe(true);
     expect(
       models.text.catalog["openai/gpt-5.5-pro"].deprecated

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -300,10 +300,11 @@ export namespace models {
     ] as const satisfies readonly ImageInputMime[];
 
     // OpenAI bills the full request at these multipliers once its total input
-    // exceeds 272K tokens. The same rule is published for GPT-5.5 and every
-    // GPT-5.6 family member.
+    // exceeds 272K tokens. The same rule is published for GPT-5.5, every
+    // GPT-5.6 family member, and GPT-6 Astra.
     // https://developers.openai.com/api/docs/models/gpt-5.5
     // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+    // https://developers.openai.com/api/docs/models/gpt-6-astra
     const OPENAI_LONG_CONTEXT_PRICING = {
       inputTokensAbove: 272_000,
       inputMultiplier: 2,
@@ -416,6 +417,32 @@ export namespace models {
           longContext: OPENAI_LONG_CONTEXT_PRICING,
         },
       },
+      // OpenAI's September 3 introduction remained a limited rollout. The
+      // September 4 date below is the exact Vercel route's broad availability,
+      // which is the release fact relevant to this gateway-shaped card.
+      // https://openai.com/products/release-notes/
+      // https://vercel.com/ai-gateway/models/gpt-6-astra
+      "openai/gpt-6-astra": {
+        id: "openai/gpt-6-astra",
+        label: "GPT-6 Astra",
+        release: {
+          date: "2026-09-04",
+          basis: "provider_endpoint",
+          source_url: "https://vercel.com/ai-gateway/models/gpt-6-astra",
+        },
+        multimodal: true,
+        imageInputMimes: OPENAI_IMAGE_INPUT_MIMES,
+        tool_call: true,
+        contextWindow: 1_050_000,
+        outputLimit: 128_000,
+        cost: {
+          input: 10,
+          output: 50,
+          cacheRead: 1,
+          cacheWrite: 12.5,
+          longContext: OPENAI_LONG_CONTEXT_PRICING,
+        },
+      },
       // $2/$10 is the standard rate, not a live discount: it launched as an
       // introductory rate and Anthropic made it permanent, cancelling the
       // announced step up to $3/$15. Do not restore the higher card.
@@ -441,7 +468,7 @@ export namespace models {
       // cut to $0.25/MTok. Not a drop-in successor — forced tool choice
       // (`tool_choice` `any`/`tool`) is rejected here — which is why Fable 5
       // stays catalogued rather than being removed.
-      // https://platform.claude.com/docs/en/about-claude/pricing
+      // https://platform.claude.com/docs/en/models/fable-5-1/overview
       "anthropic/claude-fable-5.1": {
         id: "anthropic/claude-fable-5.1",
         label: "Claude Fable 5.1",
@@ -449,7 +476,7 @@ export namespace models {
           date: "2026-09-01",
           basis: "model",
           source_url:
-            "https://platform.claude.com/docs/en/release-notes/overview",
+            "https://platform.claude.com/docs/en/models/fable-5-1/overview",
         },
         short_label: "Fable 5.1",
         multimodal: true,

--- a/packages/grida-ai-models/src/tiers.ts
+++ b/packages/grida-ai-models/src/tiers.ts
@@ -35,27 +35,17 @@ export type ModelTier = "nano" | "mini" | "pro" | "max";
  * tier mapped to an id that lacks a matching entry in the text
  * catalogue (see `./models`).
  *
- * `nano` is a floor, not a price point: it holds the cheapest model
- * still good enough for background work. So it is **never more
- * expensive than `mini`**, but it is *not* guaranteed to be strictly
- * cheaper — when one model is both the lowest reasonable choice and
- * the best value at `mini`, the two tiers collapse onto the same id.
- *
- * That is the state today. OpenAI positions GPT-5.6 Luna as the 5.6
- * generation's nano-class model, and its current rate and 1.05M context
- * make it both the lowest reasonable choice and the best value at `mini`.
- * This is one model serving two tiers, not a tier being over-served.
- * See https://github.com/gridaco/grida/pull/1009.
- *
- * Expect the tiers to separate again as new models land. The invariant
- * that survives either way is `nano <= mini` on every cost bucket,
- * pinned by a catalogue test in `__tests__/models.test.ts`.
+ * Each tier is one adjacent rung in the current capability ladder:
+ * GPT-6 Astra > GPT-5.6 Sol > GPT-5.6 Terra > GPT-5.6 Luna. When a new
+ * model becomes the capability leader, shift the existing assignments by
+ * one rung; do not skip a still-current model or collapse tiers without a
+ * separate reason to change the topology.
  */
 export const TIER_MODEL_IDS = {
   nano: "openai/gpt-5.6-luna",
-  mini: "openai/gpt-5.6-luna",
-  pro: "openai/gpt-5.6-terra",
-  max: "openai/gpt-5.6-sol",
+  mini: "openai/gpt-5.6-terra",
+  pro: "openai/gpt-5.6-sol",
+  max: "openai/gpt-6-astra",
 } as const satisfies Record<ModelTier, models.text.CatalogId>;
 
 /** Literal union of tier-mapped model ids (values of {@link TIER_MODEL_IDS}). */


### PR DESCRIPTION
## Summary

- add GPT-6 Astra to the shared text-model catalogue with grounded release provenance, limits, pricing, and long-context metering
- refresh Claude Fable 5.1's release provenance to Anthropic's exact model page
- move the capability ladder to Luna → Terra → Sol → Astra across nano → mini → pro → max
- propagate Sol as the generic, Grida Gateway, and ChatGPT-ready default while keeping ChatGPT-subscription `max` on Sol because Astra is outside its closed observed allowlist
- keep release dates in the final column of the public models tables and update the long-context pricing note
- bump Desktop to 0.0.21 because the bundled native model configuration changes

## Screenshot

![Agent-model tier table with release date as the final column](https://github.com/gridaco/grida/blob/8c049e22d1a80a333aebdb6e426a982c66344941/gh-pr-images/pr-1027/model-tiers.jpg?raw=true)

## Grounding

- [GPT-6 Astra — OpenAI](https://developers.openai.com/api/docs/models/gpt-6-astra)
- [GPT-6 Astra — Vercel AI Gateway endpoint](https://vercel.com/ai-gateway/models/gpt-6-astra)
- [Claude Fable 5.1 — Anthropic](https://platform.claude.com/docs/en/models/fable-5-1/overview)

Astra's September 4 release is intentionally recorded with `provider_endpoint` basis. OpenAI's September 3 introduction was limited-org access; September 4 is the exact callable Vercel route's availability.

## Verification

- `pnpm --filter @grida/ai-models build`
- `pnpm --filter @grida/ai-models test` — 197 passed
- `pnpm --filter @grida/ai-models typecheck`
- focused editor catalogue, API, pricing, and default-model tests — 45 passed
- `pnpm --filter editor typecheck`
- `pnpm --filter @grida/agent typecheck`
- `pnpm --filter @grida/agent test` — 1,202 passed; 25 skipped; 2 todo
- Desktop typecheck and focused subscription-configuration test — 9 passed
- focused `oxfmt` and `oxlint`
- browser verification of `/ai/models` and `/home` — successful render, no console errors

## Security

- GRIDA-SEC-003: org-id attribution and billing seams are unchanged; this adds pricing coverage only
- GRIDA-SEC-006: exclusive scoped-token authentication is unchanged; only catalogue response expectations move with the tiers
- GRIDA-SEC-008: OAuth authorities, PKCE, credential custody, egress pins, and session stickiness are unchanged; subscription mappings remain inside the closed allowlist

Desktop release impact: version bump included (`0.0.21`).

`docs/models/index.md` is intentionally untouched; it is customer-facing documentation and outside this change.
