### PR TITLE
docs(auth): document native OAuth deployment configuration

### DIFF
--- a/editor/.env.example
+++ b/editor/.env.example
@@ -6,6 +6,15 @@ NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:54321" # same as SUPABASE_URL
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="sb_publishable_..."
 SUPABASE_SECRET_KEY="sb_secret_..."
 
+# [native OAuth — optional until using CLI account/consent flows]
+# Server deployment contract: editor/lib/auth/README.md.
+# Use the disposable local OAuth fixture for development; it provisions these
+# settings independently. Blank values fail closed. Never copy production keys.
+# GRIDA_OAUTH_CLIENT_IDS=""
+# GRIDA_OAUTH_ORIGIN=""
+# GRIDA_OAUTH_REDIRECT_URIS=""
+# GRIDA_OAUTH_CONSENT_SECRET=""
+
 # [required]
 # public app url (host only, no scheme)
 # used for canonical host logic and tenant parsing in hosted environments

--- a/editor/lib/api/README.md
+++ b/editor/lib/api/README.md
@@ -144,6 +144,11 @@ GG's `gg:ai` tokens remain different credential families.
 
 ## Configuration
 
+Native account access also requires the server-owned
+[OAuth deployment configuration](../auth/README.md): issuer, registered client
+allowlist and the separate browser consent settings. Configure and verify the
+deployed web server before releasing a CLI that depends on it.
+
 `GRIDA_API_ORIGIN` sets one exact canonical origin, without a trailing slash,
 path or credentials. HTTPS is required except for explicit HTTP loopback origins.
 Set it for a custom self-hosted address or local fixture; forwarded headers never

