### PR TITLE
fix(database): restrict billing RPC execution to service role

### DIFF
--- a/.agents/skills/database/SKILL.md
+++ b/.agents/skills/database/SKILL.md
@@ -18,8 +18,11 @@ Three contracts this skill protects:
 2. **The RLS spec is the source of truth — implementations follow tests, not the reverse.**
 3. **`schemas/*.sql` is the human-friendly description of the final shape.**
 
-`supabase/AGENTS.md` is the harder rule layer (RLS, grants, security
-boundaries). This skill covers the recurring workflow tasks. Read both.
+[supabase/AGENTS.md](../../../supabase/AGENTS.md) is the harder rule layer
+(RLS, grants, security boundaries). For function changes, follow its canonical
+[RPC role contract](../../../supabase/AGENTS.md#rpc-role-contract), including
+effective privileges, caller tests, and coverage of new overloads. This skill
+covers the recurring workflow tasks. Read both.
 
 For realistic optional Library data without changing schema history or the
 canonical base seed, use the [opt-library skill](../opt-library/SKILL.md).
@@ -93,7 +96,7 @@ one coherent migration per feature.
 FUNCTION`, `ADD COLUMN IF NOT EXISTS`) make local re-runs safe.
 6. **Delete the superseded local-only files.** Only those — never
    touch the applied list.
-7. **`supabase db reset`** locally. Run `supabase db test` if pgTAP
+7. **`supabase db reset`** locally. Run `supabase test db` if pgTAP
    covers the affected tables.
 8. **Note the fold in the PR description.** Reviewers shouldn't have
    to diff timestamps to figure it out.

--- a/.agents/skills/security/SKILL.md
+++ b/.agents/skills/security/SKILL.md
@@ -64,6 +64,11 @@ brief but explicit:
    for the id may list specific tests; use `grep -rn GRIDA-SEC-<id>
 --include='*test*' --include='*spec*'` to find any others.
 
+For database-backed boundaries, follow the canonical
+[RPC role contract](../../../supabase/AGENTS.md#rpc-role-contract). Trace public
+entry points through their role privileges and tenant policies; a private inner
+schema or a service-role grant comment does not prove that callers are denied.
+
 If you cannot satisfy steps 1–4, do not commit. Either revert the
 change, or explicitly amend the SECURITY.md entry to reflect a
 deliberate update of the contract — and surface that to the user.

--- a/supabase/AGENTS.md
+++ b/supabase/AGENTS.md
@@ -79,7 +79,7 @@ This codebase currently contains **multiple schema conventions** and is not perf
   - Keep wrappers tenant-safe (RLS-safe, no widening joins) and backed by pgTAP tests.
 - **Be explicit and defensive**.
   - Minimize grants; avoid accidental exposure via default privileges.
-  - For any `SECURITY DEFINER` in `public`, set a safe `search_path`, fully qualify referenced relations, validate tenant boundary inside the function, and prove behavior with tests.
+  - For any `SECURITY DEFINER` in `public`, set a safe `search_path`, fully qualify referenced relations, and prove its [RPC role contract](#rpc-role-contract). User-callable functions must validate the tenant boundary inside the function.
 
 ---
 
@@ -99,7 +99,7 @@ This codebase currently contains **multiple schema conventions** and is not perf
 - **Permissive policies for `anon`** unless explicitly required and tested.
 - **Policy predicates that don’t include tenant boundary** (easy to leak cross-tenant).
 - **Views that bypass RLS** (e.g. selecting from tables without RLS or using privileged functions).
-- **`SECURITY DEFINER` functions that read tenant tables without enforcing tenant checks internally**.
+- **User-callable `SECURITY DEFINER` functions that read tenant tables without enforcing tenant checks internally**.
 
 ---
 
@@ -109,7 +109,7 @@ We use **pgTAP** to assert RLS behavior at the database level.
 
 - **Tests live in** `supabase/tests/*.sql`.
 - Create new tests with `supabase test new <name>` (local only).
-- Run tests with `supabase db test` (local only).
+- Run tests with `supabase test db` (local only).
 
 **How tests should be written**
 
@@ -230,34 +230,90 @@ Prefer **plain RLS + normal DML**. Use RPC only when you need:
 - performance that would be hard to achieve through PostgREST
 - carefully audited “capability” operations (e.g. safe cascade deletion)
 
-### If you must use `SECURITY DEFINER`
+### RPC role contract
 
-Non-negotiables for privileged RPC:
+Declare the intended callers for every function signature, including overloads:
 
-- **Set a safe `search_path`**
-- **Fully qualify** tables/functions where reasonable (`public.my_table`)
-- **Validate inputs** (types, existence, tenant boundary)
-- **Lock down privileges** (`REVOKE ALL ... FROM PUBLIC;` then grant to the minimum role)
-- **Test escalation resistance** (outsider cannot delete/read/modify cross-tenant)
+- **Service-only:** grant `EXECUTE` only to the intended trusted role, normally
+  `service_role`. A privileged wrapper must deny `anon` and `authenticated`
+  even when its internal tables/functions are private or protected by RLS.
+- **User-callable tenant operations:** prefer `SECURITY INVOKER`. If `SECURITY DEFINER` is necessary,
+  require an authenticated caller and enforce the tenant boundary inside the
+  function. Bind user-scoped lookups to `auth.uid()`; reject a supplied foreign
+  user ID. Grant only the intended API roles.
 
-Template:
+Every definer function needs a safe `search_path`, fully qualified relation and
+function references, and input validation appropriate to that contract.
+
+PostgreSQL grants function `EXECUTE` to `PUBLIC` by default. This repository also
+has defaults granting `public` functions created by `postgres` directly to `anon`
+and `authenticated`. Revoking from `PUBLIC` leaves those direct grants intact;
+grants inherited through other roles also count. `GRANT ... TO service_role`
+does not make access exclusive.
+
+Create/replace the function and set privileges for its exact signature in the
+same transaction, so no permissive intermediate state is committed. Service-only
+template:
 
 ```sql
-CREATE OR REPLACE FUNCTION public.my_rpc(arg_project_id uuid)
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.my_rpc(arg_project_id bigint)
 RETURNS void
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
 AS $$
 BEGIN
-  -- enforce tenant boundary explicitly inside the function
-  -- ... do work ...
+  -- Validate inputs and perform the privileged operation.
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.my_rpc(uuid) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.my_rpc(uuid) TO authenticated;
+REVOKE ALL ON FUNCTION public.my_rpc(bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.my_rpc(bigint) TO service_role;
+
+COMMIT;
 ```
+
+For a user-callable RPC, use the same explicit revoke, implement the caller/tenant
+guard, then grant the intended roles. Inspect existing ACLs and role memberships
+for additional grants; `CREATE OR REPLACE FUNCTION` preserves existing ACLs.
+
+**Default privileges are not a substitute for function ACLs.** They apply only to
+future objects created by the specified creator role. Schema-scoped
+`ALTER DEFAULT PRIVILEGES ... REVOKE` cannot cancel a global default grant,
+including PostgreSQL's built-in `PUBLIC EXECUTE` on functions. Verify a default
+change by creating a test function as the actual migration role and checking its
+ACLs, then roll back. Do not change global defaults or revoke unrelated `public`
+functions as a shortcut for a scoped permission fix.
+
+**Required pgTAP proof:**
+
+- Replay the complete migration history and seed locally (`supabase db reset`),
+  then run `supabase test db`. A function tested in an empty scratch schema may
+  miss inherited defaults and grants.
+- Check `has_function_privilege(role, 'public.my_rpc(bigint)', 'EXECUTE')` for
+  `anon`, `authenticated`, and `service_role`, against the declared contract.
+  This checks effective access, including inherited grants. Separately assert
+  no unintended `PUBLIC EXECUTE` ACL: inspect
+  `aclexplode(coalesce(proacl, acldefault('f', proowner)))` in `pg_proc`, where
+  `grantee = 0` denotes PUBLIC. A NULL `proacl` means the built-in default
+  function ACL, not an empty ACL.
+- Make real calls after `SET LOCAL ROLE`, with appropriate JWT claims. Prove
+  permission denial (`42501`) for untrusted callers and a successful call as
+  `service_role` for service-only RPCs; a call as `postgres` does not prove that
+  path. Use valid fixtures/arguments so validation errors cannot stand in for
+  permission denial.
+  For user-callable RPCs, cover own-tenant success, other tenant, no membership,
+  anon, and supplied foreign user IDs where applicable. Table/view denial alone
+  does not prove an RPC is denied.
+- Discover the complete RPC family and overloads from the catalog and assert
+  the expected signatures as well as their privileges. A new function or
+  overload must trigger coverage rather than silently escape a fixed test list.
+
+When reviewing history, reconstruct access from role memberships, ownership,
+grants/defaults, wrapper bodies, policies, and role-based tests at the relevant
+revisions. Comments and grant intent are not evidence of effective access.
 
 ---
 
@@ -286,7 +342,7 @@ Agents are allowed to run **local-only** Supabase commands.
 - `supabase migration new ...`
 - `supabase migration up`
 - `supabase test new ...`
-- `supabase db test`
+- `supabase test db`
 - `supabase gen types typescript --local ...`
 
 **Forbidden without explicit user permission**
@@ -307,8 +363,8 @@ Agents are allowed to run **local-only** Supabase commands.
 
 - **RLS**: enabled (and forced when appropriate) for tenant/user data tables.
 - **Policies**: minimal, tenant-scoped, and readable.
-- **Grants**: no accidental `PUBLIC` access; only required roles have access.
-- **RPC**: privileged functions have safe `search_path`, locked-down `EXECUTE`, and tenant checks inside.
+- **Grants**: no unintended effective access through `PUBLIC`, direct grants, or role membership.
+- **RPC**: every signature satisfies the [RPC role contract](#rpc-role-contract), including caller/tenant guards for user-callable definer functions.
 - **Tests**: pgTAP added/updated to prove tenant isolation and intended access.
 - **Seed**: still supports multi-tenant scenarios and hasn’t become brittle.
 - **Privileged code**: no unnecessary `SECURITY DEFINER`, safe `search_path` where used.

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -91,8 +91,11 @@ supabase test new <name>
 Run tests against your local database:
 
 ```bash
-supabase db test
+supabase test db
 ```
+
+For RPC permissions and the required privilege and caller tests, follow the
+canonical [RPC role contract](AGENTS.md#rpc-role-contract).
 
 ### Supabase Types
 

--- a/supabase/migrations/20260909090825_billing_rpc_grants.sql
+++ b/supabase/migrations/20260909090825_billing_rpc_grants.sql
@@ -1,0 +1,50 @@
+-- GRIDA-EE: billing
+-- Billing RPCs run only through the server's service_role client. Member
+-- reads use the existing RLS-protected views. PUBLIC revocation alone does
+-- not remove anon/authenticated grants inherited from public-schema defaults.
+
+BEGIN;
+
+REVOKE ALL ON FUNCTION
+  public.fn_billing_apply_metronome_event(text, text, jsonb),
+  public.fn_billing_apply_stripe_event(text, text, jsonb),
+  public.fn_billing_attach_stripe_customer(bigint, text),
+  public.fn_billing_debit_balance_cache(bigint, bigint, bigint),
+  public.fn_billing_get_active_subscription(bigint),
+  public.fn_billing_get_ai_credit_processed(text),
+  public.fn_billing_get_catalogue(text),
+  public.fn_billing_get_customer_id(bigint),
+  public.fn_billing_get_metronome_account(bigint),
+  public.fn_billing_list_metronome_events(bigint, integer),
+  public.fn_billing_list_provisioned_orgs(),
+  public.fn_billing_resolve_org_by_metronome_customer(text),
+  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
+  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
+  public.fn_billing_set_metronome_ids(bigint, text, text),
+  public.fn_billing_setup_product(text, text, text),
+  public.fn_billing_stamp_ai_credit_processed(text, text),
+  public.fn_billing_stamp_failure(text, text, text)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION
+  public.fn_billing_apply_metronome_event(text, text, jsonb),
+  public.fn_billing_apply_stripe_event(text, text, jsonb),
+  public.fn_billing_attach_stripe_customer(bigint, text),
+  public.fn_billing_debit_balance_cache(bigint, bigint, bigint),
+  public.fn_billing_get_active_subscription(bigint),
+  public.fn_billing_get_ai_credit_processed(text),
+  public.fn_billing_get_catalogue(text),
+  public.fn_billing_get_customer_id(bigint),
+  public.fn_billing_get_metronome_account(bigint),
+  public.fn_billing_list_metronome_events(bigint, integer),
+  public.fn_billing_list_provisioned_orgs(),
+  public.fn_billing_resolve_org_by_metronome_customer(text),
+  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
+  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
+  public.fn_billing_set_metronome_ids(bigint, text, text),
+  public.fn_billing_setup_product(text, text, text),
+  public.fn_billing_stamp_ai_credit_processed(text, text),
+  public.fn_billing_stamp_failure(text, text, text)
+TO service_role;
+
+COMMIT;

--- a/supabase/schemas/grida_billing.sql
+++ b/supabase/schemas/grida_billing.sql
@@ -1162,33 +1162,21 @@ GRANT EXECUTE ON FUNCTION public.fn_billing_stamp_ai_credit_processed(text, text
 
 
 ---------------------------------------------------------------------
--- Metronome RPC privileges.
--- Their definitions and account/event extensions are described by
--- 20260508130000_grida_billing_metronome.sql; this reference remains partial.
--- Permission inventory covers every public billing entry point, including
--- those definitions, and is verified by billing_rpc_grants_test.sql.
+-- Metronome RPC permission reference (definitions not yet mirrored here).
+-- Definitions and account/event extensions live in
+-- ../migrations/20260508130000_grida_billing_metronome.sql.
+-- ../migrations/20260909090825_billing_rpc_grants.sql applies their grants:
+-- service_role has EXECUTE; PUBLIC, anon and authenticated have none.
+-- Keep this inventory as comments until the definitions are mirrored, so
+-- declarative schema tooling does not execute grants on absent functions.
+-- ../tests/billing_rpc_grants_test.sql verifies the migrated permissions.
 ---------------------------------------------------------------------
-
-REVOKE ALL ON FUNCTION
-  public.fn_billing_apply_metronome_event(text, text, jsonb),
-  public.fn_billing_get_metronome_account(bigint),
-  public.fn_billing_set_metronome_ids(bigint, text, text),
-  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
-  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
-  public.fn_billing_resolve_org_by_metronome_customer(text),
-  public.fn_billing_list_provisioned_orgs(),
-  public.fn_billing_list_metronome_events(bigint, integer),
-  public.fn_billing_debit_balance_cache(bigint, bigint, bigint)
-FROM PUBLIC, anon, authenticated;
-
-GRANT EXECUTE ON FUNCTION
-  public.fn_billing_apply_metronome_event(text, text, jsonb),
-  public.fn_billing_get_metronome_account(bigint),
-  public.fn_billing_set_metronome_ids(bigint, text, text),
-  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
-  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
-  public.fn_billing_resolve_org_by_metronome_customer(text),
-  public.fn_billing_list_provisioned_orgs(),
-  public.fn_billing_list_metronome_events(bigint, integer),
-  public.fn_billing_debit_balance_cache(bigint, bigint, bigint)
-TO service_role;
+-- public.fn_billing_apply_metronome_event(text, text, jsonb)
+-- public.fn_billing_get_metronome_account(bigint)
+-- public.fn_billing_set_metronome_ids(bigint, text, text)
+-- public.fn_billing_set_balance_cache(bigint, bigint, boolean)
+-- public.fn_billing_set_auto_reload(bigint, boolean, integer, integer)
+-- public.fn_billing_resolve_org_by_metronome_customer(text)
+-- public.fn_billing_list_provisioned_orgs()
+-- public.fn_billing_list_metronome_events(bigint, integer)
+-- public.fn_billing_debit_balance_cache(bigint, bigint, bigint)

--- a/supabase/schemas/grida_billing.sql
+++ b/supabase/schemas/grida_billing.sql
@@ -1,3 +1,4 @@
+-- GRIDA-EE: billing
 -- grida_billing schema
 --
 -- Core billing primitives. Mirrors Stripe lifecycle objects (Customer,
@@ -5,8 +6,8 @@
 -- the product can react to billing changes without ever touching Stripe
 -- directly.
 --
--- The schema is locked down: only postgres owner and service_role can
--- reach grida_billing.* tables. PostgREST surface lives in public.*.
+-- Billing writes and server RPCs require service_role. Authenticated members
+-- retain RLS-scoped reads through the invoker views in public.*.
 --
 -- Stripe-sourced amounts are in CENTS (Stripe's smallest currency unit)
 -- and stored as `*_cents` columns to keep the boundary explicit.
@@ -34,10 +35,9 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA grida_billing GRANT ALL ON 
 ALTER DEFAULT PRIVILEGES IN SCHEMA grida_billing REVOKE ALL ON TABLES    FROM authenticated, anon;
 ALTER DEFAULT PRIVILEGES IN SCHEMA grida_billing REVOKE ALL ON ROUTINES  FROM authenticated, anon;
 ALTER DEFAULT PRIVILEGES IN SCHEMA grida_billing REVOKE ALL ON SEQUENCES FROM authenticated, anon;
--- Default-privileges only revoke from authenticated/anon explicitly; PUBLIC
--- still inherits EXECUTE on every routine and authenticated inherits PUBLIC.
--- Strip PUBLIC too so the schema USAGE we grant above doesn't make signed-in
--- users able to call internal SECURITY DEFINER functions like the projector.
+-- Per-schema defaults cannot remove globally granted PUBLIC EXECUTE. This
+-- statement only reverses a matching per-schema grant; explicit per-function
+-- revocations below enforce the boundary for existing and new routines.
 ALTER DEFAULT PRIVILEGES IN SCHEMA grida_billing REVOKE EXECUTE ON ROUTINES FROM PUBLIC;
 
 
@@ -952,7 +952,7 @@ AS $$
   SELECT * FROM grida_billing.fn_apply_stripe_event(p_event_id, p_event_type, p_payload);
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_apply_stripe_event(text, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_apply_stripe_event(text, text, jsonb) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_apply_stripe_event(text, text, jsonb) TO service_role;
 
 
@@ -975,7 +975,7 @@ AS $$
   SELECT grida_billing.fn_stamp_failure(p_event_id, p_event_type, p_reason);
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_stamp_failure(text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_stamp_failure(text, text, text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_stamp_failure(text, text, text) TO service_role;
 
 
@@ -995,7 +995,7 @@ AS $$
   SELECT * FROM grida_billing.fn_attach_stripe_customer(p_org_id, p_stripe_customer_id);
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_attach_stripe_customer(bigint, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_attach_stripe_customer(bigint, text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_attach_stripe_customer(bigint, text) TO service_role;
 
 
@@ -1014,7 +1014,7 @@ AS $$
   SELECT stripe_customer_id FROM grida_billing.account WHERE organization_id = p_org_id;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_get_customer_id(bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_get_customer_id(bigint) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_get_customer_id(bigint) TO service_role;
 
 
@@ -1048,7 +1048,7 @@ AS $$
    LIMIT 1;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_get_active_subscription(bigint) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_get_active_subscription(bigint) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_get_active_subscription(bigint) TO service_role;
 
 
@@ -1073,7 +1073,7 @@ AS $$
    WHERE id = p_id;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_get_catalogue(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_get_catalogue(text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_get_catalogue(text) TO service_role;
 
 
@@ -1107,7 +1107,7 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_setup_product(text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_setup_product(text, text, text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_setup_product(text, text, text) TO service_role;
 
 
@@ -1131,7 +1131,7 @@ AS $$
    WHERE id = p_event_id;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_get_ai_credit_processed(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_get_ai_credit_processed(text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_get_ai_credit_processed(text) TO service_role;
 
 
@@ -1157,5 +1157,38 @@ AS $$
     ai_credit_processed_at = EXCLUDED.ai_credit_processed_at;
 $$;
 
-REVOKE ALL ON FUNCTION public.fn_billing_stamp_ai_credit_processed(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_billing_stamp_ai_credit_processed(text, text) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_billing_stamp_ai_credit_processed(text, text) TO service_role;
+
+
+---------------------------------------------------------------------
+-- Metronome RPC privileges.
+-- Their definitions and account/event extensions are described by
+-- 20260508130000_grida_billing_metronome.sql; this reference remains partial.
+-- Permission inventory covers every public billing entry point, including
+-- those definitions, and is verified by billing_rpc_grants_test.sql.
+---------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION
+  public.fn_billing_apply_metronome_event(text, text, jsonb),
+  public.fn_billing_get_metronome_account(bigint),
+  public.fn_billing_set_metronome_ids(bigint, text, text),
+  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
+  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
+  public.fn_billing_resolve_org_by_metronome_customer(text),
+  public.fn_billing_list_provisioned_orgs(),
+  public.fn_billing_list_metronome_events(bigint, integer),
+  public.fn_billing_debit_balance_cache(bigint, bigint, bigint)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION
+  public.fn_billing_apply_metronome_event(text, text, jsonb),
+  public.fn_billing_get_metronome_account(bigint),
+  public.fn_billing_set_metronome_ids(bigint, text, text),
+  public.fn_billing_set_balance_cache(bigint, bigint, boolean),
+  public.fn_billing_set_auto_reload(bigint, boolean, integer, integer),
+  public.fn_billing_resolve_org_by_metronome_customer(text),
+  public.fn_billing_list_provisioned_orgs(),
+  public.fn_billing_list_metronome_events(bigint, integer),
+  public.fn_billing_debit_balance_cache(bigint, bigint, bigint)
+TO service_role;

--- a/supabase/tests/billing_rpc_grants_test.sql
+++ b/supabase/tests/billing_rpc_grants_test.sql
@@ -1,0 +1,297 @@
+-- GRIDA-EE: billing
+-- pgTAP regression: billing RPCs are a service-role boundary, including
+-- effective EXECUTE inherited from PUBLIC or Supabase's default grants.
+-- Member reads remain available through the intended, tenant-scoped views.
+-- Uses the canonical local seed; every synthetic change rolls back.
+
+BEGIN;
+
+-- 18 RPCs x 4 ACL assertions + 1 complete-catalog assertion +
+-- 4 service-role round trips + 8 denied RPC calls + 10 view assertions +
+-- 2 denied direct writes + 2 unchanged-cache assertions.
+SELECT plan(99);
+
+-- Keep exact signatures: a new RPC or overload must join this inventory
+-- and receive the same role checks. Sources: the base billing migration,
+-- 20260508130000 (Metronome), and 20260512000000 (AI-credit markers).
+CREATE TEMP TABLE billing_rpc_signatures (signature text PRIMARY KEY);
+INSERT INTO billing_rpc_signatures (signature) VALUES
+  ('public.fn_billing_apply_metronome_event(text, text, jsonb)'),
+  ('public.fn_billing_apply_stripe_event(text, text, jsonb)'),
+  ('public.fn_billing_attach_stripe_customer(bigint, text)'),
+  ('public.fn_billing_debit_balance_cache(bigint, bigint, bigint)'),
+  ('public.fn_billing_get_active_subscription(bigint)'),
+  ('public.fn_billing_get_ai_credit_processed(text)'),
+  ('public.fn_billing_get_catalogue(text)'),
+  ('public.fn_billing_get_customer_id(bigint)'),
+  ('public.fn_billing_get_metronome_account(bigint)'),
+  ('public.fn_billing_list_metronome_events(bigint, integer)'),
+  ('public.fn_billing_list_provisioned_orgs()'),
+  ('public.fn_billing_resolve_org_by_metronome_customer(text)'),
+  ('public.fn_billing_set_auto_reload(bigint, boolean, integer, integer)'),
+  ('public.fn_billing_set_balance_cache(bigint, bigint, boolean)'),
+  ('public.fn_billing_set_metronome_ids(bigint, text, text)'),
+  ('public.fn_billing_setup_product(text, text, text)'),
+  ('public.fn_billing_stamp_ai_credit_processed(text, text)'),
+  ('public.fn_billing_stamp_failure(text, text, text)');
+
+WITH actual AS (
+  SELECT format('public.%s(%s)', p.proname, oidvectortypes(p.proargtypes)) AS signature
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname ~ '^fn_billing_'
+)
+SELECT is(
+  (SELECT array_agg(signature ORDER BY signature) FROM actual),
+  (SELECT array_agg(signature ORDER BY signature) FROM billing_rpc_signatures),
+  'all public billing RPCs and overloads are covered by the explicit inventory'
+);
+
+SELECT ok(
+  NOT has_function_privilege('anon', to_regprocedure(signature), 'EXECUTE'),
+  'anon cannot execute ' || signature
+)
+FROM billing_rpc_signatures ORDER BY signature;
+
+SELECT ok(
+  NOT has_function_privilege('authenticated', to_regprocedure(signature), 'EXECUTE'),
+  'authenticated cannot execute ' || signature
+)
+FROM billing_rpc_signatures ORDER BY signature;
+
+SELECT ok(
+  has_function_privilege('service_role', to_regprocedure(signature), 'EXECUTE'),
+  'service_role can execute ' || signature
+)
+FROM billing_rpc_signatures ORDER BY signature;
+
+-- A NULL proacl means PostgreSQL's default ACL, including PUBLIC EXECUTE;
+-- expand that default too, rather than treating NULL as locked down.
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+      FROM pg_proc p
+      CROSS JOIN LATERAL aclexplode(
+        COALESCE(p.proacl, acldefault('f', p.proowner))
+      ) acl
+     WHERE p.oid = to_regprocedure(signature)
+       AND acl.grantee = 0 AND acl.privilege_type = 'EXECUTE'
+  ),
+  'PUBLIC has no EXECUTE ACL on ' || signature
+)
+FROM billing_rpc_signatures ORDER BY signature;
+
+-- Resolve regenerated seed UUIDs and organization IDs before switching roles.
+DO $$
+BEGIN
+  PERFORM set_config('test.billing_insider_uid',
+    (SELECT id::text FROM auth.users WHERE email = 'insider@grida.co'), true);
+  PERFORM set_config('test.billing_alice_uid',
+    (SELECT id::text FROM auth.users WHERE email = 'alice@acme.com'), true);
+  PERFORM set_config('test.billing_random_uid',
+    (SELECT id::text FROM auth.users WHERE email = 'random@example.com'), true);
+  PERFORM set_config('test.billing_local_org',
+    (SELECT id::text FROM public.organization WHERE name = 'local'), true);
+  PERFORM set_config('test.billing_acme_org',
+    (SELECT id::text FROM public.organization WHERE name = 'acme'), true);
+END $$;
+
+-- Actual service calls prove the intended server boundary still works.
+SET LOCAL ROLE service_role;
+
+SELECT lives_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_local_org')::bigint, 7300, true
+  )
+$$, 'service_role can refresh the local cache');
+
+SELECT lives_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_acme_org')::bigint, 2900, false
+  )
+$$, 'service_role can refresh the acme cache');
+
+SELECT results_eq($$
+  SELECT organization_id, cached_balance_cents, customer_entitled
+    FROM public.fn_billing_get_metronome_account(
+      current_setting('test.billing_local_org')::bigint
+    )
+$$, $$
+  VALUES (current_setting('test.billing_local_org')::bigint, 7300::bigint, true)
+$$, 'service_role reads the synthetic local cache through the RPC');
+
+SELECT results_eq($$
+  SELECT organization_id, cached_balance_cents, customer_entitled
+    FROM public.fn_billing_get_metronome_account(
+      current_setting('test.billing_acme_org')::bigint
+    )
+$$, $$
+  VALUES (current_setting('test.billing_acme_org')::bigint, 2900::bigint, false)
+$$, 'service_role reads the synthetic acme cache through the RPC');
+
+-- Owner-audit fixtures distinguish a filtered row from an empty table.
+INSERT INTO grida_billing.audit (organization_id, operation, note) VALUES
+  (current_setting('test.billing_local_org')::bigint, 'customer_attach', 'pgTAP billing RPC grants'),
+  (current_setting('test.billing_acme_org')::bigint, 'customer_attach', 'pgTAP billing RPC grants');
+
+-- Anonymous callers must fail at EXECUTE, before any definer body runs.
+SET LOCAL ROLE anon;
+SELECT set_config('request.jwt.claim.sub', '', true);
+
+SELECT throws_ok($$
+  SELECT * FROM public.fn_billing_get_metronome_account(
+    current_setting('test.billing_local_org')::bigint
+  )
+$$, '42501', 'permission denied for function fn_billing_get_metronome_account',
+  'anon cannot read a billing account through the RPC');
+
+SELECT throws_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_local_org')::bigint, 999900, false
+  )
+$$, '42501', 'permission denied for function fn_billing_set_balance_cache',
+  'anon cannot overwrite the billing cache through the RPC');
+
+-- Even organization owners use the member views, never these server RPCs.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', current_setting('test.billing_insider_uid'), true);
+
+SELECT throws_ok($$
+  SELECT * FROM public.fn_billing_get_metronome_account(
+    current_setting('test.billing_local_org')::bigint
+  )
+$$, '42501', 'permission denied for function fn_billing_get_metronome_account',
+  'an owner cannot call the billing reader for their own organization');
+
+SELECT throws_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_local_org')::bigint, 999900, false
+  )
+$$, '42501', 'permission denied for function fn_billing_set_balance_cache',
+  'an owner cannot call the cache writer for their own organization');
+
+SELECT throws_ok($$
+  SELECT * FROM public.fn_billing_get_metronome_account(
+    current_setting('test.billing_acme_org')::bigint
+  )
+$$, '42501', 'permission denied for function fn_billing_get_metronome_account',
+  'an owner cannot call the billing reader for another organization');
+
+SELECT throws_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_acme_org')::bigint, 999900, true
+  )
+$$, '42501', 'permission denied for function fn_billing_set_balance_cache',
+  'an owner cannot call the cache writer for another organization');
+
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_subscription
+    WHERE organization_id = current_setting('test.billing_local_org')::bigint),
+  1::bigint, 'insider still reads the local subscription view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_subscription
+    WHERE organization_id = current_setting('test.billing_acme_org')::bigint),
+  0::bigint, 'insider cannot read the acme subscription view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_audit
+    WHERE organization_id = current_setting('test.billing_local_org')::bigint
+      AND note = 'pgTAP billing RPC grants'),
+  1::bigint, 'owner insider still reads the local audit view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_audit
+    WHERE organization_id = current_setting('test.billing_acme_org')::bigint
+      AND note = 'pgTAP billing RPC grants'),
+  0::bigint, 'insider cannot read the acme audit view'
+);
+
+-- SELECT granted for the invoker views must not become a direct write path.
+SELECT throws_ok($$
+  UPDATE grida_billing.account SET cached_balance_cents = 999900
+   WHERE organization_id = current_setting('test.billing_local_org')::bigint
+   RETURNING *
+$$, '42501', 'permission denied for table account',
+  'authenticated cannot UPDATE their account with RETURNING');
+
+SELECT throws_ok($$
+  DELETE FROM grida_billing.account
+   WHERE organization_id = current_setting('test.billing_local_org')::bigint
+   RETURNING *
+$$, '42501', 'permission denied for table account',
+  'authenticated cannot DELETE their account with RETURNING');
+
+SELECT set_config('request.jwt.claim.sub', current_setting('test.billing_alice_uid'), true);
+
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_subscription
+    WHERE organization_id = current_setting('test.billing_acme_org')::bigint),
+  1::bigint, 'alice still reads the acme subscription view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_subscription
+    WHERE organization_id = current_setting('test.billing_local_org')::bigint),
+  0::bigint, 'alice cannot read the local subscription view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_audit
+    WHERE organization_id = current_setting('test.billing_acme_org')::bigint
+      AND note = 'pgTAP billing RPC grants'),
+  1::bigint, 'owner alice still reads the acme audit view'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_audit
+    WHERE organization_id = current_setting('test.billing_local_org')::bigint
+      AND note = 'pgTAP billing RPC grants'),
+  0::bigint, 'alice cannot read the local audit view'
+);
+
+SELECT set_config('request.jwt.claim.sub', current_setting('test.billing_random_uid'), true);
+
+SELECT throws_ok($$
+  SELECT * FROM public.fn_billing_get_metronome_account(
+    current_setting('test.billing_local_org')::bigint
+  )
+$$, '42501', 'permission denied for function fn_billing_get_metronome_account',
+  'a user with no membership cannot call the billing reader');
+
+SELECT throws_ok($$
+  SELECT public.fn_billing_set_balance_cache(
+    current_setting('test.billing_local_org')::bigint, 999900, false
+  )
+$$, '42501', 'permission denied for function fn_billing_set_balance_cache',
+  'a user with no membership cannot call the cache writer');
+
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_subscription),
+  0::bigint, 'a user with no membership sees no subscriptions'
+);
+SELECT is(
+  (SELECT count(*) FROM public.v_billing_audit),
+  0::bigint, 'a user with no membership sees no billing audit rows'
+);
+
+SET LOCAL ROLE service_role;
+
+SELECT results_eq($$
+  SELECT organization_id, cached_balance_cents, customer_entitled
+    FROM public.fn_billing_get_metronome_account(
+      current_setting('test.billing_local_org')::bigint
+    )
+$$, $$
+  VALUES (current_setting('test.billing_local_org')::bigint, 7300::bigint, true)
+$$, 'denied calls leave the local cache and entitlement unchanged');
+
+SELECT results_eq($$
+  SELECT organization_id, cached_balance_cents, customer_entitled
+    FROM public.fn_billing_get_metronome_account(
+      current_setting('test.billing_acme_org')::bigint
+    )
+$$, $$
+  VALUES (current_setting('test.billing_acme_org')::bigint, 2900::bigint, false)
+$$, 'denied calls leave the acme cache and entitlement unchanged');
+
+RESET ROLE;
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
# fix(database): restrict billing RPC execution to service role

Public billing RPCs are intended for server callers, but revoking EXECUTE only from PUBLIC leaves explicit anon/authenticated grants intact. This change revokes all three roles on the 18 exact billing RPC signatures and preserves service_role access. Member reads continue through the existing RLS-protected views.

The forward migration changes privileges only. Existing migrations, function bodies, business data, RLS policies and global defaults remain unchanged. The schema reference records the corrected grants, and the canonical database guide now requires effective-privilege checks and actual calls as both allowed and denied roles.

The cause extends across a repeated function family: default role grants survived the existing revoke recipe, while tests covered tables and views without testing the RPC caller boundary. The new regression test checks every signature and detects new functions or overloads that need an explicit permission contract.

## Validation

- New regression: 46 expected failures out of 99 assertions before correction.
- Complete database suite: 265/265 tests pass after an upgrade and after a fresh migration replay.
- Local PostgREST: anonymous calls denied with 401; authenticated owner and representative client_id-token calls denied with 403; intended member and service reads succeed; denied calls leave state unchanged.
- Independent security review and formatting checks complete.
- Repository-wide typecheck did not complete because this isolated worktree lacks installed dependencies. No TypeScript source changed.
- External Stripe/Metronome E2E has not run. Service-role SQL round trips and existing database projector tests passed.

## Review scope

The review covers the scoped migration/regression tests, canonical database/security guidance, and a comment-only permission inventory for the partial Metronome schema reference. The exact migration has been applied with maintainer approval. Production catalog postchecks confirm the intended effective grants, unchanged function definitions and owners, and the exact migration-history entry. Merge remains pending review.
