### PR TITLE
chore: align issue template label defaults

### DIFF
--- a/.github/ISSUE_TEMPLATE/accounts--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/accounts--bug-report.md
@@ -2,7 +2,7 @@
 name: "Accounts: Bug report"
 about: Create a report related to accounts & management (billing)
 title: ""
-labels: accounts
+labels: bug
 assignees: softmarshmallow
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: ""
+labels: bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/desktop--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/desktop--bug-report.md
@@ -2,7 +2,7 @@
 name: "Desktop: Bug report"
 about: Report a bug specific to the Grida Desktop app (Electron)
 title: "[Desktop] "
-labels: desktop
+labels: "bug, desktop"
 assignees: softmarshmallow
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: ""
+labels: enhancement
 assignees: ""
 ---
 


### PR DESCRIPTION
New reports currently arrive without type labels, and account reports request an `accounts` label that does not exist. Assign `bug` to general and account reports, `bug` plus `desktop` to Desktop reports, and `enhancement` to feature requests so new issues use the repository's existing taxonomy.

Validation: checked all four frontmatter values and confirmed every other template byte is unchanged. Formatting and `git diff --check` pass.