--- a/editor/lib/auth/README.md
+++ b/editor/lib/auth/README.md
@@ -1,0 +1,107 @@
+# Native OAuth deployment configuration
+
+For operators deploying Grida's browser consent and native account API. The
+configuration reader is [oauth-server.ts](oauth-server.ts); consent proofs belong
+to [oauth-consent.ts](oauth-consent.ts). Keep this reference and deployment notes
+aligned when either contract changes.
+
+## Environment variables
+
+Set these on the **web server**, not in GitHub Actions or the installed CLI.
+For Grida's hosted service, use Vercel's `grida` project → Settings → Environment
+Variables → **Production**. Save a description with each variable identifying
+its purpose below and linking to this document. A new production deployment is
+required after adding or changing values; an existing deployment retains its
+configuration.
+
+| Variable                     | Shape                                                            | Purpose                                                                                                                                                                                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GRIDA_OAUTH_CLIENT_IDS`     | Comma-separated UUIDs; nonempty                                  | Allows registered native clients at consent and the account API. For the shipped CLI, use `clientId` from the [public registration](../../../packages/grida-cli/src/oauth-client-registration.ts).                                                                     |
+| `GRIDA_OAUTH_ORIGIN`         | One HTTPS origin, without a path, query, fragment or credentials | Pins the browser consent Host/Origin and proof issuer. It must match the deployed consent page's origin and the Supabase OAuth authorization-path configuration.                                                                                                       |
+| `GRIDA_OAUTH_REDIRECT_URIS`  | Comma-separated exact callback URLs; nonempty                    | Allows only the registered CLI callbacks. Use `redirectUris` from the same public registration; keep Supabase's app registration identical. Each URL must be canonical HTTP on `127.0.0.1`, with an explicit port at least 1024 and no query, fragment or credentials. |
+| `GRIDA_OAUTH_CONSENT_SECRET` | Independent random server-only string, at least 32 UTF-8 bytes   | Signs ten-minute browser consent proofs. Store as a sensitive Vercel variable. It is not an OAuth client secret, Supabase key or GG signing key.                                                                                                                       |
+
+The common reader also requires `NEXT_PUBLIC_SUPABASE_URL` and
+`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` for the same Supabase project. It derives
+the issuer by appending `/auth/v1` to that URL. Never substitute a privileged
+Supabase credential for the publishable key. The four `GRIDA_OAUTH_*` variables
+must not acquire a `NEXT_PUBLIC_` prefix.
+
+The client ID and callback addresses are public registration metadata. Keep
+their concrete values in the linked CLI registration file instead of copying
+another list here. Changing issuer, client ID or API origin also changes the
+CLI's durable credential profile identity; already installed binaries retain
+their shipped registration. Coordinate server allowlists, Supabase registration
+and client releases before changing them.
+
+## Production and local use
+
+Supabase must have its OAuth server enabled and a public native client registered
+with no client secret, authorization-code/refresh-token grants and the exact
+callbacks. Its configured consent path must reach Grida's `/oauth/consent` page.
+Web environment variables do not create that registration or apply a database
+migration. Account APIs retain their [machine request policy](../api/README.md)
+and [security contract](../../../SECURITY.md).
+
+Production uses the shipped registration and production Supabase project. Do
+not copy those settings or its consent secret into Preview or local development.
+There is no separate hosted staging database. A Vercel Preview is not an isolated
+auth environment merely because it has a different web URL.
+
+For local auth development, use the [disposable OAuth fixture](../../../scripts/auth-local/README.md).
+It creates its own client, local Supabase settings and independent consent/GG
+secrets, and supplies them to an isolated editor. The reader permits HTTP origins
+only on `127.0.0.1` for this use. Restart the fixture editor after bootstrap
+changes its settings. The blank entries in [the environment example](../../.env.example)
+only make the required names discoverable; they do not enable native OAuth.
+
+## Secret lifecycle
+
+Generate a fresh value from at least 32 cryptographically random bytes, for
+example with `openssl rand -hex 32` in a private operator session. Transfer it
+directly into sensitive server configuration; never put the result in Git,
+deployment descriptions, command arguments, screenshots or CI logs. Share the
+same value across instances of the same active deployment.
+
+Rotation replaces the value and requires a new deployment. There is no previous
+consent-key slot: forms signed with the old key fail when submitted to the new
+deployment. Users must restart login or reload consent. Proofs otherwise expire
+after ten minutes. Rotation does not revoke existing Supabase account sessions,
+refresh tokens or GG grants. Rolling back to an old deployment can restore its
+old configuration; when retiring a compromised secret, redeploy compatible code
+with the new secret instead of restoring the old deployment.
+
+## Verify the deployed configuration
+
+Missing or invalid common configuration fails closed: a native account request
+returns JSON `503` with `error.code: "not_configured"`. Consent-only configuration
+errors likewise prevent approval; the decision endpoint returns a safe error,
+while the consent GET renders an error page and may still return HTTP `200`.
+An HTML status alone is not a readiness check.
+
+A credential-free request to the canonical production origin is a useful first
+check:
+
+```sh
+curl --include --max-time 15 https://grida.co/api/v1/auth/me
+```
+
+Expect JSON `401 unauthorized`, `Cache-Control: no-store`, a Bearer challenge,
+and no redirect or session cookie. This checks routing and acceptance of the
+common configuration without issuing an account credential. It does **not**
+validate the consent-only settings, issuer reachability, client registration,
+login, refresh, logout or credit access. Confirm those settings in the deployment
+and finish with a real native login/account smoke test. Inspect hosted consent
+responses for `no-store`, frame denial and origin-only referrers as required by
+the security contract; never save tokens, consent proofs or authorization URLs
+in verification logs.
+
+Existing offline OAuth contracts run without dotenv files:
+
+```sh
+node_modules/.bin/vitest run --config editor/vitest.oauth.config.ts
+```
+
+They and the local fixture prove their respective contracts, not production
+activation. [CLI release readiness](../../../scripts/cli-release/README.md)
+requires deployed account access to be verified separately from green CI.

--- a/scripts/cli-release/README.md
+++ b/scripts/cli-release/README.md
@@ -5,6 +5,11 @@ Publication requires deployed account access, public documentation and release
 configuration. These scripts do not provision services or change the package's
 release metadata.
 
+The web server's [OAuth deployment reference](../../editor/lib/auth/README.md)
+owns the required environment variables, registration alignment, secret rotation
+and hosted verification. Supabase registration and green CI do not activate
+those settings in an existing Vercel deployment.
+
 ## Local candidate
 
 Use Node 24 and its bundled npm. Build before packing; choose a new absolute


### PR DESCRIPTION
Native account access remains unavailable when the web deployment lacks its OAuth settings, even after Supabase registration and passing CI. Document the server deployment contract beside its configuration reader, and link it from the API and CLI release references.

The reference covers variable ownership and shapes, registration alignment, independent local configuration, consent-secret rotation, and the limits of credential-free readiness checks. The environment example exposes the four names without values.

Validation: OAuth contracts and API tests passed; API source/network guards and relative links passed; repository typecheck passed all 52 tasks; formatting passed. Independent documentation/security review found no actionable issues. Documentation only; no runtime, database, or native Desktop release changes.
