### PR TITLE
Use Grida Projects as the Desktop default project folder

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -784,7 +784,7 @@ no manifest, no document of any kind). This adds a new renderer-reachable
 user had already picked through the OS dialog), so it is recorded here. The
 boundary holds by three rules, none of which trust the caller for a path: (a)
 the managed root is **host-injected** — the supervisor passes
-`--projects-root=<~/Documents/Grida>` (`desktop/src/main/agent-sidecar-supervisor.ts`),
+`--projects-root=<~/Documents/Grida Projects>` (`desktop/src/main/agent-sidecar-supervisor.ts`),
 never derived from the request; a host that wired no root refuses with a 400.
 (b) The request's `name` is **slugified to a single filesystem segment**
 (`WorkspaceRegistry.createProject` / `slugifyProjectName`): path separators,

--- a/desktop/src/agent-sidecar.ts
+++ b/desktop/src/agent-sidecar.ts
@@ -122,7 +122,7 @@ const runtimeEditorBaseUrl = getCliArg("editor-base-url") ?? EDITOR_BASE_URL;
 // expose an unsandboxed shell.
 const sandboxEnforced = getCliArg("sandbox-enforced") === "1";
 // GRIDA-SEC-004 — host-injected managed root for auto-created projects
-// (`~/Documents/Grida`). The supervisor owns the path fact and forwards it;
+// (`~/Documents/Grida Projects`). The supervisor owns the path fact and forwards it;
 // absent (e.g. a future supervisor bug) means auto-create simply refuses.
 const projectsRoot = getCliArg("projects-root");
 // The host-bundled skills dir (repo-root `skills/`), resolved by the supervisor

--- a/desktop/src/main/agent-sidecar-supervisor.ts
+++ b/desktop/src/main/agent-sidecar-supervisor.ts
@@ -380,7 +380,7 @@ export class AgentSidecarSupervisor {
       // A visible, Finder-navigable location (files stay visible); the sidecar
       // may only mint project folders INSIDE this root. `documents` needs a
       // ready app, which holds at spawn time (post `app.whenReady`).
-      `--projects-root=${path.join(app.getPath("documents"), "Grida")}`,
+      `--projects-root=${path.join(app.getPath("documents"), "Grida Projects")}`,
       `--editor-base-url=${EDITOR_BASE_URL}`,
       // GRIDA-SEC-004 — attest the coarse outer SRT wrap. The sidecar exposes
       // `run_command` only when this is true AND main injected the private

--- a/editor/app/desktop/welcome/page.tsx
+++ b/editor/app/desktop/welcome/page.tsx
@@ -5,7 +5,7 @@
  *
  * Composer-first and outcome-first: describe what you want, or gather references
  * from the gallery — then Grida AUTO-CREATES a fresh, EMPTY project for you (a
- * plain folder under `~/Documents/Grida`) and hands your prompt to that
+ * plain folder under `~/Documents/Grida Projects`) and hands your prompt to that
  * project's agent as its first turn via {@link welcome_handoff}. No workspace
  * picker, no folder dialog to get started: the newcomer never has to choose a
  * folder. "Open folder…" and the recents list stay for opening work that
@@ -15,12 +15,12 @@
  *
  * The home NEVER mints a per-session folder and NEVER dirties the user's
  * workspace. Starting a session roots the agent at the DEFAULT workspace — the
