### PR TITLE
chore(ai): deprecate GPT Image 2 and explain GPT Image 2.5

### DIFF
--- a/docs/models/gpt-image-2-5.md
+++ b/docs/models/gpt-image-2-5.md
@@ -1,0 +1,77 @@
+---
+title: "GPT Image 2.5: two variants, one rate card"
+description: Why GPT Image 2.5 succeeds GPT Image 2 in Grida, how Flare and Sunburst differ, and why equal token prices do not mean equal image costs.
+keywords: [GPT Image 2.5, Flare, Sunburst, image generation, AI pricing, Grida]
+format: md
+---
+
+# GPT Image 2.5: two variants, one rate card
+
+GPT Image 2.5 is the successor to GPT Image 2 in Grida's catalog. The change
+is about better creative results, not a higher price per token: **Flare and
+Sunburst share the same OpenAI token rates as GPT Image 2**, while offering
+different speed and precision trade-offs.
+
+## Why move to GPT Image 2.5?
+
+In its [September 8 announcement](https://openai.com/index/introducing-chatgpt-images-2-5/),
+OpenAI describes improvements to lighting, texture, reference-image fidelity,
+and targeted editing. The practical benefit is keeping the parts of an image
+you like while changing the part you asked to change, including across
+successive edits. OpenAI reports up to 50% lower generation latency compared
+with Images 2.0; this is a vendor claim, not a Grida benchmark.
+
+There are two models to choose from, rather than a cheaper model and a
+higher-priced premium model:
+
+- **Flare** is the everyday starting point: fast iteration, concept
+  exploration, and high-volume image generation.
+- **Sunburst** is for work where precise edits and fine detail justify
+  a longer wait, such as carefully controlled product or campaign imagery.
+
+Both accept text and image inputs and offer six quality settings, from `low`
+through `max`, plus `auto`. Model choice and quality are separate controls:
+Sunburst is not simply Flare with its quality setting turned up.
+See OpenAI's [Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
+and [Sunburst model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst).
+
+## Same token prices, different image costs
+
+OpenAI's published rates, in USD per million tokens:
+
+| Token type         | GPT Image 2 | 2.5 Flare | 2.5 Sunburst |
+| ------------------ | ----------- | --------- | ------------ |
+| Text input         | $5.00       | $5.00     | $5.00        |
+| Cached text input  | $1.25       | $1.25     | $1.25        |
+| Image input        | $8.00       | $8.00     | $8.00        |
+| Cached image input | $2.00       | $2.00     | $2.00        |
+| Image output       | $30.00      | $30.00    | $30.00       |
+
+These are **unit prices, not fixed prices per image**. The bill depends on
+tokens consumed, which can vary with the model, quality, dimensions, prompt,
+and reference images. For illustration, 1,000 image-output tokens cost $0.03;
+3,000 cost $0.09, before input charges. Those are arithmetic examples, not
+estimates for either variant.
+
+OpenAI explicitly notes that the GPT Image 2 calculator does **not** estimate
+GPT Image 2.5 token consumption. Do not carry GPT Image 2's per-image table
+over to Flare or Sunburst, or assume either variant always costs less.
+Compare actual usage for the quality and workflow you need. The model cards
+above and the [OpenAI pricing page](https://developers.openai.com/api/docs/pricing)
+are the sources for this rate comparison; individual providers can expose
+different billing meters.
+
+## What changes in Grida?
+
+GPT Image 2 is marked **deprecated**, not removed or shut down. Its ID and
+provider routes remain available for existing workflows; this is a Grida
+catalog decision, not an announcement of OpenAI retiring the model. Existing
+defaults and saved model selections are unchanged.
+
+Both 2.5 variants are already available through Grida credits and connected
+Vercel, fal, or OpenRouter keys. Generation with Grida credits does not require
+a provider key. Reference editing remains provider-key-only, and native
+transparency is currently enabled through Vercel and fal, not OpenRouter.
+Desktop users need 0.0.22 or later for 2.5; this deprecation adds no new runtime
+requirement. See [Models & Pricing](./index.md) for provider-specific rates
+and availability.

--- a/docs/models/gpt-image-2-5.md
+++ b/docs/models/gpt-image-2-5.md
@@ -1,43 +1,75 @@
 ---
-title: "GPT Image 2.5: two variants, one rate card"
-description: Why GPT Image 2.5 succeeds GPT Image 2 in Grida, how Flare and Sunburst differ, and why equal token prices do not mean equal image costs.
-keywords: [GPT Image 2.5, Flare, Sunburst, image generation, AI pricing, Grida]
+title: "GPT Image 2.5: Flare vs Sunburst, pricing and features"
+description: "Compare GPT Image 2.5 Flare and Sunburst: pricing, image quality, speed, transparent backgrounds, and how they differ from GPT Image 2."
+keywords:
+  [
+    GPT Image 2.5,
+    Flare vs Sunburst,
+    GPT Image 2.5 pricing,
+    transparent backgrounds,
+  ]
+sidebar_label: GPT Image 2.5
+slug: gpt-image-2.5
+image: https://grida.co/brand/grida-wordmark-400.png
 format: md
 ---
 
-# GPT Image 2.5: two variants, one rate card
+# GPT Image 2.5: Flare vs Sunburst, pricing and features
 
-GPT Image 2.5 is the successor to GPT Image 2 in Grida's catalog. The change
-is about better creative results, not a higher price per token: **Flare and
-Sunburst share the same OpenAI token rates as GPT Image 2**, while offering
-different speed and precision trade-offs.
+GPT Image 2.5 is OpenAI's image-generation and editing model family,
+[released on September 8, 2026](https://openai.com/index/introducing-chatgpt-images-2-5/).
+It comes in two variants: **Flare** for fast, everyday creation and
+**Sunburst** for detailed work that needs more precise edits. Both can
+generate images from text, work with reference images, and produce
+transparent backgrounds.
 
-## Why move to GPT Image 2.5?
+The unusual part is the pricing: Flare and Sunburst share the same token
+rates as GPT Image 2. Choosing between them is about speed, precision, and
+actual usage, not a higher price for each token.
 
-In its [September 8 announcement](https://openai.com/index/introducing-chatgpt-images-2-5/),
-OpenAI describes improvements to lighting, texture, reference-image fidelity,
-and targeted editing. The practical benefit is keeping the parts of an image
-you like while changing the part you asked to change, including across
-successive edits. OpenAI reports up to 50% lower generation latency compared
-with Images 2.0; this is a vendor claim, not a Grida benchmark.
+_Pricing and availability checked September 9, 2026. Provider support can change._
 
-The variants differ in speed and editing precision, not their per-token
-rate card:
+## GPT Image 2.5 Flare vs Sunburst
 
-- **Flare** is the everyday starting point: fast iteration, concept
-  exploration, and high-volume image generation.
-- **Sunburst** is for work where precise edits and fine detail justify
-  a longer wait, such as carefully controlled product or campaign imagery.
+| Comparison              | Flare                                             | Sunburst                                                |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------------------- |
+| Best starting point for | Exploring ideas and everyday image generation     | Precise edits and fine-detail creative work             |
+| Speed and precision     | Faster iteration                                  | Greater editing precision, with longer generation times |
+| Example workflows       | Concept drafts, social images, visual exploration | Product imagery, campaign assets, controlled revisions  |
+| OpenAI API model ID     | `gpt-image-2.5-flare`                             | `gpt-image-2.5-sunburst`                                |
+| Token prices            | Same rate card                                    | Same rate card                                          |
 
-Both accept text and image inputs and offer five fixed quality levels
-(`low`, `medium`, `high`, `xhigh`, `max`) plus `auto`. Model choice and quality are separate controls:
-Sunburst is not simply Flare with its quality setting turned up.
-See OpenAI's [Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
-and [Sunburst model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst).
+Both accept text and image inputs and produce images. Each offers five
+fixed quality settings—`low`, `medium`, `high`, `xhigh`, and `max`—plus
+`auto`. **The variant and the quality setting are separate choices:**
+Sunburst is not simply Flare with quality turned up. See OpenAI's
+[Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
+and [Sunburst model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst)
+for the current model specifications.
 
-## Same token prices, different image costs
+## What changed from GPT Image 2?
 
-OpenAI's standard API rates, in USD per million tokens:
+OpenAI's [Images 2.5 announcement](https://openai.com/index/introducing-chatgpt-images-2-5/)
+describes improvements in four areas:
+
+- **Image fidelity:** more natural lighting and texture, with better
+  preservation of subjects from reference photos.
+- **Targeted editing:** change the requested part of an image while
+  keeping the surrounding composition and details.
+- **Successive revisions:** carry earlier edits forward more consistently
+  across a sequence of changes.
+- **Speed:** OpenAI reports up to 50% lower generation latency compared
+  with Images 2.0. This is OpenAI's claim, not a Grida benchmark.
+
+For example, a product-image workflow might keep the same bottle and
+composition while changing the background, then refine the lighting in a
+second edit. This is the kind of controlled revision 2.5 is designed to
+improve; it is not a guarantee that every generated detail will be correct.
+
+## GPT Image 2.5 pricing compared with GPT Image 2
+
+The table shows **OpenAI's standard API rates in USD per million tokens**,
+not a fixed price per image or a discounted Batch rate.
 
 | Token type         | GPT Image 2 | 2.5 Flare | 2.5 Sunburst |
 | ------------------ | ----------- | --------- | ------------ |
@@ -47,31 +79,69 @@ OpenAI's standard API rates, in USD per million tokens:
 | Cached image input | $2.00       | $2.00     | $2.00        |
 | Image output       | $30.00      | $30.00    | $30.00       |
 
-These are **unit prices, not fixed prices per image**. The bill depends on
-tokens consumed, which can vary with the model, quality, dimensions, prompt,
-and reference images. For illustration, 1,000 image-output tokens cost $0.03;
-3,000 cost $0.09, before input charges. Those are arithmetic examples, not
-estimates for either variant.
+Sources: the [GPT Image 2 model card](https://developers.openai.com/api/docs/models/gpt-image-2),
+the Flare and Sunburst model cards above, and
+[OpenAI API pricing](https://developers.openai.com/api/docs/pricing).
 
-OpenAI explicitly notes that the GPT Image 2 calculator does **not** estimate
-GPT Image 2.5 token consumption. Do not carry GPT Image 2's per-image table
-over to Flare or Sunburst, or assume either variant always costs less.
-Compare actual usage for the quality and workflow you need. The model cards
-above and the [OpenAI pricing page](https://developers.openai.com/api/docs/pricing)
-are the sources for this rate comparison; individual providers can expose
-different billing meters.
+### How much does one image cost?
 
-## What changes in Grida?
+Tokens are the units the API meters, not a count of pictures. The final
+cost depends on the tokens consumed by the prompt, reference images, and
+generated output. Model choice, quality, and dimensions can change that
+usage even when the rate card is identical.
 
-GPT Image 2 is marked **deprecated**, not removed or shut down. Its ID and
-provider routes remain available for existing workflows; this is a Grida
-catalog decision, not an announcement of OpenAI retiring the model. Existing
-defaults and saved model selections are unchanged.
+For a size-and-quality estimate, use the model selector in OpenAI's
+[image-generation cost calculator](https://developers.openai.com/api/docs/guides/image-generation#gpt-image-25-and-gpt-image-2-output-tokens)
+and select **GPT Image 2.5**. It groups Flare and Sunburst together and
+gives these examples for a 1024 × 1024 image:
 
-Both 2.5 variants are already available through Grida credits and connected
-Vercel, fal, or OpenRouter keys. Generation with Grida credits does not require
-a provider key. Reference editing remains provider-key-only, and native
-transparency is currently enabled through Vercel and fal, not OpenRouter.
-Desktop users need 0.0.22 or later for 2.5; this deprecation adds no new runtime
-requirement. See [Models & Pricing](./index.md) for provider-specific rates
-and availability.
+| Quality  | Estimated image-output tokens | Image-output cost |
+| -------- | ----------------------------: | ----------------: |
+| `medium` |                           439 |          $0.01317 |
+| `high`   |                         1,756 |          $0.05268 |
+
+These estimates exclude text and image inputs and any streaming partial
+images; they are **not total request prices**. Do not reuse GPT Image 2's
+per-image table for 2.5. Compare the provider's reported usage for your own
+workflow; neither variant is guaranteed to cost less on every request.
+
+## Does GPT Image 2.5 support transparent backgrounds?
+
+**Yes.** Both variants support native transparent-background generation.
+In OpenAI's API, request `background: "transparent"` with PNG or WebP
+output. JPEG does not preserve transparency. See the
+[OpenAI output settings guide](https://developers.openai.com/api/docs/guides/image-generation).
+
+Native transparency creates an image with an alpha channel, which can be
+placed over other artwork. It is different from generating a solid-color
+background and removing it afterward. For stickers, isolated product
+assets, or overlays, check that both the selected provider and the output
+format expose this capability.
+
+## Using GPT Image 2.5 in Grida
+
+Both variants are available in Grida using purchased AI credits.
+**Text-to-image generation does not require your own provider API key.**
+You can also connect Vercel AI Gateway, fal, or OpenRouter keys. Native
+model support and the options available in a particular application are
+not always the same:
+
+| Access in Grida       | Text-to-image | Reference-image editing | Transparent output   |
+| --------------------- | ------------- | ----------------------- | -------------------- |
+| Grida credits         | Yes           | No                      | Yes                  |
+| Vercel AI Gateway key | Yes           | No                      | Yes                  |
+| fal key               | Yes           | Yes                     | Yes                  |
+| OpenRouter key        | Yes           | Yes                     | Not enabled in Grida |
+
+Reference editing requires an agent integration that explicitly selects
+one of these variants and uses a connected fal or OpenRouter key. The
+desktop image playground generates from text only. Desktop users need
+version 0.0.22 or later for these models. For provider-specific prices,
+settings, and billing details, see [Models & Pricing](./index.md).
+
+### Is GPT Image 2 being removed?
+
+No. Grida marks GPT Image 2 as **deprecated**, meaning it is a legacy
+choice, but keeps it listed and callable. Existing defaults and saved
+model selections are unchanged. This is a Grida catalog decision, not an
+announcement that OpenAI has retired GPT Image 2.

--- a/docs/models/gpt-image-2-5.md
+++ b/docs/models/gpt-image-2-5.md
@@ -21,23 +21,23 @@ you like while changing the part you asked to change, including across
 successive edits. OpenAI reports up to 50% lower generation latency compared
 with Images 2.0; this is a vendor claim, not a Grida benchmark.
 
-There are two models to choose from, rather than a cheaper model and a
-higher-priced premium model:
+The variants differ in speed and editing precision, not their per-token
+rate card:
 
 - **Flare** is the everyday starting point: fast iteration, concept
   exploration, and high-volume image generation.
 - **Sunburst** is for work where precise edits and fine detail justify
   a longer wait, such as carefully controlled product or campaign imagery.
 
-Both accept text and image inputs and offer six quality settings, from `low`
-through `max`, plus `auto`. Model choice and quality are separate controls:
+Both accept text and image inputs and offer five fixed quality levels
+(`low`, `medium`, `high`, `xhigh`, `max`) plus `auto`. Model choice and quality are separate controls:
 Sunburst is not simply Flare with its quality setting turned up.
 See OpenAI's [Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
 and [Sunburst model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst).
 
 ## Same token prices, different image costs
 
-OpenAI's published rates, in USD per million tokens:
+OpenAI's standard API rates, in USD per million tokens:
 
 | Token type         | GPT Image 2 | 2.5 Flare | 2.5 Sunburst |
 | ------------------ | ----------- | --------- | ------------ |

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -128,6 +128,10 @@ OpenAI image models are billed by token usage, including text and image inputs. 
 
 [Released September 8, 2026](https://openai.com/index/introducing-chatgpt-images-2-5/), Flare is the faster everyday option; Sunburst prioritizes precise edits and intricate detail, with longer generation times. Both are available through Grida-hosted credit and connected **fal**, **OpenRouter**, or **Vercel AI Gateway** keys. Desktop requires version 0.0.22 or later, including when the hosted model catalog has already refreshed.
 
+Read [GPT Image 2.5: two variants, one rate card](./gpt-image-2-5.md) for why
+2.5 succeeds GPT Image 2 and how equal token prices can produce different
+per-image costs.
+
 Both variants support generation and, through fal or OpenRouter, editing with up to 16 reference images. Grida accepts 1–4 outputs per request. Quality options are `auto`, `low`, `medium`, `high`, `xhigh`, and `max`; Grida selects `high` initially. Dimensions must be multiples of 16, neither edge may exceed 3840 px, the aspect ratio must be at most 3:1, and total area must be 655,360–8,294,400 pixels. Transparent backgrounds require PNG or WebP output. See the [Flare API](https://fal.ai/models/openai/gpt-image-2.5/flare/text-to-image/api) and [Sunburst editing API](https://fal.ai/models/openai/gpt-image-2.5/sunburst/edit/api).
 
 The Desktop image playground generates from text. This update does not add a
@@ -141,11 +145,16 @@ Both variants have the same [fal token rates](https://fal.ai/models/openai/gpt-i
 | Text       | $5.00 | $1.25        | $10.00 |
 | Image      | $8.00 | $2.00        | $30.00 |
 
-For a 1024x1024 image, OpenAI's [output-token calculator](https://developers.openai.com/api/docs/guides/image-generation) estimates $0.01317 at `medium` and $0.05268 at `high`. These are output-only estimates, not fixed per-image prices; input tokens add to the bill. fal rounds the total charge up to the nearest $0.0001.
+Equal token rates do not imply equal per-image costs: model choice, quality,
+dimensions, and inputs affect token usage. OpenAI's [Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
+explicitly says that the GPT Image 2 calculator does not estimate GPT Image
+2.5 token consumption. Use actual provider usage when comparing the variants;
+do not apply GPT Image 2's per-image table to them. fal rounds the total charge
+up to the nearest $0.0001.
 
 [Vercel AI Gateway](https://vercel.com/ai-gateway/models/gpt-image-2.5-flare) publishes $5/M input tokens, $1.25/M cached input tokens, and $30/M output tokens. [OpenRouter](https://openrouter.ai/api/v1/images/models/openai/gpt-image-2.5-flare/endpoints) publishes $5/M text input, $8/M image input, and $30/M image output tokens. Grida keeps each provider's published meter separately. Hosted image billing uses Gateway's reported response cost when available. Without that receipt, it falls back to the catalog's coarse per-image estimate ($0.055 for these variants), which can differ from actual token cost across quality levels and dimensions.
 
-**GPT Image 2** (`openai/gpt-image-2`)
+**GPT Image 2** (`openai/gpt-image-2`) — _deprecated in Grida, superseded by GPT Image 2.5_
 
 Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · image cached $2.00 · output $30.00`
 
@@ -157,7 +166,10 @@ Per 1M tokens: `text input $5.00 · text cached $1.25 · image input $8.00 · im
 
 GPT Image 2 also accepts arbitrary resolutions (multiples of 16, edges ≤ 3840 px, aspect ratio ≤ 3:1, total pixels in 655,360 – 8,294,400). Cost for non-standard sizes is computed from output token count.
 
-GPT Image 2 remains available through Vercel AI Gateway, fal, and OpenRouter, including Grida's hosted route.
+GPT Image 2 remains available through Vercel AI Gateway, fal, and OpenRouter,
+including Grida's hosted route. Deprecation marks it as a legacy choice; it is
+not an upstream OpenAI retirement and does not remove its ID, change existing
+defaults, or replace saved model selections.
 
 **Transparent backgrounds**
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -128,9 +128,9 @@ OpenAI image models are billed by token usage, including text and image inputs. 
 
 [Released September 8, 2026](https://openai.com/index/introducing-chatgpt-images-2-5/), Flare is the faster everyday option; Sunburst prioritizes precise edits and intricate detail, with longer generation times. Both are available through Grida-hosted credit and connected **fal**, **OpenRouter**, or **Vercel AI Gateway** keys. Desktop requires version 0.0.22 or later, including when the hosted model catalog has already refreshed.
 
-Read [GPT Image 2.5: two variants, one rate card](./gpt-image-2-5.md) for why
-2.5 succeeds GPT Image 2 and how equal token prices can produce different
-per-image costs.
+Read [GPT Image 2.5: Flare vs Sunburst, pricing and features](./gpt-image-2-5.md)
+for a model comparison, transparent-background support, and an explanation
+of why equal token prices can produce different per-image costs.
 
 Both variants support generation and, through fal or OpenRouter, editing with up to 16 reference images. Grida accepts 1–4 outputs per request. Quality options are `auto`, `low`, `medium`, `high`, `xhigh`, and `max`; Grida selects `high` initially. Dimensions must be multiples of 16, neither edge may exceed 3840 px, the aspect ratio must be at most 3:1, and total area must be 655,360–8,294,400 pixels. Transparent backgrounds require PNG or WebP output. See the [Flare API](https://fal.ai/models/openai/gpt-image-2.5/flare/text-to-image/api) and [Sunburst editing API](https://fal.ai/models/openai/gpt-image-2.5/sunburst/edit/api).
 
@@ -148,9 +148,11 @@ Both variants have the same [fal token rates](https://fal.ai/models/openai/gpt-i
 Equal token rates do not imply equal per-image costs: model choice, quality,
 dimensions, and inputs affect token usage. OpenAI's [Flare model card](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare)
 explicitly says that the GPT Image 2 calculator does not estimate GPT Image
-2.5 token consumption. Use actual provider usage when comparing the variants;
-do not apply GPT Image 2's per-image table to them. fal rounds the total charge
-up to the nearest $0.0001.
+2.5 token consumption. OpenAI's [image-generation guide](https://developers.openai.com/api/docs/guides/image-generation)
+now has a model-specific output-cost calculator: select GPT Image 2.5 rather
+than applying GPT Image 2's per-image table. Its estimate excludes input
+charges; use actual provider usage when comparing total costs. fal rounds
+the total charge up to the nearest $0.0001.
 
 [Vercel AI Gateway](https://vercel.com/ai-gateway/models/gpt-image-2.5-flare) publishes $5/M input tokens, $1.25/M cached input tokens, and $30/M output tokens. [OpenRouter](https://openrouter.ai/api/v1/images/models/openai/gpt-image-2.5-flare/endpoints) publishes $5/M text input, $8/M image input, and $30/M image output tokens. Grida keeps each provider's published meter separately. Hosted image billing uses Gateway's reported response cost when available. Without that receipt, it falls back to the catalog's coarse per-image estimate ($0.055 for these variants), which can differ from actual token cost across quality levels and dimensions.
 

--- a/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
+++ b/editor/app/(api)/(public)/api/v1/ai/models/route.test.ts
@@ -50,6 +50,24 @@ describe("GET /api/v1/ai/models", () => {
     expect(ids).toContain("openai/gpt-image-2.5-sunburst");
   });
 
+  it("retains GPT Image 2 as deprecated while its successors stay active", async () => {
+    const { token } = await signGgToken("user-1", 7);
+    const res = await GET(request(token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Entry[] };
+    const byId = new Map(body.data.map((entry) => [entry.id, entry]));
+    for (const [id, deprecated] of [
+      ["openai/gpt-image-2", true],
+      ["openai/gpt-image-2.5-flare", false],
+      ["openai/gpt-image-2.5-sunburst", false],
+    ] as const) {
+      expect(byId.get(id)?.grida).toMatchObject({
+        modality: "image",
+        deprecated,
+      });
+    }
+  });
+
   it("lists text+image+video with tiers, deprecation flags, and no pricing", async () => {
     const { token } = await signGgToken("user-1", 7);
     const res = await GET(request(token));

--- a/editor/app/robots.txt
+++ b/editor/app/robots.txt
@@ -3,6 +3,7 @@ Allow: /
 Disallow: /private/
 
 Sitemap: https://grida.co/sitemap.xml
+Sitemap: https://grida.co/docs/sitemap.xml
 Sitemap: https://grida.co/packages/sitemap.xml
 Sitemap: https://grida.co/library/sitemap.xml
 Sitemap: https://grida.co/library/o/sitemap.xml

--- a/editor/lib/ai/openai-compat/hosted-models.ts
+++ b/editor/lib/ai/openai-compat/hosted-models.ts
@@ -109,7 +109,7 @@ function buildHostedModelList(): HostedModelEntry[] {
         modality: "image",
         tier: null,
         label: card.label,
-        deprecated: false,
+        deprecated: card.deprecated,
       },
     });
   }

--- a/packages/grida-ai-models/__tests__/models.test.ts
+++ b/packages/grida-ai-models/__tests__/models.test.ts
@@ -107,6 +107,16 @@ describe("models.image catalogue invariants", () => {
     }
   });
 
+  it("retains GPT Image 2 as a listed, deprecated model", () => {
+    const card = models.image.findImageModelCard("openai/gpt-image-2")!;
+    expect(card).toMatchObject({
+      id: "openai/gpt-image-2",
+      listed: true,
+      deprecated: true,
+    });
+    expect(models.image.listed_models()).toContain(card);
+  });
+
   it("toCompact preserves id, label, release, pricing, speed_label, deprecated", () => {
     const card = models.image.models["bfl/flux-pro-1.1"]!;
     const compact = models.image.toCompact(card);

--- a/packages/grida-ai-models/__tests__/snapshot.test.ts
+++ b/packages/grida-ai-models/__tests__/snapshot.test.ts
@@ -474,6 +474,7 @@ describe("models.snapshot media — seed and round-trip", () => {
       max: 16,
     });
     expect(gpt.listed).toBe(true);
+    expect(gpt.deprecated).toBe(true);
     expect(gpt.providers.vercel!.id).toBe("openai/gpt-image-2");
     expect(gpt.transparent_background).toBe(true);
     expect(gpt.providers.openrouter!.transparent_background).toBe(false);

--- a/packages/grida-ai-models/src/models.ts
+++ b/packages/grida-ai-models/src/models.ts
@@ -1180,9 +1180,9 @@ export namespace models {
           source_url:
             "https://developers.openai.com/api/docs/models/gpt-image-2",
         },
-        deprecated: false,
+        deprecated: true,
         short_description:
-          "State-of-the-art image generation and editing with flexible resolutions",
+          "Previous-generation image model. Superseded by GPT Image 2.5.",
         vendor: "openai",
         provider: "vercel",
         listed: true,


### PR DESCRIPTION
## GPT Image 2.5: two variants, one rate card

Deprecate GPT Image 2 in Grida in favor of GPT Image 2.5, without removing it. OpenAI's [original announcement](https://openai.com/index/introducing-chatgpt-images-2-5/) describes improvements to image fidelity and targeted editing. Flare favors everyday iteration; Sunburst favors precise, detailed edits. Their distinction is the speed/quality trade-off and token consumption, **not a different per-token price**.

## Price comparison

**OpenAI standard API prices — USD per 1 million tokens, verified September 9, 2026.** These are upstream unit rates, not fixed Grida credit prices per image or discounted Batch rates.

| Billing meter | GPT Image 2 | GPT Image 2.5 Flare | GPT Image 2.5 Sunburst |
| :--- | ---: | ---: | ---: |
| Text input | $5.00 | $5.00 | $5.00 |
| Cached text input | $1.25 | $1.25 | $1.25 |
| Image input | $8.00 | $8.00 | $8.00 |
| Cached image input | $2.00 | $2.00 | $2.00 |
| Image output | $30.00 | $30.00 | $30.00 |

Sources: OpenAI's [GPT Image 2](https://developers.openai.com/api/docs/models/gpt-image-2), [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare), and [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst) model cards and [API pricing](https://developers.openai.com/api/docs/pricing).

**Same token price does not mean the same final image cost.** Actual token consumption can vary by model, quality, dimensions, prompt, and reference images. OpenAI now provides a dedicated **GPT Image 2.5** selector in its [image-output calculator](https://developers.openai.com/api/docs/guides/image-generation#gpt-image-25-and-gpt-image-2-output-tokens). Use that selector, not GPT Image 2's estimates. Provider billing meters can also differ.

| GPT Image 2.5 calculator example | Image-output tokens | Image-output cost |
| :--- | ---: | ---: |
| 1024 × 1024, medium | 439 | $0.01317 |
| 1024 × 1024, high | 1,756 | $0.05268 |

These examples apply to the calculator's combined Flare/Sunburst selector and **exclude input charges and streaming partial images**. They are not total request prices.

## Which 2.5 variant?

| Dimension | Flare | Sunburst |
| :--- | :--- | :--- |
| Best fit | Everyday generation and rapid exploration | Precise edits and intricate detail |
| Speed trade-off | Faster iteration | Longer waits for greater editing precision |
| Quality controls | `low`, `medium`, `high`, `xhigh`, `max`, plus `auto` | Same controls; a distinct model, not simply Flare at a higher setting |
| Unit pricing | Same rate card as GPT Image 2 | Same rate card as GPT Image 2 and Flare |
| Cost per finished image | Depends on actual usage; no fixed price claimed | Depends on actual usage; not assumed equal to Flare |

## Focused scope

| Area | Change in this PR |
| :--- | :--- |
| GPT Image 2 | Mark deprecated; retain its ID, listing, and callable provider routes |
| GPT Image 2.5 | Both variants remain active; already supported, not newly integrated here |
| Hosted model listing | Forward the catalog's image deprecation flag instead of hardcoding `false` |
| Public model reference | Publish [GPT Image 2.5: Flare vs Sunburst, pricing and features](https://grida.co/docs/models/gpt-image-2.5) after merge, written for general readers comparing models |
| Reference content | Variant and pricing tables, output-only cost examples, successor improvements, native transparency, and Grida/provider availability caveats, linked to original OpenAI sources |
| SEO and discovery | Exact dotted slug, descriptive title/description, social-preview metadata, reciprocal Models & Pricing links, generated docs sitemap, and docs sitemap discovery in robots.txt |
| Unchanged | Existing defaults, saved selections, provider bindings, pricing, generation behavior, and schema |
| Desktop release impact | **None** — existing hosted catalog refresh distributes the metadata; no new runtime requirement or version bump |
| Merge policy | **Manual merge only; no auto-merge or Desktop release** |

Deprecation is a Grida catalog decision, not an announcement that OpenAI has retired GPT Image 2.

## Local verification

| Check | Result |
| :--- | :--- |
| AI-model package | 228 tests passed; build and typecheck passed |
| Gateway/auth/catalog boundary | 107 tests passed; new regression confirmed failing before the fix |
| Repository typecheck | 48/48 tasks passed |
| Docs production build | All four locales passed; existing unrelated warnings remain |
| SEO output | Exact dotted canonical/OG URL, one H1, no noindex, locale sitemap entries and reciprocal pricing links verified |
| Responsive layout | Desktop and 390px mobile checked; wide availability table scrolls within the page |
| Deployed docs preview | Direct dotted article URL, pricing reference and sitemap all return 200; canonical metadata, four tables and reciprocal links verified on head `78de8f7fd` |
| Formatting, lint, diff checks | Passed |
| Deprecation regression | GPT Image 2 stays listed and deprecated in the catalog, snapshot, and hosted listing; both 2.5 variants remain active |

Final-head CI and CodeRabbit review must also be green before the maintainer merges.

## Metadata consistency and security review

The hosted image listing previously hardcoded `deprecated: false`, so it would contradict the catalog. The existing card contract already owns this flag; the projection now copies it. No new contract or model-access rule is needed. This is a localized image-metadata projection oversight, covered at the hosted HTTP route.

GRIDA-SEC-006 review: token mint and membership validation, signing algorithm and audience, expiry, fail-closed secret handling, exclusive token verification, memory-only custody, and mint rate limiting are all untouched. All boundary tags remain, and adjacent gateway/authentication tests pass. Deprecation does not remove the model from the hosted allowlist or change billing.
