### PR TITLE
fix(cli): complete session-local logout and document auth flows

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       tag:
-        description: npm distribution tag (first public preview uses next)
+        description: npm distribution tag (stable releases use latest)
         required: true
         type: choice
-        default: next
-        options: [next, latest]
+        default: latest
+        options: [latest, next]
 
 permissions:
   contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1142,7 +1142,11 @@ paths, and params are public, so the design must not rely on obscurity.
    ever delivers a build its own declared scheme.
 
 Electron main holds no durable desktop account or provider credential.
-Chromium's default session owns the HttpOnly cookie jar;
+Chromium's default session owns the account cookie jar. The current Supabase SSR
+helpers do not configure these cookies as HttpOnly; trusted same-origin renderer
+code is not excluded from that cookie authority. This boundary relies on the
+fixed ceremony, renderer/navigation controls and native capability separation,
+not a renderer-inaccessible cookie guarantee;
 the entry account client invokes `session.defaultSession.fetch` only for the
 two fixed same-origin account routes. Main never reads or exports cookie/token
 material, and `DesktopAccountSession` returns only the three-state projection
@@ -2585,9 +2589,77 @@ platform evidence, not Windows or cross-platform release certification.
 
 ---
 
+### `GRIDA-SEC-015` — Account-to-media credential handoff
+
+**What it protects.** Composing native account access with media execution does
+not make the account access or refresh token a provider credential. The CLI
+host explicitly selects BYOK or a scoped GG handoff, and the corresponding
+account/GG server verifiers keep their credential families separate. The
+[client authentication blueprint](docs/reference/authentication.md) maps this
+composition alongside browser, Desktop and independent provider sessions.
+
+**Vulnerable scenario (prevented).** A new media command forwards the user's
+full account token as an AI key, treats a GG grant as account identity, or turns
+a missing BYOK key into implicit account access/credit spending. Sharing model
+operations must not merge the credentials held by their different hosts.
+
+**Why it's specifically risky here.** CLI and Desktop expose the same models
+through different account ceremonies and storage owners. A common account,
+provider interface or HTTP bearer shape does not make those credentials
+interchangeable. Public application registration/API keys are not user identity.
+
+**How the code prevents it.**
+
+1. **Explicit CLI composition.** `MediaCommands` resolves the selected provider
+   and validates generation input/output admission before account authority. Its
+   GG branch opens native auth with one captured in-memory grant sink; the media
+   HTTP owner receives a GG store and an empty BYOK reader. Its BYOK branch opens
+   provider custody without opening native account custody. Errors do not switch
+   the selected provider or funding path; final cleanup clears the GG store.
+2. **Account ingress is not GG ingress.** The native bearer owner admits only
+   the configured issuer/client and required user/session/expiry claims, then
+   verifies the same bearer at fixed live OAuth userinfo. Cookies and GG tokens
+   cannot satisfy that account contract. GRIDA-SEC-010/012 own the full native
+   principal and machine request boundary.
+3. **Scoped media authority has its own verifier.** GG signs/verifies with its
+   dedicated server key, HS256 algorithm, `gg:ai` audience, organization and bounded
+   lifetime. The shared mint policy resolves membership before signing. An
+   account bearer cannot substitute for that grant; a resulting GG grant is
+   rejected by the account API. GRIDA-SEC-006 owns cryptographic scope and the
+   Desktop/native mint adapters; GRIDA-SEC-013 owns CLI credential egress.
+4. **Existing owners stay independent.** GRIDA-SEC-005 owns Desktop account
+   cookies, 010 owns CLI account custody, 008 owns ChatGPT provider OAuth, and
+   014 owns shared BYOK. The blueprint is an index of those owners, not a new
+   store, token type, authentication service or permission mechanism.
+
+**Limits.** This is a composition contract over existing enforcement. It does
+not certify hosted logout, make all clients' logout scope identical, revoke
+already-issued GG grants immediately, or sandbox an account bearer against
+every legacy/browser/Supabase endpoint. CLI explicit-provider policy is not an
+account-wide BYOK-only preference. Independent stores do not prevent deliberate
+account-wide revocation by another client. Keep release-specific acceptance and
+incident investigations out of the architectural guarantee.
+
+**Files bound by this id.**
+
+- [CLI media composition](packages/grida-cli/src/media-run.ts) and
+  [tests](packages/grida-cli/src/media-run.test.ts) — real SDK handoff, BYOK/account
+  independence, missing-key failure, no stale grant reuse or credential output.
+- [Native bearer verifier](editor/lib/auth/bearer.ts) and
+  [tests](editor/lib/auth/__tests__/oauth-bearer.test.ts) — accepted account family
+  and live issuer verification, including rejection of other credential classes.
+- [GG token policy](editor/lib/gg/tokens.ts) and
+  [tests](editor/lib/gg/tokens.test.ts) — separate scoped authority and lifetime.
+- [Native GG exchange tests](editor/lib/api/gg.test.ts) — membership-bound mint
+  and the minted grant's rejection as account authority.
+- [Client authentication blueprint](docs/reference/authentication.md) — the
+  cross-client authority and lifecycle model contributors must keep aligned.
+
+---
+
 ## Adding a new GRIDA-SEC entry
 
-1. Allocate the next sequential id (`GRIDA-SEC-015` for the next one).
+1. Allocate the next sequential id (`GRIDA-SEC-016` for the next one).
 2. Add an "Active boundaries" subsection here with the same shape as
    GRIDA-SEC-001: what it protects, vulnerable scenario, why it's risky
    here, how the code prevents it, files bound.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1766,8 +1766,15 @@ credential through reuse of an existing browser or daemon bridge.
    and refresh, and invalidates stale work on logout/cancellation. Accepted
    refresh rotations survive a later identity-check failure; the access token
    and identity remain the last verified values until that check succeeds. Logout
-   clears this custody and requests only `scope=local`; failed remote
-   revocation is reported rather than changing to global/grant revocation.
+   clears this custody before remote work. It constrains the captured JWT to
+   the configured issuer/client/user and a non-nil session ID; missing session
+   targeting cannot reach an issuer fallback to account-wide logout. Expired
+   or near-expired logout performs at most one detached refresh in memory and
+   requires the same session binding. It never persists the renewed credentials
+   or emits signed-in metadata after clearing. Live identity verifies the
+   selected bearer before requesting only `scope=local`; failed remote revocation
+   is reported rather than changing to global/grant revocation. Only completed
+   200/204 responses confirm logout; their bodies are discarded.
 5. **Durable profile authority.** The Node factory binds a private profile to
    canonical home, issuer, client ID, and API origin. Keyring is the initial
    default; explicit file selection is remembered. Backend failure never
@@ -1836,6 +1843,10 @@ credential through reuse of an existing browser or daemon bridge.
     registered loopback callbacks. No environment or repository configuration
     changes hosted destination authority. Custody uses the canonical Grida home
     or an explicit absolute `GRIDA_HOME`, with issuer/client/API profile binding.
+    The bundled `sb_publishable_...` project key supplies admission only on the
+    fixed issuer logout request, alongside the user bearer. It is not identity;
+    key rotation does not create a different credential profile. Secret/service
+    keys and legacy JWT keys fail configuration validation before custody.
     Empty/relative overrides and filesystem-root/user-home targets fail before
     custody. The explicit local fixture file remains bounded and owner-controlled,
     accepts only the fixed local issuer/API and registered callbacks, and requires
@@ -2062,9 +2073,13 @@ defaults would cross those boundaries.
    the exact fixture API/editor ports and callback listeners, and refuses
    external module resolution. The macOS custody owner's exact read-only ACL
    command remains real. Reports contain hashes and safe phase metadata only;
-   owned browser/profile/process cleanup precedes report writing. One bounded
-   application-clock injection exercises real near-expiry refresh without
-   modifying issuer time, tokens or credential files.
+   owned browser/profile/process cleanup precedes report writing. Bounded
+   application-clock injections exercise near-expiry reads and detached logout
+   renewal without modifying issuer time, tokens or credential files. The fixture
+   explicitly asserts the logout admission key and its absence on other account
+   requests; the more permissive local gateway alone cannot prove hosted key
+   admission. Both captured and renewed refresh tokens must fail after logout,
+   while another native session and the browser remain usable.
 
 **Limits.** This is local provisioning, not hosted deployment certification.
 The executable, repository, dependencies, Docker engine, and same-user process

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -65,14 +65,19 @@ Small, non-secret native preferences live in `preferences.json` under
 Electron's `userData` directory and are owned exclusively by main. The hosted
 renderer receives purpose-specific actions, never a generic preferences
 key/value bridge. `DesktopPreferences` uses a small versioned JSON document
-with owner-only atomic writes. Account cookies remain in Chromium's HttpOnly
-session, while macOS/Linux BYOK API keys use the shared native
+with owner-only atomic writes. Account cookies remain in Chromium's default
+session cookie jar, while macOS/Linux BYOK API keys use the shared native
 `providers/credentials.toml` under Grida home through the sidecar's secret adapter.
 ChatGPT OAuth stays in the
 agent's `auth.json`. On the first upgrade from Desktop 0.0.13, main consumes the former
 renderer onboarding-completion flag through one fixed hidden same-origin probe
 and records the migration before selecting an authenticated role. That legacy
 flag is never consulted again.