- * managed root itself (`~/Documents/Grida`), always registered — and the agent
+ * managed root itself (`~/Documents/Grida Projects`), always registered — and the agent
  * takes the wheel: whether the workspace becomes a board, a slides deck, or a
  * tree of files is the AGENT's choice on turn one (guided by the advertised
  * skills), and produced files land where the agent decides. The system provides
  * MINIMALLY — the default workspace + a per-session scratch dir. (The old flow
- * minted `~/Documents/Grida/<prompt>` folders per session and pre-picked where
+ * minted `~/Documents/Grida Projects/<prompt>` folders per session and pre-picked where
  * to work; that's the legacy this replaces.)
  *
  * A reference card opens related Library ideas; its Add action drops that
@@ -413,7 +413,7 @@ function WelcomeSurface({
     [modelId, modelProviderId, isUserPick, router]
   );
 
-  // Start a session in the DEFAULT workspace (`~/Documents/Grida`). We NEVER mint
+  // Start a session in the DEFAULT workspace (`~/Documents/Grida Projects`). We NEVER mint
   // a per-session folder — that littered the managed root and pre-picked where to
   // work; the agent roots at the default workspace and takes the wheel, writing
   // only what it decides. Optional `scratchSeed` (a picked template's unzipped
@@ -565,7 +565,7 @@ function WelcomeSurface({
             together (no nested scroll); the gallery virtualizes against this. */}
         <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
           {/* Top-left workspace picker — where a start lands (the managed
-              ~/Documents/Grida root by default, shown as "Default workspace")
+              ~/Documents/Grida Projects root by default, shown as "Default workspace")
               or which existing project to aim at. Borderless + friendly;
               replaces the old picker-above-composer + "start blank" row. */}
           <div className="px-3 pt-3">

--- a/editor/lib/desktop/bridge.ts
+++ b/editor/lib/desktop/bridge.ts
@@ -1061,7 +1061,7 @@ export namespace workspaces {
     return await bridgeOrThrow().workspaces.create(input);
   }
   /**
-   * The host's DEFAULT workspace — the managed root itself (`~/Documents/Grida`),
+   * The host's DEFAULT workspace — the managed root itself (`~/Documents/Grida Projects`),
    * surfaced by {@link list} with `is_default`. The home roots a fresh session
    * HERE instead of minting a per-session folder (the old auto-create flow
    * littered the managed root and pre-picked where to work). Null on a host with

--- a/editor/scaffolds/desktop/home/workspace-picker.tsx
+++ b/editor/scaffolds/desktop/home/workspace-picker.tsx
@@ -9,7 +9,7 @@
  * confusing up-front choice.
  *
  * `value === null` is the default: a fresh project is auto-created under the
- * managed `~/Documents/Grida` root on submit — surfaced here as
+ * managed `~/Documents/Grida Projects` root on submit — surfaced here as
  * "Default workspace" (not "New project"). Picking a recent workspace, or
  * "Open folder…", aims submissions at that existing project instead.
  */

--- a/editor/scaffolds/desktop/onboarding/steps/workspace-step.tsx
+++ b/editor/scaffolds/desktop/onboarding/steps/workspace-step.tsx
@@ -14,11 +14,17 @@ import type { OnboardingStepProps } from "../types";
 
 function displayWorkspaceRoot(root: string): string {
   return root
-    .replace(/^\/Users\/[^/]+\/Documents\/Grida(?=\/|$)/, "~/Documents/Grida")
-    .replace(/^\/home\/[^/]+\/Documents\/Grida(?=\/|$)/, "~/Documents/Grida")
     .replace(
-      /^[A-Z]:\\Users\\[^\\]+\\Documents\\Grida(?=\\|$)/i,
-      "~/Documents/Grida"
+      /^\/Users\/[^/]+\/Documents\/Grida Projects(?=\/|$)/,
+      "~/Documents/Grida Projects"
+    )
+    .replace(
+      /^\/home\/[^/]+\/Documents\/Grida Projects(?=\/|$)/,
+      "~/Documents/Grida Projects"
+    )
+    .replace(
+      /^[A-Z]:\\Users\\[^\\]+\\Documents\\Grida Projects(?=\\|$)/i,
+      "~/Documents/Grida Projects"
     );
 }
 

--- a/packages/grida-ai-agent/src/skills/discovery.ts
+++ b/packages/grida-ai-agent/src/skills/discovery.ts
@@ -89,7 +89,7 @@ export async function discoverSkills(
   // 1. Project — upward from workspaceRoot, nearest first. The HOME dir is
   //    skipped here: `~/.claude/skills` / `~/.agents/skills` are the USER-scoped
   //    source (§2, gated by `include_user_scoped`), NOT project skills. Without
-  //    this skip a workspace under `~` (e.g. `~/Documents/Grida/<project>`) would
+  //    this skip a workspace under `~` (e.g. `~/Documents/Grida Projects/<project>`) would
   //    climb through home and re-discover the user's global skills as "project"
   //    ones — which is exactly how a `find-skills` meta-skill hijacked a deck task.
   if (opts.workspace_root) {

--- a/packages/grida-ai-agent/src/skills/skills-fs.test.ts
+++ b/packages/grida-ai-agent/src/skills/skills-fs.test.ts
@@ -182,7 +182,12 @@ describe("discoverSkills — bundled layer", () => {
         "find-skills",
         "name: find-skills\ndescription: meta finder"
       );
-      const project = path.join(fakeHome, "Documents", "Grida", "deck-proj");
+      const project = path.join(
+        fakeHome,
+        "Documents",
+        "Grida Projects",
+        "deck-proj"
+      );
       await fs.mkdir(project, { recursive: true });
       await writeManifest(bundled, "slides", "name: slides\ndescription: deck");
 

--- a/packages/grida-daemon/src/daemon-server.ts
+++ b/packages/grida-daemon/src/daemon-server.ts
@@ -52,7 +52,7 @@ export type DaemonServerOptions = {
   user_data_path: string;
   /**
    * GRIDA-SEC-004 — host-injected managed root for the auto-create flow
-   * (`POST /workspaces/create`). The desktop supervisor passes `~/Documents/Grida`;
+   * (`POST /workspaces/create`). The desktop supervisor passes `~/Documents/Grida Projects`;
    * CLI/dev leave it unset (auto-create then refuses). Forwarded to
    * {@link ServerOptions} by the `...opts` spread below.
    */

--- a/packages/grida-daemon/src/http/server.ts
+++ b/packages/grida-daemon/src/http/server.ts
@@ -112,7 +112,7 @@ export type ServerOptions = {
   /**
    * GRIDA-SEC-004 — host-injected managed root under which the auto-create
    * flow (`POST /workspaces/create`) mints new project folders (desktop:
-   * `~/Documents/Grida`). Host-owned, never client-derived. Omitted on hosts
+   * `~/Documents/Grida Projects`). Host-owned, never client-derived. Omitted on hosts
    * that don't wire it (CLI/dev), where `createProject` throws.
    */
   projects_root?: string;

--- a/packages/grida-daemon/src/protocol/resources.ts
+++ b/packages/grida-daemon/src/protocol/resources.ts
@@ -53,7 +53,7 @@ export type Workspace = {
   opened_at: number;
   pinned: boolean;
   /** True for the host's DEFAULT workspace (the managed root itself, e.g.
-   *  `~/Documents/Grida`). The desktop home roots a fresh session here instead
+   *  `~/Documents/Grida Projects`). The desktop home roots a fresh session here instead
    *  of minting a per-session folder. Computed per `list()`, never persisted;
    *  absent on hosts with no managed root. */
   is_default?: boolean;

--- a/packages/grida-daemon/src/workspaces.ts
+++ b/packages/grida-daemon/src/workspaces.ts
@@ -22,7 +22,7 @@
  * The client never sees absolute paths through this surface — wait,
  * yes it does, in `Workspace.root`. Unlike `/files/*` where the
  * client talks in opaque docIds, workspaces are inherently
- * user-facing ("you opened /Users/x/Documents/grida"). The display
+ * user-facing ("you opened /Users/x/Documents/Grida Projects"). The display
  * path is the file-name in this surface. Hiding it would break
  * "Recent Workspaces" UX.
  */
@@ -43,7 +43,7 @@ export type Workspace = {
   pinned: boolean;
   /**
    * True for the host's DEFAULT workspace — the managed root itself
-   * ({@link WorkspaceRegistry} `projects_root`, e.g. `~/Documents/Grida`).
+   * ({@link WorkspaceRegistry} `projects_root`, e.g. `~/Documents/Grida Projects`).
    * COMPUTED per {@link WorkspaceRegistry.list} (root === realpath'd
    * `projects_root`); never persisted. The desktop home roots a fresh session
    * HERE instead of minting a per-session folder — the agent takes the wheel
@@ -64,7 +64,7 @@ export class WorkspaceRegistry {
   /**
    * GRIDA-SEC-004 — the host-injected managed root under which
    * {@link createProject} mints new project folders (desktop:
-   * `~/Documents/Grida`). Host-owned, NEVER derived from client input — the
+   * `~/Documents/Grida Projects`). Host-owned, NEVER derived from client input — the
    * one writable root the auto-create path may touch. Undefined for hosts that
    * don't wire it (the CLI/dev daemon), where `createProject` throws.
    */
@@ -252,7 +252,7 @@ export class WorkspaceRegistry {
 
   /**
    * Ensure the host's DEFAULT workspace — the managed {@link projects_root}
-   * itself (e.g. `~/Documents/Grida`) — is registered, so {@link list} always
+   * itself (e.g. `~/Documents/Grida Projects`) — is registered, so {@link list} always
    * surfaces it and the desktop home can root a session there WITHOUT minting a
    * per-session folder or knowing the (host-owned, GRIDA-SEC-004) path. This is
    * the correction to the old auto-create flow: the managed root IS the


### PR DESCRIPTION
Grida Desktop now uses `~/Documents/Grida Projects` as its default project folder, following the recognizable “App Projects” naming convention. Update the host-supplied root, onboarding path display for macOS/Linux/Windows, and related comments, security documentation, and test fixtures.

The update creates or uses the new default without migrating files. Existing workspace registrations and sessions retain their old absolute paths, so existing work remains accessible while its folders stay in place. Manually renaming a folder does not reconnect its prior workspace or session references.

Validation:
- 32 existing tests passed: supervisor recovery, workspace registry/create routes, and skill discovery.
- Five onboarding path-display checks passed across macOS, Linux, Windows, child paths, and a similar-name boundary.
- Temporary-directory upgrade simulation confirmed a new empty default, preserved old files, and retained old workspace IDs and registrations.
- Linked packages built and Desktop typecheck passed; formatting and lint ran through pre-commit hooks.
- Repository typecheck: 47/48 tasks passed; editor is blocked by an existing generated `.next/dev/types/validator.ts` reference to missing `app/(www)/(ai)/ai/models/[slug]/page.js`.

Security review: GRIDA-SEC-004 host ownership and path containment remain intact; GRIDA-SEC-007 discovery/load containment is unchanged. All security tags are retained.

Desktop release impact: follow-up release required. The current `0.0.21` version is unpublished and can carry this change.
