### PR TITLE
chore(cli): prepare first npm preview release

### DIFF
--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -13,10 +13,6 @@ format: md
 Grida login is for account services and Grida Gateway (GG). [BYOK generation](./providers.md)
 uses your provider key independently and does not require this login.
 
-> **Preview status:** this CLI has not been released. Hosted account access is
-> awaiting deployment verification. Contributors can use the isolated
-> [local CLI proof](https://github.com/gridaco/grida/tree/main/scripts/cli-local).
-
 ## Sign in
 
 ```sh

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,26 +13,16 @@ format: md
 Discover models, generate media, and keep the files in your own workflow.
 Desktop does not need to be running.
 
-> **Private development preview.** These guides describe the replacement CLI
-> in this repository. It has not been published to npm. Installing the legacy
-> `grida` package does not provide these commands. Hosted Grida login and GG
-> setup are not yet available for this preview.
+> **Preview.** Install the replacement CLI from npm's `next` channel. The legacy
+> `latest` package does not provide these commands.
 
-## Run the preview
+## Install
 
-Use Node.js 24 or later and a repository checkout with dependencies installed.
-Build and invoke the preview from the repository root:
+Use Node.js 24 or later:
 
 ```sh grida-setup
-pnpm --filter grida... build
-node packages/grida-cli/dist/bin.mjs --help
+npm install -g grida@next
 ```
-
-Below, `grida` means that executable. During development, replace it with
-`node packages/grida-cli/dist/bin.mjs` from the repository root. See the
-[contributing guide](https://github.com/gridaco/grida/blob/main/CONTRIBUTING.md)
-for checkout setup. Global installation instructions will accompany the npm
-release.
 
 Stored credentials currently support macOS and Linux. Windows users can supply
 BYOK through explicit environment variables or stdin; durable account login is
@@ -75,7 +65,7 @@ grida docs generate
 
 `--help` describes your installed version and works offline. `docs` prints a
 guide URL without opening a browser; reading the guide needs a connection.
-These pages describe the development preview. Agent, render, and MCP commands
+These pages describe the `next` preview. Agent, render, and MCP commands
 are deferred.
 
 ## Use Grida in scripts

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,8 +13,10 @@ format: md
 Discover models, generate media, and keep the files in your own workflow.
 Desktop does not need to be running.
 
-> **Preview.** Install the replacement CLI from npm's `next` channel. The legacy
-> `latest` package does not provide these commands.
+> **Preview channel: `next`.** Installation requires a published `next` version;
+> check [npm's versions and tags](https://www.npmjs.com/package/grida?activeTab=versions)
+> for availability. Before that tag exists, the command below cannot install the
+> preview. The legacy `latest` package does not provide these commands.
 
 ## Install
 

--- a/docs/wg/cli/account-infrastructure.md
+++ b/docs/wg/cli/account-infrastructure.md
@@ -12,7 +12,7 @@ format: md
 
 > **Status: accepted architecture.** This specifies the account foundation for
 > independent native clients. CLI commands, media execution and npm distribution
-> are separate delivery. The replacement CLI has not shipped. See the
+> have their own contracts. See the
 > [doctrine](./index.md) for product boundaries.
 
 ## Scope and ownership

--- a/docs/wg/cli/credential-custody.md
+++ b/docs/wg/cli/credential-custody.md
@@ -10,7 +10,7 @@ format: md
 
 # CLI credential custody
 
-> **Status: accepted design; the replacement CLI has not shipped.** Native
+> **Status: accepted custody design for the CLI preview.** Native
 > account custody and shared BYOK storage in TOML are implemented.
 > Environment/stdin keys remain explicit per-invocation overrides.
 > The [native package contract](https://github.com/gridaco/grida/blob/main/packages/grida-auth/README.md)
@@ -106,7 +106,7 @@ still require login. Recovery must report that outcome honestly.
 
 ## Provider credentials
 
-**Implemented in the development preview:** Desktop and CLI share
+**Implemented in the CLI preview:** Desktop and CLI share
 `providers/credentials.toml` for BYOK API keys under the user's Grida home
 (`~/.grida` by default, or the explicit `GRIDA_HOME`). Plaintext
 with user-only permissions is the default. Both clients use the same credential

--- a/docs/wg/cli/documentation.md
+++ b/docs/wg/cli/documentation.md
@@ -10,9 +10,8 @@ format: md
 
 # CLI documentation
 
-> **Status: implemented for the private preview.** The public guide source and
-> local currency check exist. Publication and the first npm release remain
-> separate release steps; local validation does not establish deployment.
+> **Status: implemented for the CLI preview.** Public guides and their currency
+> check accompany the npm release. Local validation does not establish deployment.
 
 ## Current position
 

--- a/docs/wg/cli/index.md
+++ b/docs/wg/cli/index.md
@@ -10,7 +10,7 @@ format: md
 
 # Grida CLI
 
-> **Status: accepted doctrine; implementation is a private preview.** Examples
+> **Status: accepted doctrine for the CLI preview.** Examples
 > describe the replacement CLI, not the legacy npm release.
 > See the [v1 spec](./v1.md) for the immediate scope and
 > [account infrastructure](./account-infrastructure.md) for its foundation.

--- a/docs/wg/cli/media.md
+++ b/docs/wg/cli/media.md
@@ -10,9 +10,8 @@ format: md
 
 # AI tools
 
-> **Command contract for the private development preview.** These commands are
-> implemented locally; the replacement npm CLI has not been released. Broader
-> provider-native execution and detached jobs remain proposals below.
+> **Command contract for the CLI preview.** Broader provider-native execution
+> and detached jobs remain proposals below.
 
 **Discover by modality. Invoke one exact operation through a provider.**
 `models`, `providers`, `voices` and `generate` are root commands. Desktop does

--- a/docs/wg/cli/v1.md
+++ b/docs/wg/cli/v1.md
@@ -21,9 +21,8 @@ format: md
 
 # Grida CLI v1
 
-> **Status: accepted command contract, implemented as a private preview.** The
-> CLI has not shipped. Immediate is the first-release scope; planned has no
-> release commitment. See the
+> **Status: accepted command contract for the CLI preview.** Immediate is the
+> first-release scope; planned has no release commitment. See the
 > [doctrine](./index.md) for product boundaries.
 
 ## Scope: account infrastructure and AI tools
@@ -47,7 +46,7 @@ features are separate extensions.
 The intended first session is:
 
 ```sh
-npm install -g grida
+npm install -g grida@next
 grida auth login
 grida account view
 grida account credits --org studio

--- a/packages/grida-cli/README.md
+++ b/packages/grida-cli/README.md
@@ -6,12 +6,25 @@
 The `grida` command composes Grida's account services and tools for people and
 their own harnesses. It runs independently of Desktop.
 
-**Private development preview.** This package is not published. The legacy npm
-release does not provide these commands. Current commands cover auth, credential
-storage, identity, organization membership, cached credits, help/version and docs.
+**Preview.** Install the replacement CLI from npm's `next` channel. The legacy
+`latest` package does not provide these commands. Current commands cover auth,
+credential storage, identity, organization membership, cached credits, help/version
+and docs.
 Media commands discover models/schemas, inspect provider key presence, list speech
 voices and generate image, video, music, sound effects, speech and supported 3D.
 Agent, render and MCP are deferred.
+
+Use Node.js 24 or later:
+
+```sh
+npm install -g grida@next
+grida --version
+grida --help
+```
+
+Stored credentials support macOS and Linux. Windows users can supply BYOK
+through explicit environment variables or stdin; durable account login is not
+supported there yet.
 
 User documentation has one canonical home: the
 [Grida CLI guide](https://grida.co/docs/cli). Contributor design lives in the

--- a/packages/grida-cli/package.json
+++ b/packages/grida-cli/package.json
@@ -1,8 +1,9 @@
 {
   "name": "grida",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0-next.0",
+  "private": false,
   "description": "The Grida command line: account access and tools, independent of Desktop.",
+  "homepage": "https://grida.co/docs/cli",
   "license": "Apache-2.0",
   "repository": "https://github.com/gridaco/grida",
   "bin": {

--- a/scripts/cli-docs/README.md
+++ b/scripts/cli-docs/README.md
@@ -42,8 +42,9 @@ proof owns synthetic execution and saving behavior.
 Author ordinary `sh` fences with one literal Grida invocation per logical line;
 backslash continuation and shell quotes are supported. Shell expansion, pipes,
 redirection, and arbitrary shell evaluation are rejected. Only the exact
-two-command preview build block is marked `grida-setup` and exempted. Named
-`text`/`json` fences are copied literally into each guide's temporary directory.
+`npm install -g grida@next` setup block is marked `grida-setup` and exempted; the
+checker never runs that command. Named `text`/`json` fences are copied literally
+into each guide's temporary directory.
 If a workflow needs additional shell orchestration, explain it separately and
 keep its Grida commands in ordinary checked fences.
 

--- a/scripts/cli-docs/check.mjs
+++ b/scripts/cli-docs/check.mjs
@@ -120,8 +120,8 @@ export const CliDocs = {
       if (info === "sh grida-setup") {
         assert.equal(
           body.trim(),
-          "pnpm --filter grida... build\nnode packages/grida-cli/dist/bin.mjs --help",
-          "Only the documented preview build is exempt from command parsing"
+          "npm install -g grida@next",
+          "Only the documented preview install is exempt from command parsing"
         );
       } else if (info === "sh") {
         for (const line of body.replace(/\\\r?\n/g, "").split(/\r?\n/)) {

--- a/scripts/cli-docs/check.test.mjs
+++ b/scripts/cli-docs/check.test.mjs
@@ -59,6 +59,20 @@ test("literal guide parsing preserves quoted prompts, escaped quotes, false and 
 });
 
 test("guide commands never acquire shell evaluation and cannot silently opt out", () => {
+  assert.deepEqual(
+    CliDocs.examples("```sh grida-setup\nnpm install -g grida@next\n```"),
+    { examples: [], files: [] }
+  );
+  for (const setup of [
+    "npm install -g grida",
+    "npm install -g grida@latest",
+    "npm install -g grida@next\ngrida removed-command",
+    "npm install -g grida@next; id",
+    "pnpm --filter grida... build\nnode packages/grida-cli/dist/bin.mjs --help",
+  ])
+    assert.throws(() =>
+      CliDocs.examples(`\`\`\`sh grida-setup\n${setup}\n\`\`\``)
+    );
   for (const text of [
     "grida $(id)",
     "grida `id`",

--- a/scripts/cli-release/README.md
+++ b/scripts/cli-release/README.md
@@ -1,9 +1,9 @@
 # CLI package preparation and release
 
 For maintainers preparing the independently installed `grida` executable.
-The CLI remains a private preview until deployed account access, public
-documentation and release configuration are ready. These scripts do not provision
-services or make the package publishable.
+Publication requires deployed account access, public documentation and release
+configuration. These scripts do not provision services or change the package's
+release metadata.
 
 ## Local candidate
 
@@ -16,7 +16,7 @@ pnpm turbo run typecheck test --filter=grida...
 node --test scripts/cli-release/prepare.test.mjs
 node scripts/cli-release/prepare.mjs --out "$PWD/.cache/cli-candidate"
 node scripts/cli-release/prepare.mjs --verify --out "$PWD/.cache/cli-candidate"
-node scripts/cli-media-local/proof.mjs --archive "$PWD/.cache/cli-candidate/grida-0.0.0.tgz"
+node scripts/cli-media-local/proof.mjs --archive "$PWD/.cache/cli-candidate/grida-0.1.0-next.0.tgz"
 ```
 
 Use the actual archive name from `candidate.json` after a version change. The


### PR DESCRIPTION
The standalone CLI from #1038 needs an explicit publishable version and installation instructions before its first npm release. This sets `grida@0.1.0-next.0`, adds the canonical docs homepage, and documents `npm install -g grida@next`. The legacy `latest` tag remains unchanged.

The docs checker exempts only that exact install command from CLI parsing and rejects untagged installs, `latest`, and appended commands. Obsolete private/unpublished banners are removed; Node 24 and platform/custody limits remain explicit. There are no runtime, dependency, OAuth-registration, database, or release-workflow changes.

Validation: CLI dependency build/typecheck passed; 13 release/docs/publisher helper tests passed; the exact packed candidate passed 28 installed synthetic scenarios; all four docs locales built and the candidate passed 22 help topics, 35 examples, seven generation inputs and 22 links. Formatting and scoped lint passed. The candidate uses the existing OIDC-only release workflow and must pass its release checks again before publication.

Hosted OAuth configuration and deployment verification remain operational prerequisites for the `next` publication. This PR does not apply production settings or publish by itself.

Desktop release impact: none for this metadata-only change. The native follow-up identified in #1038 remains separate.
