### PR TITLE
fix(auth): separate OAuth issuer from Supabase data routing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1721,8 +1721,12 @@ credential through reuse of an existing browser or daemon bridge.
 **How the code prevents it.**
 
 1. **Server-owned authority.** Issuer, allowed client IDs, web origin, and exact
-   callback URIs come from server configuration. Bearer preflight requires the
-   exact issuer, `authenticated` audience, expiry, user/session IDs, and an
+   callback URIs come from server configuration. The required `GRIDA_OAUTH_ISSUER`
+   pins the canonical Auth issuer independently of the same project's Data API
+   origin (`NEXT_PUBLIC_SUPABASE_URL`), which may use a replica or load balancer.
+   Neither JWT claims nor hostname rewriting selects either destination.
+   Bearer preflight requires the exact issuer, `authenticated` audience, expiry,
+   user/session IDs, and an
    allowed client ID. Decoded JWT claims are not identity: the same token must
    then succeed at the fixed issuer's `/oauth/userinfo`, whose subject must
    match. Cookies are never a fallback. Issuer calls reject redirects, bound
@@ -1901,7 +1905,9 @@ membership separately, without a snapshot guarantee across page requests.
 - [editor/lib/auth/oauth-server.ts](editor/lib/auth/oauth-server.ts),
   [bearer.ts](editor/lib/auth/bearer.ts), and
   [oauth-consent.ts](editor/lib/auth/oauth-consent.ts) — configured authority,
-  issuer verification, consent proof, and callback policy.
+  issuer verification, consent proof, and callback policy. Configuration
+  separation and fail-closed validation are covered by
+  [oauth-server.test.ts](editor/lib/auth/__tests__/oauth-server.test.ts).
 - [Consent page](<editor/app/(untracked)/oauth/consent/page.tsx>),
   [decision route](<editor/app/(api)/private/oauth/decision/route.ts>), and
   [identity route](<editor/app/(api)/(public)/api/v1/auth/me/route.ts>) — browser
@@ -2143,8 +2149,10 @@ browser cookies, UI code or request-global state into account operations.
    bodyless OPTIONS declares its methods, while GET/HEAD and other methods are 405. The parser rejects extra/duplicate fields, query input, malformed UTF-8,
    invalid media/encoding/length declarations and noncanonical IDs before issuer
    work. It bounds route-entry body reads to 1024 bytes and one second. The shared
-   REST transport retains the verified bearer; the mint's member query filters
-   that user and organization together before the GG owner signs. Authentication,
+   REST transport retains the verified bearer and uses the independently configured
+   same-project Data API origin, never a destination derived from the Auth issuer;
+   the mint's member query filters that user and organization together before
+   the GG owner signs. Authentication,
    parsing, membership and signing failures keep the native no-store envelope.
 4. **Source checks reject drift.** `audit-api.ts` compares real App/Pages route
    placements with the inventory and verifies the complete native binding AST.
@@ -2155,8 +2163,9 @@ browser cookies, UI code or request-global state into account operations.
    prove the checks fail. The API workflow runs on every PR without path filters.
 5. **Runtime proof stays local.** `scripts/api-local` builds a private production
    Next snapshot from the real API, proxy and config sources. Its synthetic
-   loopback issuer and web tripwires verify two-user identity/cache separation,
-   credential rejection, method/input errors, configured hosts, API maintenance,
+   loopback Auth and Data servers reject crossed service requests; web tripwires
+   verify two-user identity/cache separation, credential rejection, method/input
+   errors, configured hosts, API maintenance,
    organization pagination and failure semantics, and production insiders gating.
    The GG extension uses a fresh synthetic signing key with the real mint and
    model-list implementations, including credential-family separation and

--- a/editor/.env.example
+++ b/editor/.env.example
@@ -10,6 +10,7 @@ SUPABASE_SECRET_KEY="sb_secret_..."
 # Server deployment contract: editor/lib/auth/README.md.
 # Use the disposable local OAuth fixture for development; it provisions these
 # settings independently. Blank values fail closed. Never copy production keys.
+# GRIDA_OAUTH_ISSUER="" # canonical Auth issuer, including /auth/v1; not a read-replica URL
 # GRIDA_OAUTH_CLIENT_IDS=""
 # GRIDA_OAUTH_ORIGIN=""
 # GRIDA_OAUTH_REDIRECT_URIS=""

--- a/editor/lib/api/account.test.ts
+++ b/editor/lib/api/account.test.ts
@@ -5,6 +5,7 @@ import { accountApi } from "./account";
 import { bearer } from "../auth/bearer";
 
 const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const endpoint = "http://127.0.0.1:3041/api/v1/auth/me";
 const clientId = "11111111-1111-4111-8111-111111111111";
 const userId = "22222222-2222-4222-8222-222222222222";