+
+The [client authentication blueprint](https://grida.co/docs/reference/authentication)
+maps the separate web, Desktop, CLI and provider lifecycles. Current account
+cookies are not configured as HttpOnly; this is not a guarantee of isolation
+from the trusted same-origin renderer.
 
 Shared BYOK custody (GRIDA-SEC-014) is private plaintext on macOS/Linux.
 Desktop and CLI see the same provider changes without either requiring the

--- a/desktop/src/main/desktop-entry-window.ts
+++ b/desktop/src/main/desktop-entry-window.ts
@@ -42,7 +42,7 @@ type DesktopEntryWindowOptions = {
  * Authentication, onboarding completion, and native window role remain three
  * separate authorities:
  *
- * - {@link DesktopAccountSession} projects the HttpOnly cookie session.
+ * - {@link DesktopAccountSession} projects Chromium's account cookie session.
  * - {@link DesktopPreferences} owns native onboarding completion.
  * - this controller owns the exact BrowserWindow and turns those facts into a
  *   mutually exclusive full-window role.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -71,5 +71,6 @@ grida auth logout
 
 Logout removes this CLI's credentials and requests remote session revocation.
 Local removal still happens offline; unconfirmed revocation is reported with
-exit code `1`. Already signed out locally is a successful no-op. Logout leaves
+exit code `1`. When online, logout renews expired credentials if needed to revoke
+that session, without saving them again. Already signed out locally is a successful no-op. Logout leaves
 provider API keys intact.

--- a/docs/cli/flutter-daemon.md
+++ b/docs/cli/flutter-daemon.md
@@ -10,6 +10,6 @@ format: md
 `grida flutter daemon` belonged to the former design-to-code CLI. That command,
 along with `grida init` and `grida add`, is not part of the replacement CLI.
 
-See [Grida CLI](./index.md) for the current preview, account access, and media
+See [Grida CLI](./index.md) for the 0.1 release line, account access, and media
 tools. The new CLI runs independently of Desktop and does not start a Flutter
 preview daemon.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,17 +13,16 @@ format: md
 Discover models, generate media, and keep the files in your own workflow.
 Desktop does not need to be running.
 
-> **Preview channel: `next`.** Installation requires a published `next` version;
-> check [npm's versions and tags](https://www.npmjs.com/package/grida?activeTab=versions)
-> for availability. Before that tag exists, the command below cannot install the
-> preview. The legacy `latest` package does not provide these commands.
+These guides describe Grida CLI 0.1. See
+[npm's versions and tags](https://www.npmjs.com/package/grida?activeTab=versions)
+for published release availability.
 
 ## Install
 
 Use Node.js 24 or later:
 
 ```sh grida-setup
-npm install -g grida@next
+npm install -g grida
 ```
 
 Stored credentials currently support macOS and Linux. Windows users can supply
@@ -67,8 +66,7 @@ grida docs generate
 
 `--help` describes your installed version and works offline. `docs` prints a
 guide URL without opening a browser; reading the guide needs a connection.
-These pages describe the `next` preview. Agent, render, and MCP commands
-are deferred.
+Agent, render, and MCP commands are deferred.
 
 ## Use Grida in scripts
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -1,0 +1,201 @@
+---
+title: Client authentication blueprint
+description: How Grida web, Desktop, CLI, and AI providers establish identity, hold credentials, and end sessions.
+keywords: [grida, authentication, oauth, cli, desktop, supabase, credentials]
+tags: [internal, reference, platform, infra, cli, architecture]
+format: md
+---
+
+# Client authentication blueprint
+
+Grida has one account authority, Supabase Auth, and several independent clients.
+A shared account does not mean a shared credential store or identical logout
+behavior. AI-provider credentials are a separate authority from Grida identity.
+
+This is an architecture reference for contributors. It maps the current client
+model and its security contracts; it is not certification of a particular
+deployment or installed release. The [native account architecture](../wg/cli/account-infrastructure.md)
+owns the CLI contract, and the [security registry](https://github.com/gridaco/grida/blob/main/SECURITY.md)
+owns enforcement and its source/test inventory.
+
+**GRIDA-SEC-015 — Account-to-media credential handoff** binds the composition
+rule: adding a media consumer must not turn an account session into a provider
+credential. The existing boundaries below retain their individual ownership.
+
+## Clients and session owners
+
+| Client or consumer         | How it authenticates                                                                                                                   | Where its credentials live                                                                               | What it calls                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Web browser                | Google sign-in or the supported email flow creates a Supabase session.                                                                 | The browser's Supabase SSR cookie store.                                                                 | Grida web routes and permitted Supabase client operations.                         |
+| Desktop account            | System-browser sign-in binds a code to an Electron-held PKCE verifier; a fixed `grida://auth/callback` handoff completes the exchange. | Electron's Chromium default-session cookie jar, separate from the system browser.                        | Same-origin `/desktop/*` account, billing and GG-mint routes.                      |
+| CLI account                | Registered public OAuth client; browser consent, authorization code and S256 PKCE, then a fixed loopback callback.                     | Its own Grida auth profile: OS keyring by default, explicitly selected private plaintext file otherwise. | Supabase OAuth lifecycle endpoints and fixed Grida `/api/v1` account/GG-mint APIs. |
+| Desktop native media/agent | Receives a scoped GG grant, or uses a configured provider credential.                                                                  | GG in memory; provider credentials in their separate native stores.                                      | GG or the selected provider, through the native transport owner.                   |
+| CLI media                  | Explicit provider selection chooses GG account exchange or BYOK.                                                                       | GG for one invocation in memory; BYOK through explicit input/environment or the shared provider store.   | GG or the selected provider; never needs Desktop running.                          |
+
+Web and Desktop use SSR-compatible cookies. The current helpers do not configure
+them as HttpOnly; the blueprint does not assume the trusted renderer cannot
+access its own same-origin cookies. Electron main obtains an account projection
+through fixed routes rather than exporting cookie/token material through the
+bridge. Renderer trust, CSP, navigation admission and native IPC are separate
+controls under GRIDA-SEC-004/005.
+
+The [custody contract](../wg/cli/credential-custody.md) owns CLI platform support,
+private-file rules and refresh coordination. Main and published binaries can
+advance independently: shared BYOK support in source does not imply every older
+Desktop installation has adopted that store.
+
+## CLI login, use and logout
+
+1. **Start locally.** The CLI binds a registered loopback listener and creates
+   fresh state and PKCE material before opening the system browser.
+2. **Authorize in the browser.** Supabase's authorization endpoint sends the
+   browser to Grida consent when needed. Grida verifies the signed-in user and
+   pending request before submitting the decision to Supabase.
+3. **Exchange the code.** The browser delivers Supabase's one-use code through
+   the registered loopback callback. The CLI checks that callback and exchanges
+   the code with its PKCE verifier directly at Supabase.
+4. **Verify and save.** The CLI calls Grida's identity API with the new bearer.
+   Grida verifies it at the fixed OAuth userinfo endpoint. Only then does the CLI
+   persist the verified session in its own profile.
+5. **Use and renew.** Account, membership and credit commands call Grida's API.
+   The CLI renews credentials directly at Supabase when an online operation
+   needs them and saves accepted rotation under its custody rules.
+6. **Sign out.** The CLI clears local custody and asks Supabase to revoke only
+   the captured CLI session. It reports remote revocation as `confirmed`,
+   `unconfirmed`, or `not-needed`, separately from local clearing.
+
+Existing browser consent can skip the decision screen; it still authorizes a
+separate native session. The browser callback receipt means a code arrived,
+not that exchange, identity verification or persistence succeeded. Only the CLI's
+completed result establishes those later steps.
+
+The shipped registration fixes issuer, client ID, API origin and two callbacks:
+`http://127.0.0.1:55435/callback` and `http://127.0.0.1:55436/callback`.
+Those ports are registered addresses, not secrets. The client binds one before
+browser launch and fails if neither is available. State, PKCE and strict callback
+admission provide the protection; a local port number does not.
+
+An online account operation refreshes near expiry as needed. `auth status` only
+reads local metadata. Refresh rotation and custody writes are coordinated across
+CLI processes; an accepted rotation must not be replaced with an old refresh
+token after a later request fails. Ordinary account reads never start login.
+
+## Which credential means what
+
+| Credential                         | Authority                                                                                                                                      | It does not establish                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| OAuth public client ID             | Identifies a registered application and its callbacks.                                                                                         | A trustworthy binary, a user identity, or a client secret.                 |
+| Supabase publishable key           | Public project/API admission where the endpoint requires it. Safe to distribute in a client.                                                   | User identity, organization membership, or RLS bypass.                     |
+| Supabase account access token      | A user's session and existing authorized access. Native APIs additionally require the configured issuer/client and live identity verification. | A GG or external-provider credential.                                      |
+| Supabase refresh token             | Renewal of its account session at the issuer.                                                                                                  | Direct access to Grida account or generation APIs.                         |
+| GG grant                           | Short-lived, one-organization `gg:ai` access, signed with GG's separate authority.                                                             | Account identity, account refresh, or direct access to upstream providers. |
+| Provider API key (BYOK)            | Whatever the selected external provider permits for that key.                                                                                  | Grida login or Grida credit eligibility.                                   |
+| ChatGPT subscription OAuth         | The separate experimental text-provider connection in the full native agent.                                                                   | Grida login, shared CLI account custody, or an installed Codex session.    |
+| Native daemon transport credential | Access to its admitted local daemon capabilities.                                                                                              | A Grida account session or provider entitlement.                           |
+
+The account-to-media boundary is enforced in both directions: native account
+APIs reject GG credentials; GG verifies its dedicated signing key, HS256 algorithm,
+`gg:ai` audience, organization and bounded lifetime.
+The CLI's GG branch receives only a scoped grant through the auth owner's narrow
+memory handoff. Its BYOK branch does not open account custody, and failure does
+not silently switch to GG. These are GRIDA-SEC-015's composition rules; token
+cryptography and egress remain GRIDA-SEC-006/010/013.
+
+Desktop selects provider access through its own application policy. Its renderer
+exchanges account cookies for GG at `/desktop/auth/token` and supplies only that
+grant to the native media/agent consumer. The CLI uses `/api/v1/auth/gg`; both
+mint paths share membership and GG policy. GG grants are memory-only and normally
+last fifteen minutes, with the verifier's documented clock tolerance.
+
+Native BYOK uses a shared private TOML store on supported macOS/Linux clients.
+Changing that provider entry affects both clients that use it; Grida account
+logout does not remove it. ChatGPT OAuth has a separate native `auth.json`
+credential lifecycle, not the CLI keyring. Media-only Desktop startup does not
+mount that text-provider OAuth manager. See [Desktop's provider contract](https://github.com/gridaco/grida/blob/main/desktop/docs/chatgpt-subscription-oauth.md)
+and GRIDA-SEC-008/014 for support and custody limits.
+
+Server-only credentials stay out of these clients: Supabase secret/service-role
+authority, GG's signing key, and the consent-proof HMAC secret have different
+owners and purposes. The existing fixed server-to-server hook credential is
+another separate lane, not a general CLI authentication mechanism.
+
+## Account data remains server-authorized
+
+The supported CLI calls Grida's wrapped account APIs. Native bearer verification
+checks issuer, expiry, client and session claims, then verifies live userinfo;
+decoded claims alone do not establish identity. Account and credit reads retain
+the user's bearer and project publishable key for database RLS, while GG minting
+checks current organization membership before issuing a grant.
+
+The command surface is not a security sandbox around the token. A custom client
+can send a Supabase bearer directly to accessible Supabase APIs. Grants, RLS,
+membership checks and each endpoint's credential contract must enforce access
+regardless of which executable sent the request. Identity scopes are not a
+read-only permission model. Legacy browser/bearer endpoints do not acquire the
+native API's stronger client allowlist merely because the CLI exists.
+
+## Logout has an explicit scope
+
+| Action                           | Local effect                                                                                                | Requested server effect                                                                        |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| CLI `auth logout`                | Clear only its own account profile, including stale-write fencing.                                          | `scope=local`: revoke that CLI session. Report remote failure independently of local clearing. |
+| Current web sign-out             | On successful SDK sign-out, clear the initiating browser's auth state.                                      | Account-wide sign-out through the SDK's default `global` scope.                                |
+| Current Desktop account sign-out | Clear Desktop's hosted GG capacity and transition its native entry window after the account route succeeds. | Account-wide sign-out through the SDK's default `global` scope.                                |
+| Provider disconnect / remove     | Change that provider's own credential store.                                                                | Provider-specific behavior; not Grida account logout.                                          |
+
+Isolation is directional: CLI session-local logout must preserve other sessions;
+current web/Desktop sign-out requests broader revocation. Independent cookie and
+keyring stores do not override server-side scope. Changing that policy requires
+an explicit client behavior decision and compatibility tests.
+
+Local clearing, a successful HTTP response, and verified server revocation are
+different observations. `unconfirmed` must not be presented as completed remote
+revocation. A later login cannot repair or prove an earlier session's revocation.
+Application-grant revocation and account-wide sign-out are not fallbacks for a
+failed session-local request.
+
+Supabase revocation stops affected refresh tokens; already-issued access JWTs
+can retain their remaining lifetime. Grida's native account and GG-mint APIs
+add live userinfo verification, so revoked sessions are rejected on new requests
+even before JWT expiry. An already-issued GG grant retains its own bounded
+lifetime, and logout cannot recall work already accepted by a server.
+See [Supabase sign-out semantics](https://supabase.com/docs/guides/auth/signout).
+
+## Configuration and change ownership
+
+| Concern                                      | Canonical owner                                                                                                           | Change consequence                                                                                                                          |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLI issuer, client ID, API origin, callbacks | [Public CLI registration](https://github.com/gridaco/grida/blob/main/packages/grida-cli/src/oauth-client-registration.ts) | Bundled into installed binaries; coordinate registration, allowlists and client releases. Issuer/client/API also bind durable profiles.     |
+| Native bearer acceptance and consent         | [Web auth configuration](https://github.com/gridaco/grida/blob/main/editor/lib/auth/README.md)                            | Web deployment plus matching Supabase OAuth registration. Consent signing authority stays server-only.                                      |
+| Auth issuer versus Data API origin           | Same web configuration                                                                                                    | The canonical issuer is independent of a same-project Data API replica/load-balancer URL. Never infer one by rewriting the other.           |
+| API gateway admission                        | Endpoint contract plus public application configuration                                                                   | Public project keys and user tokens are distinct. OAuth token exchange and ordinary Auth endpoints can have different gateway requirements. |
+| Native account lifecycle and persistence     | [`@grida/auth`](https://github.com/gridaco/grida/blob/main/packages/grida-auth/README.md)                                 | Shared lifecycle/host changes need package and installed-client tests.                                                                      |
+| Desktop cookie ceremony and native entry     | [Desktop](https://github.com/gridaco/grida/blob/main/desktop/README.md), GRIDA-SEC-005                                    | Distinguish hosted renderer changes from native payload releases.                                                                           |
+| Organization, billing and GG authority       | Account APIs, RLS and GG policy                                                                                           | Client configuration cannot grant membership or replace server checks.                                                                      |
+
+The environment topology is production and disposable local Supabase. A Vercel
+Preview deployment is not an isolated auth/database environment. Local fixtures
+must use their own project, registration, secrets and credential home.
+
+## Verification and maintenance
+
+Each change names its credential owner, destination, accepted credential family,
+logout scope and release surface. Review callback admission, refresh rotation,
+local clearing, remote revocation, concurrency and failure reporting together.
+Keep this reference and the owning SEC entry aligned when any of those change.
+
+Unit tests prove owner contracts. A disposable real issuer proves exchange,
+refresh-token invalidation and preservation of other sessions. Gateway-shaped
+tests must also cover hosted admission and successful empty response bodies.
+An installed-client hosted check then proves the deployed routing/configuration
+and real user experience; neither green CI nor an unauthenticated HTTP response
+substitutes for it. Record deployment-specific evidence privately and never put
+tokens, authorization URLs, callbacks containing codes/state, operator data or
+implementation TODOs in this blueprint. Registered callback addresses are public.
+
+The boundary map is GRIDA-SEC-004 (native perimeter), 005 (Desktop ceremony),
+006 (GG), 008 (ChatGPT provider), 010 (native account), 011 (local fixture),
+012 (machine API routing), 013 (CLI media egress), 014 (BYOK custody), and
+015 (account-to-media composition). Consult the
+[registry](https://github.com/gridaco/grida/blob/main/SECURITY.md) for the exact
+enforcement files and tests.

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -61,7 +61,10 @@ Desktop installation has adopted that store.
    The CLI renews credentials directly at Supabase when an online operation
    needs them and saves accepted rotation under its custody rules.
 6. **Sign out.** The CLI clears local custody and asks Supabase to revoke only
-   the captured CLI session. It reports remote revocation as `confirmed`,
+   the captured CLI session. Near expiry, one detached refresh stays in memory;
+   the renewed bearer must belong to the same user, client and session. Live
+   identity verification precedes the fixed logout request, which carries the
+   public project admission key. It reports remote revocation as `confirmed`,
    `unconfirmed`, or `not-needed`, separately from local clearing.
 
 Existing browser consent can skip the decision screen; it still authorizes a
@@ -79,6 +82,9 @@ An online account operation refreshes near expiry as needed. `auth status` only
 reads local metadata. Refresh rotation and custody writes are coordinated across
 CLI processes; an accepted rotation must not be replaced with an old refresh
 token after a later request fails. Ordinary account reads never start login.
+Logout's detached renewal never saves credentials after local clearing and cannot
+replace or revoke a newer independent login. A missing/mismatched session target
+fails closed; account-wide and application-grant revocation are never substitutes.
 
 ## Which credential means what
 
@@ -163,15 +169,15 @@ See [Supabase sign-out semantics](https://supabase.com/docs/guides/auth/signout)
 
 ## Configuration and change ownership
 
-| Concern                                      | Canonical owner                                                                                                           | Change consequence                                                                                                                          |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| CLI issuer, client ID, API origin, callbacks | [Public CLI registration](https://github.com/gridaco/grida/blob/main/packages/grida-cli/src/oauth-client-registration.ts) | Bundled into installed binaries; coordinate registration, allowlists and client releases. Issuer/client/API also bind durable profiles.     |
-| Native bearer acceptance and consent         | [Web auth configuration](https://github.com/gridaco/grida/blob/main/editor/lib/auth/README.md)                            | Web deployment plus matching Supabase OAuth registration. Consent signing authority stays server-only.                                      |
-| Auth issuer versus Data API origin           | Same web configuration                                                                                                    | The canonical issuer is independent of a same-project Data API replica/load-balancer URL. Never infer one by rewriting the other.           |
-| API gateway admission                        | Endpoint contract plus public application configuration                                                                   | Public project keys and user tokens are distinct. OAuth token exchange and ordinary Auth endpoints can have different gateway requirements. |
-| Native account lifecycle and persistence     | [`@grida/auth`](https://github.com/gridaco/grida/blob/main/packages/grida-auth/README.md)                                 | Shared lifecycle/host changes need package and installed-client tests.                                                                      |
-| Desktop cookie ceremony and native entry     | [Desktop](https://github.com/gridaco/grida/blob/main/desktop/README.md), GRIDA-SEC-005                                    | Distinguish hosted renderer changes from native payload releases.                                                                           |
-| Organization, billing and GG authority       | Account APIs, RLS and GG policy                                                                                           | Client configuration cannot grant membership or replace server checks.                                                                      |
+| Concern                                                  | Canonical owner                                                                                                           | Change consequence                                                                                                                          |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLI issuer, client ID, public key, API origin, callbacks | [Public CLI registration](https://github.com/gridaco/grida/blob/main/packages/grida-cli/src/oauth-client-registration.ts) | Bundled into installed binaries; coordinate registration, allowlists and client releases. Issuer/client/API also bind durable profiles.     |
+| Native bearer acceptance and consent                     | [Web auth configuration](https://github.com/gridaco/grida/blob/main/editor/lib/auth/README.md)                            | Web deployment plus matching Supabase OAuth registration. Consent signing authority stays server-only.                                      |
+| Auth issuer versus Data API origin                       | Same web configuration                                                                                                    | The canonical issuer is independent of a same-project Data API replica/load-balancer URL. Never infer one by rewriting the other.           |
+| API gateway admission                                    | Endpoint contract plus public application configuration                                                                   | Public project keys and user tokens are distinct. OAuth token exchange and ordinary Auth endpoints can have different gateway requirements. |
+| Native account lifecycle and persistence                 | [`@grida/auth`](https://github.com/gridaco/grida/blob/main/packages/grida-auth/README.md)                                 | Shared lifecycle/host changes need package and installed-client tests.                                                                      |
+| Desktop cookie ceremony and native entry                 | [Desktop](https://github.com/gridaco/grida/blob/main/desktop/README.md), GRIDA-SEC-005                                    | Distinguish hosted renderer changes from native payload releases.                                                                           |
+| Organization, billing and GG authority                   | Account APIs, RLS and GG policy                                                                                           | Client configuration cannot grant membership or replace server checks.                                                                      |
 
 The environment topology is production and disposable local Supabase. A Vercel
 Preview deployment is not an isolated auth/database environment. Local fixtures

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,6 +7,7 @@ tags:
 
 # API References & Blueprints
 
+- [Client authentication blueprint](./authentication.md) — web, Desktop, CLI, credential authorities and logout scope.
 - [Figma to code blueprints](../@designto-code/figma-autolayout)
 - [Components handling blueprints](../@designto-code/component-multi-proxied-property)
 - [CSS handling blueprints](../@designto-code/css-box-sizing)

--- a/docs/wg/cli/account-infrastructure.md
+++ b/docs/wg/cli/account-infrastructure.md
@@ -15,6 +15,10 @@ format: md
 > have their own contracts. See the
 > [doctrine](./index.md) for product boundaries.
 
+The [client authentication blueprint](../../reference/authentication.md) maps
+this native contract alongside current web, Desktop and provider lifecycles.
+It distinguishes independent custody from server-side logout scope.
+
 ## Scope and ownership
 
 A native client can sign in, inspect its own account and obtain scoped Grida

--- a/docs/wg/cli/documentation.md
+++ b/docs/wg/cli/documentation.md
@@ -10,13 +10,13 @@ format: md
 
 # CLI documentation
 
-> **Status: implemented for the CLI preview.** Public guides and their currency
+> **Status: implemented for Grida CLI 0.1.** Public guides and their currency
 > check accompany the npm release. Local validation does not establish deployment.
 
 ## Current position
 
 The [user guide](../../cli/index.md), installed help, and package README cover
-the implemented preview. `grida docs` links to the user guides. The
+the 0.1 release line. `grida docs` links to the user guides. The
 [v1](./v1.md), [media](./media.md), and
 [credential custody](./credential-custody.md) documents retain contributor
 design and rationale.
@@ -39,7 +39,7 @@ routes are produced by the local docs build; publication is a release step.
 
 | Route                 | The reader's task                                                                                                                                        |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/docs/cli`           | Install the supported release, check its version, configure one access route, and save the first result. State platform support and preview limitations. |
+| `/docs/cli`           | Install the supported release, check its version, configure one access route, and save the first result. State platform support and current limitations. |
 | `/docs/cli/auth`      | Sign in to Grida, inspect the session, choose credential storage, and sign out.                                                                          |
 | `/docs/cli/account`   | Inspect memberships and select an organization for cached credits.                                                                                       |
 | `/docs/cli/providers` | Configure BYOK, locate and safely edit the TOML file, understand precedence, validate a key, and remove it.                                              |
@@ -58,8 +58,8 @@ and which failures can have incurred a charge.
 `grida docs [command...]` continues to print a URL without fetching it or opening
 a browser. Every supported topic maps to its owning public page or explicit
 section. Installed help remains authoritative for the installed version;
-hosted pages identify the preview until release, then describe the latest
-released version and mark newer examples with a minimum version when needed.
+hosted pages describe the latest released version and mark newer examples with
+a minimum version when needed.
 No bundled guide tree or separate agent-only
 documentation is required.
 
@@ -80,7 +80,7 @@ marketing links and the docs ownership index as part of that migration.
 Installed help, `grida docs`, and the npm README share the new guide home.
 Publish the matching guides before promoting the executable. An install
 example must identify an available release, never imply
-that the legacy npm package contains preview commands.
+that the retired design-to-code package contains the replacement CLI's commands.
 
 ## Keep it current with a small check
 

--- a/docs/wg/cli/v1.md
+++ b/docs/wg/cli/v1.md
@@ -21,7 +21,7 @@ format: md
 
 # Grida CLI v1
 
-> **Status: accepted command contract for the CLI preview.** Immediate is the
+> **Status: accepted command contract for Grida CLI 0.1.** Immediate is the
 > first-release scope; planned has no release commitment. See the
 > [doctrine](./index.md) for product boundaries.
 
@@ -46,7 +46,7 @@ features are separate extensions.
 The intended first session is:
 
 ```sh
-npm install -g grida@next
+npm install -g grida
 grida auth login
 grida account view
 grida account credits --org studio

--- a/docs/wg/platform/index.md
+++ b/docs/wg/platform/index.md
@@ -12,6 +12,7 @@ Working group documents for Grida platform and infrastructure topics.
 
 ## Documents
 
+- [Client authentication blueprint](../../reference/authentication.md) — current web, Desktop and CLI flows, credential owners and security boundaries.
 - [Grida CLI](../cli/index.md) — CLI doctrine and independent account infrastructure: native login, memberships, cached credits, and scoped GG access.
 - [Billing](./billing) — subscriptions, AI credit, Stripe ↔ Metronome sync.
 - [Grida Gateway (GG)](./hosted-ai) — the first-party metered, no-BYOK AI gateway: scoped-token federation → org-credit spend; the desktop's no-key AI path.

--- a/editor/e2e/auth-oauth.spec.mts
+++ b/editor/e2e/auth-oauth.spec.mts
@@ -254,6 +254,10 @@ test("isolated OAuth: browser consent, native sessions, restart, permissions and
   );
   expect(config.issuer).toBe(`${api}/auth/v1`);
   expect(config.apiOrigin).toBe(web);
+  expect(/^sb_publishable_[A-Za-z0-9_-]+$/.test(config.publishableKey)).toBe(
+    true
+  );
+  expect(config.publishableKey === setup.publishableKey).toBe(true);
   expect(config.redirectUris).toEqual(callbacks);
   const insider: User = setup.users.find(
     (user: User) => user.email === "insider@grida.co"
@@ -275,6 +279,16 @@ test("isolated OAuth: browser consent, native sessions, restart, permissions and
           ? input.href
           : input.url;
     if (!allowed(url)) throw new Error("Node request escaped the fixture");
+    if (
+      new URL(url).pathname === "/auth/v1/logout" &&
+      new URL(url).search === "?scope=local"
+    ) {
+      // Local Kong does not require this key when a bearer is present. Keep
+      // hosted admission an explicit fixture contract, not an accidental pass.
+      const headers = new Headers(init?.headers);
+      expect(headers.get("apikey") === config.publishableKey).toBe(true);
+      expect(headers.get("authorization")?.startsWith("Bearer ")).toBe(true);
+    }
     if (new URL(url).pathname === "/auth/v1/oauth/token") {
       tokenPosts++;
       if (
@@ -973,11 +987,22 @@ test("isolated OAuth: browser consent, native sessions, restart, permissions and
       "local logout revokes only the captured native session",
       async () => {
         const oldAccess = first.session()!.accessToken;
+        const oldRefresh = first.session()!.refreshToken;
         expect(await first.auth.logout()).toEqual({
           state: "signed-out",
           revocation: "confirmed",
         });
         expect(await accountStatus(oldAccess)).toBe(401);
+        const refresh = await request("/auth/v1/oauth/token", {
+          method: "POST",
+          form: new URLSearchParams({
+            grant_type: "refresh_token",
+            client_id: config.clientId,
+            refresh_token: oldRefresh,
+          }).toString(),
+        });
+        expect([400, 401].includes(refresh.status)).toBe(true);
+        await refresh.body?.cancel();
         expect(await mintStatus(oldAccess, logoutGrant!.organization.id)).toBe(
           401
         );
@@ -1114,7 +1139,7 @@ test("isolated OAuth: browser consent, native sessions, restart, permissions and
         expect(
           await probe("organizations", organizations.organizations[0]!.id)
         ).toEqual({ organizations: [], next_cursor: null });
-        expect(await probe("logout")).toEqual({
+        expect(await probe("logout-expired")).toEqual({
           state: "signed-out",
           revocation: "confirmed",
         });
@@ -1125,6 +1150,14 @@ test("isolated OAuth: browser consent, native sessions, restart, permissions and
           )
         ).toBe(false);
         expect((await second.auth.verify()).state).toBe("signed-in");
+        const afterExpiredLogout = client(page);
+        expect(
+          (await login(afterExpiredLogout, page, insider, "Allow", "reuse")).ok
+        ).toBe(true);
+        expect(await afterExpiredLogout.auth.logout()).toEqual({
+          state: "signed-out",
+          revocation: "confirmed",
+        });
       }
     );
 

--- a/editor/lib/api/gg.test.ts
+++ b/editor/lib/api/gg.test.ts
@@ -1,5 +1,6 @@
 // GRIDA-GG: token — native exchange enforcing-binding contract.
 // GRIDA-SEC-006 / GRIDA-SEC-010 / GRIDA-SEC-012
+// GRIDA-SEC-015 — account-to-GG exchange does not create a new account credential.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SignJWT, jwtVerify } from "jose";
 import { ggApi } from "./gg";

--- a/editor/lib/auth/README.md
+++ b/editor/lib/auth/README.md
@@ -1,5 +1,9 @@
 # Native OAuth deployment configuration
 
+The [client authentication blueprint](https://grida.co/docs/reference/authentication)
+maps web, Desktop, CLI and provider authority. This document owns the concrete
+web-server configuration for native OAuth; avoid duplicating its variable table.
+
 For operators deploying Grida's browser consent and native account API. The
 configuration reader is [oauth-server.ts](oauth-server.ts); consent proofs belong
 to [oauth-consent.ts](oauth-consent.ts). Keep this reference and deployment notes

--- a/editor/lib/auth/__tests__/oauth-bearer.test.ts
+++ b/editor/lib/auth/__tests__/oauth-bearer.test.ts
@@ -1,4 +1,5 @@
 // GRIDA-SEC-010 — native bearer identity rejects other credential classes.
+// GRIDA-SEC-015 — account ingress remains separate from scoped media authority.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SignJWT, jwtVerify } from "jose";
 import { bearer } from "../bearer";

--- a/editor/lib/auth/bearer.ts
+++ b/editor/lib/auth/bearer.ts
@@ -1,3 +1,4 @@
+// GRIDA-SEC-015 — scoped media credentials cannot establish native account identity.
 import "server-only";
 import { decodeJwt } from "jose";
 import { oauthServer } from "./oauth-server";

--- a/editor/lib/gg/tokens.test.ts
+++ b/editor/lib/gg/tokens.test.ts
@@ -1,4 +1,5 @@
 // GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-SEC-015 — separate signing, audience and lifetime prevent credential substitution.
 // GRIDA-GG: token — policy runs only against explicit host capabilities.
 import { describe, expect, it, vi } from "vitest";
 import { SignJWT, jwtVerify } from "jose";

--- a/editor/lib/gg/tokens.ts
+++ b/editor/lib/gg/tokens.ts
@@ -1,4 +1,5 @@
 // GRIDA-SEC-006 — see /SECURITY.md
+// GRIDA-SEC-015 — media grants have a separate verifier from account credentials.
 // GRIDA-GG: token — policy receives its clock, key reader and quota capability.
 import { SignJWT, jwtVerify, errors as joseErrors } from "jose";
 

--- a/packages/grida-auth/README.md
+++ b/packages/grida-auth/README.md
@@ -27,6 +27,7 @@ import { createNativeAuth } from "@grida/auth/node";
 const config: AuthClient.Config = {
   clientId: "registered-public-client-id",
   issuer: "http://127.0.0.1:55431/auth/v1",
+  publishableKey: "sb_publishable_fixture_project_key",
   apiOrigin: "http://127.0.0.1:3041",
   redirectUris: [
     "http://127.0.0.1:55435/callback",
@@ -71,11 +72,16 @@ bearer-only `/api/v1/auth/me` and refreshes near expiry when needed.
 
 `logout()` returns `{state: "signed-out", revocation}`. Revocation is
 `confirmed`, `unconfirmed`, or `not-needed`; a network failure does not restore
-locally cleared credentials. It sends only `POST <issuer>/logout?scope=local`,
-never global sign-out or application-grant revocation. Custody failures reject
-instead of claiming local sign-out. Server behavior, including preservation of
-other sessions and already-issued JWT lifetime, still needs the real issuer
-integration proof.
+locally cleared credentials. After clearing, it validates the captured session
+target. A near-expired or expired session gets at most one detached refresh in
+memory, with the same issuer, user, client and session binding. Neither renewed
+credentials nor signed-in metadata are persisted or returned. Live identity
+verification precedes `POST <issuer>/logout?scope=local`; the request supplies
+the public project admission key alongside the user bearer. A completed 200/204
+confirms revocation; response bodies are discarded. Other statuses or failures
+remain unconfirmed, with no retry or global/application-grant fallback. Custody
+failures reject instead of claiming local sign-out. Issued JWT/GG lifetimes and
+other sessions still require the real issuer integration proof.
 
 Failures are `AuthClient.Failure` with a stable `code` and a fixed message.
 Upstream error bodies and thrown host error messages are not exposed.
@@ -237,6 +243,12 @@ retry policy require a separate producer contract with the media owner.
   `http://127.0.0.1:<port>` origins. The issuer must end in `/auth/v1`.
   Production and local HTTP origins cannot be mixed. No discovery, redirect,
   or token payload can change this trusted binding.
+- `publishableKey` is required trusted registration metadata in
+  `sb_publishable_...` form. Secret/service-role keys and legacy JWT keys are
+  rejected before custody. Only the fixed issuer logout request receives its
+  `apikey` header; OAuth token, account and GG requests do not. It grants no user
+  identity and is excluded from durable profile identity, so rotating it does
+  not strand the user's saved session.
 - Redirects are an explicit list of fixed `http://127.0.0.1:<port>/<path>`
   addresses, registered ahead of time. There is no `localhost`, wildcard,
   port zero, query, fragment, or arbitrary ephemeral callback fallback.
@@ -305,6 +317,9 @@ consent, and checks the revision when committing the verified session. Logout
 clears under the same authority even when already signed out, so a prior login
 cannot recreate that session. Remote revocation uses the captured old session
 after releasing authority; it cannot clear a newer login.
+Detached logout renewal likewise stays outside custody: it uses only the captured
+refresh token and must match that session before revocation. Normal persisting
+refresh is never reused after the local clear.
 
 An accepted refresh rotation is saved before the separate live identity check.
 Until that check succeeds, custody retains the previous access token, expiry,

--- a/packages/grida-auth/src/auth-client.test.ts
+++ b/packages/grida-auth/src/auth-client.test.ts
@@ -6,6 +6,7 @@ import { AuthClient } from "./index";
 const config: AuthClient.Config = {
   issuer: "https://auth.example.com/auth/v1",
   clientId: "native-client",
+  publishableKey: "sb_publishable_synthetic",
   apiOrigin: "https://api.example.com",
   redirectUris: ["http://127.0.0.1:55435/callback"],
 };
@@ -16,6 +17,22 @@ const identity = {
 };
 const state = "s".repeat(43);
 const now = 1_800_000_000_000;
+const sessionId = "11111111-1111-4111-8111-111111111111";
+function access(suffix: string, claims: Record<string, unknown> = {}) {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "ES256" })}.${encode({
+    iss: config.issuer,
+    aud: "authenticated",
+    sub: identity.id,
+    client_id: config.clientId,
+    session_id: sessionId,
+    exp: now / 1000 + 3600,
+    ...claims,
+  })}.${encode(suffix)}`;
+}
+const oldAccess = access("old");
+const newAccess = access("new");
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -32,7 +49,7 @@ function session(
 ): AuthClient.Session {
   return {
     ...config,
-    accessToken: "old-access-secret",
+    accessToken: oldAccess,
     refreshToken: "old-refresh-secret",
     expiresAt: now + 3_600_000,
     identity,
@@ -91,7 +108,7 @@ function harness(
             ? {
                 status: 200,
                 body: {
-                  access_token: "new-access-secret",
+                  access_token: newAccess,
                   refresh_token: "new-refresh-secret",
                   token_type: "Bearer",
                   expires_in: 3600,
@@ -189,7 +206,7 @@ function tokenResponse(suffix: string): AuthClient.Response {
   return {
     status: 200,
     body: {
-      access_token: `access-${suffix}`,
+      access_token: access(suffix),
       refresh_token: `refresh-${suffix}`,
       token_type: "Bearer",
       expires_in: 3600,
@@ -290,7 +307,7 @@ describe("AuthClient.requestGgAccess", () => {
         url: `${config.apiOrigin}/api/v1/auth/gg`,
         method: "POST",
         headers: {
-          authorization: "Bearer old-access-secret",
+          authorization: `Bearer ${oldAccess}`,
           "content-type": "application/json",
         },
         body: '{"organization_id":7}',
@@ -519,7 +536,7 @@ describe("AuthClient.requestGgAccess", () => {
         "new-refresh-secret"
       );
       expect(h.requests.at(-1)?.headers.authorization).toBe(
-        "Bearer new-access-secret"
+        `Bearer ${newAccess}`
       );
       expect(accept).not.toHaveBeenCalled();
       expect(
@@ -760,7 +777,7 @@ describe("AuthClient.requestAccount credits.read", () => {
       {
         url: `${config.apiOrigin}/api/v1/account/credits?organization_id=7`,
         method: "GET",
-        headers: { authorization: "Bearer old-access-secret" },
+        headers: { authorization: `Bearer ${oldAccess}` },
       },
     ]);
     expect(h.writes).toHaveLength(0);
@@ -981,7 +998,7 @@ describe("AuthClient.requestAccount credits.read", () => {
         {
           url: `${config.apiOrigin}/api/v1/account/credits?organization_id=7`,
           method: "GET",
-          headers: { authorization: "Bearer new-access-secret" },
+          headers: { authorization: `Bearer ${newAccess}` },
         },
       ]);
     }
@@ -1073,7 +1090,7 @@ describe("AuthClient.requestAccount", () => {
       {
         url: `${config.apiOrigin}/api/v1/account/organizations?after=3`,
         method: "GET",
-        headers: { authorization: "Bearer old-access-secret" },
+        headers: { authorization: `Bearer ${oldAccess}` },
       },
     ]);
     expect(h.writes).toHaveLength(0);
@@ -1272,7 +1289,7 @@ describe("AuthClient.requestAccount", () => {
     );
     expect(reads).toHaveLength(2);
     expect(
-      reads.every((r) => r.headers.authorization === "Bearer new-access-secret")
+      reads.every((r) => r.headers.authorization === `Bearer ${newAccess}`)
     ).toBe(true);
   });
 
@@ -1292,7 +1309,7 @@ describe("AuthClient.requestAccount", () => {
       )
     ).toHaveLength(1);
     expect(second.requests[0]?.headers.authorization).toBe(
-      "Bearer new-access-secret"
+      `Bearer ${newAccess}`
     );
     expect(store.acquisitions()).toBe(2);
     expect(store.active()).toBe(0);
@@ -1306,7 +1323,7 @@ describe("AuthClient.requestAccount", () => {
       h.client.requestAccount("organizations.list")
     ).rejects.toMatchObject({ code: "unavailable" });
     expect(store.stored()?.refreshToken).toBe("new-refresh-secret");
-    expect(store.stored()?.accessToken).toBe("new-access-secret");
+    expect(store.stored()?.accessToken).toBe(newAccess);
     expect(
       h.requests.filter((r) => r.url.includes("/account/organizations"))
     ).toHaveLength(1);
@@ -1519,9 +1536,7 @@ describe("AuthClient", () => {
     expect(h.requests[0]!.headers["content-type"]).toBe(
       "application/x-www-form-urlencoded"
     );
-    expect(h.requests[1]!.headers.authorization).toBe(
-      "Bearer new-access-secret"
-    );
+    expect(h.requests[1]!.headers.authorization).toBe(`Bearer ${newAccess}`);
     expect(h.stored()?.refreshToken).toBe("new-refresh-secret");
     expect(status).toEqual({
       state: "signed-in",
@@ -1550,7 +1565,7 @@ describe("AuthClient", () => {
       h.callback.resolve(callback);
       expect(await result).toMatchObject({ code });
       expect(h.requests).toHaveLength(0);
-      expect(h.stored()?.accessToken).toBe("old-access-secret");
+      expect(h.stored()?.accessToken).toBe(oldAccess);
       expect(h.listener.close).toHaveBeenCalledOnce();
     }
   );
@@ -1598,7 +1613,7 @@ describe("AuthClient", () => {
     await h.bound;
     h.callback.resolve({ state, code: "code" });
     await expect(login).rejects.toMatchObject({ code: "token_rejected" });
-    expect(h.stored()?.accessToken).toBe("old-access-secret");
+    expect(h.stored()?.accessToken).toBe(oldAccess);
   });
 
   it("single-flights refresh and saves the rotated refresh token before returning", async () => {
@@ -1624,15 +1639,13 @@ describe("AuthClient", () => {
     const h = harness(session());
     const token = deferred<AuthClient.Response>();
     const entered = deferred<void>();
+    const original = h.host.request;
     h.host.request = (request) => {
       if (request.url.endsWith("/oauth/token")) {
         entered.resolve();
         return { result: token.promise, cancel() {} };
       }
-      return {
-        result: Promise.resolve({ status: 204, body: null }),
-        cancel() {},
-      };
+      return original(request);
     };
     const refreshing = h.client.refresh();
     const rejected = refreshing.catch((error: unknown) => error);
@@ -1658,13 +1671,14 @@ describe("AuthClient", () => {
 
   it("clears only its custody and requests session-local logout even when remote revocation fails", async () => {
     const h = harness(session());
+    const original = h.host.request;
+    const attempted: AuthClient.Request[] = [];
+    let observedCustody: AuthClient.Session | null | undefined;
     h.host.request = (request) => {
-      expect(h.stored()).toBeNull();
-      expect(request).toEqual({
-        url: `${config.issuer}/logout?scope=local`,
-        method: "POST",
-        headers: { authorization: "Bearer old-access-secret" },
-      });
+      if (!request.url.endsWith("/logout?scope=local"))
+        return original(request);
+      observedCustody = h.stored();
+      attempted.push(request);
       return {
         cancel() {},
         result: Promise.reject(new Error("secret-upstream-body")),
@@ -1674,10 +1688,23 @@ describe("AuthClient", () => {
       state: "signed-out",
       revocation: "unconfirmed",
     });
+    expect(observedCustody).toBeNull();
+    expect(attempted).toEqual([
+      {
+        url: `${config.issuer}/logout?scope=local`,
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${oldAccess}`,
+          apikey: config.publishableKey,
+        },
+        response: "empty",
+      },
+    ]);
     expect(await h.client.logout()).toEqual({
       state: "signed-out",
       revocation: "not-needed",
     });
+    expect(attempted).toHaveLength(1);
   });
 
   it("rejects custody from a different issuer, client, or API before network I/O", async () => {
@@ -1725,7 +1752,7 @@ describe("AuthClient", () => {
     const release = deferred<void>();
     const original = h.host.custody.write;
     h.host.custody.write = async (next) => {
-      if (next.accessToken === "new-access-secret") {
+      if (next.accessToken === newAccess) {
         writing.resolve();
         await release.promise;
       }
@@ -1739,7 +1766,7 @@ describe("AuthClient", () => {
     await h.client.cancelLogin();
     release.resolve();
     expect(await rejected).toMatchObject({ code: "cancelled" });
-    expect(h.stored()?.accessToken).toBe("old-access-secret");
+    expect(h.stored()?.accessToken).toBe(oldAccess);
   });
 
   it("does not let an earlier live verification overwrite rotated credentials", async () => {
@@ -1748,7 +1775,7 @@ describe("AuthClient", () => {
     const entered = deferred<void>();
     const original = h.host.request;
     h.host.request = (request) => {
-      if (request.headers.authorization === "Bearer old-access-secret") {
+      if (request.headers.authorization === `Bearer ${oldAccess}`) {
         entered.resolve();
         return { result: verifying.promise, cancel() {} };
       }
@@ -1781,14 +1808,14 @@ describe("AuthClient", () => {
     };
     const logout = h.client.logout();
     await entered.promise;
-    expect(revoked).toEqual(["Bearer old-access-secret"]);
+    expect(revoked).toEqual([`Bearer ${oldAccess}`]);
     const login = h.client.login();
     await h.bound;
     h.callback.resolve({ state, code: "new-code" });
     await login;
     revocation.resolve({ status: 204, body: null });
     await logout;
-    expect(h.stored()?.accessToken).toBe("new-access-secret");
+    expect(h.stored()?.accessToken).toBe(newAccess);
   });
 
   it.each([
@@ -1817,7 +1844,7 @@ describe("AuthClient", () => {
       await expect(h.client.refresh()).rejects.toMatchObject({
         code: "invalid_response",
       });
-      expect(h.stored()?.accessToken).toBe("old-access-secret");
+      expect(h.stored()?.accessToken).toBe(oldAccess);
     }
   );
 
@@ -1920,7 +1947,7 @@ describe("AuthClient", () => {
     expect(new URLSearchParams(grants[1]!.body).get("refresh_token")).toBe(
       "new-refresh-secret"
     );
-    expect(h.stored()?.accessToken).toBe("new-access-secret");
+    expect(h.stored()?.accessToken).toBe(newAccess);
   });
 
   it("fails before identity I/O when accepted rotation cannot be saved", async () => {
@@ -1935,7 +1962,7 @@ describe("AuthClient", () => {
     expect(h.requests.map((request) => request.url)).toEqual([
       `${config.issuer}/oauth/token`,
     ]);
-    expect(h.stored()?.accessToken).toBe("old-access-secret");
+    expect(h.stored()?.accessToken).toBe(oldAccess);
   });
 
   it("lets logout win after rotation is saved while live identity is still pending", async () => {
@@ -1944,7 +1971,10 @@ describe("AuthClient", () => {
     const entered = deferred<void>();
     const original = h.host.request;
     h.host.request = (request) => {
-      if (request.method === "GET") {
+      if (
+        request.method === "GET" &&
+        request.headers.authorization === `Bearer ${newAccess}`
+      ) {
         entered.resolve();
         return { result: verifying.promise, cancel() {} };
       }
@@ -1953,7 +1983,7 @@ describe("AuthClient", () => {
     const refresh = h.client.refresh().catch((error: unknown) => error);
     await entered.promise;
     expect(h.stored()?.refreshToken).toBe("new-refresh-secret");
-    expect(h.stored()?.accessToken).toBe("old-access-secret");
+    expect(h.stored()?.accessToken).toBe(oldAccess);
     expect((await h.client.logout()).revocation).toBe("confirmed");
     verifying.resolve({ status: 200, body: identity });
     expect(await refresh).toMatchObject({ code: "cancelled" });
@@ -2022,7 +2052,7 @@ describe("AuthClient", () => {
     release.resolve({ status: 200, body: identity });
     await Promise.all([refresh, verify]);
     expect(second.requests[0]?.headers.authorization).toBe(
-      "Bearer new-access-secret"
+      `Bearer ${newAccess}`
     );
     expect(store.stored()?.refreshToken).toBe("new-refresh-secret");
     expect(store.revision()).toBe(3);
@@ -2070,7 +2100,7 @@ describe("AuthClient", () => {
     first.callback.resolve({ state, code: "late-code" });
     expect(await a).toMatchObject({ code: "session_changed" });
     expect(store.writes).toHaveLength(1);
-    expect(store.stored()?.accessToken).toBe("new-access-secret");
+    expect(store.stored()?.accessToken).toBe(newAccess);
   });
 
   it("releases authority after identity failure without rolling back an accepted rotation", async () => {
@@ -2086,7 +2116,7 @@ describe("AuthClient", () => {
       code: "unavailable",
     });
     expect(store.stored()?.refreshToken).toBe("new-refresh-secret");
-    expect(store.stored()?.accessToken).toBe("old-access-secret");
+    expect(store.stored()?.accessToken).toBe(oldAccess);
     expect(store.active()).toBe(0);
     await second.client.refresh();
     expect(
@@ -2219,11 +2249,9 @@ describe("AuthClient", () => {
     await login;
     expect(store.writes.map((value) => value?.accessToken ?? null)).toEqual([
       null,
-      "new-access-secret",
+      newAccess,
     ]);
-    expect(h.requests[0]?.headers.authorization).toBe(
-      "Bearer old-access-secret"
-    );
+    expect(h.requests[0]?.headers.authorization).toBe(`Bearer ${oldAccess}`);
   });
 
   it("does not compensate an accepted memory-custody rotation when logout arrives during its write", async () => {
@@ -2246,5 +2274,321 @@ describe("AuthClient", () => {
       "new-refresh-secret",
     ]);
     expect(h.stored()).toBeNull();
+  });
+});
+
+describe("session-local logout lifecycle", () => {
+  it("accepts UTF-8 metadata but rejects noncanonical base64url of otherwise valid claims", async () => {
+    const token = access("unicode", { name: "안녕 👋" });
+    const valid = harness(session({ accessToken: token }));
+    expect((await valid.client.logout()).revocation).toBe("confirmed");
+    const parts = token.split(".");
+    // Choose a valid payload with padding bits, then change only unused bits.
+    let padding = "";
+    while (parts[1]!.length % 4 === 0) {
+      padding += "x";
+      parts[1] = access("unicode", { name: "안녕 👋", padding }).split(".")[1]!;
+    }
+    const alphabet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const payload = parts[1]!;
+    parts[1] =
+      payload.slice(0, -1) + alphabet[alphabet.indexOf(payload.at(-1)!) | 1];
+    const invalid = harness(session({ accessToken: parts.join(".") }));
+    expect((await invalid.client.logout()).revocation).toBe("unconfirmed");
+    expect(invalid.requests).toEqual([]);
+    expect(invalid.stored()).toBeNull();
+  });
+
+  it.each([
+    undefined,
+    "",
+    "sb_secret_synthetic",
+    "eyJhbGci.synthetic.jwt",
+    "sb_publishable_key\n",
+    "sb_publishable_" + "x".repeat(257),
+  ])(
+    "rejects missing, secret, legacy or malformed public admission metadata (%s)",
+    (publishableKey) => {
+      const h = harness();
+      expect(
+        () =>
+          new AuthClient(
+            { ...config, publishableKey } as AuthClient.Config,
+            h.host
+          )
+      ).toThrow(expect.objectContaining({ code: "invalid_config" }));
+      expect(h.requests).toHaveLength(0);
+    }
+  );
+
+  it.each([false, true])(
+    "renews an expired captured session only in memory after clearing (coordinated=%s)",
+    async (coordinated) => {
+      const previous = session({
+        accessToken: access("expired", { exp: now / 1000 - 1 }),
+        expiresAt: now - 1000,
+      });
+      const store = sharedCustody(previous);
+      const h = coordinated ? store.client() : harness(previous);
+      const stored = coordinated ? store.stored : h.stored;
+      const observed: (AuthClient.Session | null)[] = [];
+      const original = h.host.request;
+      h.host.request = (request) => {
+        observed.push(stored());
+        return original(request);
+      };
+      expect(await h.client.logout()).toEqual({
+        state: "signed-out",
+        revocation: "confirmed",
+      });
+      expect(observed).toEqual([null, null, null]);
+      expect(h.requests.map((r) => r.url)).toEqual([
+        `${config.issuer}/oauth/token`,
+        `${config.apiOrigin}/api/v1/auth/me`,
+        `${config.issuer}/logout?scope=local`,
+      ]);
+      expect(h.requests.map((r) => r.headers.apikey)).toEqual([
+        undefined,
+        undefined,
+        config.publishableKey,
+      ]);
+      expect(
+        new URLSearchParams(h.requests[0]!.body).get("refresh_token")
+      ).toBe(previous.refreshToken);
+      expect(h.requests[2]!.headers.authorization).toBe(`Bearer ${newAccess}`);
+      expect(coordinated ? store.writes : h.writes).toEqual(
+        coordinated ? [null] : []
+      );
+      expect(await h.client.status()).toEqual({ state: "signed-out" });
+    }
+  );
+
+  it.each([
+    { expiresAt: now + 30_000 },
+    { accessToken: access("near-expiry", { exp: now / 1000 + 20 }) },
+  ])(
+    "uses the earlier token or saved expiry for near-expiry logout",
+    async (change) => {
+      const h = harness(session(change));
+      expect((await h.client.logout()).revocation).toBe("confirmed");
+      expect(
+        h.requests.filter((r) => r.url.endsWith("/oauth/token"))
+      ).toHaveLength(1);
+      expect(h.writes).toEqual([]);
+    }
+  );
+
+  it.each([
+    { session_id: undefined },
+    { session_id: "" },
+    { session_id: "not-a-session" },
+    { session_id: "00000000-0000-0000-0000-000000000000" },
+    { iss: "https://elsewhere.example/auth/v1" },
+    { sub: "another-user" },
+    { client_id: "another-client" },
+    { aud: "gg:ai" },
+    { exp: "1800000000" },
+    { exp: null },
+    { exp: 0 },
+  ])(
+    "refuses malformed or mismatched captured authority before I/O: %j",
+    async (claims) => {
+      const h = harness(
+        session({
+          accessToken: access("malformed", claims),
+          expiresAt: now - 1,
+        })
+      );
+      expect(await h.client.logout()).toEqual({
+        state: "signed-out",
+        revocation: "unconfirmed",
+      });
+      expect(h.stored()).toBeNull();
+      expect(h.requests).toEqual([]);
+    }
+  );
+
+  it.each(["not-a-jwt", "e30.A.eA", "e30._w.eA", "e30.eyJ.eA", "e30.e30=.eA"])(
+    "contains malformed JWT encoding without network or credential output (%s)",
+    async (accessToken) => {
+      const h = harness(session({ accessToken }));
+      expect(await h.client.logout()).toEqual({
+        state: "signed-out",
+        revocation: "unconfirmed",
+      });
+      expect(h.requests).toEqual([]);
+      expect(h.stored()).toBeNull();
+    }
+  );
+
+  it.each([
+    { session_id: "22222222-2222-4222-8222-222222222222" },
+    { session_id: undefined },
+    { sub: "another-user" },
+    { client_id: "another-client" },
+    { iss: "https://elsewhere.example/auth/v1" },
+    { exp: now / 1000 - 1 },
+  ])(
+    "does not revoke or persist a renewed token with changed authority: %j",
+    async (claims) => {
+      const h = harness(session({ expiresAt: now - 1 }));
+      const calls: AuthClient.Request[] = [];
+      h.host.request = (request) => {
+        calls.push(request);
+        return {
+          cancel() {},
+          result: Promise.resolve({
+            status: 200,
+            body: {
+              access_token: access("renewed", claims),
+              refresh_token: "rotated-refresh",
+              expires_in: 3600,
+              token_type: "Bearer",
+            },
+          }),
+        };
+      };
+      expect((await h.client.logout()).revocation).toBe("unconfirmed");
+      expect(calls.map((r) => r.url)).toEqual([`${config.issuer}/oauth/token`]);
+      expect(h.stored()).toBeNull();
+      expect(h.writes).toEqual([]);
+    }
+  );
+
+  it.each(["refresh", "identity", "identity-subject", "revoke"])(
+    "keeps local sign-out and never retries when detached %s fails",
+    async (phase) => {
+      const h = harness(session({ expiresAt: now - 1 }));
+      const original = h.host.request;
+      const calls: AuthClient.Request[] = [];
+      h.host.request = (request) => {
+        calls.push(request);
+        if (
+          (phase === "refresh" && request.url.endsWith("/oauth/token")) ||
+          (phase === "identity" && request.url.endsWith("/auth/me")) ||
+          (phase === "revoke" && request.url.endsWith("/logout?scope=local"))
+        )
+          return {
+            cancel() {},
+            result: Promise.resolve({
+              status: 401,
+              body: { secret: "never-expose" },
+            }),
+          };
+        if (phase === "identity-subject" && request.url.endsWith("/auth/me"))
+          return {
+            cancel() {},
+            result: Promise.resolve({
+              status: 200,
+              body: { ...identity, id: "other" },
+            }),
+          };
+        return original(request);
+      };
+      expect(await h.client.logout()).toEqual({
+        state: "signed-out",
+        revocation: "unconfirmed",
+      });
+      expect(calls).toHaveLength(
+        phase === "refresh" ? 1 : phase === "revoke" ? 3 : 2
+      );
+      expect(h.stored()).toBeNull();
+      expect(h.writes).toEqual([]);
+    }
+  );
+
+  it.each([200, 204, 202, 302, 401, 500])(
+    "reports only completed logout statuses as confirmed (%s)",
+    async (status) => {
+      const h = harness(session());
+      const original = h.host.request;
+      h.host.request = (request) =>
+        request.url.endsWith("/logout?scope=local")
+          ? { cancel() {}, result: Promise.resolve({ status, body: null }) }
+          : original(request);
+      expect((await h.client.logout()).revocation).toBe(
+        [200, 204].includes(status) ? "confirmed" : "unconfirmed"
+      );
+      expect(h.requests.some((r) => r.url.endsWith("/oauth/token"))).toBe(
+        false
+      );
+    }
+  );
+
+  it.each([false, true])(
+    "detached expiry refresh cannot overwrite or revoke a newer login (coordinated=%s)",
+    async (coordinated) => {
+      const previous = session({ expiresAt: now - 1 });
+      const store = sharedCustody(previous);
+      const h = coordinated ? store.client() : harness(previous);
+      const newer = coordinated ? store.client() : h;
+      const stored = coordinated ? store.stored : h.stored;
+      const entered = deferred<void>();
+      const released = deferred<AuthClient.Response>();
+      const original = h.host.request;
+      const replacement = access("new-session", {
+        session_id: "22222222-2222-4222-8222-222222222222",
+      });
+      const revoked: string[] = [];
+      const handle: AuthClient.Host["request"] = (request) => {
+        const grant = new URLSearchParams(request.body).get("grant_type");
+        if (grant === "refresh_token") {
+          entered.resolve();
+          return { cancel() {}, result: released.promise };
+        }
+        if (grant === "authorization_code")
+          return {
+            cancel() {},
+            result: Promise.resolve({
+              status: 200,
+              body: {
+                access_token: replacement,
+                refresh_token: "new-login-refresh",
+                expires_in: 3600,
+                token_type: "Bearer",
+              },
+            }),
+          };
+        if (request.url.endsWith("/logout?scope=local"))
+          revoked.push(request.headers.authorization!);
+        return original(request);
+      };
+      h.host.request = handle;
+      newer.host.request = handle;
+      const logout = h.client.logout();
+      await entered.promise;
+      expect(stored()).toBeNull();
+      const login = newer.client.login();
+      await newer.bound;
+      newer.callback.resolve({ state, code: "new-login-code" });
+      await login;
+      expect(stored()?.accessToken).toBe(replacement);
+      released.resolve({
+        status: 200,
+        body: {
+          access_token: newAccess,
+          refresh_token: "detached-rotation",
+          expires_in: 3600,
+          token_type: "Bearer",
+        },
+      });
+      expect((await logout).revocation).toBe("confirmed");
+      expect(revoked).toEqual([`Bearer ${newAccess}`]);
+      expect(stored()?.accessToken).toBe(replacement);
+      expect(stored()?.refreshToken).toBe("new-login-refresh");
+    }
+  );
+
+  it("does not claim sign-out or contact the issuer when custody cannot clear", async () => {
+    const h = harness(session());
+    h.host.custody.clear = async () => {
+      throw new Error("private custody error");
+    };
+    await expect(h.client.logout()).rejects.toMatchObject({
+      code: "custody_failed",
+    });
+    expect(h.requests).toEqual([]);
+    expect(h.stored()).not.toBeNull();
   });
 });

--- a/packages/grida-auth/src/auth-client.ts
+++ b/packages/grida-auth/src/auth-client.ts
@@ -362,15 +362,54 @@ export class AuthClient {
     await closeListener(listener);
     if (!session) return { state: "signed-out", revocation: "not-needed" };
     try {
+      // The issuer can fall back to account-wide logout when session_id is
+      // absent. Claims only constrain the target; live identity below supplies
+      // authority. Never use grant/global revocation as a fallback.
+      const captured = logoutSession(
+        session.accessToken,
+        this.config,
+        session.identity
+      );
+      let accessToken = session.accessToken;
+      if (
+        Math.min(session.expiresAt, captured.expiresAt) <=
+        this.host.now() + 30_000
+      ) {
+        // Custody is already cleared. This detached rotation must never use the
+        // persisting refresh path or publish signed-in metadata, even on failure.
+        const tokens = await this.exchange(
+          {
+            grant_type: "refresh_token",
+            client_id: this.config.clientId,
+            refresh_token: session.refreshToken,
+          },
+          session.refreshToken
+        );
+        const renewed = logoutSession(
+          tokens.accessToken,
+          this.config,
+          session.identity
+        );
+        if (renewed.id !== captured.id || renewed.expiresAt <= this.host.now())
+          throw new AuthClient.Failure("token_rejected");
+        accessToken = tokens.accessToken;
+      }
+      const identity = await this.identity(accessToken);
+      if (identity.id !== session.identity.id)
+        throw new AuthClient.Failure("token_rejected");
       const response = await this.request({
         url: `${this.config.issuer}/logout?scope=local`,
         method: "POST",
-        headers: { authorization: `Bearer ${session.accessToken}` },
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          apikey: this.config.publishableKey,
+        },
+        response: "empty",
       });
       return {
         state: "signed-out",
         revocation:
-          response.status >= 200 && response.status < 300
+          response.status === 200 || response.status === 204
             ? "confirmed"
             : "unconfirmed",
       };
@@ -741,6 +780,10 @@ export namespace AuthClient {
   export type Config = {
     clientId: string;
     issuer: string;
+    /** Public project admission for issuer logout; never a secret/service key.
+     * Rotation does not change the issuer/client/API credential profile identity.
+     */
+    publishableKey: string;
     apiOrigin: string;
     redirectUris: readonly string[];
   };
@@ -866,6 +909,8 @@ export namespace AuthClient {
     method: "GET" | "POST";
     headers: Record<string, string>;
     body?: string;
+    /** JSON is required by default; logout explicitly has no response payload. */
+    response?: "json" | "empty";
   };
   export type Response = { status: number; body: unknown };
   export type RequestOperation = { result: Promise<Response>; cancel(): void };
@@ -1118,10 +1163,68 @@ function timestamp(value: unknown): value is string {
   return month >= 1 && month <= 12 && day >= 1 && day <= days[month - 1]!;
 }
 
+/** Target constraint only, never signature/identity verification. Kept neutral
+ * (no Node/DOM decoder); the fixed live account API verifies the same bearer.
+ */
+function logoutSession(
+  token: string,
+  config: AuthClient.Config,
+  identity: AuthClient.Identity
+) {
+  try {
+    if (!opaque(token)) throw new Error();
+    const parts = token.split(".");
+    if (
+      parts.length !== 3 ||
+      parts.some((part) => !/^[A-Za-z0-9_-]+$/.test(part))
+    )
+      throw new Error();
+    const encoded = parts[1]!;
+    if (encoded.length % 4 === 1) throw new Error();
+    const alphabet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let bits = 0;
+    let value = 0;
+    let bytes = "";
+    for (const character of encoded) {
+      value = (value << 6) | alphabet.indexOf(character);
+      bits += 6;
+      if (bits >= 8) {
+        bits -= 8;
+        bytes += `%${((value >> bits) & 255).toString(16).padStart(2, "0")}`;
+      }
+    }
+    if ((value & ((1 << bits) - 1)) !== 0) throw new Error();
+    const claims = record(JSON.parse(decodeURIComponent(bytes)));
+    if (
+      !claims ||
+      claims.iss !== config.issuer ||
+      claims.aud !== "authenticated" ||
+      claims.client_id !== config.clientId ||
+      claims.sub !== identity.id ||
+      typeof claims.session_id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        claims.session_id
+      ) ||
+      claims.session_id === "00000000-0000-0000-0000-000000000000" ||
+      typeof claims.exp !== "number" ||
+      !Number.isSafeInteger(claims.exp) ||
+      claims.exp <= 0 ||
+      !Number.isSafeInteger(claims.exp * 1000)
+    )
+      throw new Error();
+    return { id: claims.session_id, expiresAt: claims.exp * 1000 };
+  } catch {
+    throw new AuthClient.Failure("token_rejected");
+  }
+}
+
 function validateConfig(config: AuthClient.Config) {
   if (
     !config ||
     !opaque(config.clientId) ||
+    typeof config.publishableKey !== "string" ||
+    !/^sb_publishable_[A-Za-z0-9_-]{1,256}$/.test(config.publishableKey) ||
     !Array.isArray(config.redirectUris) ||
     config.redirectUris.length === 0 ||
     config.redirectUris.length > 8 ||

--- a/packages/grida-auth/src/credential-store.test.ts
+++ b/packages/grida-auth/src/credential-store.test.ts
@@ -12,6 +12,7 @@ const config: AuthClient.Config = {
   issuer: "http://127.0.0.1:55431/auth/v1",
   apiOrigin: "http://127.0.0.1:3041",
   clientId: "synthetic-public-client",
+  publishableKey: "sb_publishable_synthetic",
   redirectUris: ["http://127.0.0.1:55435/callback"],
 };
 const session: AuthClient.Session = {
@@ -90,6 +91,25 @@ describe.skipIf(process.platform === "win32")("durable native custody", () => {
     expect(await next.info()).toMatchObject({ backend: "file" });
     expect(keyring.read).not.toHaveBeenCalled();
     expect(keyring.write).not.toHaveBeenCalled();
+  });
+
+  it("keeps the credential profile and revision across public admission-key rotation", async () => {
+    const { store, directory, keyring } = await setup("file");
+    await save(store);
+    const before = await snapshot(store);
+    const rotated = await CredentialStore.open(
+      {
+        ...config,
+        publishableKey: "sb_publishable_rotated",
+      },
+      { home: directory, keyring }
+    );
+    expect(await rotated.info()).toEqual(await store.info());
+    expect(await snapshot(rotated)).toEqual(before);
+    expect(await readdir(join(directory, "auth"))).toHaveLength(1);
+    expect(await readFile(await metadataPath(directory), "utf8")).not.toContain(
+      config.publishableKey
+    );
   });
 
   it("keeps invalidation durable even when already signed out", async () => {

--- a/packages/grida-auth/src/node.test.ts
+++ b/packages/grida-auth/src/node.test.ts
@@ -28,7 +28,9 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-async function server(handler?: Parameters<typeof createServer>[0]) {
+async function server(
+  handler?: NonNullable<Parameters<typeof createServer>[1]>
+) {
   const instance = handler ? createServer(handler) : createServer();
   const sockets = new Set<Socket>();
   instance.on("connection", (socket) => {
@@ -55,14 +57,23 @@ async function redirect() {
   return `${reservation.origin}/callback`;
 }
 
-async function fixture() {
+async function fixture(logout?: (response: ServerResponse) => void) {
   const calls: { path: string; body: string; authorization?: string }[] = [];
+  const logoutRequests: {
+    method?: string;
+    cookie?: string;
+    apiKey?: string | string[];
+  }[] = [];
   const ggRequests: {
     method?: string;
     cookie?: string;
     contentType?: string;
   }[] = [];
   const upstream = await server();
+  const accessTokens = {
+    initial: syntheticAccessToken(`${upstream.origin}/auth/v1`, "initial"),
+    rotated: syntheticAccessToken(`${upstream.origin}/auth/v1`, "rotated"),
+  };
   upstream.instance.on("request", (request, response) => {
     const parts: Buffer[] = [];
     request.on("data", (chunk) => parts.push(chunk));
@@ -81,8 +92,8 @@ async function fixture() {
           JSON.stringify({
             token_type: "Bearer",
             access_token: isRefresh
-              ? "rotated-access-secret"
-              : "initial-access-secret",
+              ? accessTokens.rotated
+              : accessTokens.initial,
             refresh_token: isRefresh
               ? "rotated-refresh-secret"
               : "initial-refresh-secret",
@@ -115,6 +126,12 @@ async function fixture() {
           })
         );
       } else if (call.path === "/auth/v1/logout?scope=local") {
+        logoutRequests.push({
+          method: request.method,
+          cookie: request.headers.cookie,
+          apiKey: request.headers.apikey,
+        });
+        if (logout) return logout(response);
         response.writeHead(204);
         response.end();
       } else {
@@ -137,6 +154,7 @@ async function fixture() {
   };
   const config: AuthClient.Config = {
     clientId: "synthetic-public-client",
+    publishableKey: "sb_publishable_synthetic-project-key",
     issuer: `${upstream.origin}/auth/v1`,
     apiOrigin: upstream.origin,
     redirectUris: [await redirect()],
@@ -146,9 +164,28 @@ async function fixture() {
     custody,
     calls,
     ggRequests,
+    logoutRequests,
     session: () => session,
     upstream,
+    accessTokens,
   };
+}
+
+function syntheticAccessToken(issuer: string, signature: string) {
+  return [
+    { alg: "ES256", typ: "JWT" },
+    {
+      iss: issuer,
+      aud: "authenticated",
+      sub: "synthetic-user",
+      client_id: "synthetic-public-client",
+      session_id: "11111111-1111-4111-8111-111111111111",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    },
+  ]
+    .map((part) => Buffer.from(JSON.stringify(part)).toString("base64url"))
+    .concat(Buffer.from(signature).toString("base64url"))
+    .join(".");
 }
 
 function callback(authorizationUrl: string) {
@@ -234,7 +271,7 @@ describe("createNativeAuth", () => {
           {
             path: "/api/v1/auth/gg",
             body: '{"organization_id":7}',
-            authorization: "Bearer initial-access-secret",
+            authorization: `Bearer ${f.accessTokens.initial}`,
           },
         ]
       );
@@ -353,6 +390,7 @@ describe("createNativeAuth", () => {
         issuer: `${upstream.origin}/auth/v1`,
         apiOrigin: upstream.origin,
         clientId: "synthetic-public-client",
+        publishableKey: "sb_publishable_synthetic-project-key",
         redirectUris: ["http://127.0.0.1:55435/callback"],
       };
       const session: AuthClient.Session = {
@@ -458,11 +496,145 @@ describe("createNativeAuth", () => {
     expect(f.calls.at(-1)).toEqual({
       path: "/auth/v1/logout?scope=local",
       body: "",
-      authorization: "Bearer rotated-access-secret",
+      authorization: `Bearer ${f.accessTokens.rotated}`,
     });
     expect(f.session()).toBeNull();
     expect(JSON.stringify(status)).not.toMatch(/secret|ignored/);
     await provesClosed(f.config.redirectUris[0]!);
+  });
+
+  it.each([200, 204])(
+    "accepts the logout operation's empty HTTP %s response without JSON parsing",
+    async (status) => {
+      const f = await fixture((response) => response.writeHead(status).end());
+      const client = createNativeAuth(f.config, {
+        custody: f.custody,
+        async openBrowser(url) {
+          await fetch(callback(url));
+        },
+      });
+      await client.login();
+      expect(await client.logout()).toEqual({
+        state: "signed-out",
+        revocation: "confirmed",
+      });
+      expect(f.calls.slice(-2).map((call) => call.path)).toEqual([
+        "/api/v1/auth/me",
+        "/auth/v1/logout?scope=local",
+      ]);
+      expect(f.calls.at(-1)).toEqual({
+        path: "/auth/v1/logout?scope=local",
+        body: "",
+        authorization: `Bearer ${f.accessTokens.initial}`,
+      });
+      expect(f.logoutRequests).toEqual([
+        {
+          method: "POST",
+          cookie: undefined,
+          apiKey: f.config.publishableKey,
+        },
+      ]);
+      expect(f.session()).toBeNull();
+    }
+  );
+
+  it("discards a logout success body without parsing, retaining, or waiting for it to finish", async () => {
+    const closed = deferred<void>();
+    const f = await fixture((response) => {
+      response.once("close", () => closed.resolve());
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.write("upstream-secret-that-must-not-escape");
+      // The server deliberately never ends this body. Status-only handling
+      // cancels the stream instead of reading it until the network deadline.
+    });
+    const client = createNativeAuth(f.config, {
+      custody: f.custody,
+      async openBrowser(url) {
+        await fetch(callback(url));
+      },
+    });
+    await client.login();
+    expect(await client.logout()).toEqual({
+      state: "signed-out",
+      revocation: "confirmed",
+    });
+    await closed.promise;
+    expect(f.session()).toBeNull();
+  });
+
+  it.each(["", "upstream-secret-that-is-not-json"])(
+    "still requires token JSON when the successful response body is %j",
+    async (body) => {
+      const f = await fixture();
+      f.upstream.instance.removeAllListeners("request");
+      f.upstream.instance.on("request", (_request, response) => {
+        response.writeHead(200).end(body);
+      });
+      const client = createNativeAuth(f.config, {
+        custody: f.custody,
+        async openBrowser(url) {
+          await fetch(callback(url));
+        },
+      });
+      await expect(client.login()).rejects.toMatchObject({
+        code: "invalid_response",
+        message: "Grida authentication failed (invalid_response)",
+      });
+      expect(f.session()).toBeNull();
+    }
+  );
+
+  it("refuses logout redirects without forwarding credentials or exposing an upstream body", async () => {
+    const capture = vi.fn<() => void>();
+    const destination = await server((_request, response) => {
+      capture();
+      response.writeHead(200).end();
+    });
+    const f = await fixture((response) => {
+      response
+        .writeHead(307, {
+          location: `${destination.origin}/capture`,
+          "set-cookie": "upstream-secret=must-not-be-retained",
+        })
+        .end("upstream-secret-that-must-not-escape");
+    });
+    const client = createNativeAuth(f.config, {
+      custody: f.custody,
+      async openBrowser(url) {
+        await fetch(callback(url));
+      },
+    });
+    await client.login();
+    expect(await client.logout()).toEqual({
+      state: "signed-out",
+      revocation: "unconfirmed",
+    });
+    expect(capture).not.toHaveBeenCalled();
+    expect(f.logoutRequests).toHaveLength(1);
+    expect(f.logoutRequests[0]?.cookie).toBeUndefined();
+    expect(f.session()).toBeNull();
+  });
+
+  it("retains the network deadline for a logout that never returns response headers", async () => {
+    const entered = deferred<void>();
+    const f = await fixture(() => entered.resolve());
+    const client = createNativeAuth(f.config, {
+      custody: f.custody,
+      async openBrowser(url) {
+        await fetch(callback(url));
+      },
+    });
+    await client.login();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const logout = client.logout();
+    await entered.promise;
+    await vi.advanceTimersByTimeAsync(15_000);
+    vi.useRealTimers();
+    expect(await logout).toEqual({
+      state: "signed-out",
+      revocation: "unconfirmed",
+    });
+    expect(f.session()).toBeNull();
   });
 
   it("keeps a pending ceremony usable after wrong method, path, host, state, and duplicate parameters", async () => {

--- a/packages/grida-auth/src/node.ts
+++ b/packages/grida-auth/src/node.ts
@@ -296,9 +296,11 @@ function nativeRequest(
         await response.body?.cancel();
         return { status: response.status, body: null };
       }
-      if (response.status === 204) {
+      // Logout confirms by status alone. Discard its body without buffering or
+      // parsing it; other successful operations still require bounded JSON.
+      if (request.response === "empty" || response.status === 204) {
         await response.body?.cancel();
-        return { status: 204, body: null };
+        return { status: response.status, body: null };
       }
       const reader = response.body?.getReader();
       if (!reader) throw new AuthClient.Failure("invalid_response");

--- a/packages/grida-auth/src/persistent-auth.test.ts
+++ b/packages/grida-auth/src/persistent-auth.test.ts
@@ -49,6 +49,10 @@ function send(message) { process.send(message); }
 process.on('message', async (message) => {
   try {
     if (message.type === 'init') {
+      // Test clock only: exercise real persisted expiry across process restarts
+      // without changing the machine clock or adding a production clock hook.
+      const now = Date.now;
+      Date.now = () => now() + message.clockOffsetMs;
       let nativeAddonAbsent = false;
       try { require.resolve('@github/keytar'); }
       catch (error) { nativeAddonAbsent = error.code === 'MODULE_NOT_FOUND'; }
@@ -109,7 +113,12 @@ class Consumer {
   private listeners = new Set<() => void>();
   private ended = false;
 
-  constructor(root: string, config: object, home: string) {
+  constructor(
+    root: string,
+    config: object,
+    home: string,
+    clockOffsetMs: number
+  ) {
     this.child = spawn(process.execPath, [path.join(root, "consumer.mjs")], {
       cwd: root,
       env: {
@@ -127,7 +136,7 @@ class Consumer {
       this.ended = true;
       for (const listener of this.listeners) listener();
     });
-    this.child.send({ type: "init", config, home });
+    this.child.send({ type: "init", config, home, clockOffsetMs });
   }
 
   wait(type: string): Promise<Message> {
@@ -185,16 +194,26 @@ class Issuer {
     { challenge: string; redirect: string }
   >();
   private readonly refreshTokens = new Map<string, number>();
-  private readonly accessTokens = new Map<string, number>();
+  private readonly accessTokens = new Map<
+    string,
+    { session: number; expiresAt: number }
+  >();
   private readonly active = new Set<number>();
   private sequence = 0;
   private rotation = 0;
   private gate: {
-    kind: "refresh" | "verify";
+    kind: "refresh" | "verify" | "logout";
     entered: ReturnType<typeof deferred<void>>;
     release: ReturnType<typeof deferred<void>>;
   } | null = null;
   private releases: (() => void)[] = [];
+  private rejectVerification = false;
+  clockOffsetMs = 0;
+  readonly issuedTokens: {
+    session: number;
+    access: string;
+    refresh: string;
+  }[] = [];
   readonly refreshes: string[] = [];
   readonly verifications: string[] = [];
   readonly revocations: string[] = [];
@@ -202,6 +221,7 @@ class Issuer {
     issuer: string;
     apiOrigin: string;
     clientId: string;
+    publishableKey: string;
     redirectUris: string[];
   };
 
@@ -218,15 +238,24 @@ class Issuer {
       issuer: `${origin}/auth/v1`,
       apiOrigin: origin,
       clientId: "synthetic-public-client",
+      publishableKey: "sb_publishable_synthetic",
       redirectUris: [`http://127.0.0.1:${port}/callback`],
     };
   }
 
-  hold(kind: "refresh" | "verify") {
+  hold(kind: "refresh" | "verify" | "logout") {
     const gate = { kind, entered: deferred<void>(), release: deferred<void>() };
     this.gate = gate;
     this.releases.push(() => gate.release.resolve());
     return gate;
+  }
+
+  rejectNextVerification() {
+    this.rejectVerification = true;
+  }
+
+  sessionFor(access: string) {
+    return this.accessTokens.get(access)?.session;
   }
 
   async approve(authorization: string) {
@@ -268,10 +297,21 @@ class Issuer {
 
   private tokens(session: number) {
     const suffix = `${session}-${++this.rotation}`;
-    const access = `synthetic-access-${suffix}`;
+    const expiresAt = Date.now() + this.clockOffsetMs + 3_600_000;
+    const encode = (value: unknown) =>
+      Buffer.from(JSON.stringify(value)).toString("base64url");
+    const access = `${encode({ alg: "ES256" })}.${encode({
+      iss: this.config.issuer,
+      aud: "authenticated",
+      sub: identity.id,
+      client_id: this.config.clientId,
+      session_id: `11111111-1111-4111-8111-${String(session).padStart(12, "0")}`,
+      exp: Math.floor(expiresAt / 1000),
+    })}.${encode(suffix)}`;
     const refresh = `synthetic-refresh-${suffix}`;
-    this.accessTokens.set(access, session);
+    this.accessTokens.set(access, { session, expiresAt });
     this.refreshTokens.set(refresh, session);
+    this.issuedTokens.push({ session, access, refresh });
     return {
       access_token: access,
       refresh_token: refresh,
@@ -280,7 +320,7 @@ class Issuer {
     };
   }
 
-  private async pause(kind: "refresh" | "verify") {
+  private async pause(kind: "refresh" | "verify" | "logout") {
     if (this.gate?.kind !== kind) return;
     const gate = this.gate;
     this.gate = null;
@@ -328,19 +368,31 @@ class Issuer {
       return this.respond(response, 400, {});
     }
     const token = request.headers.authorization?.replace(/^Bearer /, "") ?? "";
-    const session = this.accessTokens.get(token);
-    if (!session || !this.active.has(session))
+    const grant = this.accessTokens.get(token);
+    if (
+      !grant ||
+      !this.active.has(grant.session) ||
+      grant.expiresAt <= Date.now() + this.clockOffsetMs
+    )
       return this.respond(response, 401, {});
+    const session = grant.session;
     if (request.method === "GET" && request.url === "/api/v1/auth/me") {
       this.verifications.push(token);
       await this.pause("verify");
+      if (this.rejectVerification) {
+        this.rejectVerification = false;
+        return this.respond(response, 401, {});
+      }
       return this.respond(response, 200, identity);
     }
     if (
       request.method === "POST" &&
       request.url === "/auth/v1/logout?scope=local"
     ) {
+      if (request.headers.apikey !== this.config.publishableKey)
+        return this.respond(response, 401, {});
       this.revocations.push(token);
+      await this.pause("logout");
       this.active.delete(session);
       return this.respond(response, 200, {});
     }
@@ -406,7 +458,12 @@ describe.skipIf(!["darwin", "linux"].includes(process.platform))(
     });
 
     async function consumer() {
-      const value = new Consumer(root, issuer.config, home);
+      const value = new Consumer(
+        root,
+        issuer.config,
+        home,
+        issuer.clockOffsetMs
+      );
       consumers.push(value);
       const ready = await value.wait("ready");
       expect(ready.nativeAddonAbsent).toBe(true);
@@ -437,6 +494,8 @@ describe.skipIf(!["darwin", "linux"].includes(process.platform))(
       expect(JSON.stringify(result)).not.toMatch(
         /synthetic-access|synthetic-refresh|code_verifier/
       );
+      for (const issued of issuer.issuedTokens)
+        expect(JSON.stringify(result)).not.toContain(issued.access);
       expect(issuer.verifications).toHaveLength(requestCount);
     }, 20_000);
 
@@ -459,7 +518,7 @@ describe.skipIf(!["darwin", "linux"].includes(process.platform))(
       ]);
       const restarted = await consumer();
       expect(await restarted.run("verify")).toMatchObject({ ok: true });
-      expect(issuer.verifications.at(-1)).toBe("synthetic-access-1-3");
+      expect(issuer.verifications.at(-1)).toBe(issuer.issuedTokens[2]?.access);
     }, 20_000);
 
     it("keeps verification writes from overwriting a concurrent process rotation", async () => {
@@ -477,7 +536,7 @@ describe.skipIf(!["darwin", "linux"].includes(process.platform))(
       expect(await b).toMatchObject({ ok: true });
       const restarted = await consumer();
       expect(await restarted.run("verify")).toMatchObject({ ok: true });
-      expect(issuer.verifications.at(-1)).toBe("synthetic-access-1-2");
+      expect(issuer.verifications.at(-1)).toBe(issuer.issuedTokens[1]?.access);
     }, 20_000);
 
     it("persists logout invalidation against an earlier browser login in another process", async () => {
@@ -501,6 +560,95 @@ describe.skipIf(!["darwin", "linux"].includes(process.platform))(
         ok: true,
         result: { state: "signed-out" },
       });
+    }, 20_000);
+
+    it("captures the latest durable refresh rotation when another process's expired refresh fails verification", async () => {
+      await login();
+      issuer.clockOffsetMs = 3_601_000;
+      const [refresher, signingOut] = await Promise.all([
+        consumer(),
+        consumer(),
+      ]);
+      const rotation = issuer.hold("refresh");
+      const refresh = refresher.run("refresh");
+      await rotation.entered.promise;
+      const logout = signingOut.run("logout");
+      await signingOut.wait("started");
+      await delay(100);
+      expect(issuer.refreshes).toEqual(["synthetic-refresh-1-1"]);
+      expect(issuer.revocations).toHaveLength(0);
+
+      // Rotation has spent the issuer credential. Its replacement must be
+      // retained under the lock even when the following live check fails.
+      issuer.rejectNextVerification();
+      rotation.release.resolve();
+      expect(await refresh).toMatchObject({
+        ok: false,
+        code: "token_rejected",
+      });
+      expect(await logout).toMatchObject({
+        ok: true,
+        result: { state: "signed-out", revocation: "confirmed" },
+      });
+      expect(issuer.refreshes).toEqual([
+        "synthetic-refresh-1-1",
+        "synthetic-refresh-1-2",
+      ]);
+      expect(issuer.revocations).toEqual([issuer.issuedTokens[2]?.access]);
+      const restarted = await consumer();
+      expect(await restarted.run("status")).toMatchObject({
+        ok: true,
+        result: { state: "signed-out" },
+      });
+    }, 20_000);
+
+    it("keeps a newer same-home login and rotation while an expired logout finishes detached revocation", async () => {
+      await login();
+      issuer.clockOffsetMs = 3_601_000;
+      const signingOut = await consumer();
+      const rotation = issuer.hold("refresh");
+      const logout = signingOut.run("logout");
+      await rotation.entered.promise;
+
+      // Reaching the issuer does not hold the old profile lock. A separate
+      // process observes the durable clear while the old refresh is pending.
+      const cleared = await consumer();
+      expect(await cleared.run("status")).toMatchObject({
+        ok: true,
+        result: { state: "signed-out" },
+      });
+      await login();
+      const revocation = issuer.hold("logout");
+      rotation.release.resolve();
+      await revocation.entered.promise;
+      expect(issuer.revocations).toHaveLength(1);
+      expect(issuer.sessionFor(issuer.revocations[0]!)).toBe(1);
+
+      // The replacement session has independent issuer authority and can
+      // rotate while the old logout is pending. Old completion cannot rewrite
+      // its durable envelope or revoke that replacement session.
+      const replacement = await consumer();
+      expect(await replacement.run("refresh")).toMatchObject({
+        ok: true,
+        result: { state: "signed-in", identity },
+      });
+      expect(issuer.refreshes).toEqual([
+        "synthetic-refresh-1-1",
+        "synthetic-refresh-2-2",
+      ]);
+      revocation.release.resolve();
+      expect(await logout).toMatchObject({
+        ok: true,
+        result: { state: "signed-out", revocation: "confirmed" },
+      });
+      const restarted = await consumer();
+      expect(await restarted.run("verify")).toMatchObject({
+        ok: true,
+        result: { state: "signed-in", identity },
+      });
+      expect(issuer.verifications.at(-1)).toBe(issuer.issuedTokens[3]?.access);
+      expect(issuer.sessionFor(issuer.verifications.at(-1)!)).toBe(2);
+      expect(issuer.revocations).toHaveLength(1);
     }, 20_000);
   }
 );

--- a/packages/grida-cli/README.md
+++ b/packages/grida-cli/README.md
@@ -6,8 +6,7 @@
 The `grida` command composes Grida's account services and tools for people and
 their own harnesses. It runs independently of Desktop.
 
-**Preview.** Install the replacement CLI from npm's `next` channel. The legacy
-`latest` package does not provide these commands. Current commands cover auth,
+This README describes the Grida CLI 0.1 release line. Commands cover auth,
 credential storage, identity, organization membership, cached credits, help/version
 and docs.
 Media commands discover models/schemas, inspect provider key presence, list speech
@@ -17,7 +16,7 @@ Agent, render and MCP are deferred.
 Use Node.js 24 or later:
 
 ```sh
-npm install -g grida@next
+npm install -g grida
 grida --version
 grida --help
 ```

--- a/packages/grida-cli/README.md
+++ b/packages/grida-cli/README.md
@@ -51,12 +51,15 @@ observations, not an atomic identity/membership snapshot.
 
 ## OAuth client registration
 
-The production client ID, issuer, API origin and callback URLs live in
+The production client ID, issuer, public project admission key, API origin and callback URLs live in
 [`src/oauth-client-registration.ts`](https://github.com/gridaco/grida/blob/main/packages/grida-cli/src/oauth-client-registration.ts).
 These public values are intentionally versioned in Git and bundled with the CLI.
 The CLI host consumes them; the shared auth SDK remains registration-agnostic.
 Changes must stay aligned with the Supabase OAuth app and Grida server allowlist.
 Issuer/client/API changes also affect existing credential profile identity.
+The public project key is sent only to the fixed issuer logout endpoint;
+rotating that key does not change credential profile identity. It is distinct
+from the OAuth client ID and from every user/provider credential.
 
 Account commands use this hosted public registration:
 Grida's HTTPS issuer/API and the two registered loopback callbacks. Public client

--- a/packages/grida-cli/package.json
+++ b/packages/grida-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grida",
-  "version": "0.1.0-next.0",
+  "version": "0.1.0-next.1",
   "private": false,
   "description": "The Grida command line: account access and tools, independent of Desktop.",
   "homepage": "https://grida.co/docs/cli",

--- a/packages/grida-cli/package.json
+++ b/packages/grida-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grida",
-  "version": "0.1.0-next.1",
+  "version": "0.1.0",
   "private": false,
   "description": "The Grida command line: account access and tools, independent of Desktop.",
   "homepage": "https://grida.co/docs/cli",

--- a/packages/grida-cli/src/commands/auth.test.ts
+++ b/packages/grida-cli/src/commands/auth.test.ts
@@ -4,12 +4,29 @@ import { AuthCommands } from "./auth";
 
 const config: AuthClient.Config = {
   clientId: "synthetic-public-client",
+  publishableKey: "sb_publishable_synthetic",
   issuer: "https://issuer.invalid/auth/v1",
   apiOrigin: "https://grida.invalid",
   redirectUris: ["http://127.0.0.1:55435/callback"],
 };
 const identity = { id: "synthetic-user", email: null, display_name: "Insider" };
 const now = 1_800_000_000_000;
+const accessToken = [
+  Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString(
+    "base64url"
+  ),
+  Buffer.from(
+    JSON.stringify({
+      iss: config.issuer,
+      aud: "authenticated",
+      sub: identity.id,
+      client_id: config.clientId,
+      session_id: "11111111-1111-4111-8111-111111111111",
+      exp: now / 1000 + 3600,
+    })
+  ).toString("base64url"),
+  "synthetic-access",
+].join(".");
 
 function setup() {
   let session: AuthClient.Session | null = null;
@@ -23,7 +40,7 @@ function setup() {
       return {
         status: 200,
         body: {
-          access_token: "synthetic-access",
+          access_token: accessToken,
           refresh_token: "synthetic-refresh",
           expires_in: 3600,
           token_type: "bearer",
@@ -118,6 +135,25 @@ describe("AuthCommands", () => {
       revocation: "not-needed",
     });
     expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns confirmed session-local logout without exposing admission or account tokens", async () => {
+    const { runtime, send } = setup();
+    await AuthCommands.login(runtime);
+    expect(await AuthCommands.logout(runtime)).toEqual({
+      state: "signed-out",
+      revocation: "confirmed",
+    });
+    expect(send).toHaveBeenLastCalledWith({
+      url: `${config.issuer}/logout?scope=local`,
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        apikey: config.publishableKey,
+      },
+      response: "empty",
+    });
+    expect(await AuthCommands.status(runtime)).toEqual({ state: "signed-out" });
   });
 
   it("preserves a safe producer failure without retry or inventing a session", async () => {

--- a/packages/grida-cli/src/host.test.ts
+++ b/packages/grida-cli/src/host.test.ts
@@ -28,6 +28,7 @@ vi.mock("@grida/auth/node", () => ({
 
 const config = {
   clientId: "local-public-client",
+  publishableKey: "sb_publishable_local_fixture",
   issuer: "http://127.0.0.1:55431/auth/v1",
   apiOrigin: "http://127.0.0.1:3041",
   redirectUris: [
@@ -37,6 +38,7 @@ const config = {
 };
 const hostedConfig = {
   clientId: "ab2b3b01-a0a1-4d40-969c-b8fc177a2557",
+  publishableKey: "sb_publishable_dRc62vMF3jbqm2UD8cTGig_blvDStbc",
   issuer: "https://mozagqllybnbytfcmvdh.supabase.co/auth/v1",
   apiOrigin: "https://grida.co",
   redirectUris: config.redirectUris,
@@ -118,6 +120,7 @@ describe("CliHost.open", () => {
         GRIDA_OAUTH_ORIGIN: "https://untrusted.example",
         GRIDA_API_ORIGIN: "https://untrusted.example",
         NEXT_PUBLIC_SUPABASE_URL: "https://untrusted.example",
+        NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_untrusted",
       }
     );
     expect(nativeFactory).toHaveBeenCalledExactlyOnceWith(hostedConfig, {
@@ -248,6 +251,19 @@ describe("CliHost.open", () => {
     ).not.toHaveProperty("storage");
   });
 
+  it("passes the explicit local key without borrowing or discovering a hosted key", async () => {
+    const local = { ...config, publishableKey: "sb_publishable_rotated_local" };
+    await writeConfig(local);
+    await CliHost.open(
+      {},
+      {
+        ...env,
+        NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: hostedConfig.publishableKey,
+      }
+    );
+    expect(nativeFactory.mock.calls[0]![0]).toEqual(local);
+  });
+
   it("propagates public custody failure without fallback or browser launch", async () => {
     const failure = new Error("synthetic public custody failure");
     vi.mocked(createPersistentNativeAuth).mockRejectedValueOnce(failure);
@@ -269,6 +285,9 @@ describe("CliHost.open", () => {
     { redirectUris: [] },
     { clientId: "untrusted client id" },
     { clientId: "" },
+    { publishableKey: null },
+    { publishableKey: 42 },
+    { publishableKey: undefined },
     { client_secret: "must-never-be-read" },
   ])("rejects untrusted registration before custody: %j", async (change) => {
     await writeConfig({ ...config, ...change });

--- a/packages/grida-cli/src/host.ts
+++ b/packages/grida-cli/src/host.ts
@@ -179,13 +179,14 @@ async function localRegistration(
       data === null ||
       Array.isArray(data) ||
       Object.keys(data).sort().join(",") !==
-        "apiOrigin,clientId,issuer,redirectUris"
+        "apiOrigin,clientId,issuer,publishableKey,redirectUris"
     )
       throw new CliHost.Failure("invalid_config");
     const config = data as Record<string, unknown>;
     if (
       typeof config.clientId !== "string" ||
       !/^[A-Za-z0-9_-]{1,256}$/.test(config.clientId) ||
+      typeof config.publishableKey !== "string" ||
       config.issuer !== localIssuer ||
       config.apiOrigin !== localApiOrigin ||
       !Array.isArray(config.redirectUris) ||
@@ -199,6 +200,9 @@ async function localRegistration(
       throw new CliHost.Failure("invalid_config");
     return Object.freeze({
       clientId: config.clientId,
+      // The SDK validates key admission before constructing durable custody.
+      // An explicit local registration never borrows the hosted project's key.
+      publishableKey: config.publishableKey,
       issuer: localIssuer,
       apiOrigin: localApiOrigin,
       redirectUris: Object.freeze([

--- a/packages/grida-cli/src/media-run.test.ts
+++ b/packages/grida-cli/src/media-run.test.ts
@@ -1,4 +1,5 @@
 // GRIDA-SEC-013 — CLI preflight, explicit BYOK, safe media publication.
+// GRIDA-SEC-015 — composing real media clients does not mix account, GG and BYOK authority.
 // GRIDA-SEC-006 — only the public native scoped sink supplies GG to the real media SDK.
 // GRIDA-GG: token — synthetic tokens only; no services, auth custody or provider calls.
 import { MediaOperations } from "@grida/ai";

--- a/packages/grida-cli/src/media-run.ts
+++ b/packages/grida-cli/src/media-run.ts
@@ -1,4 +1,5 @@
 // GRIDA-SEC-014 — shared provider custody retains explicit host authority.
+// GRIDA-SEC-015 — account authority enters media only through an explicit scoped GG handoff.
 // GRIDA-SEC-013 — explicit CLI media authority, preflight and safe result presentation.
 // GRIDA-SEC-006 — the native account owner hands off only a scoped in-memory GG grant.
 // GRIDA-GG: token — one invocation, no persistence, remint or provider fallback.

--- a/packages/grida-cli/src/oauth-client-registration.ts
+++ b/packages/grida-cli/src/oauth-client-registration.ts
@@ -9,10 +9,14 @@ import type { AuthClient } from "@grida/auth";
  * Keep application registration here, outside the registration-agnostic auth SDK.
  * Changes must stay aligned with Supabase's OAuth app and Grida's server allowlist;
  * issuer/client/API changes also affect durable credential profile identity.
+ * The publishable key admits the fixed issuer's logout request; it is not an
+ * OAuth client secret or user authority. Key rotation does not select a new
+ * account profile. Keep it aligned with the same project's public web key.
  * Do not add client secrets, user credentials or environment lookup here.
  */
 export const oauthClientRegistration: AuthClient.Config = Object.freeze({
   clientId: "ab2b3b01-a0a1-4d40-969c-b8fc177a2557",
+  publishableKey: "sb_publishable_dRc62vMF3jbqm2UD8cTGig_blvDStbc",
   issuer: "https://mozagqllybnbytfcmvdh.supabase.co/auth/v1",
   apiOrigin: "https://grida.co",
   redirectUris: Object.freeze([

--- a/scripts/auth-local/README.md
+++ b/scripts/auth-local/README.md
@@ -87,8 +87,9 @@ mode `0700`. Outputs have mode `0600`:
 
 - `fixture.json`: validated paths, versions, lifecycle phase, and copied-source
   hashes. `readState(path)` is exported from `stack.mjs` for the editor launcher.
-- `public-client.json`: `{clientId, issuer, apiOrigin, redirectUris}` for the native
-  auth producer. It contains no OAuth client secret.
+- `public-client.json`: `{clientId, publishableKey, issuer, apiOrigin, redirectUris}`
+  for the native auth producer. The fixture's `sb_publishable_…` admission key
+  comes from local CLI status; it is not an OAuth client secret or user authority.
 - `setup.json`: fixture API keys, seeded test credentials, and an `editorEnv`
   object for the isolated editor launcher. These are local fixture credentials.
 - `editor.env`: the same editor settings for tools that explicitly consume an env
@@ -167,6 +168,19 @@ endpoints. It verifies browser sign-in, denial and reused consent, one-use codes
 bearer credential rejection, independent native sessions, rotating refresh,
 seeded `local`/`acme` organization RLS, and the distinct effects of session-local
 logout, application-grant revocation, and account-wide logout.
+
+Session-local logout checks rejection of the captured refresh credential and
+account bearer while another native session and the browser remain usable. A
+standalone process also advances only its application clock beyond the captured
+JWT expiry, performs one detached renewal, and proves both the original and
+renewed refresh credentials are rejected afterward. Renewed credentials never
+return to custody or IPC. Issuer time and token bytes stay unchanged: this covers
+the application's expired-session path, not naturally expired issuer JWTs.
+
+Local Kong accepts a user bearer on `/auth/v1/logout` without an admission key;
+the hosted gateway requires the publishable `apikey` too. The proof explicitly
+checks that native logout carries both, and unit tests cover rejection when the
+key is absent. A successful local run does not certify hosted gateway admission.
 
 The account check calls the package's public
 `auth.requestAccount("organizations.list", { after })` operation through Grida's

--- a/scripts/auth-local/native-probe.mjs
+++ b/scripts/auth-local/native-probe.mjs
@@ -23,13 +23,16 @@ assert.equal((await fs.stat(root)).mode & 0o777, 0o700);
 const config = JSON.parse(await fs.readFile(configPath, "utf8"));
 assert.equal(config.issuer, "http://127.0.0.1:55431/auth/v1");
 assert.equal(config.apiOrigin, "http://127.0.0.1:3041");
+assert.match(config.publishableKey, /^sb_publishable_[A-Za-z0-9_-]+$/);
 assert.deepEqual(config.redirectUris, [
   "http://127.0.0.1:55435/callback",
   "http://127.0.0.1:55436/callback",
 ]);
 
+let rotatedLogoutTokens;
+let logoutRefreshRequests = 0;
 const originalFetch = globalThis.fetch;
-globalThis.fetch = (input, init) => {
+globalThis.fetch = async (input, init) => {
   const url = new URL(
     typeof input === "string"
       ? input
@@ -42,7 +45,36 @@ globalThis.fetch = (input, init) => {
     "Probe network escaped the fixture"
   );
   assert(!url.username && !url.password && !url.hash);
-  return originalFetch(input, { ...init, redirect: "manual" });
+  const headers = new Headers(init?.headers);
+  if (url.pathname === "/auth/v1/logout") {
+    assert.equal(url.search, "?scope=local");
+    // Local Kong also accepts a bearer without this key; enforce the hosted
+    // admission contract explicitly so this proof cannot repeat that blind spot.
+    assert(headers.get("apikey") === config.publishableKey);
+    assert(headers.get("authorization")?.startsWith("Bearer "));
+  } else {
+    assert(headers.get("apikey") !== config.publishableKey);
+  }
+  if (
+    operation === "logout-expired" &&
+    url.pathname === "/auth/v1/oauth/token"
+  ) {
+    assert.equal(++logoutRefreshRequests, 1);
+  }
+  const response = await originalFetch(input, { ...init, redirect: "manual" });
+  if (
+    operation === "logout-expired" &&
+    url.pathname === "/auth/v1/oauth/token" &&
+    response.status === 200
+  ) {
+    assert.equal(rotatedLogoutTokens, undefined);
+    const tokens = await response.clone().json();
+    rotatedLogoutTokens = {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+    };
+  }
+  return response;
 };
 
 const custody = {
@@ -69,6 +101,29 @@ const custody = {
     await fs.rm(sessionPath, { force: true });
   },
 };
+
+let capturedLogoutSession;
+if (["logout", "logout-expired"].includes(operation)) {
+  capturedLogoutSession = await custody.read();
+  assert(capturedLogoutSession);
+  if (operation === "logout-expired") {
+    // Advance only this isolated application's clock beyond its issued JWT.
+    // GoTrue keeps its real clock; this proves detached renewal, not natural
+    // issuer expiry. Leave time for the replacement JWT to have a later expiry.
+    await new Promise((resolve) => setTimeout(resolve, 2_100));
+    const claims = JSON.parse(
+      Buffer.from(
+        capturedLogoutSession.accessToken.split(".")[1],
+        "base64url"
+      ).toString("utf8")
+    );
+    const now = Date.now;
+    const offset =
+      Math.max(capturedLogoutSession.expiresAt, claims.exp * 1000) + 1 - now();
+    assert(Number.isSafeInteger(offset) && offset > 0 && offset <= 3_600_000);
+    Date.now = () => now() + offset;
+  }
+}
 
 let browserOpened;
 let ggGrant;
@@ -170,8 +225,43 @@ try {
     } finally {
       ggGrant = undefined;
     }
-  } else if (operation === "logout") result = await auth.logout();
-  else throw new Error("Unknown probe operation");
+  } else if (["logout", "logout-expired"].includes(operation)) {
+    result = await auth.logout();
+    assert.deepEqual(result, { state: "signed-out", revocation: "confirmed" });
+    assert.equal(await custody.read(), null);
+    if (operation === "logout-expired") {
+      assert.equal(logoutRefreshRequests, 1);
+      assert(rotatedLogoutTokens);
+      assert(
+        rotatedLogoutTokens.refreshToken !== capturedLogoutSession.refreshToken
+      );
+    }
+    for (const tokens of [capturedLogoutSession, rotatedLogoutTokens].filter(
+      Boolean
+    )) {
+      const identity = await fetch(`${config.apiOrigin}/api/v1/auth/me`, {
+        headers: { authorization: `Bearer ${tokens.accessToken}` },
+        signal: AbortSignal.timeout(15_000),
+      });
+      assert.equal(identity.status, 401);
+      await identity.body?.cancel();
+      // Use the underlying guarded destination directly so these negative probes
+      // cannot be mistaken for the application's one detached renewal above.
+      const refresh = await originalFetch(`${config.issuer}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          client_id: config.clientId,
+          refresh_token: tokens.refreshToken,
+        }).toString(),
+        redirect: "manual",
+        signal: AbortSignal.timeout(15_000),
+      });
+      assert([400, 401].includes(refresh.status));
+      await refresh.body?.cancel();
+    }
+  } else throw new Error("Unknown probe operation");
   await browserOpened;
   process.send({ type: "result", result });
 } catch {
@@ -179,5 +269,7 @@ try {
   process.exitCode = 1;
 } finally {
   ggGrant = undefined;
+  capturedLogoutSession = undefined;
+  rotatedLogoutTokens = undefined;
   process.disconnect();
 }

--- a/scripts/auth-local/stack.mjs
+++ b/scripts/auth-local/stack.mjs
@@ -480,6 +480,7 @@ async function bootstrap(state) {
   assert.equal(dbUrl.hostname, "127.0.0.1");
   assert.equal(dbUrl.port, "55432");
   assert.equal(typeof status.ANON_KEY, "string");
+  assert.match(status.PUBLISHABLE_KEY, /^sb_publishable_[A-Za-z0-9_-]+$/);
   assert.equal(typeof status.SERVICE_ROLE_KEY, "string");
   const credentials = {
     token: status.SERVICE_ROLE_KEY,
@@ -509,13 +510,14 @@ async function bootstrap(state) {
   assert.match(client.client_id, /^[0-9a-f-]{36}$/);
   const publicClient = {
     clientId: client.client_id,
+    publishableKey: status.PUBLISHABLE_KEY,
     issuer: fixture.issuer,
     apiOrigin: fixture.editorOrigin,
     redirectUris: fixture.redirectUris,
   };
   const editorEnv = {
     NEXT_PUBLIC_SUPABASE_URL: fixture.apiUrl,
-    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: status.ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: status.PUBLISHABLE_KEY,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: status.ANON_KEY,
     SUPABASE_SECRET_KEY: status.SERVICE_ROLE_KEY,
     SUPABASE_SERVICE_ROLE_KEY: status.SERVICE_ROLE_KEY,
@@ -534,6 +536,7 @@ async function bootstrap(state) {
   await privateJson(state.setupPath, {
     apiUrl: fixture.apiUrl,
     anonKey: status.ANON_KEY,
+    publishableKey: status.PUBLISHABLE_KEY,
     serviceRoleKey: status.SERVICE_ROLE_KEY,
     editorOrigin: fixture.editorOrigin,
     editorEnv,

--- a/scripts/cli-docs/README.md
+++ b/scripts/cli-docs/README.md
@@ -42,7 +42,7 @@ proof owns synthetic execution and saving behavior.
 Author ordinary `sh` fences with one literal Grida invocation per logical line;
 backslash continuation and shell quotes are supported. Shell expansion, pipes,
 redirection, and arbitrary shell evaluation are rejected. Only the exact
-`npm install -g grida@next` setup block is marked `grida-setup` and exempted; the
+`npm install -g grida` setup block is marked `grida-setup` and exempted; the
 checker never runs that command. Named `text`/`json` fences are copied literally
 into each guide's temporary directory.
 If a workflow needs additional shell orchestration, explain it separately and

--- a/scripts/cli-docs/check.mjs
+++ b/scripts/cli-docs/check.mjs
@@ -120,8 +120,8 @@ export const CliDocs = {
       if (info === "sh grida-setup") {
         assert.equal(
           body.trim(),
-          "npm install -g grida@next",
-          "Only the documented preview install is exempt from command parsing"
+          "npm install -g grida",
+          "Only the documented install is exempt from command parsing"
         );
       } else if (info === "sh") {
         for (const line of body.replace(/\\\r?\n/g, "").split(/\r?\n/)) {

--- a/scripts/cli-docs/check.test.mjs
+++ b/scripts/cli-docs/check.test.mjs
@@ -60,14 +60,14 @@ test("literal guide parsing preserves quoted prompts, escaped quotes, false and 
 
 test("guide commands never acquire shell evaluation and cannot silently opt out", () => {
   assert.deepEqual(
-    CliDocs.examples("```sh grida-setup\nnpm install -g grida@next\n```"),
+    CliDocs.examples("```sh grida-setup\nnpm install -g grida\n```"),
     { examples: [], files: [] }
   );
   for (const setup of [
-    "npm install -g grida",
+    "npm install -g grida@next",
     "npm install -g grida@latest",
-    "npm install -g grida@next\ngrida removed-command",
-    "npm install -g grida@next; id",
+    "npm install -g grida\ngrida removed-command",
+    "npm install -g grida; id",
     "pnpm --filter grida... build\nnode packages/grida-cli/dist/bin.mjs --help",
   ])
     assert.throws(() =>

--- a/scripts/cli-local/README.md
+++ b/scripts/cli-local/README.md
@@ -56,7 +56,9 @@ The proof covers:
   to ten seconds before its observed expiry. This avoids waiting an hour; JWTs,
   token exchange, issuer time, and credential files are unchanged by the harness.
 - Safe offline failures, local status without network, session-local logout,
-  cleared credential envelopes, and survival of the other CLI session.
+  cleared credential envelopes, and survival of the other CLI session. A second
+  logout advances the application clock past its captured expiry and requires
+  exactly one detached refresh without restoring credentials.
 
 The CLI preload permits only the exact API/editor ports and callback listeners.
 It records method/path counts without headers or bodies, rejects outside module
@@ -69,7 +71,10 @@ These are tripwires for a trusted repository/runtime, not an OS sandbox. The
 guard, clock injection, real local issuer and manual browser path do not certify
 hosted registration, the system browser launcher, Windows, native keyring
 availability, or naturally expired JWT behavior. The fixture's existing OAuth
-proof separately covers revocation and API/RLS details.
+proof separately covers revocation of both captured and detached-rotation refresh
+credentials, same-user session/browser preservation, and API/RLS details. Local
+Kong is more permissive about the logout admission key than the hosted gateway;
+the auth proof and unit tests enforce that header contract explicitly.
 
 All CLI children, browser storage and temporary installation/profile files are
 removed before a safe report is written under ignored `.cache/cli-local`.

--- a/scripts/cli-local/linux-smoke.mjs
+++ b/scripts/cli-local/linux-smoke.mjs
@@ -51,6 +51,7 @@ async function main() {
       env.GRIDA_CLI_LOCAL_CONFIG,
       JSON.stringify({
         clientId: "cli-offline-smoke",
+        publishableKey: "sb_publishable_synthetic_offline",
         issuer: "http://127.0.0.1:55431/auth/v1",
         apiOrigin: "http://127.0.0.1:3041",
         redirectUris: [

--- a/scripts/cli-local/proof.mjs
+++ b/scripts/cli-local/proof.mjs
@@ -117,6 +117,8 @@ async function main() {
   );
   assert.equal(registration.issuer, fixture.issuer);
   assert.equal(registration.apiOrigin, fixture.editorOrigin);
+  assert.match(registration.publishableKey, /^sb_publishable_[A-Za-z0-9_-]+$/);
+  assert.equal(registration.publishableKey, setup.publishableKey);
   assert.deepEqual(registration.redirectUris, fixture.redirectUris);
   const owned = await realpath(
     await mkdtemp(path.join(tmpdir(), "grida-cli-proof-"))
@@ -693,6 +695,41 @@ async function main() {
         assert(
           !jwt.test(await readFile(file.filename, "utf8")),
           "Logout retained a bearer credential"
+        );
+        await login(profiles[0], "insider@grida.co");
+        const expiring = (await json(["auth", "status"])).value;
+        // Advance only this application's clock beyond the issued expiry.
+        // Leave time for the replacement JWT to have a later real expiry.
+        await new Promise((resolve) => setTimeout(resolve, 2_100));
+        const offset = expiring.expiresAt + 1 - Date.now();
+        assert(
+          Number.isSafeInteger(offset) && offset > 0 && offset <= 3_600_000
+        );
+        const expiredLogout = await json(["auth", "logout"], {
+          extra: { GRIDA_CLI_PROOF_CLOCK_OFFSET: String(offset) },
+        });
+        assert.deepEqual(expiredLogout.value, {
+          state: "signed-out",
+          revocation: "confirmed",
+        });
+        assert.equal(
+          expiredLogout.stats.requests.filter(
+            (value) => value.path === "/auth/v1/oauth/token"
+          ).length,
+          1,
+          "Expired logout must consume exactly one detached rotation"
+        );
+        assert.equal(
+          (await json(["auth", "status"], { code: 1 })).value.state,
+          "signed-out"
+        );
+        assert(
+          !jwt.test(await readFile(file.filename, "utf8")),
+          "Expired logout restored a bearer credential"
+        );
+        assert.deepEqual(
+          (await json(["account", "view"], { profile: profiles[1] })).value,
+          secondAccount
         );
         assert.equal(
           (await json(["auth", "logout"], { profile: profiles[1] })).value

--- a/scripts/cli-media-local/proof.mjs
+++ b/scripts/cli-media-local/proof.mjs
@@ -537,6 +537,7 @@ async function main() {
       path.join(owned, "public-client.json"),
       JSON.stringify({
         clientId: "synthetic-media-client",
+        publishableKey: "sb_publishable_synthetic_media",
         issuer: "http://127.0.0.1:55431/auth/v1",
         apiOrigin: "http://127.0.0.1:3041",
         redirectUris: [

--- a/scripts/cli-release/README.md
+++ b/scripts/cli-release/README.md
@@ -21,7 +21,7 @@ pnpm turbo run typecheck test --filter=grida...
 node --test scripts/cli-release/prepare.test.mjs
 node scripts/cli-release/prepare.mjs --out "$PWD/.cache/cli-candidate"
 node scripts/cli-release/prepare.mjs --verify --out "$PWD/.cache/cli-candidate"
-node scripts/cli-media-local/proof.mjs --archive "$PWD/.cache/cli-candidate/grida-0.1.0-next.0.tgz"
+node scripts/cli-media-local/proof.mjs --archive "$PWD/.cache/cli-candidate/grida-0.1.0.tgz"
 ```
 
 Use the actual archive name from `candidate.json` after a version change. The
@@ -103,8 +103,10 @@ default to staged publication only, so direct publishing must be explicitly
 allowed in npm. See [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
 and [provenance](https://docs.npmjs.com/generating-provenance-statements/).
 
-The first preview uses the `next` distribution tag. A prerelease cannot replace
-`latest`. Review the existing reserved package's versions and tags before
+Stable releases use the `latest` distribution tag, the workflow's default.
+The standalone CLI's first stable version is `0.1.0`, installed with
+`npm install -g grida`. Prereleases use `next` and cannot replace
+`latest`. Review the existing package's versions and tags before
 choosing a version; an old package name does not imply an empty release history.
 Successful CI is a prerequisite, not evidence that docs, OAuth or API changes
 have been deployed. Verify those separately before approving publication.

--- a/scripts/cli-release/prepare.test.mjs
+++ b/scripts/cli-release/prepare.test.mjs
@@ -29,6 +29,7 @@ const files = () =>
   ].map((path) => ({ path }));
 
 test("release guard refuses private/placeholder/mismatched/unreviewed package releases", () => {
+  CliRelease.release(manifest(), "1.0.0", "latest");
   CliRelease.release(manifest(), "1.0.0", "next");
   CliRelease.release(
     { ...manifest(), version: "1.0.0-rc.1" },


### PR DESCRIPTION
CLI logout clears local credentials but can leave remote revocation unconfirmed: its issuer logout request omits the public project admission key, and it cannot revoke an expired access session. This fixes the endpoint contract and logout lifecycle, with a cross-client auth blueprint explaining credential ownership and logout scope.

- Bundle the existing public project key in explicit CLI registration and send it only to the fixed issuer logout endpoint. Key rotation preserves existing account profiles.
- Clear local custody first. Near expiry, refresh once in memory, require the captured issuer/user/client/session binding, verify live identity, then revoke only that session. Never persist renewed credentials or overwrite a newer login. Confirm only completed 200/204 responses and discard logout bodies.
- Extend existing transport, custody, browser and installed-CLI proofs. The local gateway is more permissive than hosted admission, so the required header is asserted explicitly.
- Document web/Desktop/CLI/provider flows, register SEC015 for account-to-media credential separation, update SEC010/011, and correct inaccurate HttpOnly wording without changing cookie policy. Prepare stable `grida@0.1.0` for npm `latest`, with plain `npm install -g grida` instructions and the matching documentation guard.

The cause is an integration-contract gap: successful OAuth token exchange and permissive local logout did not prove hosted logout admission. No database migration, new server endpoint, or production setting change is introduced. Web/Desktop logout scope is unchanged.

Validation: 444 auth tests passed (one opt-in real-keyring smoke skipped), 422 CLI tests passed, 52 repository typecheck tasks passed, guard/release tests passed, and all-locale docs build plus installed docs checks passed. Stable release metadata and the corresponding install-example guard also passed focused release/docs checks. Real local OAuth and the final packed CLI prove revocation and preservation of other sessions. Expiry coverage uses synthetic issuer expiry enforcement and explicitly bounded client-clock advancement against real local Auth; hosted installed acceptance remains a release gate.

Ready for peer review. No production mutation or npm publication has been performed.
