### PR TITLE
chore(ci): register the CLI release workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,15 @@
+name: Release CLI
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  bootstrap:
+    if: github.repository == 'gridaco/grida' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Release is not enabled
+        run: echo "CLI release workflow registered. Publishing is not enabled."


### PR DESCRIPTION
Establish `.github/workflows/cli-release.yml` on main ahead of the standalone CLI release, providing a stable workflow identity and manual dispatch entry for npm Trusted Publisher setup.

The workflow only prints that publishing is disabled. It has no checkout, npm command, secrets, environment access or OIDC permission. The release implementation can replace it under the same filename once the CLI and infrastructure are ready.

Validation: YAML parsed; confirmed a one-file diff, manual dispatch only, a `gridaco/grida` main-branch guard, empty permissions and a one-minute timeout. Runtime dispatch can be checked after merge to main.