@@ -64,7 +65,8 @@ const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
 beforeEach(() => {
   fetcher.mockClear();
   vi.stubGlobal("fetch", fetcher);
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
   // Account identity cannot acquire unrelated infrastructure configuration.
@@ -107,6 +109,7 @@ describe("accountApi.bind", () => {
   it.each([
     ["cookie-only", null],
     ["ordinary account token", { client_id: undefined }],
+    ["Data API alias issuer", { iss: `${dataOrigin}/auth/v1` }],
     ["GG token", { aud: "gg:ai" }],
     ["other OAuth client", { client_id: sessionId }],
   ])(
@@ -145,6 +148,7 @@ describe("accountApi.bind", () => {
 
   it("OPTIONS reports only the allowed methods without account or issuer configuration", async () => {
     vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", "");
+    vi.stubEnv("GRIDA_OAUTH_ISSUER", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     const response = await handlers.OPTIONS(request("OPTIONS"));
     expect(response.status).toBe(204);

--- a/editor/lib/api/credits.test.ts
+++ b/editor/lib/api/credits.test.ts
@@ -5,6 +5,7 @@ import { SignJWT, jwtVerify } from "jose";
 import { accountApi } from "./account";
 
 const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const endpoint = "http://127.0.0.1:3041/api/v1/account/credits";
 const clientId = "11111111-1111-4111-8111-111111111111";
 const users = [
@@ -51,7 +52,7 @@ const fetcher = vi.fn<typeof fetch>(async (target, init) => {
     { issuer, audience: "authenticated" }
   );
   const url = new URL(String(target));
-  if (url.pathname === "/auth/v1/oauth/userinfo") {
+  if (url.href === `${issuer}/oauth/userinfo`) {
     return Response.json({
       sub: payload.sub,
       name: "Verified User",
@@ -59,6 +60,7 @@ const fetcher = vi.fn<typeof fetch>(async (target, init) => {
     });
   }
   if (
+    url.origin !== dataOrigin ||
     url.pathname !== "/rest/v1/v_billing_credits" ||
     headers.get("apikey") !== "synthetic-public-key" ||
     headers.has("cookie")
@@ -98,7 +100,8 @@ beforeEach(() => {
   visible = { [users[0]]: [orgs[0]], [users[1]]: [orgs[1]] };
   fetcher.mockClear();
   vi.stubGlobal("fetch", fetcher);
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
   for (const name of [
@@ -137,7 +140,12 @@ describe("native credits operation", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
       expect(response.headers.has("set-cookie")).toBe(false);
       expect(response.headers.has("location")).toBe(false);
-      for (const [, init] of fetcher.mock.calls.slice(-2)) {
+      const recent = fetcher.mock.calls.slice(-2);
+      expect(recent.map(([target]) => new URL(String(target)).origin)).toEqual([
+        new URL(issuer).origin,
+        dataOrigin,
+      ]);
+      for (const [, init] of recent) {
         expect(new Headers(init?.headers).get("authorization")).toBe(
           `Bearer ${value}`
         );

--- a/editor/lib/api/gg.test.ts
+++ b/editor/lib/api/gg.test.ts
@@ -5,6 +5,7 @@ import { SignJWT, jwtVerify } from "jose";
 import { ggApi } from "./gg";
 import { gg } from "../gg/gg";
 const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const endpoint = "http://127.0.0.1:3041/api/v1/auth/gg";
 const user = "22222222-2222-4222-8222-222222222222";
 const clientId = "11111111-1111-4111-8111-111111111111";
@@ -20,9 +21,10 @@ const fetcher = vi.fn<typeof fetch>(async (target, init) => {
     { issuer, audience: "authenticated" }
   );
   const url = new URL(String(target));
-  if (url.pathname === "/auth/v1/oauth/userinfo")
+  if (url.href === `${issuer}/oauth/userinfo`)
     return Response.json({ sub: payload.sub, email: null, name: "Test" });
   if (
+    url.origin !== dataOrigin ||
     url.pathname !== "/rest/v1/organization_member" ||
     url.searchParams.get("user_id") !== `eq.${payload.sub}` ||
     headers.has("cookie")
@@ -74,7 +76,8 @@ beforeEach(() => {
   dbStatus = 200;
   fetcher.mockClear();
   vi.stubGlobal("fetch", fetcher);
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
   vi.stubEnv("GG_TOKEN_SECRET", "fixture-gg-signing-key-only-".repeat(3));
@@ -116,6 +119,9 @@ describe("native GG exchange", () => {
     expect(claims.exp - claims.iat).toBe(900);
     expect(Date.parse(grant.expires_at)).toBe(claims.exp * 1000);
     expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(
+      fetcher.mock.calls.map(([target]) => new URL(String(target)).origin)
+    ).toEqual([new URL(issuer).origin, dataOrigin]);
     for (const [, init] of fetcher.mock.calls)
       expect(new Headers(init?.headers).get("authorization")).toBe(
         `Bearer ${value}`

--- a/editor/lib/api/organizations.test.ts
+++ b/editor/lib/api/organizations.test.ts
@@ -4,6 +4,7 @@ import { SignJWT, jwtVerify } from "jose";
 import { accountApi } from "./account";
 
 const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const endpoint = "http://127.0.0.1:3041/api/v1/account/organizations";
 const clientId = "11111111-1111-4111-8111-111111111111";
 const users = [
@@ -49,7 +50,7 @@ const fetcher = vi.fn<typeof fetch>(async (target, init) => {
     { issuer, audience: "authenticated" }
   );
   const url = new URL(String(target));
-  if (url.pathname === "/auth/v1/oauth/userinfo") {
+  if (url.href === `${issuer}/oauth/userinfo`) {
     return Response.json({
       sub: payload.sub,
       name: "Verified User",
@@ -57,6 +58,7 @@ const fetcher = vi.fn<typeof fetch>(async (target, init) => {
     });
   }
   if (
+    url.origin !== dataOrigin ||
     url.pathname !== "/rest/v1/organization" ||
     headers.get("apikey") !== "synthetic-public-key" ||
     headers.has("cookie")
@@ -83,7 +85,8 @@ beforeEach(() => {
   visible = { [users[0]]: [orgs[0]], [users[1]]: [orgs[1]] };
   fetcher.mockClear();
   vi.stubGlobal("fetch", fetcher);
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
   for (const name of [
@@ -116,6 +119,10 @@ describe("native organization operation", () => {
       expect(response.headers.has("location")).toBe(false);
       const recent = fetcher.mock.calls.slice(-2);
       expect(recent).toHaveLength(2);
+      expect(recent.map(([target]) => new URL(String(target)).origin)).toEqual([
+        new URL(issuer).origin,
+        dataOrigin,
+      ]);
       for (const [, init] of recent)
         expect(new Headers(init?.headers).get("authorization")).toBe(
           `Bearer ${credential}`

--- a/editor/lib/api/proxy.test.ts
+++ b/editor/lib/api/proxy.test.ts
@@ -40,7 +40,8 @@ beforeEach(() => {
   vi.stubEnv("NODE_ENV", "production");
   vi.stubEnv("GRIDA_API_ORIGIN", "http://127.0.0.1:3041");
   vi.stubEnv("GRIDA_API_MAINTENANCE", "0");
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", "http://127.0.0.1:55431/auth/v1");
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55432");
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic");
   web.maintenance.mockResolvedValue(false);
   web.session.mockImplementation(async () => NextResponse.next());

--- a/editor/lib/auth/README.md
+++ b/editor/lib/auth/README.md
@@ -16,16 +16,26 @@ configuration.
 
 | Variable                     | Shape                                                            | Purpose                                                                                                                                                                                                                                                                |
 | ---------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GRIDA_OAUTH_ISSUER`         | Exact canonical HTTPS Auth issuer ending in `/auth/v1`           | Pins token issuer comparison and Auth requests. Use `issuer` from the [public registration](../../../packages/grida-cli/src/oauth-client-registration.ts). A Data API load balancer or read-replica alias is not this identity.                                        |
 | `GRIDA_OAUTH_CLIENT_IDS`     | Comma-separated UUIDs; nonempty                                  | Allows registered native clients at consent and the account API. For the shipped CLI, use `clientId` from the [public registration](../../../packages/grida-cli/src/oauth-client-registration.ts).                                                                     |
 | `GRIDA_OAUTH_ORIGIN`         | One HTTPS origin, without a path, query, fragment or credentials | Pins the browser consent Host/Origin and proof issuer. It must match the deployed consent page's origin and the Supabase OAuth authorization-path configuration.                                                                                                       |
 | `GRIDA_OAUTH_REDIRECT_URIS`  | Comma-separated exact callback URLs; nonempty                    | Allows only the registered CLI callbacks. Use `redirectUris` from the same public registration; keep Supabase's app registration identical. Each URL must be canonical HTTP on `127.0.0.1`, with an explicit port at least 1024 and no query, fragment or credentials. |
 | `GRIDA_OAUTH_CONSENT_SECRET` | Independent random server-only string, at least 32 UTF-8 bytes   | Signs ten-minute browser consent proofs. Store as a sensitive Vercel variable. It is not an OAuth client secret, Supabase key or GG signing key.                                                                                                                       |
 
 The common reader also requires `NEXT_PUBLIC_SUPABASE_URL` and
-`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` for the same Supabase project. It derives
-the issuer by appending `/auth/v1` to that URL. Never substitute a privileged
-Supabase credential for the publishable key. The four `GRIDA_OAUTH_*` variables
-must not acquire a `NEXT_PUBLIC_` prefix.
+`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` for the same Supabase project. The URL
+supplies the Data API origin; it may use that project's read-replica or load
+balancer hostname. It does not select the OAuth issuer. Native organization,
+credit and membership reads retain that data origin, while consent and live
+identity verification use `GRIDA_OAUTH_ISSUER`. Never substitute a privileged
+Supabase credential for the publishable key. The `GRIDA_OAUTH_*` variables must
+not acquire a `NEXT_PUBLIC_` prefix.
+
+Both destinations are trusted server configuration and must belong to the same
+Supabase project. Do not derive the issuer by rewriting a replica hostname or
+reading a JWT claim. Keep the canonical issuer explicit even when Auth and Data
+API traffic currently use one hostname. Changing data routing must not change
+which issuer is accepted, and changing auth configuration must not reroute data.
 
 The client ID and callback addresses are public registration metadata. Keep
 their concrete values in the linked CLI registration file instead of copying
@@ -50,8 +60,8 @@ auth environment merely because it has a different web URL.
 
 For local auth development, use the [disposable OAuth fixture](../../../scripts/auth-local/README.md).
 It creates its own client, local Supabase settings and independent consent/GG
-secrets, and supplies them to an isolated editor. The reader permits HTTP origins
-only on `127.0.0.1` for this use. Restart the fixture editor after bootstrap
+secrets, and supplies an explicit local issuer to an isolated editor. The reader
+permits HTTP origins only on `127.0.0.1` for this use. Restart the fixture editor after bootstrap
 changes its settings. The blank entries in [the environment example](../../.env.example)
 only make the required names discoverable; they do not enable native OAuth.
 
@@ -78,6 +88,11 @@ returns JSON `503` with `error.code: "not_configured"`. Consent-only configurati
 errors likewise prevent approval; the decision endpoint returns a safe error,
 while the consent GET renders an error page and may still return HTTP `200`.
 An HTML status alone is not a readiness check.
+
+Configure `GRIDA_OAUTH_ISSUER` before deploying code that requires it. Confirm it
+matches the installed CLI registration and the issuer in Supabase's public OAuth
+discovery metadata. A reachable Data API alias is not evidence of a matching JWT
+issuer; a mismatch rejects login before the live identity request.
 
 A credential-free request to the canonical production origin is a useful first
 check:

--- a/editor/lib/auth/__tests__/oauth-bearer.test.ts
+++ b/editor/lib/auth/__tests__/oauth-bearer.test.ts
@@ -6,11 +6,13 @@ import { oauthServer } from "../oauth-server";
 import { GET } from "@/app/(api)/(public)/api/v1/auth/me/route";
 
 const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const clientId = "11111111-1111-4111-8111-111111111111";
 const userId = "22222222-2222-4222-8222-222222222222";
 const sessionId = "33333333-3333-4333-8333-333333333333";
 const config: oauthServer.Config = {
   issuer,
+  dataOrigin,
   clientIds: [clientId],
   publishableKey: "test-public-key",
 };
@@ -68,7 +70,8 @@ function identityIssuer() {
 }
 
 beforeEach(() => {
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
 });
@@ -108,6 +111,7 @@ describe("OAuth bearer identity", () => {
 
   it.each([
     ["wrong issuer", { iss: "https://untrusted.invalid/auth/v1" }],
+    ["Data API alias issuer", { iss: `${dataOrigin}/auth/v1` }],
     ["GG audience", { aud: "grida-gateway" }],
     ["other client", { client_id: "44444444-4444-4444-8444-444444444444" }],
     ["ordinary browser token", { client_id: undefined }],

--- a/editor/lib/auth/__tests__/oauth-consent.test.ts
+++ b/editor/lib/auth/__tests__/oauth-consent.test.ts
@@ -9,6 +9,7 @@ const userId = "22222222-2222-4222-8222-222222222222";
 const callback = "http://127.0.0.1:55435/callback";
 const config: oauthServer.ConsentConfig = {
   issuer: "http://127.0.0.1:55431/auth/v1",
+  dataOrigin: "http://127.0.0.1:55432",
   publishableKey: "test-public-key",
   clientIds: [clientId],
   origin: "http://127.0.0.1:3041",
@@ -93,6 +94,11 @@ describe("browser consent intent", () => {
         target.searchParams.get(action === "approve" ? "code" : "error")
       ).toBe(action === "approve" ? "test-code" : "access_denied");
       expect(f.fetcher).toHaveBeenCalledTimes(3);
+      expect(f.fetcher.mock.calls.map(([target]) => String(target))).toEqual([
+        `${config.issuer}/oauth/authorizations/${id}`,
+        `${config.issuer}/oauth/authorizations/${id}`,
+        `${config.issuer}/oauth/authorizations/${id}/consent`,
+      ]);
       const [url, init] = f.fetcher.mock.calls[2]!;
       expect(url).toBe(`${config.issuer}/oauth/authorizations/${id}/consent`);
       expect(JSON.parse(init?.body as string)).toEqual({ action });
@@ -311,7 +317,8 @@ describe("issuer callback perimeter", () => {
 
 describe("server-owned configuration", () => {
   it("requires explicit client, web origin, callbacks, and consent secret", () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+    vi.stubEnv("GRIDA_OAUTH_ISSUER", config.issuer);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", config.dataOrigin);
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-public-key");
     vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
     vi.stubEnv("GRIDA_OAUTH_ORIGIN", config.origin);
@@ -322,12 +329,14 @@ describe("server-owned configuration", () => {
     );
     expect(oauthServer.consentConfig()).toMatchObject({
       issuer: config.issuer,
+      dataOrigin: config.dataOrigin,
       origin: config.origin,
       clientIds: [clientId],
       redirectUris: config.redirectUris,
     });
     for (const [key, value] of [
       ["GRIDA_OAUTH_CLIENT_IDS", ""],
+      ["GRIDA_OAUTH_ISSUER", ""],
       ["GRIDA_OAUTH_ORIGIN", "http://untrusted.invalid"],
       ["NEXT_PUBLIC_SUPABASE_URL", "https://example.invalid/selected-issuer"],
       ["GRIDA_OAUTH_REDIRECT_URIS", `${callback}?unregistered=query`],

--- a/editor/lib/auth/__tests__/oauth-server.test.ts
+++ b/editor/lib/auth/__tests__/oauth-server.test.ts
@@ -1,0 +1,111 @@
+// GRIDA-SEC-010 — canonical Auth issuer and Data API routing are independent server authority.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { oauthServer } from "../oauth-server";
+
+const issuer = "https://project.example.invalid/auth/v1";
+const dataOrigin = "https://project-all.example.invalid";
+const clientId = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => {
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "synthetic-public-key");
+  vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe("oauthServer.config", () => {
+  it("keeps the canonical issuer independent of the Data API replica alias", () => {
+    expect(oauthServer.config()).toEqual({
+      issuer,
+      dataOrigin,
+      publishableKey: "synthetic-public-key",
+      clientIds: [clientId],
+    });
+    vi.stubEnv(
+      "NEXT_PUBLIC_SUPABASE_URL",
+      "https://other-data.example.invalid"
+    );
+    expect(oauthServer.config()).toMatchObject({
+      issuer,
+      dataOrigin: "https://other-data.example.invalid",
+    });
+  });
+
+  it("accepts explicit canonical loopback fixture destinations", () => {
+    vi.stubEnv("GRIDA_OAUTH_ISSUER", "http://127.0.0.1:55431/auth/v1");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55432");
+    expect(oauthServer.config()).toMatchObject({
+      issuer: "http://127.0.0.1:55431/auth/v1",
+      dataOrigin: "http://127.0.0.1:55432",
+    });
+  });
+
+  it("does not derive a missing issuer even when the Data API uses the primary host", () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://project.example.invalid");
+    vi.stubEnv("GRIDA_OAUTH_ISSUER", undefined);
+    expect(() => oauthServer.config()).toThrow(
+      expect.objectContaining({ code: "not_configured", status: 503 })
+    );
+  });
+
+  it.each([
+    undefined,
+    "",
+    "https://project.example.invalid",
+    `${issuer}/`,
+    `${issuer}?query=invalid`,
+    `${issuer}#fragment`,
+    "https://user:password@project.example.invalid/auth/v1",
+    "https://project.example.invalid/other/auth/v1",
+    "https://project.example.invalid/other/../auth/v1",
+    "https://project.example.invalid//auth/v1",
+    "https://PROJECT.example.invalid/auth/v1",
+    "https://project.example.invalid:443/auth/v1",
+    "https://project.example.invalid/%61uth/v1",
+    "http://project.example.invalid/auth/v1",
+    "http://localhost:55431/auth/v1",
+    "http://127.1:55431/auth/v1",
+    "ftp://project.example.invalid/auth/v1",
+    ` ${issuer}`,
+    `${issuer}\n`,
+  ])(
+    "rejects missing or noncanonical issuer %# without a fallback",
+    (value) => {
+      vi.stubEnv("GRIDA_OAUTH_ISSUER", value);
+      expect(() => oauthServer.config()).toThrow(
+        expect.objectContaining({
+          code: "not_configured",
+          status: 503,
+          message: "OAuth access is not configured.",
+        })
+      );
+    }
+  );
+
+  it.each([
+    undefined,
+    "",
+    "https://data.example.invalid/rest/v1",
+    "https://data.example.invalid?query=invalid",
+    "https://data.example.invalid#fragment",
+    "https://user:password@data.example.invalid",
+    "http://data.example.invalid",
+  ])("requires a separately valid Data API origin %#", (value) => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", value);
+    expect(() => oauthServer.config()).toThrow(
+      expect.objectContaining({ code: "not_configured", status: 503 })
+    );
+  });
+
+  it.each([
+    ["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", ""],
+    ["GRIDA_OAUTH_CLIENT_IDS", ""],
+    ["GRIDA_OAUTH_CLIENT_IDS", "not-a-registered-client"],
+  ])("retains the required %s contract", (name, value) => {
+    vi.stubEnv(name, value);
+    expect(() => oauthServer.config()).toThrow(
+      expect.objectContaining({ code: "not_configured", status: 503 })
+    );
+  });
+});

--- a/editor/lib/auth/__tests__/oauth-web.test.tsx
+++ b/editor/lib/auth/__tests__/oauth-web.test.tsx
@@ -32,6 +32,8 @@ const id = "authorization_1234567890";
 const clientId = "11111111-1111-4111-8111-111111111111";
 const userId = "22222222-2222-4222-8222-222222222222";
 const origin = "http://127.0.0.1:3041";
+const issuer = "http://127.0.0.1:55431/auth/v1";
+const dataOrigin = "http://127.0.0.1:55432";
 const callback = "http://127.0.0.1:55435/callback";
 const details = {
   authorization_id: id,
@@ -42,7 +44,8 @@ const details = {
 };
 
 beforeEach(() => {
-  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:55431");
+  vi.stubEnv("GRIDA_OAUTH_ISSUER", issuer);
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", dataOrigin);
   vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-public-key");
   vi.stubEnv("GRIDA_OAUTH_CLIENT_IDS", clientId);
   vi.stubEnv("GRIDA_OAUTH_ORIGIN", origin);
@@ -153,6 +156,10 @@ describe("OAuth consent page", () => {
     );
     expect(html).toContain("Authorize Grida CLI");
     expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      `${issuer}/oauth/authorizations/${id}`,
+      expect.objectContaining({ method: "GET", redirect: "error" })
+    );
   });
 
   it("keeps hosted Google sign-in's next target on this consent page", async () => {

--- a/editor/lib/auth/oauth-server.ts
+++ b/editor/lib/auth/oauth-server.ts
@@ -4,6 +4,7 @@ import "server-only";
 export namespace oauthServer {
   export type Config = Readonly<{
     issuer: string;
+    dataOrigin: string;
     publishableKey: string;
     clientIds: readonly string[];
   }>;
@@ -80,7 +81,10 @@ export namespace oauthServer {
 
   /** Config is server-owned. No request header, cookie, or JWT selects an issuer. */
   export function config(): Config {
-    const base = origin(process.env.NEXT_PUBLIC_SUPABASE_URL);
+    // A Data API load-balancer/replica alias is not the token's canonical issuer.
+    // Keep both destinations explicit; neither is inferred from the other.
+    const authIssuer = issuer(process.env.GRIDA_OAUTH_ISSUER);
+    const dataOrigin = origin(process.env.NEXT_PUBLIC_SUPABASE_URL);
     const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
     const clientIds = list(process.env.GRIDA_OAUTH_CLIENT_IDS);
     if (
@@ -90,7 +94,7 @@ export namespace oauthServer {
     ) {
       throw new Failure("not_configured");
     }
-    return { issuer: `${base}/auth/v1`, publishableKey, clientIds };
+    return { issuer: authIssuer, dataOrigin, publishableKey, clientIds };
   }
 
   export function consentConfig(): ConsentConfig {
@@ -149,6 +153,15 @@ export namespace oauthServer {
       throw new Failure("not_configured");
     }
     return url.origin;
+  }
+
+  function issuer(value: string | undefined): string {
+    const path = "/auth/v1";
+    if (!value?.endsWith(path)) throw new Failure("not_configured");
+    const base = origin(value.slice(0, -path.length));
+    const canonical = `${base}${path}`;
+    if (value !== canonical) throw new Failure("not_configured");
+    return canonical;
   }
 
   export function uuid(value: unknown): value is string {

--- a/editor/lib/supabase/account-data.test.ts
+++ b/editor/lib/supabase/account-data.test.ts
@@ -5,6 +5,7 @@ import { account } from "../account/account";
 
 const config = {
   issuer: "http://127.0.0.1:55431/auth/v1",
+  dataOrigin: "http://127.0.0.1:55432",
   publishableKey: "synthetic-public-key",
   clientIds: ["11111111-1111-4111-8111-111111111111"],
 };
@@ -25,8 +26,9 @@ describe("accountData.forBearer", () => {
     expect(fetcher).toHaveBeenCalledOnce();
     const [target, init] = fetcher.mock.calls[0]!;
     const url = new URL(String(target));
+    expect(url.origin).not.toBe(new URL(config.issuer).origin);
     expect(url.origin + url.pathname).toBe(
-      "http://127.0.0.1:55431/rest/v1/organization"
+      "http://127.0.0.1:55432/rest/v1/organization"
     );
     expect(Object.fromEntries(url.searchParams)).toEqual({
       select: "id,name,display_name",

--- a/editor/lib/supabase/credits-data.test.ts
+++ b/editor/lib/supabase/credits-data.test.ts
@@ -6,6 +6,7 @@ import { creditsData } from "./credits-data";
 
 const config = {
   issuer: "http://127.0.0.1:55431/auth/v1",
+  dataOrigin: "http://127.0.0.1:55432",
   publishableKey: "synthetic-public-key",
   clientIds: ["11111111-1111-4111-8111-111111111111"],
 };
@@ -23,8 +24,9 @@ describe("creditsData.forBearer", () => {
     expect(fetcher).toHaveBeenCalledOnce();
     const [target, init] = fetcher.mock.calls[0]!;
     const url = new URL(String(target));
+    expect(url.origin).not.toBe(new URL(config.issuer).origin);
     expect(url.origin + url.pathname).toBe(
-      "http://127.0.0.1:55431/rest/v1/v_billing_credits"
+      "http://127.0.0.1:55432/rest/v1/v_billing_credits"
     );
     expect(Object.fromEntries(url.searchParams)).toEqual({
       select:

--- a/editor/lib/supabase/gg-data.test.ts
+++ b/editor/lib/supabase/gg-data.test.ts
@@ -6,6 +6,7 @@ import { nativeData } from "./native-data";
 const user = "22222222-2222-4222-8222-222222222222";
 const config = {
   issuer: "http://127.0.0.1:55431/auth/v1",
+  dataOrigin: "http://127.0.0.1:55432",
   publishableKey: "synthetic-key",
   clientIds: [],
 };
@@ -27,8 +28,9 @@ describe("ggData.forBearer", () => {
     ).toEqual({ id: 4, name: "local" });
     const [target, init] = fetcher.mock.calls[0];
     const url = new URL(String(target));
+    expect(url.origin).not.toBe(new URL(config.issuer).origin);
     expect(url.origin + url.pathname).toBe(
-      "http://127.0.0.1:55431/rest/v1/organization_member"
+      "http://127.0.0.1:55432/rest/v1/organization_member"
     );
     expect(Object.fromEntries(url.searchParams)).toEqual({
       select: "organization_id,organization!inner(id,name)",

--- a/editor/lib/supabase/native-data.ts
+++ b/editor/lib/supabase/native-data.ts
@@ -6,7 +6,7 @@ import { oauthServer } from "../auth/oauth-server";
 export namespace nativeData {
   export function forBearer(
     authorization: string,
-    config: oauthServer.Config,
+    config: Pick<oauthServer.Config, "dataOrigin" | "publishableKey">,
     fetcher: typeof fetch = globalThis.fetch
   ) {
     if (
@@ -17,7 +17,6 @@ export namespace nativeData {
     ) {
       throw new oauthServer.Failure("unauthorized");
     }
-    const origin = config.issuer.slice(0, -"/auth/v1".length);
     return Object.freeze({
       async page(
         table: "organization" | "organization_member" | "v_billing_credits",
@@ -31,7 +30,7 @@ export namespace nativeData {
           ].includes(table)
         )
           throw new oauthServer.Failure("invalid_request");
-        const url = new URL(`/rest/v1/${table}`, origin);
+        const url = new URL(`/rest/v1/${table}`, config.dataOrigin);
         for (const [key, value] of Object.entries(query))
           url.searchParams.set(key, value);
         let response: Response;

--- a/scripts/api-local/README.md
+++ b/scripts/api-local/README.md
@@ -40,14 +40,19 @@ record all three calls and emit its synthetic cookie, proving the tripwires are
 active. This verifies dispatch and calls, not import-time behavior of the
 original web modules. A fixture insiders handler must never run in production.
 
-A newly owned loopback HTTP server supplies `/auth/v1/oauth/userinfo` and
-synthetic `/rest/v1/organization`, `/rest/v1/organization_member`, and
-`/rest/v1/v_billing_credits` responses. It accepts
-only exact synthetic tokens issued in memory for two synthetic users. The real
-bearer verifier performs its normal preflight and HTTP request. The database
-fixture requires the exact caller bearer, publishable key, public schema and
-fixed query shape; its per-user rows simulate visibility without implementing
-Postgres RLS. Cases cover live
+Two independently owned loopback HTTP servers represent canonical Auth and a
+separate Data API origin, such as a read-replica alias. `GRIDA_OAUTH_ISSUER` selects
+the Auth server's `/auth/v1`; only that server supplies `/auth/v1/oauth/userinfo`.
+`NEXT_PUBLIC_SUPABASE_URL` selects the Data server, which supplies synthetic
+`/rest/v1/organization`, `/rest/v1/organization_member`, and
+`/rest/v1/v_billing_credits` responses. Each server rejects the other service's
+paths. Both accept only exact synthetic tokens issued in memory for two
+synthetic users. A token claiming the reachable Data API alias as its issuer is
+rejected before issuer I/O; shared configuration does not make that alias an
+Auth authority. The real bearer verifier performs its normal preflight and HTTP
+request. The database fixture requires the exact caller bearer, publishable key,
+public schema and fixed query shape; its per-user rows simulate visibility
+without implementing Postgres RLS. Cases cover live
 identity changes, two-user cache isolation, invalid credential classes, issuer
 failure/revocation/mismatch/redirects, HEAD/OPTIONS and rejected methods/input,
 unknown paths and hosts, forwarded-host spoofing, encoded path aliases, API

--- a/scripts/api-local/proof.mjs
+++ b/scripts/api-local/proof.mjs
@@ -194,11 +194,13 @@ function issuerFixture() {
       })),
       [{ id: 1001, name: "beta", display_name: "Beta organization" }],
     ],
-    origin: "",
+    authOrigin: "",
+    dataOrigin: "",
+    wrongServiceCalls: 0,
   };
   fixture.token = (index, claims = {}) => {
     const payload = {
-      iss: `${fixture.origin}/auth/v1`,
+      iss: `${fixture.authOrigin}/auth/v1`,
       aud: "authenticated",
       sub: users[index].id,
       session_id: randomUUID(),
@@ -214,11 +216,26 @@ function issuerFixture() {
     tokens.set(token, index);
     return token;
   };
-  fixture.server = createServer((req, response) => {
-    const url = new URL(req.url, fixture.origin);
+  const handler = (service) => (req, response) => {
+    const url = new URL(
+      req.url,
+      service === "auth" ? fixture.authOrigin : fixture.dataOrigin
+    );
     const database = url.pathname === "/rest/v1/organization";
     const credits = url.pathname === "/rest/v1/v_billing_credits";
     const membership = url.pathname === "/rest/v1/organization_member";
+    const userinfo = req.url === "/auth/v1/oauth/userinfo";
+    response.setHeader("cache-control", "no-store");
+    // Auth and Data API aliases need not share an origin. Neither fixture can
+    // answer the other service's paths, so incorrect production wiring fails.
+    if (
+      (service === "auth" && !userinfo) ||
+      (service === "data" && !database && !credits && !membership)
+    ) {
+      fixture.wrongServiceCalls++;
+      response.writeHead(500).end();
+      return;
+    }
     if (credits) {
       fixture.creditsCalls++;
       fixture.databaseCalls++;
@@ -227,13 +244,8 @@ function issuerFixture() {
       fixture.databaseCalls++;
     } else if (database) fixture.databaseCalls++;
     else fixture.calls++;
-    response.setHeader("cache-control", "no-store");
     if (
       req.method !== "GET" ||
-      (!database &&
-        !credits &&
-        !membership &&
-        req.url !== "/auth/v1/oauth/userinfo") ||
       req.headers.apikey !== "synthetic-publishable-key"
     ) {
       response.writeHead(500).end();
@@ -272,7 +284,7 @@ function issuerFixture() {
       }
       if (mode === "redirect") {
         response
-          .writeHead(302, { location: `${fixture.origin}/unexpected-gg` })
+          .writeHead(302, { location: `${fixture.dataOrigin}/unexpected-gg` })
           .end();
         return;
       }
@@ -353,7 +365,9 @@ function issuerFixture() {
       }
       if (mode === "redirect") {
         response
-          .writeHead(302, { location: `${fixture.origin}/unexpected-credits` })
+          .writeHead(302, {
+            location: `${fixture.dataOrigin}/unexpected-credits`,
+          })
           .end();
         return;
       }
@@ -418,7 +432,9 @@ function issuerFixture() {
       }
       if (fixture.databaseMode === "redirect") {
         response
-          .writeHead(302, { location: `${fixture.origin}/unexpected-database` })
+          .writeHead(302, {
+            location: `${fixture.dataOrigin}/unexpected-database`,
+          })
           .end();
         return;
       }
@@ -450,7 +466,7 @@ function issuerFixture() {
     }
     if (fixture.mode === "redirect") {
       response
-        .writeHead(302, { location: `${fixture.origin}/unexpected` })
+        .writeHead(302, { location: `${fixture.authOrigin}/unexpected` })
         .end();
       return;
     }
@@ -466,7 +482,9 @@ function issuerFixture() {
             ignored: "upstream-only field",
           })
     );
-  });
+  };
+  fixture.authServer = createServer(handler("auth"));
+  fixture.dataServer = createServer(handler("data"));
   return fixture;
 }
 
@@ -1626,6 +1644,8 @@ async function assertions(port, issuer, tripwire, signingSecret) {
     auth("gg_synthetic_credential"),
     auth(issuer.token(0, { exp: Math.floor(Date.now() / 1000) - 1 })),
     auth(issuer.token(0, { iss: "https://untrusted.invalid/auth/v1" })),
+    // A reachable, configured Data API alias is still not the Auth issuer.
+    auth(issuer.token(0, { iss: `${issuer.dataOrigin}/auth/v1` })),
     auth(issuer.token(0, { client_id: randomUUID() })),
   ]) {
     safe(
@@ -1904,8 +1924,14 @@ async function main() {
     await mkdir(home, { mode: 0o700 });
     const tripwire = path.join(workspace, "tripwire.log");
     await put(tripwire, "");
-    const issuerPort = await listen(issuer.server);
-    issuer.origin = `http://127.0.0.1:${issuerPort}`;
+    const issuerPort = await listen(issuer.authServer);
+    issuer.authOrigin = `http://127.0.0.1:${issuerPort}`;
+    const dataPort = await listen(issuer.dataServer);
+    issuer.dataOrigin = `http://127.0.0.1:${dataPort}`;
+    check(
+      issuerPort !== dataPort,
+      "Auth and Data fixtures must be independent"
+    );
     const port = await listen(reservation);
     await close(reservation);
     const apiOrigin = `http://127.0.0.1:${port}`;
@@ -1921,7 +1947,8 @@ async function main() {
       NODE_ENV: "production",
       NEXT_TELEMETRY_DISABLED: "1",
       NEXT_PUBLIC_GRIDA_USE_TELEMETRY: "0",
-      NEXT_PUBLIC_SUPABASE_URL: issuer.origin,
+      NEXT_PUBLIC_SUPABASE_URL: issuer.dataOrigin,
+      GRIDA_OAUTH_ISSUER: `${issuer.authOrigin}/auth/v1`,
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "synthetic-publishable-key",
       NEXT_PUBLIC_DOCS_URL: apiOrigin,
       NEXT_PUBLIC_BLOG_URL: apiOrigin,
@@ -1929,7 +1956,7 @@ async function main() {
       GRIDA_API_ORIGIN: apiOrigin,
       GRIDA_API_MAINTENANCE: "0",
       GG_TOKEN_SECRET: signingSecret,
-      GRIDA_API_TEST_PORTS: `${port},${issuerPort}`,
+      GRIDA_API_TEST_PORTS: `${port},${issuerPort},${dataPort}`,
       GRIDA_API_TEST_TRIPWIRE: tripwire,
       NODE_OPTIONS: `--require=${JSON.stringify(path.join(scripts, "network.cjs"))}`,
     };
@@ -2061,6 +2088,10 @@ async function main() {
       logs.push(active.log());
       active = undefined;
     }
+    check(
+      issuer.wrongServiceCalls === 0,
+      "Auth and Data API destinations crossed"
+    );
     passed = true;
   } finally {
     clearInterval(progress);
@@ -2068,7 +2099,8 @@ async function main() {
       active
         ? active.stop().finally(() => logs.push(active.log()))
         : Promise.resolve(),
-      close(issuer.server),
+      close(issuer.authServer),
+      close(issuer.dataServer),
       close(reservation),
     ]);
     try {

--- a/scripts/auth-local/editor.mjs
+++ b/scripts/auth-local/editor.mjs
@@ -33,6 +33,7 @@ async function main() {
     setup.editorOrigin !== "http://127.0.0.1:3041" ||
     setup.apiUrl !== "http://127.0.0.1:55431" ||
     fixtureEnv.NEXT_PUBLIC_SUPABASE_URL !== setup.apiUrl ||
+    fixtureEnv.GRIDA_OAUTH_ISSUER !== `${setup.apiUrl}/auth/v1` ||
     fixtureEnv.GRIDA_OAUTH_ORIGIN !== setup.editorOrigin
   ) {
     throw new Error("Expected the isolated local auth fixture origins");

--- a/scripts/auth-local/stack.mjs
+++ b/scripts/auth-local/stack.mjs
@@ -520,6 +520,7 @@ async function bootstrap(state) {
     SUPABASE_SECRET_KEY: status.SERVICE_ROLE_KEY,
     SUPABASE_SERVICE_ROLE_KEY: status.SERVICE_ROLE_KEY,
     NEXT_PUBLIC_GRIDA_USE_INSIDERS_AUTH: "1",
+    GRIDA_OAUTH_ISSUER: fixture.issuer,
     GRIDA_OAUTH_ORIGIN: fixture.editorOrigin,
     GRIDA_API_ORIGIN: fixture.editorOrigin,
     GRIDA_OAUTH_CLIENT_IDS: client.client_id,


### PR DESCRIPTION
CLI login can receive an OAuth code and complete token exchange, then fail with `token_rejected` when the web server's Supabase Data API URL uses a replica or load-balancer alias. The server derived the expected JWT issuer from that URL even though Auth issues tokens under its canonical issuer.

Require an explicit server-only `GRIDA_OAUTH_ISSUER` for token comparison, consent and live identity verification. Keep native organization, credit and GG membership reads on the independently configured Data API origin. Strict bearer checks, live userinfo verification, RLS, Desktop authentication and CLI registration remain unchanged.

The cause is a configuration-contract coupling, rather than a failed callback: both identity and data routing were inferred from one value, and the tests used a single host. Regression tests now distinguish those destinations; the real Next HTTP proof runs separate Auth and Data listeners that reject crossed requests. The operator reference, environment example and security registry document the distinction.

**Deployment:** set `GRIDA_OAUTH_ISSUER` to the canonical issuer in the shipped public CLI registration before deploying this code. Missing or invalid configuration fails closed. This requires a web deployment; no database migration or npm release is needed. Production configuration and real-account acceptance remain separate rollout steps.

Validation:

- OAuth contracts: 132 passed; API suite: 603 passed (includes OAuth).
- Real production-mode Next HTTP proof: 261 cases passed with independent Auth/Data listeners.
- Local Auth/API network guards: 26 passed; API route/dependency audit passed.
- Repository typecheck: 52 tasks passed; formatting and lint passed (3 pre-existing lint warnings).
- Explicit SEC-006/010/011/012 review and independent read-only review: no actionable findings.

The HTTP proof uses synthetic loopback services. It does not replace hosted login/account acceptance after deployment.
